### PR TITLE
Fix large-binary containing platform-package addition.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mkdirp": "0.3.5",
     "mute-stream": "0.0.4",
     "node-uuid": "1.4.1",
-    "npm": "1.4.10",
+    "npm": "1.4.26",
     "osenv": "0.1.0",
     "plistlib": "0.2.1",
     "progress-stream": "0.5.0",


### PR DESCRIPTION
Adding the ios platform that contains a large binary file
got 100% CPU usage and took about an hour when unpacking
the file.

The latest NPM package has this fixed (probably in
release https://github.com/npm/npm/releases/tag/v1.4.13)

Related discussions:
https://github.com/npm/npm/issues/4738
https://github.com/npm/npm/issues/4955
