### PR TITLE
Fix fs copyFile when source and target are the same

### DIFF
--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -164,6 +164,10 @@ export class FileSystemStub implements IFileSystem {
 	readStdin(): IFuture<string> {
 		return undefined;
 	}
+
+	renameIfExists(oldPath: string, newPath: string): IFuture<boolean> {
+		return undefined;
+	}
 }
 
 export class ErrorsStub implements IErrors {


### PR DESCRIPTION
When source and target file are the same, copyFile produces empty file.
Add check and if they are the same, do not execute any action.

Move fs tests from appbuilder-cli to common. Add tests for copyFile.