### PR TITLE
Respect settings.gradle file from template

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -52,9 +52,7 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 				deviceBuildOutputPath: path.join(projectRoot, "build", "outputs", "apk"),
 				validPackageNamesForDevice: [
 					`${this.$projectData.projectName}-debug.apk`,
-					`${this.$projectData.projectName}-release.apk`,
-					"android-debug.apk",
-					"android-release.apk"
+					`${this.$projectData.projectName}-release.apk`
 				],
 				frameworkFilesExtensions: [".jar", ".dat", ".so"],
 				configurationFileName: "AndroidManifest.xml",
@@ -96,9 +94,10 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 				this.symlinkDirectory("src", projectRoot, frameworkDir).wait();
 
 				this.$fs.symlink(path.join(frameworkDir, "build.gradle"), path.join(projectRoot, "build.gradle")).wait();
+				this.$fs.symlink(path.join(frameworkDir, "settings.gradle"), path.join(projectRoot, "settings.gradle")).wait();
 			} else {
 				this.copy(projectRoot, frameworkDir, "build-tools libs src", "-R");
-				this.copy(projectRoot, frameworkDir, "build.gradle", "-f");
+				this.copy(projectRoot, frameworkDir, "build.gradle settings.gradle", "-f");
 			}
 
 			this.copyResValues(projectRoot, frameworkDir, versionNumber).wait();
@@ -145,6 +144,9 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 			let stringsFilePath = path.join(this.platformData.appResourcesDestinationDirectoryPath, 'values', 'strings.xml');
 			shell.sed('-i', /__NAME__/, this.$projectData.projectName, stringsFilePath);
 			shell.sed('-i', /__TITLE_ACTIVITY__/, this.$projectData.projectName, stringsFilePath);
+
+			let gradleSettingsFilePath = path.join(this.platformData.projectRoot, "settings.gradle");
+			shell.sed('-i', /__PROJECT_NAME__/,  this.$projectData.projectName, gradleSettingsFilePath);
 		}).future<void>()();
 	}
 

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -70,7 +70,7 @@ class DoctorService implements IDoctorService {
 			this.$logger.out("You will not be able to build your projects for Android or run them in the emulator or on a connected device." + EOL
 				+ "To be able to build for Android and run apps in the emulator on on a connected device, verify that you have installed Gradle.");
 		}
-		
+
 		if(sysInfo.gradleVer && helpers.versionCompare(sysInfo.gradleVer, DoctorService.MIN_SUPPORTED_GRADLE_VERSION) === -1) {
 			this.$logger.warn(`WARNING: Gradle version is lower than ${DoctorService.MIN_SUPPORTED_GRADLE_VERSION}.`);
 			this.$logger.out("You will not be able to build your projects for Android or run them in the emulator or on a connected device." + EOL


### PR DESCRIPTION
Android runtime introduced gradle.settings file in order to produce apk named <projectName>-debug.apk or <projectName>-release.apk.
Currently the produced .apk files are named android-debug.apk or android-release.apk.