### PR TITLE
Switch the debugging on emulator for iOS to use the iOSEmulatorService

### DIFF
--- a/docs/man_pages/project/testing/debug-ios.md
+++ b/docs/man_pages/project/testing/debug-ios.md
@@ -22,7 +22,7 @@ Options:
 * `--debug-brk` - Shorthand for prepare, build and deploy. Prepares, builds and deploys the application package on a device or in an emulator, launches the developer tools of your Safari browser.
 * `--start` - Attaches the debug tools to a deployed and running app. Your app must be running on device or emulator, launches the developer tools of your Safari browser.
 * `--emulator` - Debug on already running emulator. Requires `xcrun` from Xcode 6 or later.
-* `--print-app-output` - If set, prints the standard output of the running application. (Device only)
+* `--print-app-output` - If set, prints the standard output of the running application.
 * `--no-client` - Suppresses the launch of the developer tools in Safari.
 <% if(isHtml) { %> 
 

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -66,13 +66,11 @@ class IOSDebugService implements IDebugService {
 
 	private emulatorDebugBrk(): IFuture<void> {
 		return (() => {
-			var device = this.getRunningEmulatorOrRunNew().wait();
 			var platformData = this.$platformsData.getPlatformData(this.platform);
 			this.$platformService.buildPlatform(this.platform).wait();
 			var emulatorPackage = this.$platformService.getLatestApplicationPackageForEmulator(platformData).wait();
-			device.installApp(emulatorPackage.packageName).wait();
 			this.executeOpenDebuggerClient().wait();
-			device.launchApp(this.$projectData.projectId, "--nativescript-debug-brk").wait();
+			this.$iOSEmulatorServices.startEmulator(emulatorPackage.packageName, { args: "--nativescript-debug-brk" }).wait();
 		}).future<void>()();
 	}
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gaze": "0.5.1",
     "iconv-lite": "0.4.4",
     "inquirer": "0.8.2",
-    "ios-sim-portable": "1.0.5",
+    "ios-sim-portable": "1.0.6",
     "lockfile": "1.0.0",
     "lodash": "3.6.0",
     "log4js": "0.6.22",


### PR DESCRIPTION
Switch the debugging on emulator for iOS to use the iOSEmulatorService so that it can benefit from logging in the terminal.

> **NOTE:** This requires the ios-sim-portable 1.0.6