### PR TITLE
Add support for different Android SDKs

### DIFF
--- a/docs/man_pages/project/configuration/platform-add.md
+++ b/docs/man_pages/project/configuration/platform-add.md
@@ -3,8 +3,8 @@ platform add
 
 Usage | Synopsis
 ------|-------
-Android latest runtime | `$ tns platform add android [--frameworkPath <File Path>] [--symlink]`
-Android selected runtime | `$ tns platform add android[@<Version>] [--frameworkPath <File Path>] [--symlink]`
+Android latest runtime | `$ tns platform add android [--frameworkPath <File Path>] [--symlink] [--sdk <target sdk>]`
+Android selected runtime | `$ tns platform add android[@<Version>] [--frameworkPath <File Path>] [--symlink] [--sdk <target sdk>]`
 <% if (isMacOS) { %>iOS latest runtime | `$ tns platform add ios [--frameworkPath <File Path>] [--symlink]`
 iOS selected runtime | `$ tns platform add ios[@<Version>] [--frameworkPath <File Path>] [--symlink]`<% } %>
 
@@ -13,6 +13,7 @@ Configures the current project to target the selected platform. <% if(isHtml) { 
 ### Options
 * `--frameworkPath` - Sets the path to a NativeScript runtime for the specified platform that you want to use instead of the default runtime. If `--symlink` is specified, `<File Path>` must point to directory in which the runtime is already extracted. If `--symlink` is not specified, `<File Path>` must point to a valid npm package. 
 * `--symlink` - Creates a symlink to a NativeScript runtime for the specified platform that you want to use instead of the default runtime. If `--frameworkPath` is specified, creates a symlink to the specified directory. If `--frameworkPath` is not specified, creates a symlink to platform runtime installed with your current version of NativeScript.
+* `--sdk` - Sets the Android target SDK. The value should be a valid Android API Level, for example 17, 19, MNC.
 
 ### Attributes
 * `<File Path>` is the complete path to a valid npm package or a directory that contains a NativeScript runtime for the selected platform.

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -62,4 +62,5 @@ interface IOptions extends ICommonOptions {
 	keyStorePassword: string;
 	keyStoreAlias: string;
 	keyStoreAliasPassword: string;
+	sdk: string;
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -24,7 +24,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			keyStorePath: { type: OptionType.String },
 			keyStorePassword: { type: OptionType.String,},
 			keyStoreAlias: { type: OptionType.String },
-			keyStoreAliasPassword: { type: OptionType.String }
+			keyStoreAliasPassword: { type: OptionType.String },
+			sdk: { type: OptionType.String }
 		},
 		path.join($hostInfo.isWindows ? process.env.LocalAppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),
 			$errors, $staticConfig);


### PR DESCRIPTION
* Add Android API Level 22 to supported versions. This way in case you have only API Level 22 installed, you will be able to use it and create Android project. Implements https://github.com/NativeScript/nativescript-cli/issues/551
* Add --sdk option to `$ tns platform add android` command. This option gives you the ability to specify the SDK that you would like to use. In case the value is below 17, an error will be raised. In case the value is not in the supported versions, a warning will be shown, that some functionality may not work as expected. Implements https://github.com/NativeScript/nativescript-cli/issues/552