### PR TITLE
Make sure framework dir is part of the cached framework

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -15,6 +15,7 @@ interface INpmInstallationManager {
 	install(packageName: string, options?: INpmInstallOptions): IFuture<string>;
 	getLatestVersion(packageName: string): IFuture<string>;
 	getCachedPackagePath(packageName: string, version: string): string;
+	addCleanCopyToCache(packageName: string, version: string): IFuture<void>;
 }
 
 interface INpmInstallOptions {

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -6,7 +6,7 @@ import semver = require("semver");
 import npm = require("npm");
 import constants = require("./constants");
 
-export class NpmInstallationManager {
+export class NpmInstallationManager implements INpmInstallationManager {
 	private static NPM_LOAD_FAILED = "Failed to retrieve data from npm. Please try again a little bit later.";	
 	private versionsCache: IDictionary<string[]>;	
 	
@@ -35,6 +35,15 @@ export class NpmInstallationManager {
 			if(!this.isPackageUnpacked(packagePath).wait()) {
 				this.cacheUnpack(packageName, version).wait();
 			}
+		}).future<void>()();
+	}
+
+	public addCleanCopyToCache(packageName: string, version: string): IFuture<void> {
+		return (() => {
+			let packagePath = path.join(this.getCacheRootPath(), packageName, version);
+			this.$logger.trace(`Deleting: ${packagePath}.`);
+			this.$fs.deleteDirectory(packagePath).wait();
+			this.addToCache(packageName, version).wait();
 		}).future<void>()();
 	}
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -501,6 +501,12 @@ export class PlatformService implements IPlatformService {
 			if(!this.$fs.exists(cachedPackagePath).wait()) {
 				this.$npmInstallationManager.addToCache(packageName, version).wait();
 			}
+
+			if(!this.$fs.exists(path.join(cachedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME)).wait()) {
+				// In some cases the package is not fully downloaded and the framework directory is missing
+				// Try removing the old package and add the real one to cache again
+				this.$npmInstallationManager.addCleanCopyToCache(packageName, version).wait();
+			}
 		}).future<void>()();
 	}
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -195,6 +195,10 @@ export class NpmInstallationManagerStub implements INpmInstallationManager {
 		return undefined;
 	}
 
+	addCleanCopyToCache(packageName: string, version: string): IFuture<void> {
+		return undefined;
+	}
+
 	cacheUnpack(packageName: string, version: string): IFuture<void> {
 		return undefined;
 	}


### PR DESCRIPTION
In some cases framework dir is missing in the npm cached package of the framework. Check if it exists and if not, remove the package from the cache and add it again.
Fixes https://github.com/NativeScript/nativescript-cli/issues/699