### PR TITLE
Remove duplicate -- options

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -9,13 +9,10 @@ import hostInfo = require("./common/host-info");
 var knownOpts:any = {
 		"frameworkPath": String,
 		"copy-from": String,
-		"copyFrom": String,
 		"link-to": String,
-		"linkTo": String,
 		"release": Boolean,
 		"emulator": Boolean,
 		"symlink": Boolean,
-		"forDevice": Boolean,
 		"for-device": Boolean,
 		"keyStorePath": String,
 		"keyStorePassword": String,


### PR DESCRIPTION
Yargs adds -- options to yargs.argv in two ways (--profile-dir is added as profile-dir and profileDir). In order to workaround this behavior, we had to add  all dashed options in both ways to our known options. Fix our validation logic, so we'll have to add only profile-dir.
Remove check for client name when validating -- options. This way options will be validated no matter if CLIENT_NAME( tns) or CLIENT_NAME_ALIAS (nativescript) is used on command line.

Fixes https://github.com/NativeScript/nativescript-cli/issues/251 