### PR TITLE
Show context specific help

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -40,3 +40,4 @@ $injector.requireCommand("emulate|ios", "./commands/emulate");
 $injector.require("npm", "./node-package-manager");
 $injector.require("lockfile", "./lockfile");
 $injector.require("optionsService", "./services/options-service");
+$injector.require("dynamicHelpProvider", "./dynamic-help-provider");

--- a/lib/dynamic-help-provider.ts
+++ b/lib/dynamic-help-provider.ts
@@ -1,0 +1,19 @@
+///<reference path=".d.ts"/>
+
+"use strict";
+
+import Future = require("fibers/future");
+
+export class DynamicHelpProvider implements IDynamicHelpProvider {
+	constructor() { }
+
+	public isProjectType(args: string[]): IFuture<boolean> {
+		return Future.fromResult(true);
+	}
+
+	public getLocalVariables(): IFuture<IDictionary<any>> {
+		var localVariables: IDictionary<any> = {};
+		return Future.fromResult(localVariables);
+	}
+}
+$injector.register("dynamicHelpProvider", DynamicHelpProvider);

--- a/resources/help.txt
+++ b/resources/help.txt
@@ -358,11 +358,11 @@ Before running your app in the Android emulator from the Android SDK, verify tha
         tools
 Before running your app in the Genymotion emulator, verify that your system meets the following requirements.
     * Verify that you have installed Genymotion.
-    * On Windows and Linux systems, verify that you have added the Genymotion installation directory to the PATH environment variable.
-    * On OS X systems, verify that you have added the following paths to the PATH environment variable.
+    <% if(isLinux || isWindows) { %>* On Windows and Linux systems, verify that you have added the Genymotion installation directory to the PATH environment variable.<%}%>
+    <% if(isMacOS) { %>* On OS X systems, verify that you have added the following paths to the PATH environment variable.
         * /Applications/Genymotion.app/Contents/MacOS/
         * /Applications/Genymotion Shell.app/Contents/MacOS/
-
+<% } %>
 Options:
     --device - Specifies a connected device on which to run the app.
         You cannot use --device and --emulator simultaneously.
@@ -498,11 +498,11 @@ Before running your app in the Android emulator from the Android SDK, verify tha
         tools
 Before running your app in the Genymotion emulator, verify that your system meets the following requirements.
     * Verify that you have installed Genymotion.
-    * On Windows and Linux systems, verify that you have added the Genymotion installation directory to the PATH environment variable.
-    * On OS X systems, verify that you have added the following paths to the PATH environment variable.
+    <% if(isLinux || isWindows) { %>* On Windows and Linux systems, verify that you have added the Genymotion installation directory to the PATH environment variable.<% } %>
+    <% if(isMacOS) { %>* On OS X systems, verify that you have added the following paths to the PATH environment variable.
         * /Applications/Genymotion.app/Contents/MacOS/
         * /Applications/Genymotion Shell.app/Contents/MacOS/
-
+<% } %>
 Options:
     --path - Specifies the directory that contains the project. If not specified, the project is searched
             for in the current directory and all directories above it.


### PR DESCRIPTION
In some cases we want to hide some parts of our help. For example if the user is on MacOS, information how to setup Windows or Linux system is not needed for him.
Add dynamicHelpProvider which is used to determine some context specific values.
Update common lib where we've added the following changes:
Add support for multilevel hierarchical commands. This way we can use commands like $ appbuilder appmanager upload android declared as "appmanager|upload|android".
Add support for passing multiple arguments to dynamic calls, by changing regular expressions.
Add DynamicHelpService which is used to check different conditions when printing our help.
Use _.isBoolean where possible. Add dynamicHelpProvider which should be implemented by each CLI.
Use lodash _.template as it uses microTemplate internally and pass the help through it. This way we can write javascript directly in our help.txt.
Replace of all entries in the help content (when executing), which match our dynamicCallRegex with this.$injector.dynamicCall($1).wait()
This way you can call dynamic methods, by just using:
\<%= #{platformService.validatePlatform} %\>
Add localVariables that allow easy call for default scenarios (isLinux, isMacOS, is Windows).
In order to use it, just call:
\<% if (isLinux) %\>

Practically you can add whatever javascript code you want in help.txt. Just wrap it inside <% %>
In case you want to call some method that returns string and you need the string in help.txt just write:
Some text... \<%= this.$injector.resolve("project").myMethod() %\> or even simpler:
Some text... \<%= #{project.myMethod} %\>
The code between <%= and %> will be executed (it's pure javascript, but you are able to use our $injector and $dynamicHelpService) and the returned string will be placed in the help file.
In case you want to limit some text only for specific case, just write:
\<% if (this.$dynamicHelpService.isPlatform("linux")) { %\>
In this version of the NativeScript CLI, you cannot build and deploy to iOS connected devices on Linux systems.
\<% } %\>

This way the code in if statement will be shown only in case command is run on linux.
You can simplify it by using localVariables added in common lib:
\<% if (isLinux) { %\>
In this version of the NativeScript CLI, you cannot build and deploy to iOS connected devices on Linux systems.
\<% } %\>

https://huboard.com/NativeScript/nativescript-cli#/issues/60481986