### PR TITLE
Fix copy-from and link-to options

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -9,7 +9,9 @@ import hostInfo = require("./common/host-info");
 var knownOpts:any = {
 		"frameworkPath": String,
 		"copy-from": String,
+		"copyFrom": String,
 		"link-to": String,
+		"linkTo": String,
 		"release": Boolean,
 		"emulator": Boolean,
 		"symlink": Boolean,


### PR DESCRIPTION
Due to yargs issues, we have to add copy-from as copyFrom and link-to as linkTo.