### PR TITLE
Enable proxy using for http requests

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,8 @@
+{
+	"DEBUG": false,
+	"USE_PROXY": false,
+	"PROXY_PORT": 8888,
+	"PROXY_HOSTNAME": "127.0.0.1",
+	"TYPESCRIPT_COMPILER_OPTIONS": {},
+	"CI_LOGGER": false
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,12 +4,21 @@
 import path = require("path");
 import util = require("util");
 import staticConfigBaseLibPath = require("./common/static-config-base");
+import configBaseLib = require("./common/config-base");
 
-$injector.register("config", {
-	CI_LOGGER: false,
-	DEBUG: process.env.NATIVESCRIPT_DEBUG,
-	TYPESCRIPT_COMPILER_OPTIONS: { }
-});
+export class Configuration extends configBaseLib.ConfigBase { // User specific config
+	CI_LOGGER = false;
+	DEBUG = process.env.NATIVESCRIPT_DEBUG;
+	TYPESCRIPT_COMPILER_OPTIONS = {};
+	USE_PROXY = false;
+
+	/*don't require logger and everything that has logger as dependency in config.js due to cyclic dependency*/
+	constructor(protected $fs: IFileSystem) {
+		super($fs);
+		_.extend(this, this.loadConfig("config").wait());
+	}
+}
+$injector.register("config", Configuration);
 
 export class StaticConfig extends staticConfigBaseLibPath.StaticConfigBase implements IStaticConfig {
 	public PROJECT_FILE_NAME = ".tnsproject";

--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -8,11 +8,12 @@ import Future = require("fibers/future");
 import errors = require("./common/errors");
 errors.installUncaughtExceptionListener();
 
-var config = <Config.IConfig>$injector.resolve("$config");
-(<IErrors>$injector.resolve("$errors")).printCallStack = config.DEBUG;
-
 fiber(() => {
-	var commandDispatcher : ICommandDispatcher = $injector.resolve("commandDispatcher");
+	var config = <Config.IConfig>$injector.resolve("$config");
+	var err = <IErrors>$injector.resolve("$errors");
+	err.printCallStack = config.DEBUG;
+
+	var commandDispatcher: ICommandDispatcher = $injector.resolve("commandDispatcher");
 
 	if (process.argv[2] === "completion") {
 		commandDispatcher.completeCommand().wait();


### PR DESCRIPTION
Add config.json file inside new config directory. This file is required in order to allow user specific configurations. Modify nativescript-cli.ts in order to wrap resolving of config and errors inside fiber as the new implementation of config has .wait().

Update common lib, where the following changes are applied:
Rename the following config options:
 - FIDDLER_HOSTNAME to PROXY_HOSTNAME
 - PROXY_TO_FIDDLER to USE_PROXY

Add PROXY_PORT option to config with default value 8888. Add ConfigBase class which should be used as a base for CLI specific configs.

Required for https://github.com/NativeScript/nativescript-cli/issues/297 and https://github.com/NativeScript/nativescript-cli/issues/302