### PR TITLE
Add preuninstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "./lib/nativescript-cli.js",
   "scripts": {
     "test": "node_modules\\.bin\\_mocha --ui mocha-fibers --recursive --reporter spec --require test/test-bootstrap.js --timeout 15000 test/",
-    "postinstall": "node postinstall.js"
+    "postinstall": "node postinstall.js",
+    "preuninstall": "node preuninstall.js"
   },
   "repository": {
     "type": "git",

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,0 +1,10 @@
+var child_process = require("child_process");
+
+var child = child_process.exec("node bin/nativescript.js dev-preuninstall", function (error) {
+	if (error) {
+		console.error("Failed to complete all pre-uninstall steps. ");
+		console.log(error);
+	}
+});
+
+child.stdout.pipe(process.stdout);


### PR DESCRIPTION
Add preuninstall script that is executed before installation of the new version. It calls dev-preuninstall command and tries to kill adb server (as it may prevent us from successfully installing nativescript-cli when it is used from our resources).