### PR TITLE
Do not call npm install if everything is installed

### DIFF
--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -84,7 +84,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 				.sortBy(verData => verData.patch)
 				.value();
 
-			let result = _.last(compatibleVersions);
+			let result = _.last(compatibleVersions) || this.getVersionData(latestVersion);
 
 			let latestCompatibleVersion = `${result.major}.${result.minor}.${result.patch}`;
 			return latestCompatibleVersion;

--- a/test/npm-installation-manager.ts
+++ b/test/npm-installation-manager.ts
@@ -72,6 +72,7 @@ describe("Npm installation manager tests", () => {
 		let expectedLatestCompatibleVersion = "1.4.0";
 		assert.equal(actualLatestCompatibleVersion, expectedLatestCompatibleVersion);
 	});
+
 	it("returns correct latest compatible version", () => {
 		let testInjector = createTestInjector();
 
@@ -91,5 +92,24 @@ describe("Npm installation manager tests", () => {
 		let actualLatestCompatibleVersion = npmInstallationManager.getLatestCompatibleVersion("").wait();
 		let expectedLatestCompatibleVersion = "1.3.3";
 		assert.equal(actualLatestCompatibleVersion, expectedLatestCompatibleVersion);
+	});
+
+	it("returns correct latest compatible version", () => {
+		let testInjector = createTestInjector();
+
+		let versions = ["1.2.0", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.4.0"];
+		let latestVersion = _.last(versions);
+		mockNpm(testInjector, versions, latestVersion);
+
+		// Mock staticConfig.version
+		let staticConfig = testInjector.resolve("staticConfig");
+		staticConfig.version = "1.5.0";
+
+		// Mock npmInstallationManager.getLatestVersion
+		let npmInstallationManager = testInjector.resolve("npmInstallationManager");
+		npmInstallationManager.getLatestVersion = (packageName: string) => Future.fromResult(latestVersion);
+
+		let actualLatestCompatibleVersion = npmInstallationManager.getLatestCompatibleVersion("").wait();
+		assert.equal(actualLatestCompatibleVersion, latestVersion);
 	});
 });


### PR DESCRIPTION
In case there's node_modules dir and there's directory for each dependency defined
in package.json of the project, we should not call `npm install`. In case `node_modules` dir
does not exist and the project has dependencies or any of the dependencies is not installed,
we'll call `npm install`. Another case when we'll call `npm install` is when `--force` option is used.

This change is in order to allow modifications of modules inside `node_modules` directory.

## Second commit
Install latest available version if no matching version is found

In case CLI is version 1.4.x, on platform add we are trying to install latest available
1.4.x runtime. In case there's no 1.4.x version, the code fails. 
Instead we should install latest available version in this case.
