### PR TITLE
Fix tabtab for -- options

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -34,3 +34,4 @@ $injector.requireCommand("list-devices", "./commands/list-devices");
 
 $injector.require("npm", "./node-package-manager");
 $injector.require("config", "./config");
+$injector.require("optionsService", "./services/options-service");

--- a/lib/services/options-service.ts
+++ b/lib/services/options-service.ts
@@ -1,0 +1,12 @@
+///<reference path="../.d.ts"/>
+
+"use strict";
+
+import options = require("../options");
+
+export class OptionsService implements IOptionsService {
+	public getKnownOptions(): string[]{
+		return Object.keys(options.knownOpts);
+	}
+}
+$injector.register("optionsService", OptionsService);


### PR DESCRIPTION
In case you use bash, we offer autocomplete for the commands. When you write "tns emulate android --a" and press tab twice, we should autocomplete the option to avd (command will be "tns emulate android --avd". Instead an error is shown.

Add implementation of IOptionsService interface with one method - getKnownOptions. This method is used in commands service in order to get full list of supported -- options. As each CLI have its own list of knownOptions and the mobile lib has only some of them, the implementation of the interface has to be outside of the lib. This way we can use autocomplete for all available options, not only for the common ones.
