### PR TITLE
Use correct .apk name

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -39,7 +39,7 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 	public get platformData(): IPlatformData {
 		if (!this._platformData) {
 			let projectRoot = path.join(this.$projectData.platformsDir, "android");
-
+			let packageName = this.getProjectNameFromId();
 			this._platformData = {
 				frameworkPackageName: "tns-android",
 				normalizedPlatformName: "Android",
@@ -49,6 +49,8 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 				projectRoot: projectRoot,
 				deviceBuildOutputPath: path.join(projectRoot, "build", "outputs", "apk"),
 				validPackageNamesForDevice: [
+					`${packageName}-debug.apk`,
+					`${packageName}-release.apk`,
 					`${this.$projectData.projectName}-debug.apk`,
 					`${this.$projectData.projectName}-release.apk`
 				],
@@ -143,9 +145,13 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 			shell.sed('-i', /__TITLE_ACTIVITY__/, this.$projectData.projectName, stringsFilePath);
 
 			let gradleSettingsFilePath = path.join(this.platformData.projectRoot, "settings.gradle");
-			shell.sed('-i', /__PROJECT_NAME__/, this.$projectData.projectId.split(".")[2], gradleSettingsFilePath);
+			shell.sed('-i', /__PROJECT_NAME__/, this.getProjectNameFromId(), gradleSettingsFilePath);
 			shell.sed('-i', /__APILEVEL__/, this.$options.sdk || this.$androidToolsInfo.getToolsInfo().wait().compileSdkVersion.toString(), manifestPath);
 		}).future<void>()();
+	}
+
+	private getProjectNameFromId(): string {
+		return this.$projectData.projectId.split(".")[2];
 	}
 
 	public afterCreateProject(projectRoot: string): IFuture<void> {


### PR DESCRIPTION
Gradle uses the third part of the identifier for apk name. Currently we are
checking for projectName (created from dir name). Check both of them when
searching for apk.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1041