### PR TITLE
Livesync typescript

### DIFF
--- a/lib/services/usb-livesync-service.ts
+++ b/lib/services/usb-livesync-service.ts
@@ -10,7 +10,7 @@ import Future = require("fibers/future");
 
 export class UsbLiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncServiceBase implements IUsbLiveSyncService {
 	private excludedProjectDirsAndFiles = [
-		"app_resources"
+		"**/*.ts",
 	];
 
 	constructor($devicesServices: Mobile.IDevicesServices,


### PR DESCRIPTION
This one is mostly aimed at fixing the double app restart issue when livesyncing TypeScript projects. The first time you save a `.ts` file it gets synced to the device (completely unnecessarily), then you need another sync after you run your compiler.

-----
Changes:

- Exclude `*.ts` files. No need to livesync them.
- Include the excluded files match fix from `lib/common`
- Fix `app_resources` exclude mask too by using the proper `**/app_resources/** form.