### PR TITLE
Fix deployment target altering in CocoaPods setup.

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -519,16 +519,16 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				let pluginPodFileContent = this.$fs.readText(pluginPodFilePath).wait();
 				let contentToWrite = this.buildPodfileContent(pluginPodFilePath, pluginPodFileContent);
 				this.$fs.appendFile(this.projectPodFilePath, contentToWrite).wait();
+
+				let project = this.createPbxProj();
+				project.updateBuildProperty("IPHONEOS_DEPLOYMENT_TARGET", "8.0");
+				this.$logger.info("The iOS Deployment Target is now 8.0 in order to support Cocoa Touch Frameworks in CocoaPods.");
+				this.savePbxProj(project).wait();
 			}
 
 			if(opts && opts.executePodInstall && this.$fs.exists(pluginPodFilePath).wait()) {
 				this.executePodInstall().wait();
 			}
-
-			let project = this.createPbxProj();
-			project.updateBuildProperty("IPHONEOS_DEPLOYMENT_TARGET", "8.0");
-			this.$logger.info("The iOS Deployment Target is now 8.0 in order to support Cocoa Touch Frameworks.");
-			this.savePbxProj(project).wait();
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
Fix incorrect deployment target altering on `prepare` phase. This is caused by CocoaPods prepare step when a plugin is being processed.
See issue: https://github.com/NativeScript/nativescript-cli/issues/1012
Other related issues: https://github.com/NativeScript/nativescript-cli/issues/944

Re-target https://github.com/NativeScript/nativescript-cli/pull/1013