### PR TITLE
Fix merging info.plist during plugin add

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -54,8 +54,9 @@ class IOSProjectService extends projectServiceBaseLib.PlatformProjectServiceBase
 			frameworkDirectoriesExtensions: [".framework"],
 			frameworkDirectoriesNames: ["Metadata"],
 			targetedOS: ['darwin'],
-			configurationFileName: this.$projectData.projectName+"-Info.plist",
-			configurationFilePath: path.join(projectRoot, this.$projectData.projectName,  this.$projectData.projectName+"-Info.plist")
+			configurationFileName: "Info.plist",
+			configurationFilePath: path.join(projectRoot, this.$projectData.projectName,  this.$projectData.projectName+"-Info.plist"),
+			mergeXmlConfig: [{ "nodename": "plist", "attrname": "*" }, {"nodename": "dict", "attrname": "*"}]
 		};
 	}
 


### PR DESCRIPTION
Fix: look for correctly named info.plist when adding a plugin
Fix: correctly merge plugin content when merging its info.plist

Fixes https://github.com/NativeScript/nativescript-cli/issues/797