### PR TITLE
Use ios-sim from master

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fibers": "https://github.com/icenium/node-fibers/tarball/vladimirov/fibers_1_0_5_fixes",
     "filesize": "2.0.3",
     "iconv-lite": "0.4.4",
-    "ios-sim-portable": "1.0.0",
+    "ios-sim-portable": "https://github.com/telerik/ios-sim-portable/tarball/master",
     "lockfile": "1.0.0",
     "lodash": "2.4.1",
     "log4js": "0.6.9",


### PR DESCRIPTION
Update package.json to use ios-sim from its master branch. This is temporary in order to be able to test latest changes of node fibers (which are merged in ios-sim master).