### PR TITLE
Fix update

### DIFF
--- a/lib/commands/update-platform.ts
+++ b/lib/commands/update-platform.ts
@@ -17,7 +17,7 @@ export class UpdatePlatformCommand implements ICommand {
 				this.$errors.fail("No platform specified. Please specify platforms to update.");
 			}
 
-			_.each(args, arg => this.$platformService.validatePlatformInstalled(arg));
+			_.each(args, arg => this.$platformService.validatePlatformInstalled(arg.split("@")[0]));
 
 			return true;
 		}).future<boolean>()();

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -5,6 +5,7 @@ interface INodePackageManager {
 	load(config?: any): IFuture<void>;
 	install(packageName: string, options?: INpmInstallOptions): IFuture<string>;
 	getLatestVersion(packageName: string): IFuture<string>;
+	getCachedPackagePath(packageName: string, version: string): string;
 }
 
 interface INpmInstallOptions {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -27,6 +27,8 @@ interface IPlatformData {
 	validPackageNamesForDevice: string[];
 	validPackageNamesForEmulator?: string[];
 	frameworkFilesExtensions: string[];
+	frameworkDirectoriesExtensions?: string[];
+	frameworkDirectoriesNames?: string[];
 	targetedOS?: string[];
 }
 

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -30,4 +30,6 @@ interface IPlatformProjectService {
 	buildProject(projectRoot: string): IFuture<void>;
 	isPlatformPrepared(projectRoot: string): IFuture<boolean>;
 	addLibrary(platformData: IPlatformData, libraryPath: string): IFuture<void>;
+	canUpdatePlatform(currentVersion: string, newVersion: string): IFuture<boolean>;
+	updatePlatform(currentVersion: string, newVersion: string): IFuture<void>;
 }

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -30,7 +30,14 @@ export class NodePackageManager implements INodePackageManager {
 	}
 
 	public addToCache(packageName: string, version: string): IFuture<void> {
-		return this.addToCacheCore(packageName, version);
+		return (() => {
+			this.addToCacheCore(packageName, version).wait();
+
+			var packagePath = path.join(npm.cache, packageName, version, "package");
+			if(!this.isPackageUnpacked(packagePath).wait()) {
+				this.cacheUnpack(packageName, version).wait();
+			}
+		}).future<void>()();
 	}
 
 	public load(config?: any): IFuture<void> {
@@ -84,7 +91,7 @@ export class NodePackageManager implements INodePackageManager {
 				}
 				return options.frameworkPath;
 			} else {
-				var version: string = version || this.getLatestVersion(packageName).wait();
+				version = version || this.getLatestVersion(packageName).wait();
 				var packagePath = path.join(npm.cache, packageName, version, "package");
 				if (!this.isPackageCached(packagePath).wait()) {
 					this.addToCacheCore(packageName, version).wait();

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -80,6 +80,10 @@ export class NodePackageManager implements INodePackageManager {
 		}).future<string>()();
 	}
 
+	public getCachedPackagePath(packageName: string, version: string): string {
+		return path.join(npm.cache, packageName, version, "package");
+	}
+
 	private installCore(packageName: string, pathToSave: string, version: string): IFuture<string> {
 		return (() => {
 			if (options.frameworkPath) {
@@ -92,7 +96,7 @@ export class NodePackageManager implements INodePackageManager {
 				return options.frameworkPath;
 			} else {
 				version = version || this.getLatestVersion(packageName).wait();
-				var packagePath = path.join(npm.cache, packageName, version, "package");
+				var packagePath = this.getCachedPackagePath(packageName, version);
 				if (!this.isPackageCached(packagePath).wait()) {
 					this.addToCacheCore(packageName, version).wait();
 				}

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -23,7 +23,6 @@ class AndroidProjectService implements IPlatformProjectService {
 		private $logger: ILogger,
 		private $projectData: IProjectData,
 		private $propertiesParser: IPropertiesParser) {
-
 	}
 
 	public get platformData(): IPlatformData {
@@ -38,7 +37,7 @@ class AndroidProjectService implements IPlatformProjectService {
 				util.format("%s-%s.%s", this.$projectData.projectName, "debug", "apk"),
 				util.format("%s-%s.%s", this.$projectData.projectName, "release", "apk")
 			],
-			frameworkFilesExtensions: [".jar", ".dat"]
+			frameworkFilesExtensions: [".jar", ".dat", ".so"]
 		};
 	}
 

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -122,6 +122,16 @@ class AndroidProjectService implements IPlatformProjectService {
 		}).future<string>()();
     }
 
+	public canUpdatePlatform(currentVersion: string, newVersion: string): IFuture<boolean> {
+		return (() => {
+			return true;
+		}).future<boolean>()();
+	}
+
+	updatePlatform(currentVersion: string, newVersion: string): IFuture<void> {
+		return (() => { }).future<void>()();
+	}
+
     private updateMetadata(projectRoot: string): void {
         var projMetadataDir = path.join(projectRoot, "assets", "metadata");
         var libsmetadataDir = path.join(projectRoot, "../../lib", this.platformData.normalizedPlatformName, AndroidProjectService.METADATA_DIRNAME);

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -20,7 +20,8 @@ class IOSProjectService implements  IPlatformProjectService {
 		private $childProcess: IChildProcess,
 		private $errors: IErrors,
 		private $logger: ILogger,
-		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices) { }
+		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
+		private $npm: INodePackageManager) { }
 
 	public get platformData(): IPlatformData {
 		return {
@@ -72,7 +73,7 @@ class IOSProjectService implements  IPlatformProjectService {
 				var xcodeProjectName = util.format("%s.xcodeproj", IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER);
 
 				shell.cp("-R", path.join(frameworkDir, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER, "*"), path.join(projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER));
-				shell.cp("-R", path.join(frameworkDir, xcodeProjectName), path.join(projectRoot));
+				shell.cp("-R", path.join(frameworkDir, xcodeProjectName), projectRoot);
 
 				var directoryContent = this.$fs.readDirectory(frameworkDir).wait();
 				var frameworkFiles = _.difference(directoryContent, [IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER, xcodeProjectName]);
@@ -195,7 +196,44 @@ class IOSProjectService implements  IPlatformProjectService {
             this.$fs.writeFile(pbxProjPath, project.writeSync()).wait();
             this.$logger.info("The iOS Deployment Target is now 8.0 in order to support Cocoa Touch Frameworks.");
         }).future<void>()();
-    }
+	}
+
+	public canUpdatePlatform(currentVersion: string, newVersion: string): IFuture<boolean> {
+		return (() => {
+			var currentXcodeProjectFile = this.buildPathToXcodeProjectFile(currentVersion);
+			var currentXcodeProjectFileContent = this.$fs.readFile(currentXcodeProjectFile).wait();
+
+			var newXcodeProjectFile = this.buildPathToXcodeProjectFile(newVersion);
+			var newXcodeProjectFileContent = this.$fs.readFile(newXcodeProjectFile).wait();
+
+			return currentXcodeProjectFileContent === newXcodeProjectFileContent;
+
+		}).future<boolean>()();
+	}
+
+	public updatePlatform(currentVersion: string, newVersion: string): IFuture<void> {
+		return (() => {
+			// Copy old file to options["profile-dir"]
+			var sourceFile = path.join(this.platformData.projectRoot, util.format("%s.xcodeproj", this.$projectData.projectName));
+			var destinationFile = path.join(options.profileDir, "xcodeproj");
+			//this.$fs.copyFile(sourceFile, destinationFile).wait();
+			this.$logger.info("Backup file %s at location %s", sourceFile, destinationFile);
+			this.$fs.deleteDirectory(path.join(this.platformData.projectRoot, util.format("%s.xcodeproj", this.$projectData.projectName))).wait();
+
+			// Copy xcodeProject file
+			var cachedPackagePath = path.join(this.$npm.getCachedPackagePath(this.platformData.frameworkPackageName, newVersion), constants.PROJECT_FRAMEWORK_FOLDER_NAME, util.format("%s.xcodeproj", IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER));
+			shell.cp("-R", path.join(cachedPackagePath, "*"), path.join(this.platformData.projectRoot, util.format("%s.xcodeproj", this.$projectData.projectName)));
+			this.$logger.info("Copied from %s at %s.", cachedPackagePath, this.platformData.projectRoot);
+
+
+			var pbxprojFilePath = path.join(this.platformData.projectRoot, this.$projectData.projectName + IOSProjectService.XCODE_PROJECT_EXT_NAME, "project.pbxproj");
+			this.replaceFileContent(pbxprojFilePath).wait();
+		}).future<void>()();
+	}
+
+	private buildPathToXcodeProjectFile(version: string): string {
+		return path.join(this.$npm.getCachedPackagePath(this.platformData.frameworkPackageName, version), constants.PROJECT_FRAMEWORK_FOLDER_NAME, util.format("%s.xcodeproj", IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER), "project.pbxproj");
+	}
 
     private validateDynamicFramework(libraryPath: string): IFuture<void> {
         return (() => {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -216,7 +216,8 @@ class IOSProjectService implements  IPlatformProjectService {
 			// Copy old file to options["profile-dir"]
 			var sourceFile = path.join(this.platformData.projectRoot, util.format("%s.xcodeproj", this.$projectData.projectName));
 			var destinationFile = path.join(options.profileDir, "xcodeproj");
-			//this.$fs.copyFile(sourceFile, destinationFile).wait();
+			this.$fs.deleteDirectory(destinationFile).wait();
+			shell.cp("-R", path.join(sourceFile, "*"), destinationFile);
 			this.$logger.info("Backup file %s at location %s", sourceFile, destinationFile);
 			this.$fs.deleteDirectory(path.join(this.platformData.projectRoot, util.format("%s.xcodeproj", this.$projectData.projectName))).wait();
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -37,7 +37,9 @@ class IOSProjectService implements  IPlatformProjectService {
 			validPackageNamesForEmulator: [
 				this.$projectData.projectName + ".app"
 			],
-			frameworkFilesExtensions: [".a", ".h", ".bin"],
+			frameworkFilesExtensions: [".a", ".framework", ".bin"],
+			frameworkDirectoriesExtensions: [".framework"],
+			frameworkDirectoriesNames: ["Metadata"],
 			targetedOS: ['darwin']
 		};
 	}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -450,7 +450,7 @@ export class PlatformService implements IPlatformService {
 				}
 
 				if(semver.gt(currentVersion, newVersion)) { // Downgrade
-					var isUpdateConfirmed = this.$prompter.confirm("You are going to update to lower version. Are you sure?", () => "n").wait();
+					var isUpdateConfirmed = this.$prompter.confirm(util.format("You are going to downgrade to android runtime v.%s. Are you sure?", newVersion), () => "n").wait();
 					if(isUpdateConfirmed) {
 						this.updatePlatformCore(platformData, currentVersion, newVersion).wait();
 					}
@@ -460,7 +460,7 @@ export class PlatformService implements IPlatformService {
 					this.updatePlatformCore(platformData, currentVersion, newVersion).wait();
 				}
 			} else {
-				var isUpdateConfirmed = this.$prompter.confirm(util.format("We need to override xcodeproj file. The old one will be saved at %s Are you sure?", options.profileDir), () => "y").wait();
+				var isUpdateConfirmed = this.$prompter.confirm(util.format("We need to override xcodeproj file. The old one will be saved at %s. Are you sure?", options.profileDir), () => "y").wait();
 				if(isUpdateConfirmed) {
 					platformData.platformProjectService.updatePlatform(currentVersion, newVersion).wait();
 					this.updatePlatformCore(platformData, currentVersion, newVersion).wait();

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -310,7 +310,8 @@ export class PlatformService implements IPlatformService {
 			this.$errors.fail("No platform specified.")
 		}
 
-		platform = platform.toLowerCase();
+		var parts = platform.split("@");
+		platform = parts[0].toLowerCase();
 
 		if (!this.isValidPlatform(platform)) {
 			this.$errors.fail("Invalid platform %s. Valid platforms are %s.", platform, helpers.formatListOfNames(this.$platformsData.platformsNames));

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -201,6 +201,10 @@ export class NPMStub implements INodePackageManager {
 	getLatestVersion(packageName: string): IFuture<string> {
 		return Future.fromResult("");
 	}
+
+	getCachedPackagePath(packageName: string, version: string): string {
+		return "";
+	}
 }
 
 export class ProjectDataStub implements IProjectData {
@@ -273,6 +277,12 @@ export class PlatformProjectServiceStub implements IPlatformProjectService {
     addLibrary(platformData: IPlatformData, libraryPath: string): IFuture<void> {
         return Future.fromResult();
     }
+	canUpdatePlatform(currentVersion: string, newVersion: string): IFuture<boolean> {
+		return Future.fromResult(false);
+	}
+	updatePlatform(currentVersion: string, newVersion: string): IFuture<void> {
+		return Future.fromResult();
+	}
 }
 
 export class ProjectDataService implements IProjectDataService {


### PR DESCRIPTION
Currently we're copying only framework files. With latest version are released TNSDebugging.framework and Metadata folders as part of framework. This PR changes the logic so that we can update TNSDebugging.framework and Metadata. This PR fixes the case when the old and new xcode projects are different. Also fixes $tns platform update <platform>@<version> and $tns platform add <platform>@<version> commands.

https://github.com/NativeScript/nativescript-cli/issues/305
