### PR TITLE
Always call npm install when preparing project

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -189,13 +189,11 @@ export class PluginsService implements IPluginsService {
 
 	public ensureAllDependenciesAreInstalled(): IFuture<void> {
 		return (() => {
-			if(!this.$fs.exists(path.join(this.$projectData.projectDir, constants.NODE_MODULES_FOLDER_NAME)).wait()) {
-				let command = "npm install ";
-				if(this.$options.ignoreScripts) {
-					command += "--ignore-scripts";
-				}
-				this.$childProcess.exec(command, { cwd: this.$projectData.projectDir }).wait();
+			let command = "npm install ";
+			if(this.$options.ignoreScripts) {
+				command += "--ignore-scripts";
 			}
+			this.$childProcess.exec(command, { cwd: this.$projectData.projectDir }).wait();
 		}).future<void>()();
 	}
 

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -192,7 +192,10 @@ describe("Npm support tests", () => {
 		let scopedName = "@reactivex/rxjs";
 		let scopedModule = path.join(projectFolder, "node_modules", "@reactivex/rxjs");
 		let scopedPackageJson = path.join(scopedModule, "package.json");
-		addDependencies(testInjector, projectFolder, {scopedName:  "0.0.0-prealpha.3"}).wait();
+		let dependencies: any = {};
+		dependencies[scopedName] = "0.0.0-prealpha.3";
+		// Do not pass dependencies object as the sinopia cannot work with scoped dependencies. Instead move them manually.
+		addDependencies(testInjector, projectFolder, {}).wait();
 		//create module dir, and add a package.json
 		shelljs.mkdir("-p", scopedModule);
 		fs.writeFile(scopedPackageJson, JSON.stringify({name: scopedName})).wait();


### PR DESCRIPTION
Preparing project should always call `npm install` just to make sure all dependencies
are installed. Currently we are not calling it when node_modules dir exists.
This was due to requirement that when you have node_modules and change something in
node_modules/tns-core-modules directory, `npm install` will override your changes.
The fact is that this is totally incorrect behavior on our side and also making changes
in `node_modules/<package_name>` is forbidden. Anyway, in case you make changes there,
calling `npm install` will not override them.

Remove the incorrect check and always call `npm install`.

Fix unit test which was passing due to missing npm install before. The problem with it now is that 
```
{scopedName:  "0.0.0-prealpha.3"}
```
Will create an object with property "scopedName" instead of the required one `"@reactivex/rxjs"`.