### PR TITLE
Fix iOS device debug-brk.

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -125,7 +125,6 @@ class IOSDebugService implements IDebugService {
 				var deviceDebugging: IOSDeviceDebugging = this.$injector.resolve("iosDeviceDebugging", { bundleId: this.$projectData.projectId, $iOSDevice: device });
 				deviceDebugging.debugApplicationOnStart();
 				this.executeOpenDebuggerClient().wait();
-				device.runApplication(this.$projectData.projectId).wait();
 			}).future<void>()()).wait();
 		}).future<void>()();
 	}


### PR DESCRIPTION
The deploy command now runs the application and the debug break command is starting it twice which locks the app.