### PR TITLE
Fix android emulator starting

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -250,7 +250,7 @@ export class PlatformService implements IPlatformService {
 
 			var logFilePath = path.join(platformData.projectRoot, this.$projectData.projectName, "emulator.log");
 
-			emulatorServices.startEmulator(packageFile, { stderrFilePath: logFilePath, stdoutFilePath: logFilePath }).wait();
+			emulatorServices.startEmulator(packageFile, { stderrFilePath: logFilePath, stdoutFilePath: logFilePath, appId: this.$projectData.projectId }).wait();
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
Add appId option when starting android emulator in order to fix starting of the application (it is installed correctly on the device, but last call, that has to start the app, uses appid). Update common lib where support for genymotion emulator has been added.

https://github.com/NativeScript/nativescript-cli/issues/167