### PR TITLE
Allow specifying compileSdk

### DIFF
--- a/docs/man_pages/project/testing/build-android.md
+++ b/docs/man_pages/project/testing/build-android.md
@@ -3,11 +3,12 @@ build android
 
 Usage | Synopsis
 ---|---
-General | `$ tns build android [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--static-bindings]`
+General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--static-bindings]`
 
 Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 
 ### Options
+* `--compileSdk` - Sets the Android SDK that will be used to build the project.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build. When set, you must also specify the `--key-store-*` options.
 * `--key-store-path` - Specifies the file path to the keystore file (P12) which you want to use to code sign your APK. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-password` - Provides the password for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
@@ -15,7 +16,10 @@ Builds the project for Android and produces an APK that you can manually deploy 
 * `--key-store-alias-password` - Provides the password for the alias specified with `--key-store-alias-password`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--static-bindings` - If set, generates static bindings from your JavaScript code to corresponding native Android APIs during build. This static bindings speed up app loading.
 
-<% if(isHtml) { %> 
+### Attributes
+`<API Level>` is a valid Android API level. For example: 22, 23.<% if(isHtml) { %> For a complete list of the Android API levels and their corresponding Android versions, click [here](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#platform).<% } %>
+
+<% if(isHtml) { %>
 ### Command Limitations
 
 * When the `--release` flag is set, you must also specify all `--key-store-*` options.

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -81,6 +81,7 @@ interface IOptions extends ICommonOptions {
 	ignoreScripts: boolean;
 	tnsModulesVersion: string;
 	staticBindings: boolean;
+	compileSdk: number;
 }
 
 interface IProjectFilesManager {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -29,7 +29,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			sdk: { type: OptionType.String },
 			ignoreScripts: {type: OptionType.Boolean },
 			tnsModulesVersion: { type: OptionType.String },
-			staticBindings: {type: OptionType.Boolean}
+			staticBindings: {type: OptionType.Boolean},
+			compileSdk: {type: OptionType.Number }
 		},
 		path.join($hostInfo.isWindows ? process.env.LocalAppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),
 			$errors, $staticConfig);


### PR DESCRIPTION
Users should be able to select compileSdk. Add `--compileSdk` option and
DO NOT verify it against our min required compile sdk.
This implements:
https://github.com/NativeScript/nativescript-cli/issues/927

Set min required compileSdk to 22 according to:
https://github.com/NativeScript/nativescript-cli/issues/920