### PR TITLE
Remove plugin platforms folder

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -118,6 +118,8 @@ export class PluginsService implements IPluginsService {
 					pluginData.pluginPlatformsFolderPath = (platform: string) => path.join(pluginData.fullPath, "platforms", platform);				
 					platformData.platformProjectService.preparePluginNativeCode(pluginData).wait();
 				
+					shelljs.rm("-rf", path.join(pluginDestinationPath, pluginData.name, "platforms"));
+				
 					// Show message
 					this.$logger.out(`Successfully prepared plugin ${pluginData.name} for ${platform}.`);
 			

--- a/lib/tools/broccoli/node-modules-dest-copy.ts
+++ b/lib/tools/broccoli/node-modules-dest-copy.ts
@@ -74,7 +74,6 @@ export class DestCopy implements IBroccoliPlugin {
 		let isPlugin = !!dependency.nativescript;
 		if(isPlugin) {
 			this.$pluginsService.prepare(dependency).wait();
-			shelljs.rm("-rf", path.join(this.outputRoot, dependency.name, "platforms"));
 		}
 	});
   }


### PR DESCRIPTION
Should be merged after this PR https://github.com/NativeScript/node-xcode/pull/4

If the platform is added before the plugin, the plugin platforms directory inside `tns_modules` is not deleted. This way the native libraries are copied twice in project - in `lib` folder and `tns_modules` folder, which increases the package size of an application a lot.