### PR TITLE
Do not delete values dirs

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -185,9 +185,10 @@ class AndroidProjectService implements IPlatformProjectService {
 	public prepareAppResources(appResourcesDirectoryPath: string): IFuture<void> {
 		return (() => {
 			let resourcesDirPath = path.join(appResourcesDirectoryPath, this.platformData.normalizedPlatformName);
-			let resourcesDirs = this.$fs.readDirectory(resourcesDirPath).wait();
+			let valuesDirRegExp = /^values/;
+			let resourcesDirs = this.$fs.readDirectory(resourcesDirPath).wait().filter(resDir => !resDir.match(valuesDirRegExp));
 			_.each(resourcesDirs, resourceDir => {
-				this.$fs.deleteDirectory(path.join(this.platformData.appResourcesDestinationDirectoryPath, resourceDir)).wait();				
+				this.$fs.deleteDirectory(path.join(this.platformData.appResourcesDestinationDirectoryPath, resourceDir)).wait();
 			});	
 		}).future<void>()();
 	}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -173,7 +173,7 @@ export class PlatformService implements IPlatformService {
 			var appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
 			if (this.$fs.exists(appResourcesDirectoryPath).wait()) {
 				platformData.platformProjectService.prepareAppResources(appResourcesDirectoryPath).wait();
-				shell.cp("-R", path.join(appResourcesDirectoryPath, platformData.normalizedPlatformName, "*"), platformData.appResourcesDestinationDirectoryPath);
+				shell.cp("-Rf", path.join(appResourcesDirectoryPath, platformData.normalizedPlatformName, "*"), platformData.appResourcesDestinationDirectoryPath);
 				this.$fs.deleteDirectory(appResourcesDirectoryPath).wait();
 			}
 			


### PR DESCRIPTION
During project preparation, we should not delete values directories as they contain specific information, which is important for android builds (strings.xml file for example).

NOTE: This fix is mandatory for integration of {N} inside AppBuilder