### PR TITLE
Improve android tools warnings

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -130,9 +130,9 @@ interface IAndroidToolsInfoData {
 	compileSdkVersion: number;
 
 	/**
-	 * The latest installed version of Android Support Library that satisfies CLI's requirements.
+	 * The latest installed version of Android Support Repository that satisfies CLI's requirements.
 	 */
-	supportLibraryVersion: string;
+	supportRepositoryVersion: string;
 
 	/**
 	 * The Android targetSdkVersion specified by the user.

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -176,7 +176,7 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 				let compileSdk = androidToolsInfo.compileSdkVersion;
 				let targetSdk = this.getTargetFromAndroidManifest().wait() || compileSdk;
 				let buildToolsVersion = androidToolsInfo.buildToolsVersion;
-				let appCompatVersion = androidToolsInfo.supportLibraryVersion;
+				let appCompatVersion = androidToolsInfo.supportRepositoryVersion;
 				let buildOptions = ["buildapk",
 					`-PcompileSdk=android-${compileSdk}`,
 					`-PtargetSdk=${targetSdk}`,


### PR DESCRIPTION
* Fix incorrect message for  selected target SDK (Bulgarian symbols were used)
* Improve message for build tools when the prefix and suffix have the same version (>=22 <=22) - https://github.com/NativeScript/nativescript-cli/issues/900
* Rename supportLibraryVersion to supportRepositoryVersion and improve messaging as Gradle does not work with Android Support Library - instead it works with Android Support Repository.