### PR TITLE
Fix the message for missing Android target 17

### DIFF
--- a/lib/commands/post-install.ts
+++ b/lib/commands/post-install.ts
@@ -8,12 +8,15 @@ export class PostInstallCommand implements ICommand {
 
 	constructor(private $autoCompletionService: IAutoCompletionService,
 		private $fs: IFileSystem,
-		private $staticConfig: IStaticConfig) { }
+		private $staticConfig: IStaticConfig,
+		private $logger: ILogger) { }
 
 	public disableAnalytics = true;
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
+			this.$logger.warn('To develop Android apps, make sure that you have Android target 17 installed. Run "android" from your command-line to install/update any missing SDKs or tools.');
+
 			if(process.platform !== "win32") {
 				this.$fs.chmod(this.$staticConfig.adbFilePath, "0777").wait();
 			}

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -200,7 +200,7 @@ class AndroidProjectService implements IPlatformProjectService {
 		var validTarget = this.getTarget(frameworkDir).wait();
 		var output = this.$childProcess.exec('android list targets').wait();
 		if (!output.match(validTarget)) {
-			this.$errors.fail("Please install Android target %s the Android newest SDK). Make sure you have the latest Android tools installed as well. Run \"android\" from your command-line to install/update any missing SDKs or tools.",
+			this.$errors.fail("Please install Android target %s. Make sure you have the latest Android tools installed as well. Run \"android\" from your command-line to install/update any missing SDKs or tools.",
 				validTarget.split('-')[1]);
 		}
 	}


### PR DESCRIPTION
Add warning on install that it is needed.

See https://github.com/NativeScript/nativescript-cli/issues/173