### PR TITLE
Fix postinstall scripts

### DIFF
--- a/lib/commands/post-install.ts
+++ b/lib/commands/post-install.ts
@@ -6,7 +6,7 @@ import util = require("util");
 
 export class PostInstallCommand implements ICommand {
 
-	constructor(private $autocompletionService: IAutoCompletionService,
+	constructor(private $autoCompletionService: IAutoCompletionService,
 		private $fs: IFileSystem,
 		private $staticConfig: IStaticConfig) { }
 
@@ -18,7 +18,7 @@ export class PostInstallCommand implements ICommand {
 				this.$fs.chmod(this.$staticConfig.adbFilePath, "0777").wait();
 			}
 
-			this.$autocompletionService.enableAutoCompletion().wait();
+			this.$autoCompletionService.enableAutoCompletion().wait();
 		}).future<void>()();
 	}
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,3 +1,4 @@
 
 var child_process = require("child_process");
-child_process.exec('node bin/nativescript.js dev-post-install');
+var command = process.argv[0] + ' bin/nativescript.js dev-post-install';
+child_process.exec(command);


### PR DESCRIPTION
- Fix spelling mistake which prevents post-install actions from runnning at all
- Accomodate for setups where node's binary is not called 'node'

Fixes https://github.com/NativeScript/nativescript-cli/issues/113 but the change affects Macs too
