### PR TITLE
Fix rule for filtering platform specific files.

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -342,8 +342,8 @@ export class PlatformService implements IPlatformService {
 	}
 
 	private static parsePlatformSpecificFileName(fileName: string, platforms: string[]): any {
-		var regex = util.format("^(.+?)\.(%s)(\..+?)$", platforms.join("|"));
-		var parsed = fileName.toLowerCase().match(new RegExp(regex, "i"));
+		var regex = util.format("^(.+?)\\.(%s)(\\..+?)$", platforms.join("|"));
+		var parsed = fileName.match(new RegExp(regex, "i"));
 		if (parsed) {
 			return {
 				platform: parsed[2],

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -235,7 +235,7 @@ describe('Platform Service Tests', () => {
 			
 			// Asserts that the files in app folder are process as platform specific
 			assert.isTrue(fs.exists(path.join(appDestFolderPath, "app" , "test1.js")).wait());
-			assert.isTrue(fs.exists(path.join(appDestFolderPath, "app", "test1-js")).wait());
+			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test1-js")).wait());
 			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test2.js")).wait());
 			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test2-js")).wait());
 			
@@ -286,7 +286,7 @@ describe('Platform Service Tests', () => {
 			
 			// Asserts that the files in app folder are process as platform specific
 			assert.isTrue(fs.exists(path.join(appDestFolderPath, "app" , "test2.js")).wait());
-			assert.isTrue(fs.exists(path.join(appDestFolderPath, "app", "test2-js")).wait());
+			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test2-js")).wait());
 			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test1.js")).wait());
 			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test1-js")).wait());
 			


### PR DESCRIPTION
Treat only files with ".platform" right before file extension are treated as platform specific.

See https://github.com/NativeScript/nativescript-cli/issues/538