### PR TITLE
Create main target scheme before installing pods.

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -347,7 +347,14 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				if(firstPostInstallIndex !== -1 && firstPostInstallIndex !== projectPodfileContent.lastIndexOf(IOSProjectService.PODFILE_POST_INSTALL_SECTION_NAME)) {
 					this.$logger.warn(`Podfile contains more than one post_install sections. You need to open ${this.projectPodFilePath} file and manually resolve this issue.`);
 				}
-
+				
+				let pbxprojFilePath = path.join(this.platformData.projectRoot, this.$projectData.projectName + IOSProjectService.XCODE_PROJECT_EXT_NAME, "xcuserdata");
+				if(!this.$fs.exists(pbxprojFilePath).wait()) {
+					this.$logger.info("Creating project scheme...");
+					let createScheme_rb = `echo \"require 'xcodeproj'; xcproj = Xcodeproj::Project.open('${this.$projectData.projectName}.xcodeproj'); xcproj.recreate_user_schemes; xcproj.save\" | ruby`;
+					this.$childProcess.exec(createScheme_rb, { cwd: this.platformData.projectRoot }).wait();
+				}
+				
 				this.$logger.info("Installing pods...");
 				this.$childProcess.exec("pod install", { cwd: this.platformData.projectRoot }).wait();
 			}

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -335,8 +335,9 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				// Check availability
 				try {
 					this.$childProcess.exec("gem which cocoapods").wait();
+					this.$childProcess.exec("gem which xcodeproj").wait();
 				} catch(e) {
-					this.$errors.failWithoutHelp("CocoaPods are not installed. Run `sudo gem install cocoapods` and try again.");
+					this.$errors.failWithoutHelp("CocoaPods or ruby gem 'xcodeproj' is not installed. Run `sudo gem install cocoapods` and try again.");
 				}
 
 				let projectPodfileContent = this.$fs.readText(this.projectPodFilePath).wait();
@@ -351,8 +352,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				let pbxprojFilePath = path.join(this.platformData.projectRoot, this.$projectData.projectName + IOSProjectService.XCODE_PROJECT_EXT_NAME, "xcuserdata");
 				if(!this.$fs.exists(pbxprojFilePath).wait()) {
 					this.$logger.info("Creating project scheme...");
-					let createScheme_rb = `echo \"require 'xcodeproj'; xcproj = Xcodeproj::Project.open('${this.$projectData.projectName}.xcodeproj'); xcproj.recreate_user_schemes; xcproj.save\" | ruby`;
-					this.$childProcess.exec(createScheme_rb, { cwd: this.platformData.projectRoot }).wait();
+					let createSchemeRubyScript = `ruby -e "require 'xcodeproj'; xcproj = Xcodeproj::Project.open('${this.$projectData.projectName}.xcodeproj'); xcproj.recreate_user_schemes; xcproj.save"`;
+					this.$childProcess.exec(createSchemeRubyScript, { cwd: this.platformData.projectRoot }).wait();
 				}
 				
 				this.$logger.info("Installing pods...");


### PR DESCRIPTION
<b>Changes:</b> Create `.xcscheme` for the main target before installing pods.
<b>Reason:</b> `xcodebuild` fails to build workspaces without scheme in the main target.
Addresses <b>issue</b> #831.