### PR TITLE
Fix run/debug after livesync

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -51,6 +51,7 @@ interface IPlatformProjectService {
 	removePluginNativeCode(pluginData: IPluginData): IFuture<void>;
 	afterPrepareAllPlugins(): IFuture<void>;
 	getAppResourcesDestinationDirectoryPath(): IFuture<string>;
+	deploy(device: Mobile.IDevice, appIdentifier: string): IFuture<void>;
 }
 
 interface IAndroidProjectPropertiesManager {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -28,7 +28,8 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 		private $projectData: IProjectData,
 		private $projectDataService: IProjectDataService,
 		private $propertiesParser: IPropertiesParser,
-		private $sysInfo: ISysInfo) {
+		private $sysInfo: ISysInfo,
+		private $mobileHelper: Mobile.IMobileHelper) {
 			super($fs);
 			this._androidProjectPropertiesManagers = Object.create(null);
 	}
@@ -283,6 +284,15 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 
 	public afterPrepareAllPlugins(): IFuture<void> {
 		return Future.fromResult();
+	}
+
+	public deploy(device: Mobile.IAndroidDevice, appIdentifier: string): IFuture<void> {
+		return (() => {
+			let deviceRootPath = `/data/local/tmp/${appIdentifier}`;
+			device.adb.executeShellCommand(["rm", "-rf", this.$mobileHelper.buildDevicePath(deviceRootPath, "fullsync"),
+				this.$mobileHelper.buildDevicePath(deviceRootPath, "sync"),
+				this.$mobileHelper.buildDevicePath(deviceRootPath, "removedsync")]).wait();
+		}).future<void>()();
 	}
 
 	private _canUseGradle: boolean;

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -10,6 +10,7 @@ import * as xcode from "xcode";
 import * as constants from "../constants";
 import * as helpers from "../common/helpers";
 import * as projectServiceBaseLib from "./platform-project-service-base";
+import Future = require("fibers/future");
 
 export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServiceBase implements IPlatformProjectService {
 	private static XCODE_PROJECT_EXT_NAME = ".xcodeproj";
@@ -205,6 +206,10 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				this.$errors.failWithoutHelp(`The bundle at ${libraryPath} does not appear to be a dynamic framework package.`);
 			}
 		}).future<void>()();
+	}
+
+	public deploy(device: Mobile.IDevice, appIdentifier: string): IFuture<void> {
+		return Future.fromResult();
 	}
 
 	private addDynamicFramework(frameworkPath: string): IFuture<void> {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -274,6 +274,7 @@ export class PlatformService implements IPlatformService {
 			this.$devicesServices.initialize({platform: platform, deviceId: this.$options.device}).wait();
 			let action = (device: Mobile.IDevice): IFuture<void> => {
 				return (() => {
+					platformData.platformProjectService.deploy(device, this.$projectData.projectId).wait();
 					device.deploy(packageFile, this.$projectData.projectId).wait();
 
 					if (!this.$options.justlaunch) {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -322,6 +322,9 @@ export class PlatformProjectServiceStub implements IPlatformProjectService {
 	afterPrepareAllPlugins(): IFuture<void> {
 		return Future.fromResult();
 	}
+	deploy(device: Mobile.IAndroidDevice, appIdentifier: string): IFuture<void> {
+		return Future.fromResult();
+	}
 }
 
 export class ProjectDataService implements IProjectDataService {


### PR DESCRIPTION
Due to some policy restrictions on devices with apilevel 21+, android runtime is not able to delete sync directories. This way if some files are changed after livesync, changes are not applied on the device.

Fixes https://github.com/NativeScript/nativescript-cli/issues/943