### PR TITLE
Add --copy-to option to build command

### DIFF
--- a/docs/man_pages/project/testing/build-android.md
+++ b/docs/man_pages/project/testing/build-android.md
@@ -3,7 +3,7 @@ build android
 
 Usage | Synopsis
 ---|---
-General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--static-bindings]`
+General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--static-bindings] [--copy-to <File Path>]`
 
 Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 
@@ -15,6 +15,7 @@ Builds the project for Android and produces an APK that you can manually deploy 
 * `--key-store-alias` - Provides the alias for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-alias-password` - Provides the password for the alias specified with `--key-store-alias-password`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--static-bindings` - **This is an experimental feature**. If set, generates static bindings from your JavaScript code to corresponding native Android APIs during build. This static bindings speed up app loading.[\*\*](#note)
+* `--copy-to` - Specifies the file path where the built `.apk` will be copied. If it points to a non-existent directory, it will be created. If the specified value is directory, the original file name will be used.
 
 <% if(isHtml) { %><a id="note"></a><% } %>
 \*\* By default, NativeScript runtime for Android uses runtime binding generator. When you extend a Java class and overwrite a lot of methods, this could be a potentially slow operation.

--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -3,19 +3,20 @@ build ios
 
 Usage | Synopsis
 ---|---
-General | `$ tns build ios [--for-device] [--release]`
+General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>]`
 
 Builds the project for iOS and produces an `APP` or `IPA` that you can manually deploy in the iOS Simulator or on device, respectively.
 
-<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help build ios`<% } %> 
-<% if((isConsole && isMacOS) || isHtml) { %>  
-<% if(isHtml) { %>> <% } %>IMPORTANT: Before building for iOS device, verify that you have configured a valid pair of certificate and provisioning profile on your OS X system. <% if(isHtml) { %>For more information, see [Obtaining Signing Identities and Downloading Provisioning Profiles](https://developer.apple.com/library/mac/recipes/xcode_help-accounts_preferences/articles/obtain_certificates_and_provisioning_profiles.html).<% } %> 
+<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help build ios`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>
+<% if(isHtml) { %>> <% } %>IMPORTANT: Before building for iOS device, verify that you have configured a valid pair of certificate and provisioning profile on your OS X system. <% if(isHtml) { %>For more information, see [Obtaining Signing Identities and Downloading Provisioning Profiles](https://developer.apple.com/library/mac/recipes/xcode_help-accounts_preferences/articles/obtain_certificates_and_provisioning_profiles.html).<% } %>
 
 ### Options
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 * `--for-device` - If set, produces an application package that you can deploy on device. Otherwise, produces a build that you can run only in the native iOS Simulator.
+* `--copy-to` - Specifies the file path where the built `.ipa` will be copied. If it points to a non-existent directory, it will be created. If the specified value is directory, the original file name will be used.
 <% } %>
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Command Limitations
 
 * You can run `$ tns build ios` only on OS X systems.

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -82,6 +82,7 @@ interface IOptions extends ICommonOptions {
 	tnsModulesVersion: string;
 	staticBindings: boolean;
 	compileSdk: number;
+	copyTo: string;
 }
 
 interface IProjectFilesManager {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -16,6 +16,7 @@ interface IPlatformService {
 
 	getLatestApplicationPackageForDevice(platformData: IPlatformData): IFuture<IApplicationPackage>;
 	getLatestApplicationPackageForEmulator(platformData: IPlatformData): IFuture<IApplicationPackage>;
+	copyLastOutput(platform: string, targetPath: string, settings: {isForDevice: boolean}): IFuture<void>;
 }
 
 interface IPlatformData {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -30,7 +30,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			ignoreScripts: {type: OptionType.Boolean },
 			tnsModulesVersion: { type: OptionType.String },
 			staticBindings: {type: OptionType.Boolean},
-			compileSdk: {type: OptionType.Number }
+			compileSdk: {type: OptionType.Number },
+			copyTo: { type: OptionType.String }
 		},
 		path.join($hostInfo.isWindows ? process.env.LocalAppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),
 			$errors, $staticConfig);


### PR DESCRIPTION
Add --copy-to option to build command that allows copying the built file (.apk or .ipa)
to a specified place. For example:
```
tns build android --copy-to ./
```
or
```
tns build android --copy-to ./myDir/out.apk
```
In case the output dir does not exist, it will be created. In case the specified value
for `copy-to` option is directory, the original filename will be used.

Required for easier integration of NativeScript in AppBuilder.