### PR TITLE
Add code coverage as a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !vendor/*.js
 *.js.map
 
+coverage
 lib-cov
 *.seed
 *.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -165,6 +165,7 @@ module.exports = function(grunt) {
 	grunt.registerTask("pack", [
 		"clean",
 		"ts:release_build",
+		"shell:npm_test",
 
 		"set_package_version",
 		"shell:build_package",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "./lib/nativescript-cli.js",
   "scripts": {
-    "test": "node_modules\\.bin\\_mocha --ui mocha-fibers --recursive --reporter spec --require test/test-bootstrap.js --timeout 60000 test/ lib/common/test/unit-tests",
+    "test": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --ui mocha-fibers --recursive --reporter spec --require test/test-bootstrap.js --timeout 60000 test/ lib/common/test/unit-tests",
     "postinstall": "node postinstall.js",
     "preuninstall": "node preuninstall.js"
   },
@@ -88,6 +88,7 @@
     "grunt-shell": "1.1.2",
     "grunt-ts": "4.2.0",
     "grunt-tslint": "2.4.0",
+    "istanbul": "0.3.19",
     "mocha": "2.2.5",
     "mocha-fibers": "https://github.com/Icenium/mocha-fibers/tarball/master",
     "should": "7.0.2",


### PR DESCRIPTION
Use istanbul as a code coverage tool.

Code coverage is run on every build and one can check its output on the build console log.