### PR TITLE
Make sure framework dir is part of the cached framework

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -15,6 +15,7 @@ interface INpmInstallationManager {
 	install(packageName: string, options?: INpmInstallOptions): IFuture<string>;
 	getLatestVersion(packageName: string): IFuture<string>;
 	getCachedPackagePath(packageName: string, version: string): string;
+	addCleanCopyToCache(packageName: string, version: string): IFuture<void>;
 }
 
 interface INpmInstallOptions {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -154,6 +154,10 @@ export class FileSystemStub implements IFileSystem {
 	isRelativePath(path: string): boolean {
 		return false;
 	}
+
+	getFileShasum(fileName: string): IFuture<string> {
+		return undefined;
+	}
 }
 
 export class ErrorsStub implements IErrors {
@@ -192,6 +196,10 @@ export class NpmInstallationManagerStub implements INpmInstallationManager {
 	}
 
 	addToCache(packageName: string, version: string): IFuture<void> {
+		return undefined;
+	}
+
+	addCleanCopyToCache(packageName: string, version: string): IFuture<void> {
 		return undefined;
 	}
 


### PR DESCRIPTION
In some cases framework dir is missing in the npm cached package of the framework. Check if it exists and if not, remove the package from the cache and add it again.
Fixes https://github.com/NativeScript/nativescript-cli/issues/699