### PR TITLE
Respect correctly .jar files from plugin

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -275,11 +275,7 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 			// Handle *.jars inside libs folder
 			let libsFolderPath = path.join(pluginPlatformsFolderPath, AndroidProjectService.LIBS_FOLDER_NAME);
 			if(this.$fs.exists(libsFolderPath).wait()) {
-				let libsFolderContents = this.$fs.readDirectory(libsFolderPath).wait();
-				_(libsFolderContents)
-					.filter(libsFolderItem => path.extname(libsFolderItem) === ".jar")
-					.each(jar => this.addLibrary(path.join(libsFolderPath, jar)).wait())
-					.value();
+				this.addLibrary(libsFolderPath).wait();
 			}
 			
 			// Handle android libraries


### PR DESCRIPTION
1. Create new project
2. Add plugin that contains .jar file

Expected: The .jar file should  be added in libs folder of native project and in lib folder at project root
Actual:  the .jar file is not respected from cli.