### PR TITLE
Add platform on all commands

### DIFF
--- a/lib/commands/update-platform.ts
+++ b/lib/commands/update-platform.ts
@@ -17,7 +17,7 @@ export class UpdatePlatformCommand implements ICommand {
 				this.$errors.fail("No platform specified. Please specify platforms to update.");
 			}
 
-			_.each(args, arg => this.$platformService.validatePlatformInstalled(arg.split("@")[0]));
+			_.each(args, arg => this.$platformService.validatePlatform(arg.split("@")[0]));
 
 			return true;
 		}).future<boolean>()();

--- a/lib/platform-command-param.ts
+++ b/lib/platform-command-param.ts
@@ -6,7 +6,7 @@ export class PlatformCommandParameter implements ICommandParameter {
 	mandatory = true;
 	validate(value: string): IFuture<boolean> {
 		return (() => {
-			this.$platformService.validatePlatformInstalled(value);
+			this.$platformService.validatePlatform(value);
 			return true;
 		}).future<boolean>()();
 	}

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -227,7 +227,11 @@ describe('Platform Service Tests', () => {
 					appResourcesDestinationDirectoryPath: appResourcesFolderPath,
 					normalizedPlatformName: "iOS",
 					platformProjectService: {
-						prepareProject: () => Future.fromResult()
+						prepareProject: () => Future.fromResult(),
+						validate: () => Future.fromResult(),
+						createProject: (projectRoot: string, frameworkDir: string) => Future.fromResult(),
+						interpolateData: (projectRoot: string) => Future.fromResult(),
+						afterCreateProject: (projectRoot: string) => Future.fromResult()
 					}
 				}	
 			};
@@ -281,7 +285,11 @@ describe('Platform Service Tests', () => {
 					appResourcesDestinationDirectoryPath: appResourcesFolderPath,
 					normalizedPlatformName: "Android",
 					platformProjectService: {
-						prepareProject: () => Future.fromResult()
+						prepareProject: () => Future.fromResult(),
+						validate: () => Future.fromResult(),
+						createProject: (projectRoot: string, frameworkDir: string) => Future.fromResult(),
+						interpolateData: (projectRoot: string) => Future.fromResult(),
+						afterCreateProject: (projectRoot: string) => Future.fromResult()
 					}
 				}	
 			};


### PR DESCRIPTION
When you execute `tns run <platform>`, but you have forgotten to add the platform before that, you go in inconsistent state. Make sure to add the platform for the user when one of the following is executed:
* `tns prepare <platform>`
* `tns build <platform>`
* `tns run <platform>`
* `tns update <platform>@<version>` - this will add the specified version in case you have not added the platform before that.
* `tns emulate <platform>`

This way we simplify the workflow, now you can just do:
1) `tns create app1`
2) `tns run android --path app1`
And the application will run on your attached device.

Resolves https://github.com/NativeScript/nativescript-cli/issues/774
Part of the implementation of: https://github.com/NativeScript/nativescript-cli/issues/475