### PR TITLE
Don't save empty object into package.json file

### DIFF
--- a/lib/services/plugin-variables-service.ts
+++ b/lib/services/plugin-variables-service.ts
@@ -26,8 +26,10 @@ export class PluginVariablesService implements IPluginVariablesService {
 					values[pluginVariableData.name] = pluginVariableValue;
 				}).future<void>()()).wait();
 
-			this.$projectDataService.initialize(this.$projectData.projectDir);
-			this.$projectDataService.setValue(this.getPluginVariablePropertyName(pluginData), values).wait();
+			if(!_.isEmpty(values)) {
+				this.$projectDataService.initialize(this.$projectData.projectDir);
+				this.$projectDataService.setValue(this.getPluginVariablePropertyName(pluginData), values).wait();
+			}
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
1. Add plugin that doesn't have plugin variables
2. Open pacakge.json
3. We've added:  "[plugin-name]-variables": {}