### PR TITLE
Fix usage of --frameworkPath <directory> with --symlink

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -94,9 +94,19 @@ export class PlatformService implements IPlatformService {
 	private addPlatformCore(platformData: IPlatformData, frameworkDir: string): IFuture<void> {
 		return (() => {
 			let installedVersion = this.$fs.readJson(path.join(frameworkDir, "../", "package.json")).wait().version;
-			platformData.platformProjectService.createProject(frameworkDir, installedVersion).wait();
+			let isFrameworkPathDirectory = false,
+				isFrameworkPathNotSymlinkedFile = false;
 
-			if(this.$options.frameworkPath && !this.$options.symlink) {
+			if(this.$options.frameworkPath) {
+				let frameworkPathStats = this.$fs.getFsStats(this.$options.frameworkPath).wait();
+				isFrameworkPathDirectory = frameworkPathStats.isDirectory();
+				isFrameworkPathNotSymlinkedFile = !this.$options.symlink && frameworkPathStats.isFile();
+			}
+
+			let sourceFrameworkDir = isFrameworkPathDirectory && this.$options.symlink ? path.join(this.$options.frameworkPath, "framework") : frameworkDir;
+			platformData.platformProjectService.createProject(sourceFrameworkDir, installedVersion).wait();
+
+			if(isFrameworkPathDirectory || isFrameworkPathNotSymlinkedFile) {
 				// Need to remove unneeded node_modules folder
 				// One level up is the runtime module and one above is the node_modules folder.
 				this.$fs.deleteDirectory(path.join(frameworkDir, "../../")).wait();

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -104,7 +104,7 @@ export class PlatformService implements IPlatformService {
 			}
 
 			let sourceFrameworkDir = isFrameworkPathDirectory && this.$options.symlink ? path.join(this.$options.frameworkPath, "framework") : frameworkDir;
-			platformData.platformProjectService.createProject(sourceFrameworkDir, installedVersion).wait();
+			platformData.platformProjectService.createProject(path.resolve(sourceFrameworkDir), installedVersion).wait();
 
 			if(isFrameworkPathDirectory || isFrameworkPathNotSymlinkedFile) {
 				// Need to remove unneeded node_modules folder

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -20,8 +20,6 @@ import * as helpers from "../lib/common/helpers";
 import {assert} from "chai";
 import {Options} from "../lib/options";
 import {HostInfo} from "../lib/common/host-info";
-import {IOSProjectService} from "../lib/services/ios-project-service";
-import * as shell from "shelljs";
 
 let mockProjectNameValidator = {
 	validate: () => { return true; }
@@ -153,44 +151,6 @@ describe("Project Service Tests", () => {
 			projectIntegrationTest.createProject(projectName).wait();
 			projectIntegrationTest.assertProject(tempFolder, projectName, options.appid).wait();
 		});
-		it("creates ios project and tests post-install sandboxing of CocoaPods setup", () => {
-			if (require("os").platform() !== "darwin") {
-				console.log("Skipping CocoaPods sandbox test. It works only on darwin.");
-				return;
-			}
-
-			let testDirectoryPath = "/tmp/Podfile";
-			let testInjector = createInjectorForPodsTest();
-			let iOSProjectService: IPlatformProjectService = testInjector.resolve("iOSProjectService");
-			let fs: IFileSystem = testInjector.resolve("fs");
-			let projectIntegrationTest = new ProjectIntegrationTest();
-			let workingFolderPath = temp.mkdirSync("ios_project");
-			let iosTemplatePath = path.join(projectIntegrationTest.getNpmPackagePath("tns-ios").wait(), "framework/");
-			let postInstallCommmand = `\`cat ${testDirectoryPath}/testFile.txt > ${workingFolderPath}/copyTestFile.txt && rm -rf ${testDirectoryPath}\``;
-			let podfileContent = `post_install do |installer_representation| ${postInstallCommmand} end`;
-			let platformData =  iOSProjectService.platformData;
-
-			shell.cp("-R", iosTemplatePath, workingFolderPath);
-
-			fs.writeFile(`${testDirectoryPath}/testFile.txt`, "Test content.").wait();
-			fs.writeFile(path.join(workingFolderPath, "Podfile"), podfileContent).wait();
-
-			Object.defineProperty(iOSProjectService, "platformData", {
-				get: () => {
-					return { projectRoot: workingFolderPath };
-				}
-			});
-
-			try {
-				iOSProjectService.afterPrepareAllPlugins().wait();
-			} finally {
-				Object.defineProperty(iOSProjectService, "platformData", platformData);
-			}
-
-			assert.isTrue(fs.exists(testDirectoryPath).wait());
-			assert.isTrue(fs.exists(path.join(workingFolderPath, "copyTestFile.txt")).wait());
-			fs.deleteDirectory(testDirectoryPath).wait(); // Clean up 'tmp' after test ends.
-		});
 	});
 });
 
@@ -218,42 +178,6 @@ function createTestInjector() {
 	testInjector.register('projectData', ProjectDataLib.ProjectData);
 	testInjector.register("options", Options);
 	testInjector.register("hostInfo", HostInfo);
-
-	return testInjector;
-}
-
-function createInjectorForPodsTest() {
-	let testInjector = new yok.Yok();
-
-	testInjector.register("errors", stubs.ErrorsStub);
-	testInjector.register('logger', stubs.LoggerStub);
-	testInjector.register("projectHelper", {});
-	testInjector.register("projectData", {
-		projectName: "__PROJECT_NAME__",
-		platformsDir: ""
-	});
-	testInjector.register("iOSEmulatorServices", {});
-	testInjector.register("config", {
-		"USE_POD_SANDBOX": true
-	});
-	testInjector.register("prompter", {});
-	testInjector.register("fs", FileSystem);
-	testInjector.register("staticConfig", StaticConfig);
-	testInjector.register("npmInstallationManager", NpmInstallationManager);
-	testInjector.register("iOSProjectService", IOSProjectService);
-	testInjector.register("projectService", ProjectServiceLib.ProjectService);
-	testInjector.register("pluginsService", {
-		getAllInstalledPlugins: () => {
-			return (() => {
-				return <any>[];
-			}).future<IPluginData[]>()();
-		}
-	});
-	testInjector.register("fs", FileSystem);
-	testInjector.register("projectDataService", ProjectDataServiceLib.ProjectDataService);
-	testInjector.register("options", Options);
-	testInjector.register("hostInfo", HostInfo);
-	testInjector.register("childProcess", ChildProcess);
 
 	return testInjector;
 }


### PR DESCRIPTION
When `--frameworkPath` is used, we should follow this behavior:
Always install to `node_modules` under `platforms/<platform_name>/node_modules`

options used   | is frameworkPath File | is frameworkPath Directory
---------|--------|------------
frameworkPath + symlink | symlink to node_modules. **DO NOT DELETE node_modules**. | symlink to **frameworkPath dir**. Delete node_modules.
frameworkPath | Delete node_modules. | Delete node_modules.