### PR TITLE
Fix ios commands when platforms dir is removed

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -98,8 +98,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 	public createProject(projectRoot: string, frameworkDir: string): IFuture<void> {
 		return (() => {
+			this.$fs.ensureDirectoryExists(path.join(projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER)).wait();
 			if(this.$options.symlink) {
-				this.$fs.ensureDirectoryExists(path.join(projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER)).wait();
 				let xcodeProjectName = util.format("%s.xcodeproj", IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER);
 
 				shell.cp("-R", path.join(frameworkDir, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER, "*"), path.join(projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER));


### PR DESCRIPTION
When you run `tns run ios`, nativescript-cli will add the ios platform in case you have not added it before that. But in case you have added the platform before that, but you have removed the  platforms dir, the call fails.
Make sure the platforms/ios directory exists before executing any action of copying the files.