### PR TITLE
Add ignoreScripts option

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -65,6 +65,7 @@ interface IOptions extends ICommonOptions {
 	keyStoreAlias: string;
 	keyStoreAliasPassword: string;
 	sdk: string;
+	ignoreScripts: boolean;
 }
 
 interface IProjectFilesManager {

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -28,6 +28,11 @@ export class NodePackageManager implements INodePackageManager {
 	}
 	
 	public install(packageName: string, pathToSave: string, config?: any): IFuture<any> {
+		if(this.$options.ignoreScripts) {
+			config = config || {};
+			config["ignore-scripts"] = true;
+		}
+
 		return this.loadAndExecute("install", [pathToSave, packageName], { config: config });
 	}
 	

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -27,7 +27,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			keyStorePassword: { type: OptionType.String,},
 			keyStoreAlias: { type: OptionType.String },
 			keyStoreAliasPassword: { type: OptionType.String },
-			sdk: { type: OptionType.String }
+			sdk: { type: OptionType.String },
+			ignoreScripts: {type: OptionType.Boolean }
 		},
 		path.join($hostInfo.isWindows ? process.env.LocalAppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),
 			$errors, $staticConfig);

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -116,7 +116,11 @@ export class PluginsService implements IPluginsService {
 	}
 	
 	public ensureAllDependenciesAreInstalled(): IFuture<void> {
-		return this.$childProcess.exec("npm install ", { cwd: this.$projectData.projectDir });
+		let command = "npm install ";
+		if(this.$options.ignoreScripts) {
+			command += "--ignore-scripts";
+		}
+		return this.$childProcess.exec(command, { cwd: this.$projectData.projectDir });
 	}
 	
 	public getAllInstalledPlugins(): IFuture<IPluginData[]> {


### PR DESCRIPTION
Add ignoreScripts option, which should be used when during installation of modules you want to skip all scripts declared in package.json's of these modules. When you specify --ignoreScripts, we just add `--ignore-scripts` to npm install command.