### PR TITLE
Fail if sandbox install command fails

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -517,16 +517,19 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			let childProcess = this.$childProcess.spawnFromEvent(podTool,  ["install"], "close", { cwd: this.platformData.projectRoot, stdio: ['pipe', process.stdout, 'pipe'] }).wait();
 			if (childProcess.stderr) {
 				let warnings = childProcess.stderr.match(/(\u001b\[(?:\d*;){0,5}\d*m[\s\S]+?\u001b\[(?:\d*;){0,5}\d*m)|(\[!\].*?\n)/g);
-				let result = _.reduce(warnings, (result: string, warning: string) => {
-					return result + `[Warning]${warning.replace("\n", "")}${os.EOL}`.yellow;
-				}, "");
-				this.$logger.info(result);
+				_.each(warnings, (warning: string) => {
+					this.$logger.warnWithLabel(warning.replace("\n", ""));
+				});
 
-				let errors = childProcess.stderr;
+				// HACK for silencing irrelevant linking warnings when pod installing on
+				// El Capitan with cocoa pods version 0.38.2
+				// Reference https://github.com/CocoaPods/CocoaPods/issues/4302
+				let errors = childProcess.stderr.replace(/dyld: warning, LC_RPATH @executable_path.*?@executable_path/g, "");
 				_.each(warnings, warning => {
 					errors = errors.replace(warning, "");
 				});
-				if(errors) {
+
+				if(errors.trim()) {
 					this.$errors.failWithoutHelp(`Pod install command failed. Error output: ${errors}`);
 				}
 			}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -209,7 +209,7 @@ export class PlatformService implements IPlatformService {
 			} catch(error) {
 				this.$logger.debug(error);
 				shell.rm("-rf", appResourcesDirectoryPath);
-				this.$errors.fail(`Processing node_modules failed. Error:${error}`);
+				this.$errors.failWithoutHelp(`Processing node_modules failed. ${error}`);
 			}
 
 			// Process platform specific files

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -11,6 +11,7 @@ export class LoggerStub implements ILogger {
 	fatal(...args: string[]): void {}
 	error(...args: string[]): void {}
 	warn(...args: string[]): void {}
+	warnWithLabel(...args: string[]): void {}
 	info(...args: string[]): void {}
 	debug(...args: string[]): void {}
 	trace(...args: string[]): void {}


### PR DESCRIPTION
sandbox-pod install blocks arbitrary post-install scripts but returns with an exit code of 0. This is why we have to check the stderr for any data and fail if it is present.
Also help should not be displayed in case such a fail occurs.