### PR TITLE
Fixed grunt task name to "tests"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Before you submit a Pull Request, consider the following guidelines.
 ```
 * Ensure all the tests pass.
 ```bash
-    grunt test
+    grunt tests
 ```
 * Commit your changes and create a descriptive commit message (the commit message is used to generate release notes).
 ```bash


### PR DESCRIPTION
There is no registered task named "test". It should be "tests"