### PR TITLE
Fix livesync help

### DIFF
--- a/docs/man_pages/project/testing/livesync-android.md
+++ b/docs/man_pages/project/testing/livesync-android.md
@@ -14,6 +14,7 @@ Synchronizes the latest changes in your project to Android devices.
 ### Attributes
 * `<Device ID>` is the device index or identifier as listed by `$ tns device`
 
+<% if(isHtml) { %> 
 ### Related Commands
 
 Command | Description

--- a/docs/man_pages/project/testing/livesync-ios.md
+++ b/docs/man_pages/project/testing/livesync-ios.md
@@ -14,6 +14,7 @@ Synchronizes the latest changes in your project to iOS devices.
 ### Attributes
 * `<Device ID>` is the device index or identifier as listed by `$ tns device`
 
+<% if(isHtml) { %> 
 ### Related Commands
 
 Command | Description

--- a/docs/man_pages/project/testing/livesync.md
+++ b/docs/man_pages/project/testing/livesync.md
@@ -12,6 +12,7 @@ Synchronizes the latest changes in your project to devices. If no target platfor
 * `android` - Synchronizes the latest changes in your project to connected Android devices. 
 * `ios` - Synchronizes the latest changes in your project to connected iOS devices.
 
+<% if(isHtml) { %> 
 ### Related Commands
 
 Command | Description


### PR DESCRIPTION
Fix livesync help and html generation which was failing due to missing <% if(isHtml) { <%> sections.
Update common lib.