### PR TITLE
Fix unresolved futures

### DIFF
--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -84,7 +84,7 @@ class AndroidDebugService implements IDebugService {
             } else if (this.$options.stop) {
                 this.detachDebugger(packageName).wait();
             } else if (this.$options.debugBrk) {
-                this.startAppWithDebugger(packageFile, packageName);
+                this.startAppWithDebugger(packageFile, packageName).wait();
             } else {
                 this.$logger.info("Should specify at least one option: debug-brk, start, stop, get-port.");
             }
@@ -115,7 +115,7 @@ class AndroidDebugService implements IDebugService {
             }
         }
         if ((0 < port) && (port < 65536)) {
-            this.tcpForward(port, port);
+            this.tcpForward(port, port).wait();
             this.startDebuggerClient(port).wait();
             this.openDebuggerClient(AndroidDebugService.DEFAULT_NODE_INSPECTOR_URL + "?port=" + port);
         } else {
@@ -147,7 +147,7 @@ class AndroidDebugService implements IDebugService {
     
             let dbgPort = this.startAndGetPort(packageName).wait();
             if (dbgPort > 0) {
-                this.tcpForward(dbgPort, dbgPort);
+                this.tcpForward(dbgPort, dbgPort).wait();
                 this.startDebuggerClient(dbgPort).wait();
                 this.openDebuggerClient(AndroidDebugService.DEFAULT_NODE_INSPECTOR_URL + "?port=" + dbgPort);
             }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "./lib/nativescript-cli.js",
   "scripts": {
-    "test": "node_modules\\.bin\\_mocha --ui mocha-fibers --recursive --reporter spec --require test/test-bootstrap.js --timeout 30000 test/",
+    "test": "node_modules\\.bin\\_mocha --ui mocha-fibers --recursive --reporter spec --require test/test-bootstrap.js --timeout 60000 test/",
     "postinstall": "node postinstall.js",
     "preuninstall": "node preuninstall.js"
   },

--- a/test/android-project-properties-manager.ts
+++ b/test/android-project-properties-manager.ts
@@ -46,7 +46,7 @@ describe("Android project properties parser tests", () => {
 		let projectPropertiesManager = testInjector.resolve(ProjectPropertiesManagerLib.AndroidProjectPropertiesManager, {directoryPath: tempFolder});
 		projectPropertiesManager.addProjectReference("testValue").wait();
 		
-		let expectedContent = 'target=android-21' + os.EOL +
+		let expectedContent = 'target=android-21' + '\n' +
 		'android.library.reference.1=testValue';
 		let actualContent = fs.readText(path.join(tempFolder, "project.properties")).wait();
 		
@@ -57,7 +57,7 @@ describe("Android project properties parser tests", () => {
 		let testInjector = createTestInjector();
 		let fs = testInjector.resolve("fs"); 
 		
-		let projectPropertiesFileContent = 'target=android-21' + os.EOL +
+		let projectPropertiesFileContent = 'target=android-21' + '\n' +
 		'android.library.reference.1=someValue';
 		let tempFolder = temp.mkdirSync("AndroidProjectPropertiesManager");	
 		fs.writeFile(path.join(tempFolder, "project.properties"), projectPropertiesFileContent).wait();
@@ -65,9 +65,9 @@ describe("Android project properties parser tests", () => {
 		let projectPropertiesManager = testInjector.resolve(ProjectPropertiesManagerLib.AndroidProjectPropertiesManager, {directoryPath: tempFolder});
 		projectPropertiesManager.addProjectReference("testValue").wait();
 		
-		let expectedContent = 'target=android-21' + os.EOL +
-		'android.library.reference.1=someValue' + os.EOL + 
-		'android.library.reference.2=testValue';
+		let expectedContent = ['target=android-21',
+		'android.library.reference.1=someValue',
+		'android.library.reference.2=testValue'].join('\n');
 		let actualContent = fs.readText(path.join(tempFolder, "project.properties")).wait();
 		
 		assert.equal(expectedContent, actualContent);
@@ -77,19 +77,19 @@ describe("Android project properties parser tests", () => {
 		let testInjector = createTestInjector();
 		let fs = testInjector.resolve("fs"); 
 		
-		let projectPropertiesFileContent = 'target=android-21' + os.EOL +
-		'android.library.reference.1=value1' + os.EOL +
-		'android.library.reference.2=value2' + os.EOL + 
-		'android.library.reference.3=value3' + os.EOL +
-		'android.library.reference.4=value4' + os.EOL +
-		'android.library.reference.5=value5';
+		let projectPropertiesFileContent = ['target=android-21', 
+		'android.library.reference.1=value1',
+		'android.library.reference.2=value2', 
+		'android.library.reference.3=value3',
+		'android.library.reference.4=value4',
+		'android.library.reference.5=value5'].join('\n');
 		let tempFolder = temp.mkdirSync("AndroidProjectPropertiesManager");	
 		fs.writeFile(path.join(tempFolder, "project.properties"), projectPropertiesFileContent).wait();
 		
 		let projectPropertiesManager: IAndroidProjectPropertiesManager = testInjector.resolve(ProjectPropertiesManagerLib.AndroidProjectPropertiesManager, {directoryPath: tempFolder});
 		projectPropertiesManager.addProjectReference("testValue").wait();
 		
-		let expectedContent = projectPropertiesFileContent + os.EOL + 
+		let expectedContent = projectPropertiesFileContent + '\n' + 
 		'android.library.reference.6=testValue';
 		
 		let actualContent = fs.readText(path.join(tempFolder, "project.properties")).wait();
@@ -101,7 +101,7 @@ describe("Android project properties parser tests", () => {
 		let testInjector = createTestInjector();
 		let fs = testInjector.resolve("fs"); 
 		
-		let projectPropertiesFileContent = 'android.library.reference.1=value1' + os.EOL + 
+		let projectPropertiesFileContent = 'android.library.reference.1=value1' + '\n' + 
 		'target=android-21';
 		let tempFolder = temp.mkdirSync("AndroidProjectPropertiesManager");	
 		fs.writeFile(path.join(tempFolder, "project.properties"), projectPropertiesFileContent).wait();
@@ -119,23 +119,23 @@ describe("Android project properties parser tests", () => {
 		let testInjector = createTestInjector();
 		let fs = testInjector.resolve("fs"); 
 		
-		let projectPropertiesFileContent = 'target=android-17' + os.EOL + 
-		'android.library.reference.1=value1' + os.EOL +
-		'android.library.reference.2=value2' + os.EOL + 
-		'android.library.reference.3=value3' + os.EOL +
-		'android.library.reference.4=value4' + os.EOL +
-		'android.library.reference.5=value5';
+		let projectPropertiesFileContent = ['target=android-17',
+		'android.library.reference.1=value1',
+		'android.library.reference.2=value2', 
+		'android.library.reference.3=value3',
+		'android.library.reference.4=value4',
+		'android.library.reference.5=value5'].join('\n');
 		let tempFolder = temp.mkdirSync("AndroidProjectPropertiesManager");	
 		fs.writeFile(path.join(tempFolder, "project.properties"), projectPropertiesFileContent).wait();
 		
 		let projectPropertiesManager: IAndroidProjectPropertiesManager = testInjector.resolve(ProjectPropertiesManagerLib.AndroidProjectPropertiesManager, {directoryPath: tempFolder});
 		projectPropertiesManager.removeProjectReference("value3").wait();
 		
-		let expectedContent = 'target=android-17' + os.EOL + 
-		'android.library.reference.1=value1' + os.EOL + 
-		'android.library.reference.2=value2' + os.EOL + 
-		'android.library.reference.3=value4' + os.EOL + 
-		'android.library.reference.4=value5' + os.EOL;
+		let expectedContent = ['target=android-17',
+		'android.library.reference.1=value1',
+		'android.library.reference.2=value2',
+		'android.library.reference.3=value4',
+		'android.library.reference.4=value5'].join('\n') + '\n';
 		let actualContent = fs.readText(path.join(tempFolder, "project.properties")).wait();
 		
 		assert.equal(expectedContent, actualContent);


### PR DESCRIPTION
There are some unresolved futures in android debug service which leads to `Error: There are outstanding futures. Construction call stacks:` errors. Fix them and fix unit tests  on Windows.