### PR TITLE
Guard against errors in npm

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -6,10 +6,6 @@ import * as npm from "npm";
 
 export class NodePackageManager implements INodePackageManager {
 	constructor(private $childProcess: IChildProcess,
-		private $logger: ILogger,
-		private $errors: IErrors,
-		private $fs: IFileSystem,
-		private $lockfile: ILockFile,
 		private $options: IOptions) { }
 
 	public getCache(): string {
@@ -18,7 +14,7 @@ export class NodePackageManager implements INodePackageManager {
 
 	public load(config?: any): IFuture<void> {
 		let future = new Future<void>();
-		npm.load(config, (err) => {
+		npm.load(config, (err: Error) => {
 			if(err) {
 				future.throw(err);
 			} else {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -75,11 +75,11 @@ export class PlatformService implements IPlatformService {
 				npmOptions["version"] = version;
 			}
 
-			let downloadedPackagePath = this.$npmInstallationManager.install(packageToInstall, npmOptions).wait();
-			let frameworkDir = path.join(downloadedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME);
-			frameworkDir = path.resolve(frameworkDir);
-
 			try {
+				let downloadedPackagePath = this.$npmInstallationManager.install(packageToInstall, npmOptions).wait();
+				let frameworkDir = path.join(downloadedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME);
+				frameworkDir = path.resolve(frameworkDir);
+
 				this.addPlatformCore(platformData, frameworkDir).wait();
 			} catch(err) {
 				this.$fs.deleteDirectory(platformPath).wait();


### PR DESCRIPTION
See https://github.com/NativeScript/nativescript-cli/issues/819

Note: npm actually `assert` their parameters instead of calling the provided callback with an error.
In our code, this means that an exception is being thrown in async code which was running without being guarded in a fiber. The end result is process tear down without any chance for us to intervene.

We need to file a issue to npm to fix their code to call the callback with an error in this case.