### PR TITLE
Add dashedOptions for each command

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "xmldom": "0.1.19",
     "xmlhttprequest": "https://github.com/telerik/node-XMLHttpRequest/tarball/master",
     "xmlmerge-js": "0.2.4",
-    "yargs": "1.2.2"
+    "yargs": "3.12.0"
   },
   "analyze": true,
   "devDependencies": {


### PR DESCRIPTION
Each command can use specific dashed options (`-- avd <name>` for example is valid for one command, but not for other). Add dashedOptions parameter to ICommand interface and make sure to use it for validation when it exists. In case there's no dashedOptions paramter, use the common options. In order to validate the options, delete yargs from require and require it again as yargs.options(this.options).argv is caching the results and calling it more than once with different options is giving strange results.
Also fixes https://github.com/NativeScript/nativescript-cli/issues/539