### PR TITLE
Delete destination app dir when preparing project

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -142,6 +142,9 @@ export class PlatformService implements IPlatformService {
 
 			// Copy app folder to native project
 			var appSourceDirectoryPath = path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME);
+
+			// Delete the destination app in order to prevent EEXIST errors when symlinks are used.
+			this.$fs.deleteDirectory(path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME)).wait();
 			shell.cp("-R", appSourceDirectoryPath, platformData.appDestinationDirectoryPath);
 
 			// Copy App_Resources to project root folder


### PR DESCRIPTION
Delete dir where app will be copied on prepare. If we do not delete it, on Linux and Mac we receive EEXIST errors for symlinks inside app directory. Symlinks are common scenario when node_modules are used.

Fixes https://github.com/NativeScript/nativescript-cli/issues/394