### PR TITLE
Fix usage of shorthand options

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -20,7 +20,7 @@ var knownOpts:any = {
 		"keyStoreAlias": String,
 		"keyStoreAliasPassword": String
 	},
-	shorthands = {
+	shorthands: IStringDictionary = {
 	};
 
 _.extend(knownOpts, commonOptions.knownOpts);
@@ -37,7 +37,14 @@ if(hostInfo.isWindows()) {
 commonOptions.setProfileDir(defaultProfileDir);
 var parsed = helpers.getParsedOptions(knownOpts, shorthands, "nativescript");
 
-Object.keys(parsed).forEach((opt) => exports[opt] = parsed[opt]);
+Object.keys(parsed).forEach(opt => {
+	var key = opt;
+	if(shorthands[opt]) {
+		key = shorthands[opt];
+	}
+
+	exports[key] = parsed[opt];
+});
 exports.knownOpts = knownOpts;
 
 declare var exports:any;


### PR DESCRIPTION
Fix usage of shorthands, so when you specify -v to use verbose mode. Update common lib where shorthands for help command had been added.