### PR TITLE
Forbid MNC SDK

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -10,7 +10,7 @@ import fs = require("fs");
 import os = require("os");
 
 class AndroidProjectService implements IPlatformProjectService {
-	private SUPPORTED_TARGETS = ["android-17", "android-18", "android-19", "android-21", "android-MNC"];
+	private SUPPORTED_TARGETS = ["android-17", "android-18", "android-19", "android-21"]; // forbidden for now: "android-MNC"
 	private static RES_DIRNAME = "res";
 	private static VALUES_DIRNAME = "values";
 	private static VALUES_VERSION_DIRNAME_PREFIX = AndroidProjectService.VALUES_DIRNAME + "-v";


### PR DESCRIPTION
Programs built with it can run only on MNC devices.
We disable it until we create a good UI for the user to select target/min SDK