### PR TITLE
Rework (and fix) iOS debugging

### DIFF
--- a/lib/definitions/ws.d.ts
+++ b/lib/definitions/ws.d.ts
@@ -1,0 +1,136 @@
+// Type definitions for ws
+// Project: https://github.com/einaros/ws
+// Definitions by: Paul Loyd <https://github.com/loyd>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/// <reference path="../common/definitions/node.d.ts" />
+
+declare module "ws" {
+    import events = require('events');
+    import http   = require('http');
+    import net    = require('net');
+
+    class WebSocket extends events.EventEmitter {
+        static CONNECTING: number;
+        static OPEN: number;
+        static CLOSING: number;
+        static CLOSED: number;
+
+        bytesReceived: number;
+        readyState: number;
+        protocolVersion: string;
+        url: string;
+        supports: any;
+        upgradeReq: http.ServerRequest;
+
+        CONNECTING: number;
+        OPEN: number;
+        CLOSING: number;
+        CLOSED: number;
+
+        onopen: (event: {target: WebSocket}) => void;
+        onerror: (err: Error) => void;
+        onclose: (event: {wasClean: boolean; code: number; reason: string; target: WebSocket}) => void;
+        onmessage: (event: {data: any; type: string; target: WebSocket}) => void;
+
+        constructor(address: string, options?: {
+            protocol?: string;
+            agent?: http.Agent;
+            headers?: {[key: string]: string};
+            protocolVersion?: any;
+            host?: string;
+            origin?: string;
+            pfx?: any;
+            key?: any;
+            passphrase?: string;
+            cert?: any;
+            ca?: any[];
+            ciphers?: string;
+            rejectUnauthorized?: boolean;
+        });
+
+        close(code?: number, data?: any): void;
+        pause(): void;
+        resume(): void;
+        ping(data?: any, options?: {mask?: boolean; binary?: boolean}, dontFail?: boolean): void;
+        pong(data?: any, options?: {mask?: boolean; binary?: boolean}, dontFail?: boolean): void;
+        send(data: any, cb?: (err: Error) => void): void;
+        send(data: any, options: {mask?: boolean; binary?: boolean}, cb?: (err: Error) => void): void;
+        stream(options: {mask?: boolean; binary?: boolean}, cb?: (err: Error, final: boolean) => void): void;
+        stream(cb?: (err: Error, final: boolean) => void): void;
+        terminate(): void;
+
+        // HTML5 WebSocket events
+        addEventListener(method: 'message', cb?: (event: {data: any; type: string; target: WebSocket}) => void): void;
+        addEventListener(method: 'close', cb?: (event: {wasClean: boolean; code: number;
+                                                        reason: string; target: WebSocket}) => void): void;
+        addEventListener(method: 'error', cb?: (err: Error) => void): void;
+        addEventListener(method: 'open', cb?: (event: {target: WebSocket}) => void): void;
+        addEventListener(method: string, listener?: () => void): void;
+
+        // Events
+        on(event: 'error', cb: (err: Error) => void): WebSocket;
+        on(event: 'close', cb: (code: number, message: string) => void): WebSocket;
+        on(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        on(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        on(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        on(event: 'open', cb: () => void): WebSocket;
+        on(event: string, listener: () => void): WebSocket;
+        
+        addListener(event: 'error', cb: (err: Error) => void): WebSocket;
+        addListener(event: 'close', cb: (code: number, message: string) => void): WebSocket;
+        addListener(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        addListener(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        addListener(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
+        addListener(event: 'open', cb: () => void): WebSocket;
+        addListener(event: string, listener: () => void): WebSocket;
+    }
+
+    module WebSocket {
+        export interface IServerOptions {
+            host?: string;
+            port?: number;
+            server?: http.Server;
+            verifyClient?: {
+                (info: {origin: string; secure: boolean; req: http.ServerRequest}): boolean;
+                (info: {origin: string; secure: boolean; req: http.ServerRequest},
+                                                 callback: (res: boolean) => void): void;
+            };
+            handleProtocols?: any;
+            path?: string;
+            noServer?: boolean;
+            disableHixie?: boolean;
+            clientTracking?: boolean;
+        }
+
+        export class Server extends events.EventEmitter {
+            options: IServerOptions;
+            path: string;
+            clients: WebSocket[];
+
+            constructor(options?: IServerOptions, callback?: Function);
+
+            close(): void;
+            handleUpgrade(request: http.ServerRequest, socket: net.Socket,
+                          upgradeHead: Buffer, callback: (client: WebSocket) => void): void;
+
+            // Events
+            on(event: 'error', cb: (err: Error) => void): Server;
+            on(event: 'headers', cb: (headers: string[]) => void): Server;
+            on(event: 'connection', cb: (client: WebSocket) => void): Server;
+            on(event: string, listener: () => void): Server;
+            
+            addListener(event: 'error', cb: (err: Error) => void): Server;
+            addListener(event: 'headers', cb: (headers: string[]) => void): Server;
+            addListener(event: 'connection', cb: (client: WebSocket) => void): Server;
+            addListener(event: string, listener: () => void): Server;
+        }
+
+        export function createServer(options?: IServerOptions,
+            connectionListener?: (client: WebSocket) => void): Server;
+        export function connect(address: string, openListener?: Function): void;
+        export function createConnection(address: string, openListener?: Function): void;
+    }
+
+    export = WebSocket;
+}

--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -37,7 +37,7 @@ class AndroidDebugService implements IDebugService {
 				var cachedDeviceOption = this.$options.forDevice;
 				this.$options.forDevice = true;
 				this.$platformService.buildPlatform(this.platform).wait();
-				this.$options.forDevice = cachedDeviceOption;
+				this.$options.forDevice = !!cachedDeviceOption;
 
 				packageFile = this.$platformService.getLatestApplicationPackageForDevice(platformData).wait().packageName;
 				this.$logger.out("Using ", packageFile);

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -8,37 +8,37 @@ import http = require("http");
 import Future = require("fibers/future");
 
 module notification {
-	function formatNotification(bundleId: string, notification: string) {
-		return `${bundleId}:NativeScript.Debug.${notification}`;
-	}
-	
-	export function waitForDebug(bundleId: string): string {
-		return formatNotification(bundleId, "WaitForDebugger");
-	}
+    function formatNotification(bundleId: string, notification: string) {
+        return `${bundleId}:NativeScript.Debug.${notification}`;
+    }
+    
+    export function waitForDebug(bundleId: string): string {
+        return formatNotification(bundleId, "WaitForDebugger");
+    }
 
-	export function attachRequest(bundleId: string): string {
-		return formatNotification(bundleId, "AttachRequest");
-	}
+    export function attachRequest(bundleId: string): string {
+        return formatNotification(bundleId, "AttachRequest");
+    }
 
-	export function appLaunching(bundleId: string): string {
-		return formatNotification(bundleId, "AppLaunching");
-	}
+    export function appLaunching(bundleId: string): string {
+        return formatNotification(bundleId, "AppLaunching");
+    }
 
-	export function readyForAttach(bundleId: string): string {
-		return formatNotification(bundleId, "ReadyForAttach");
-	}
-	
-	export function attachAvailabilityQuery(bundleId: string) {
-		return formatNotification(bundleId, "AttachAvailabilityQuery");
-	}
-	
-	export function alreadyConnected(bundleId: string) {
-		return formatNotification(bundleId, "AlreadyConnected");
-	}
-	
-	export function attachAvailable(bundleId: string) {
-		return formatNotification(bundleId, "AttachAvailable");
-	}
+    export function readyForAttach(bundleId: string): string {
+        return formatNotification(bundleId, "ReadyForAttach");
+    }
+    
+    export function attachAvailabilityQuery(bundleId: string) {
+        return formatNotification(bundleId, "AttachAvailabilityQuery");
+    }
+    
+    export function alreadyConnected(bundleId: string) {
+        return formatNotification(bundleId, "AlreadyConnected");
+    }
+    
+    export function attachAvailable(bundleId: string) {
+        return formatNotification(bundleId, "AttachAvailable");
+    }
 }
 
 var InspectorBackendPort = 18181;
@@ -59,174 +59,174 @@ function connectEventually(factory: () => net.Socket, handler: (socket: net.Sock
 }
 
 class IOSDebugService implements IDebugService {
-	constructor(
-		private $platformService: IPlatformService,
-		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
-		private $devicesServices: Mobile.IDevicesServices,
-		private $platformsData: IPlatformsData,
-		private $projectData: IProjectData,
-		private $childProcess: IChildProcess,
-		private $logger: ILogger,
-		private $fs: IFileSystem,
-		private $errors: IErrors,
-		private $injector: IInjector,
-		private $npm: INodePackageManager,
-		private $options: IOptions) {
-	}
+    constructor(
+        private $platformService: IPlatformService,
+        private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
+        private $devicesServices: Mobile.IDevicesServices,
+        private $platformsData: IPlatformsData,
+        private $projectData: IProjectData,
+        private $childProcess: IChildProcess,
+        private $logger: ILogger,
+        private $fs: IFileSystem,
+        private $errors: IErrors,
+        private $injector: IInjector,
+        private $npm: INodePackageManager,
+        private $options: IOptions) {
+    }
 
-	get platform(): string {
-		return "ios";
-	}
+    get platform(): string {
+        return "ios";
+    }
 
-	public debug(): IFuture<void> {
-		if ((!this.$options.debugBrk && !this.$options.start) || (this.$options.debugBrk && this.$options.start)) {
-			this.$errors.failWithoutHelp("Expected exactly one of the --debug-brk or --start options.");
-		}
+    public debug(): IFuture<void> {
+        if ((!this.$options.debugBrk && !this.$options.start) || (this.$options.debugBrk && this.$options.start)) {
+            this.$errors.failWithoutHelp("Expected exactly one of the --debug-brk or --start options.");
+        }
 
-		if (this.$options.emulator) {
-			if (this.$options.debugBrk) {
-				return this.emulatorDebugBrk();
-			} else if (this.$options.start) {
-				return this.emulatorStart();
-			}
-		} else {
-			if (this.$options.debugBrk) {
-				return this.deviceDebugBrk();
-			} else if (this.$options.start) {
-				return this.deviceStart();
-			}
-		}
+        if (this.$options.emulator) {
+            if (this.$options.debugBrk) {
+                return this.emulatorDebugBrk();
+            } else if (this.$options.start) {
+                return this.emulatorStart();
+            }
+        } else {
+            if (this.$options.debugBrk) {
+                return this.deviceDebugBrk();
+            } else if (this.$options.start) {
+                return this.deviceStart();
+            }
+        }
 
-		this.$errors.failWithoutHelp("Failed to select device or emulator to debug on.");
-	}
+        this.$errors.failWithoutHelp("Failed to select device or emulator to debug on.");
+    }
 
-	private emulatorDebugBrk(): IFuture<void> {
-		return (() => {
-			var platformData = this.$platformsData.getPlatformData(this.platform);
-			this.$platformService.buildPlatform(this.platform).wait();
-			var emulatorPackage = this.$platformService.getLatestApplicationPackageForEmulator(platformData).wait();
+    private emulatorDebugBrk(): IFuture<void> {
+        return (() => {
+            var platformData = this.$platformsData.getPlatformData(this.platform);
+            this.$platformService.buildPlatform(this.platform).wait();
+            var emulatorPackage = this.$platformService.getLatestApplicationPackageForEmulator(platformData).wait();
 
-			this.$iOSEmulatorServices.startEmulator(emulatorPackage.packageName, { args: "--nativescript-debug-brk" }).wait();
+            this.$iOSEmulatorServices.startEmulator(emulatorPackage.packageName, { args: "--nativescript-debug-brk" }).wait();
             createWebSocketProxy(this.$logger, (callback) => connectEventually(() => net.connect(InspectorBackendPort), callback));
             this.executeOpenDebuggerClient().wait();
-		}).future<void>()();
-	}
+        }).future<void>()();
+    }
 
-	private emulatorStart(): IFuture<void> {
-		return (() => {
+    private emulatorStart(): IFuture<void> {
+        return (() => {
             createWebSocketProxy(this.$logger, (callback) => connectEventually(() => net.connect(InspectorBackendPort), callback));
             this.executeOpenDebuggerClient().wait();
-			var projectId = this.$projectData.projectId;
-			var attachRequestMessage = notification.attachRequest(projectId);
-			
-			var iOSEmulator = <Mobile.IiOSSimulatorService>this.$iOSEmulatorServices;
+            var projectId = this.$projectData.projectId;
+            var attachRequestMessage = notification.attachRequest(projectId);
+            
+            var iOSEmulator = <Mobile.IiOSSimulatorService>this.$iOSEmulatorServices;
             iOSEmulator.postDarwinNotification(attachRequestMessage).wait();
-		}).future<void>()();
-	}
+        }).future<void>()();
+    }
 
-	private deviceDebugBrk(): IFuture<void> {
-		return (() => {
-			this.$devicesServices.initialize({ platform: this.platform, deviceId: this.$options.device }).wait();
-			this.$devicesServices.execute(device => (() => {
-				// we intentionally do not wait on this here, because if we did, we'd miss the AppLaunching notification
-				let deploy = this.$platformService.deployOnDevice(this.platform);
-				
-				let iosDevice = <iOSDevice.IOSDevice>device;
-				let projectId = this.$projectData.projectId;
-				let npc = new iOSProxyServices.NotificationProxyClient(iosDevice, this.$injector);
-				
-				try {
-					awaitNotification(npc, notification.appLaunching(projectId), 60000).wait();
-					process.nextTick(() => {
-						npc.postNotificationAndAttachForData(notification.waitForDebug(projectId));
-						npc.postNotificationAndAttachForData(notification.attachRequest(projectId));
-					});
-					awaitNotification(npc, notification.readyForAttach(projectId), 5000).wait();
-				} catch(e) {
-					this.$errors.failWithoutHelp("Timeout waiting for NativeScript debugger.");
-				}
-				
+    private deviceDebugBrk(): IFuture<void> {
+        return (() => {
+            this.$devicesServices.initialize({ platform: this.platform, deviceId: this.$options.device }).wait();
+            this.$devicesServices.execute(device => (() => {
+                // we intentionally do not wait on this here, because if we did, we'd miss the AppLaunching notification
+                let deploy = this.$platformService.deployOnDevice(this.platform);
+                
+                let iosDevice = <iOSDevice.IOSDevice>device;
+                let projectId = this.$projectData.projectId;
+                let npc = new iOSProxyServices.NotificationProxyClient(iosDevice, this.$injector);
+                
+                try {
+                    awaitNotification(npc, notification.appLaunching(projectId), 60000).wait();
+                    process.nextTick(() => {
+                        npc.postNotificationAndAttachForData(notification.waitForDebug(projectId));
+                        npc.postNotificationAndAttachForData(notification.attachRequest(projectId));
+                    });
+                    awaitNotification(npc, notification.readyForAttach(projectId), 5000).wait();
+                } catch(e) {
+                    this.$errors.failWithoutHelp("Timeout waiting for NativeScript debugger.");
+                }
+                
                 createWebSocketProxy(this.$logger, (callback) => connectEventually(() => iosDevice.connectToPort(InspectorBackendPort), callback));
                 this.executeOpenDebuggerClient().wait();
-				deploy.wait();
-			}).future<void>()()).wait();
-		}).future<void>()();
-	}
+                deploy.wait();
+            }).future<void>()()).wait();
+        }).future<void>()();
+    }
 
-	private deviceStart(): IFuture<void> {
-		return (() => {
-			this.$devicesServices.initialize({ platform: this.platform, deviceId: this.$options.device }).wait();
-			this.$devicesServices.execute(device => (() => {
-				let iosDevice = <iOSDevice.IOSDevice>device;
-				let projectId = this.$projectData.projectId;
-				let npc = new iOSProxyServices.NotificationProxyClient(iosDevice, this.$injector);
-				
-				let [alreadyConnected, readyForAttach, attachAvailable] = [
-					notification.alreadyConnected(projectId),
-					notification.readyForAttach(projectId),
-					notification.attachAvailable(projectId)
-				].map((notification) => awaitNotification(npc, notification, 2000));
-				
-				npc.postNotificationAndAttachForData(notification.attachAvailabilityQuery(projectId));
-				
-				let receivedNotification: IFuture<string>;
-				try {
-					receivedNotification = whenAny(alreadyConnected, readyForAttach, attachAvailable).wait();
-				} catch (e) {
-					this.$errors.failWithoutHelp(`The application ${projectId} does not appear to be running on ${device.getDisplayName()} or is not built with debugging enabled.`);
-				}
-				
-				switch (receivedNotification) {
-					case alreadyConnected:
-						this.$errors.failWithoutHelp("A debugger is already connected.");
-					case attachAvailable:
-						process.nextTick(() => npc.postNotificationAndAttachForData(notification.attachRequest(projectId)));
-						try { awaitNotification(npc, notification.readyForAttach(projectId), 2000).wait(); }
-						catch (e) {
-							this.$errors.failWithoutHelp(`The application ${projectId} timed out when performing the NativeScript debugger handshake.`);
-						}
-					case readyForAttach:
-						createWebSocketProxy(this.$logger, (callback) => connectEventually(() => iosDevice.connectToPort(InspectorBackendPort), callback));
-            			this.executeOpenDebuggerClient().wait();
-				}
-			}).future<void>()()).wait();
-		}).future<void>()();
-	}
+    private deviceStart(): IFuture<void> {
+        return (() => {
+            this.$devicesServices.initialize({ platform: this.platform, deviceId: this.$options.device }).wait();
+            this.$devicesServices.execute(device => (() => {
+                let iosDevice = <iOSDevice.IOSDevice>device;
+                let projectId = this.$projectData.projectId;
+                let npc = new iOSProxyServices.NotificationProxyClient(iosDevice, this.$injector);
+                
+                let [alreadyConnected, readyForAttach, attachAvailable] = [
+                    notification.alreadyConnected(projectId),
+                    notification.readyForAttach(projectId),
+                    notification.attachAvailable(projectId)
+                ].map((notification) => awaitNotification(npc, notification, 2000));
+                
+                npc.postNotificationAndAttachForData(notification.attachAvailabilityQuery(projectId));
+                
+                let receivedNotification: IFuture<string>;
+                try {
+                    receivedNotification = whenAny(alreadyConnected, readyForAttach, attachAvailable).wait();
+                } catch (e) {
+                    this.$errors.failWithoutHelp(`The application ${projectId} does not appear to be running on ${device.getDisplayName()} or is not built with debugging enabled.`);
+                }
+                
+                switch (receivedNotification) {
+                    case alreadyConnected:
+                        this.$errors.failWithoutHelp("A debugger is already connected.");
+                    case attachAvailable:
+                        process.nextTick(() => npc.postNotificationAndAttachForData(notification.attachRequest(projectId)));
+                        try { awaitNotification(npc, notification.readyForAttach(projectId), 2000).wait(); }
+                        catch (e) {
+                            this.$errors.failWithoutHelp(`The application ${projectId} timed out when performing the NativeScript debugger handshake.`);
+                        }
+                    case readyForAttach:
+                        createWebSocketProxy(this.$logger, (callback) => connectEventually(() => iosDevice.connectToPort(InspectorBackendPort), callback));
+                        this.executeOpenDebuggerClient().wait();
+                }
+            }).future<void>()()).wait();
+        }).future<void>()();
+    }
 
-	public executeOpenDebuggerClient(): IFuture<void> {
-		if (this.$options.client === false) {
-			// NOTE: The --no-client has been specified. Otherwise its either false or undefined.
-			return (() => {
-				this.$logger.info("Supressing debugging client.");
-			}).future<void>()();
-		} else {
-			return this.openDebuggingClient();
-		}
-	}
+    public executeOpenDebuggerClient(): IFuture<void> {
+        if (this.$options.client === false) {
+            // NOTE: The --no-client has been specified. Otherwise its either false or undefined.
+            return (() => {
+                this.$logger.info("Supressing debugging client.");
+            }).future<void>()();
+        } else {
+            return this.openDebuggingClient();
+        }
+    }
 
-	private openDebuggingClient(): IFuture<void> {
-		return (() => {
-			var cmd = "open -a Safari " + this.getSafariPath().wait();
-			this.$childProcess.exec(cmd).wait();
-		}).future<void>()();
-	}
+    private openDebuggingClient(): IFuture<void> {
+        return (() => {
+            var cmd = "open -a Safari " + this.getSafariPath().wait();
+            this.$childProcess.exec(cmd).wait();
+        }).future<void>()();
+    }
 
-	private getSafariPath(): IFuture<string> {
-		return (() => {
-			var tnsIosPackage = "";
-			if (this.$options.frameworkPath) {
-				if (this.$fs.getFsStats(this.$options.frameworkPath).wait().isFile()) {
-					this.$errors.failWithoutHelp("frameworkPath option must be path to directory which contains tns-ios framework");
-				}
-				tnsIosPackage = path.resolve(this.$options.frameworkPath);
-			} else {
-				var platformData = this.$platformsData.getPlatformData(this.platform);
-				tnsIosPackage = this.$npm.install(platformData.frameworkPackageName).wait();
-			}
-			var safariPath = path.join(tnsIosPackage, "WebInspectorUI/Safari/Main.html");
-			return safariPath;
-		}).future<string>()();
-	}
+    private getSafariPath(): IFuture<string> {
+        return (() => {
+            var tnsIosPackage = "";
+            if (this.$options.frameworkPath) {
+                if (this.$fs.getFsStats(this.$options.frameworkPath).wait().isFile()) {
+                    this.$errors.failWithoutHelp("frameworkPath option must be path to directory which contains tns-ios framework");
+                }
+                tnsIosPackage = path.resolve(this.$options.frameworkPath);
+            } else {
+                var platformData = this.$platformsData.getPlatformData(this.platform);
+                tnsIosPackage = this.$npm.install(platformData.frameworkPackageName).wait();
+            }
+            var safariPath = path.join(tnsIosPackage, "WebInspectorUI/Safari/Main.html");
+            return safariPath;
+        }).future<string>()();
+    }
 }
 $injector.register("iOSDebugService", IOSDebugService);
 
@@ -246,7 +246,7 @@ function createWebSocketProxy($logger: ILogger, socketFactory: (handler: (socket
         verifyClient: (info: any, callback: any) => {
             $logger.info("Frontend client connected.");
             socketFactory((socket) => {
-				$logger.info("Backend socket created.");
+                $logger.info("Backend socket created.");
                 info.req["__deviceSocket"] = socket;
                 callback(true);
             });
@@ -285,48 +285,48 @@ function createWebSocketProxy($logger: ILogger, socketFactory: (handler: (socket
 }
 
 function awaitNotification(npc: iOSProxyServices.NotificationProxyClient, notification: string, timeout: number): IFuture<string> {
-	let future = new Future<string>();
-	
-	let timeoutObject = setTimeout(() => {
-		detachObserver();
-		future.throw(new Error("Timeout receiving notification."));
-	}, timeout);
-	
-	function notificationObserver(notification: string) {
-		clearTimeout(timeoutObject);
-		detachObserver();
-		future.return(notification);
-	}
-	
-	function detachObserver() {
-		process.nextTick(() => npc.removeObserver(notification, notificationObserver));
-	}
-	
-	npc.addObserver(notification, notificationObserver);
-	
-	return future;
+    let future = new Future<string>();
+    
+    let timeoutObject = setTimeout(() => {
+        detachObserver();
+        future.throw(new Error("Timeout receiving notification."));
+    }, timeout);
+    
+    function notificationObserver(notification: string) {
+        clearTimeout(timeoutObject);
+        detachObserver();
+        future.return(notification);
+    }
+    
+    function detachObserver() {
+        process.nextTick(() => npc.removeObserver(notification, notificationObserver));
+    }
+    
+    npc.addObserver(notification, notificationObserver);
+    
+    return future;
 }
 
 function whenAny<T>(...futures: IFuture<T>[]): IFuture<IFuture<T>> {
-	let resultFuture = new Future<IFuture<T>>();	
-	let futuresLeft = futures.length;
+    let resultFuture = new Future<IFuture<T>>();    
+    let futuresLeft = futures.length;
 
-	for (let future of futures) {
-		var futureLocal = future;
-		future.resolve((error, result?) => {
-			futuresLeft--;
-			
-			if (!resultFuture.isResolved()) {
-				if (typeof error === "undefined") {
-					resultFuture.return(futureLocal);
-				} else if (futuresLeft == 0) {
-					resultFuture.throw(new Error("None of the futures succeeded."));
-				}
-			}
-		});
-	}
-	
-	return resultFuture;
+    for (let future of futures) {
+        var futureLocal = future;
+        future.resolve((error, result?) => {
+            futuresLeft--;
+            
+            if (!resultFuture.isResolved()) {
+                if (typeof error === "undefined") {
+                    resultFuture.return(futureLocal);
+                } else if (futuresLeft == 0) {
+                    resultFuture.throw(new Error("None of the futures succeeded."));
+                }
+            }
+        });
+    }
+    
+    return resultFuture;
 }
 
 class PacketStream extends stream.Transform {

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -1,5 +1,6 @@
 import iOSProxyServices = require("./../common/mobile/ios/ios-proxy-services");
 import iOSDevice = require("./../common/mobile/ios/ios-device");
+import iOSEmulatorService = require("./../common/mobile/ios/ios-emulator-services");
 import net = require("net");
 import ws = require("ws");
 import stream = require("stream");
@@ -44,7 +45,7 @@ function connectEventually(factory: () => net.Socket, handler: (socket: net.Sock
 class IOSDebugService implements IDebugService {
 	constructor(
 		private $platformService: IPlatformService,
-		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
+		private $iOSEmulatorServices: iOSEmulatorService,
 		private $devicesServices: Mobile.IDevicesServices,
 		private $platformsData: IPlatformsData,
 		private $projectData: IProjectData,
@@ -101,7 +102,7 @@ class IOSDebugService implements IDebugService {
             this.executeOpenDebuggerClient().wait();
 			var projectId = this.$projectData.projectId;
 			var attachRequestMessage = notification.attachRequest(projectId);
-            // TODO: send notifications with ios-sim-portable
+            this.$iOSEmulatorServices.postDarwinNotification(attachRequestMessage).wait();
 		}).future<void>()();
 	}
 

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -1,6 +1,5 @@
 import iOSProxyServices = require("./../common/mobile/ios/ios-proxy-services");
 import iOSDevice = require("./../common/mobile/ios/ios-device");
-import iOSEmulatorService = require("./../common/mobile/ios/ios-emulator-services");
 import net = require("net");
 import ws = require("ws");
 import stream = require("stream");
@@ -45,7 +44,7 @@ function connectEventually(factory: () => net.Socket, handler: (socket: net.Sock
 class IOSDebugService implements IDebugService {
 	constructor(
 		private $platformService: IPlatformService,
-		private $iOSEmulatorServices: iOSEmulatorService,
+		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
 		private $devicesServices: Mobile.IDevicesServices,
 		private $platformsData: IPlatformsData,
 		private $projectData: IProjectData,
@@ -102,7 +101,9 @@ class IOSDebugService implements IDebugService {
             this.executeOpenDebuggerClient().wait();
 			var projectId = this.$projectData.projectId;
 			var attachRequestMessage = notification.attachRequest(projectId);
-            this.$iOSEmulatorServices.postDarwinNotification(attachRequestMessage).wait();
+			
+			var iOSEmulator = <Mobile.IiOSSimulatorService>this.$iOSEmulatorServices;
+            iOSEmulator.postDarwinNotification(attachRequestMessage).wait();
 		}).future<void>()();
 	}
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -233,7 +233,7 @@ export class PlatformService implements IPlatformService {
 			var cachedDeviceOption = this.$options.forDevice;
 			this.$options.forDevice = true;
 			this.buildPlatform(platform).wait();
-			this.$options.forDevice = cachedDeviceOption;
+			this.$options.forDevice = !!cachedDeviceOption;
 
 			// Get latest package that is produced from build
 			var packageFile = this.getLatestApplicationPackageForDevice(platformData).wait().packageName;

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "tabtab": "https://github.com/Icenium/node-tabtab/tarball/master",
     "temp": "0.8.1",
     "winreg": "0.0.12",
+    "ws": "0.7.1",
     "xcode": "https://github.com/NativeScript/node-xcode/archive/NativeScript-0.9.tar.gz",
     "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master",
     "yargs": "1.2.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gaze": "0.5.1",
     "iconv-lite": "0.4.4",
     "inquirer": "0.8.2",
-    "ios-sim-portable": "1.0.7",
+    "ios-sim-portable": "1.0.8",
     "lockfile": "1.0.0",
     "lodash": "3.6.0",
     "log4js": "0.6.22",


### PR DESCRIPTION
Right now the CLI is unable to debug iOS apps in any configuration. This change aims to gradually restore the broken functionality.

Restoring the debugger to its former glory is blocked by two things - missing functionality in `ios-sim-portable` implemented in https://github.com/telerik/ios-sim-portable/pull/29 and the refactoring of `IPlatformService.deployOnDevice`. I will update this branch with further patches as the blockers are removed.