### PR TITLE
Fix tns init command

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -151,7 +151,12 @@ class AndroidProjectService extends projectServiceBaseLib.PlatformProjectService
 	}
 
 	private getProjectNameFromId(): string {
-		return this.$projectData.projectId.split(".")[2];
+		let id: string;
+		if(this.$projectData && this.$projectData.projectId) {
+			id = this.$projectData.projectId.split(".")[2];
+		}
+
+		return id;
 	}
 
 	public afterCreateProject(projectRoot: string): IFuture<void> {


### PR DESCRIPTION
When tns init command is called in empty directory, there's no project data
and getting projectName from projectId is failing.