### PR TITLE
Pass wait for debugger option. Handle simulator output so that we cou…

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -12,7 +12,6 @@ import semver = require("semver");
 import temp = require("temp");
 import byline = require("byline");
 
-
 module notification {
     function formatNotification(bundleId: string, notification: string) {
         return `${bundleId}:NativeScript.Debug.${notification}`;
@@ -125,15 +124,15 @@ class IOSDebugService implements IDebugService {
 
             lineStream.on('data', (line: NodeBuffer) => {
                 let lineText = line.toString();
-                if(lineText && _.startsWith(lineText, emulatorPackage.packageName)) {                   
+                if(lineText && _.startsWith(lineText, emulatorPackage.packageName)) {
                     let pid = _.trimLeft(lineText, emulatorPackage.packageName + ": ");
-                    
+
                     this.$childProcess.exec(`lldb -p ${pid} -o "process continue"`);
                 } else {
                     process.stdout.write(line + "\n");
                 }
             });
-            
+
             this.wireDebuggerClient(() => net.connect(InspectorBackendPort)).wait();
         }).future<void>()();
     }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp": "3.9.0",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-sim-portable": "1.0.9-beta",
+    "ios-sim-portable": "1.0.10-alpha",
     "lockfile": "1.0.1",
     "lodash": "3.10.0",
     "log4js": "0.6.26",


### PR DESCRIPTION
…ld retrieve the PID of the running application.

If you break on a line before executing UIApplicationMain, the Simulator crashes the app after a few seconds. To workaround that behavior we attach lldb which must be killed after the debugging session ends.

Part of the fix for NativeScript/nativescript-cli#1044