### PR TITLE
Logging

### DIFF
--- a/docs/man_pages/device/device-run.md
+++ b/docs/man_pages/device/device-run.md
@@ -2,7 +2,7 @@ device run
 ==========
 
 Usage:
-    `$ tns device run <ApplicationId> [--device <Device ID>]`
+    `$ tns device run <ApplicationId> [--print-app-output] [--device <Device ID>]`
 Runs the selected application on a connected Android or iOS device.
 You can run this command on one connected device at a time.
 
@@ -15,6 +15,7 @@ Before running your app on an iOS device, verify that your system and app meet t
 * You have built your app with the debug build configuration.
 
 Options:
+* `--print-app-output` - If set, prints the output of the running application.
 * `--device` - If multiple devices are connected, sets the device on which you want to run the app. You can run this command on one connected device at a time.
 <% if(isHtml) { %> 
 

--- a/docs/man_pages/project/testing/debug-android.md
+++ b/docs/man_pages/project/testing/debug-android.md
@@ -2,11 +2,11 @@ debug android
 ==========
 
 Usage:
-    `$ tns debug android [--device <Device ID> | --emulator <Emulator Options> | --geny <Geny Name> ] [--debug-brk | --start | --stop | --get-port] [--debug-port <port>]`
+    `$ tns debug android [--device <Device ID> | --emulator <Emulator Options> | --geny <Geny Name> ] [--debug-brk | --start | --stop | --get-port] [--debug-port <port>] [--print-app-output]`
 
 Example usage:
-    `$ tns debug android --get-port`    `$ tns debug android --debug-brk [--debug-port <port>]`    
-    `$ tns debug android --start [--debug-port <port>]`  
+    `$ tns debug android --get-port`    `$ tns debug android --debug-brk [--debug-port <port>]`
+    `$ tns debug android --start [--debug-port <port>]`
     `$ tns debug android --stop`
 
 Debugs your project on a connected device or in a native emulator.
@@ -22,6 +22,7 @@ Options:
 * `--stop` - Detaches the debug tools.
 * `--get-port` - Retrieves the port on which you are debugging your application.
 * `--debug-port` - Sets a new port on which to attach the debug tools.
+* `--print-app-output` - If set, prints the system debug output (logcat). 
 <% if(isHtml) { %> 
 
 #### Related Commands

--- a/docs/man_pages/project/testing/debug-ios.md
+++ b/docs/man_pages/project/testing/debug-ios.md
@@ -2,7 +2,7 @@ debug ios
 ==========
 
 Usage:
-    `$ tns debug ios [--debug-brk | --start] [--device <Device ID> | --emulator <Emulator Options>] [--no-client]`
+    `$ tns debug ios [--debug-brk | --start] [--device <Device ID> | --emulator <Emulator Options>] [--print-app-output] [--no-client]`
 
 Example usage:
     `$ tns debug ios --debug-brk`
@@ -22,6 +22,7 @@ Options:
 * `--debug-brk` - Shorthand for prepare, build and deploy. Prepares, builds and deploys the application package on a device or in an emulator, launches the developer tools of your Safari browser.
 * `--start` - Attaches the debug tools to a deployed and running app. Your app must be running on device or emulator, launches the developer tools of your Safari browser.
 * `--emulator` - Debug on already running emulator. Requires `xcrun` from Xcode 6 or later.
+* `--print-app-output` - If set, prints the standard output of the running application. (Device only)
 * `--no-client` - Suppresses the launch of the developer tools in Safari.
 <% if(isHtml) { %> 
 

--- a/docs/man_pages/project/testing/debug.md
+++ b/docs/man_pages/project/testing/debug.md
@@ -2,7 +2,7 @@ debug
 ==========
 
 Usage:
-    `$ tns debug <Command>`
+    `$ tns debug <Command> [--print-app-output]`
 You must run the debug command with a related command.
 
 Debugs your project on a connected device or in a native emulator.
@@ -10,7 +10,10 @@ Debugs your project on a connected device or in a native emulator.
 `<Command>` is a related command that extends the debug command. You can run the following related commands:
 * `android` - Debugs your project on a connected Android device, native Android emulator or Genymotion emulator.
 * `ios` - Debugs your project on a connected iOS device or in a native iOS emulator.
-<% if(isHtml) { %> 
+
+Options:
+* `--print-app-output` - If set, prints the output of the running application.
+<% if(isHtml) { %>
 
 #### Related Commands
 

--- a/docs/man_pages/project/testing/emulate-android.md
+++ b/docs/man_pages/project/testing/emulate-android.md
@@ -2,9 +2,9 @@ emulate android
 ==========
 
 Usage:
-    `$ tns emulate android [--path <Directory>] [--timeout <Seconds>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
-    `$ tns emulate android [--avd <Name>] [--path <Directory>] [--timeout <Seconds>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
-    `$ tns emulate android [--geny <GenyName>] [--path <Directory>] [--timeout <Seconds>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
+    `$ tns emulate android [--print-app-output] [--path <Directory>] [--timeout <Seconds>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
+    `$ tns emulate android [--avd <Name>] [--print-app-output] [--path <Directory>] [--timeout <Seconds>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
+    `$ tns emulate android [--geny <GenyName>] [--print-app-output] [--path <Directory>] [--timeout <Seconds>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
 
 Builds the specified project and runs it in a native Android emulator.
 
@@ -32,6 +32,7 @@ Before running your app in the Android emulator from the Android SDK, verify tha
 <% } %>
 
 Options:
+* `--print-app-output` - If set, prints the system debug output (logcat). 
 * `--path` - Specifies the directory that contains the project. If not specified, the project is searched for in the current directory and all directories above it.
 * `--avd` - Sets the Android virtual device on which you want to run your app. You can set only one device at a time. To list the available Android virtual devices, run `$ android list avd`. You cannot use `--avd` and `--geny` simultaneously.
 * `--geny` - Sets the Genymotion virtual device on which you want to run your app. You can set only one device at a time. To list the available Genymotion virtual devices, run `$ genyshell -c "devices list"`. You cannot use `--avd` and `--geny` simultaneously.      

--- a/docs/man_pages/project/testing/emulate-ios.md
+++ b/docs/man_pages/project/testing/emulate-ios.md
@@ -4,7 +4,7 @@ emulate ios
 Usage:
     `$ tns emulate ios [--path <Directory>] [--device <Device Name>] [--availableDevices] [--release] [--timeout]`
 
-Builds the specified project in the cloud and runs it in the native iOS Simulator.
+Builds the specified project and runs it in the native iOS Simulator.
 
 `<Device Name>` is the name of the iOS Simulator device on which you want to run your app as listed by `$ tns emulate ios --availableDevices`
 Prerequisites:

--- a/docs/man_pages/project/testing/emulate-ios.md
+++ b/docs/man_pages/project/testing/emulate-ios.md
@@ -2,7 +2,7 @@ emulate ios
 ==========
 
 Usage:
-    `$ tns emulate ios [--path <Directory>] [--device <Device Name>] [--availableDevices] [--release] [--timeout]`
+    `$ tns emulate ios [--print-app-output] [--path <Directory>] [--device <Device Name>] [--availableDevices] [--release] [--timeout]`
 
 Builds the specified project and runs it in the native iOS Simulator.
 
@@ -13,6 +13,7 @@ Before running the iOS Simulator, verify that you have met the following require
 * You have installed Xcode. The version of Xcode must be compatible with the ios-sim-portable npm package on which the NativeScript CLI depends. For more information, visit https://www.npmjs.org/package/ios-sim-portable
 
 Options:
+* `--print-app-output` - If set, prints the standard output of the running application.
 * `--availableDevices` - Lists all available device type identifiers for the current XCode.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 * `--path` - Specifies the directory that contains the project. If not specified, the project is searched for in the current directory and all directories above it.

--- a/docs/man_pages/project/testing/emulate.md
+++ b/docs/man_pages/project/testing/emulate.md
@@ -9,8 +9,8 @@ You must run the emulate command with a related command.
 Builds and runs the project in the native emulator for the selected target platform.
 
 `<Command>` is a related command that sets a target platform for the emulate command. You can run the following related commands:
-* `android` - Builds the specified project in the cloud and runs it in the native Android emulator.
-* `ios` - Builds the specified project in the cloud and runs it in the native iOS Simulator.
+* `android` - Builds the specified project and runs it in the native Android emulator.
+* `ios` - Builds the specified project and runs it in the native iOS Simulator.
 
 Options:
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.

--- a/docs/man_pages/project/testing/emulate.md
+++ b/docs/man_pages/project/testing/emulate.md
@@ -2,7 +2,7 @@ emulate
 ==========
 
 Usage:
-    `$ tns emulate <Command> [--release]`
+    `$ tns emulate <Command> [--print-app-output] [--release]`
 
 You must run the emulate command with a related command.
 
@@ -13,6 +13,7 @@ Builds and runs the project in the native emulator for the selected target platf
 * `ios` - Builds the specified project and runs it in the native iOS Simulator.
 
 Options:
+* `--print-app-output` - If set, prints the output of the running application.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 <% if(isHtml) { %> 
 

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -2,8 +2,8 @@ run android
 ==========
 
 Usage:
-    `$ tns run android [--device <Device ID>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
-    `$ tns run android --emulator [<Emulator Options>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
+    `$ tns run android [--print-app-output] [--device <Device ID>] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
+    `$ tns run android --emulator [<Emulator Options>] [--print-app-output] [--keyStorePath <File Path> --keyStorePassword <Password> --keyStoreAlias <Name> --keyStoreAliasPassword <Password>] [--release]`
 
 Runs your project on a connected Android device or in a native Android emulator, if configured. This is shorthand for prepare, build and deploy.
 
@@ -23,6 +23,7 @@ Before running your app in the Android emulator from the Android SDK, verify tha
         * /Applications/Genymotion Shell.app/Contents/MacOS/
 <% } %>
 Options:
+* `--print-app-output` - If set, prints the system debug output (logcat). 
 * `--device` - Specifies a connected device on which to run the app. You cannot use `--device` and `--emulator` simultaneously.
 * `--emulator` - If set, runs the app in a native emulator for the target platform, if configured. When set, you can also set any other valid combination of emulator options as listed by `$ tns help emulate android`. You cannot use `--device` and `--emulator` simultaneously.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build. When the `--keyStore*` options are specified, produces a signed release build.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,8 +36,10 @@ export class StaticConfig extends staticConfigBaseLibPath.StaticConfigBase imple
 				break;
 			case "win32":
 				linkToSysRequirements = "http://docs.nativescript.org/setup/ns-cli-setup/ns-setup-win.html#system-requirements";
+				break;
 			case "darwin":
 				linkToSysRequirements = "http://docs.nativescript.org/setup/ns-cli-setup/ns-setup-os-x.html#system-requirements";
+				break;
 			default:
 				linkToSysRequirements = "";
 		}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -298,7 +298,7 @@ export class PlatformService implements IPlatformService {
 	public addLibrary(platform: string, libraryPath: string): IFuture<void> {
 		return (() => {
 			if (!this.$fs.exists(libraryPath).wait()) {
-				this.$errors.fail("The path %s does not exist", libraryPath);
+				this.$errors.failWithoutHelp("The path %s does not exist", libraryPath);
 			} else {
 				var platformData = this.$platformsData.getPlatformData(platform);
 				platformData.platformProjectService.addLibrary(platformData, libraryPath).wait();

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gaze": "0.5.1",
     "iconv-lite": "0.4.4",
     "inquirer": "0.8.2",
-    "ios-sim-portable": "1.0.4",
+    "ios-sim-portable": "1.0.5",
     "lockfile": "1.0.0",
     "lodash": "3.6.0",
     "log4js": "0.6.22",


### PR DESCRIPTION
Introduce `--logging` flag for `emulate`, `run`, `debug` and `device run` commands that outputs the standard output/logcat to the running terminal.