### PR TITLE
Open web inspector frontend in a standalone application instead of Safari

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -204,12 +204,15 @@ class IOSDebugService implements IDebugService {
 
     private openDebuggingClient(): IFuture<void> {
         return (() => {
-            var cmd = "open -a Safari " + this.getSafariPath().wait();
+            let inspectorPath = this.getInspectorPath().wait();
+            let inspectorApplicationPath = path.join(inspectorPath, "NativeScript Inspector.app");
+            let inspectorSourceLocation = path.join(inspectorPath, "Safari/Main.html");
+            let cmd = `open -a '${inspectorApplicationPath}' --args '${inspectorSourceLocation}' '${this.$projectData.projectName}'`;
             this.$childProcess.exec(cmd).wait();
         }).future<void>()();
     }
 
-    private getSafariPath(): IFuture<string> {
+    private getInspectorPath(): IFuture<string> {
         return (() => {
             var tnsIosPackage = "";
             if (this.$options.frameworkPath) {
@@ -221,8 +224,8 @@ class IOSDebugService implements IDebugService {
                 var platformData = this.$platformsData.getPlatformData(this.platform);
                 tnsIosPackage = this.$npmInstallationManager.install(platformData.frameworkPackageName).wait();
             }
-            var safariPath = path.join(tnsIosPackage, "WebInspectorUI/Safari/Main.html");
-            return safariPath;
+            var inspectorPath = path.join(tnsIosPackage, "WebInspectorUI/");
+            return inspectorPath;
         }).future<string>()();
     }
 }


### PR DESCRIPTION
The update of JavaScriptCore that we use in the iOS bridge goes with an updated web inspector frontend. The updated frontend is not rendered properly in latest Safari, so as a workaround open an application that would be distributed with the iOS bridge package

Related to https://github.com/NativeScript/ios-runtime/pull/201