### PR TITLE
Support library add command with iOS 7

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -194,11 +194,9 @@ class IOSProjectService extends projectServiceBaseLib.PlatformProjectServiceBase
 			shell.cp("-R", libraryPath, fullTargetPath);
 
 			let project = this.createPbxProj();
-			let frameworkPath = this.getFrameworkRelativePath(libraryPath);
-			project.addFramework(frameworkPath, { customFramework: true, embed: true });
-			project.updateBuildProperty("IPHONEOS_DEPLOYMENT_TARGET", "8.0");
+            let frameworkPath = "$(PROJECT_DIR)/" + this.getFrameworkRelativePath(libraryPath);
+			project.addFramework(frameworkPath, { customFramework: true, embed: true, weak: true });
 			this.savePbxProj(project).wait();
-			this.$logger.info("The iOS Deployment Target is now 8.0 in order to support Cocoa Touch Frameworks.");
 		}).future<void>()();
 	}
 
@@ -313,7 +311,7 @@ class IOSProjectService extends projectServiceBaseLib.PlatformProjectServiceBase
 						
 			_.each(this.getAllDynamicFrameworksForPlugin(pluginData).wait(), fileName => {
 				let fullFrameworkPath = path.join(pluginPlatformsFolderPath, fileName);
-				let relativeFrameworkPath = this.getFrameworkRelativePath(fullFrameworkPath);
+                let relativeFrameworkPath = "$(PROJECT_DIR)/" + this.getFrameworkRelativePath(fullFrameworkPath);
 				project.removeFramework(relativeFrameworkPath, { customFramework: true, embed: true })
 			});
 			


### PR DESCRIPTION
Fixed #794 

When adding library to iOS platform, keep the DEPLOYMENT_TARGET untouched , and mark the embedded framework to "weak". 

I beleive this also fixed the issue #777 (Maybe I should submit this as a separate PR? )
 