### PR TITLE
Add ability to disable scripts in package.json to avoid them being run on npm install

### DIFF
--- a/BuildPackage.cmd
+++ b/BuildPackage.cmd
@@ -2,7 +2,9 @@ call "c:\Program Files (x86)\nodejs\nodevars.bat"
 call npm.cmd install -g grunt-cli
 
 set NATIVESCRIPT_SKIP_POSTINSTALL_TASKS=1
+call grunt.cmd enableScripts:false
 call npm.cmd install
+call grunt.cmd enableScripts:true
 set NATIVESCRIPT_SKIP_POSTINSTALL_TASKS=
 
 call grunt.cmd pack --no-color

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,6 +129,18 @@ module.exports = function(grunt) {
 		grunt.file.write("package.json", JSON.stringify(packageJson, null, "  "));
 	});
 
+	grunt.registerTask("enableScripts", function(enable) {
+		var enableTester = /false/i;
+		var newScriptsAttr = !enableTester.test(enable) ? "scripts" : "skippedScripts";
+		var packageJson = grunt.file.readJSON("package.json");
+		var oldScriptsAttrValue = packageJson.scripts || packageJson.skippedScripts;
+		delete packageJson.scripts;
+		delete packageJson.skippedScripts;
+		packageJson[newScriptsAttr] = oldScriptsAttrValue;
+		grunt.file.write("package.json", JSON.stringify(packageJson, null, "  "));
+	});
+
+
 	grunt.registerTask("test", ["ts:devall", "shell:npm_test"]);
 	grunt.registerTask("pack", [
 		"clean",


### PR DESCRIPTION
Add Enable/Disable scripts to Gruntfile to workaround the run of the scripts when `npm install` called
