### PR TITLE
Improve Getting-started for Android

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -77,5 +77,29 @@ export class StaticConfig extends staticConfigBaseLibPath.StaticConfigBase imple
 	public get PATH_TO_BOOTSTRAP() : string {
 		return path.join(__dirname, "bootstrap");
 	}
+
+	public getAdbFilePath(): IFuture<string> {
+		return (() => {
+			if(!this._adbFilePath) {
+				let androidHomeEnvVar = process.env.ANDROID_HOME;
+				if(androidHomeEnvVar) {
+					let pathToAdb = path.join(androidHomeEnvVar, "platform-tools", "adb");
+					let childProcess: IChildProcess = this.$injector.resolve("$childProcess");
+					try {
+						childProcess.execFile(pathToAdb, ["help"]).wait();
+						this._adbFilePath = pathToAdb;
+					} catch (err) {
+						// adb does not exist, so ANDROID_HOME is not set correctly
+						// try getting default adb path (included in CLI package)
+						super.getAdbFilePath().wait();
+					}
+				} else {
+					super.getAdbFilePath().wait();
+				}
+			}
+
+			return this._adbFilePath;
+		}).future<string>()();
+	}
 }
 $injector.register("staticConfig", StaticConfig);

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -115,6 +115,21 @@ interface IAndroidToolsInfo {
 	 * @return {boolean} True if there are detected issues, false otherwise.
 	 */
 	validateInfo(options?: {showWarningsAsErrors: boolean, validateTargetSdk: boolean}): IFuture<boolean>;
+
+	/**
+	 * Validates the information about required JAVA version.
+	 * @param {string} installedJavaVersion The JAVA version that will be checked.
+	 * @param {any} options Defines if the warning messages should treated as error.
+	 * @return {boolean} True if there are detected issues, false otherwise.
+	 */
+	validateJavacVersion(installedJavaVersion: string, options?: {showWarningsAsErrors: boolean}): IFuture<boolean>;
+
+	/**
+	 * Returns the path to `android` executable. It should be `$ANDROID_HOME/tools/android`.
+	 * In case ANDROID_HOME is not defined, check if `android` is part of $PATH.
+	 * @return {boolean} Path to the `android` executable.
+	 */
+	getPathToAndroidExecutable(): IFuture<string>;
 }
 
 /**

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -36,17 +36,34 @@ class DoctorService implements IDoctorService {
 			this.printPackageManagerTip();
 			result = true;
 		}
-		if (this.$hostInfo.isDarwin && !sysInfo.xcodeVer) {
-			this.$logger.warn("WARNING: Xcode is not installed or is not configured properly.");
-			this.$logger.out("You will not be able to build your projects for iOS or run them in the iOS Simulator." + EOL
-			+ "To be able to build for iOS and run apps in the native emulator, verify that you have installed Xcode." + EOL);
-			result = true;
-		}
-		if (!this.$hostInfo.isDarwin) {
+
+		if (this.$hostInfo.isDarwin) {
+			if(!sysInfo.xcodeVer) {
+				this.$logger.warn("WARNING: Xcode is not installed or is not configured properly.");
+				this.$logger.out("You will not be able to build your projects for iOS or run them in the iOS Simulator." + EOL
+				+ "To be able to build for iOS and run apps in the native emulator, verify that you have installed Xcode." + EOL);
+				result = true;
+			}
+
+			if(!sysInfo.cocoapodVer ) {
+				this.$logger.warn("WARNING: CocoaPod is not installed or is not configured properly.");
+				this.$logger.out("You will not be able to build your projects for iOS if they contain plugin with CocoaPod file." + EOL
+					+ "To be able to build such projects, verify that you have installed CocoaPod.");
+				result = true;
+			}
+
+			if(sysInfo.cocoapodVer && semver.lt(sysInfo.cocoapodVer, DoctorService.MIN_SUPPORTED_POD_VERSION)) {
+				this.$logger.warn(`WARNING: CocoaPods version is lower than ${DoctorService.MIN_SUPPORTED_POD_VERSION}`);
+				this.$logger.out("You will not be able to build your projects for iOS if they contain plugin with CocoaPod file." + EOL
+					+ `To be able to build such projects, verify that you have at least ${DoctorService.MIN_SUPPORTED_POD_VERSION} version installed.`);
+				result = true;
+			}
+		} else {
 			this.$logger.warn("WARNING: You can work with iOS only on Mac OS X systems.");
 			this.$logger.out("To be able to work with iOS devices and projects, you need Mac OS X Mavericks or later." + EOL);
 			result = true;
 		}
+
 		if(!sysInfo.javaVer) {
 			this.$logger.warn("WARNING: The Java Development Kit (JDK) is not installed or is not configured properly.");
 			this.$logger.out("You will not be able to work with the Android SDK and you might not be able" + EOL
@@ -57,30 +74,9 @@ class DoctorService implements IDoctorService {
 			result = true;
 		}
 
-		if(!sysInfo.javacVersion) {
-			this.$logger.warn("WARNING: Javac is not installed or is not configured properly.");
-			this.$logger.out("You will not be able to build your projects for Android." + EOL
-				+ "To be able to build for Android, verify that you have installed The Java Development Kit (JDK) and configured it according to system requirements as" + EOL +
-				" described in https://github.com/NativeScript/nativescript-cli#system-requirements.");
-			result = true;
-		}
-
-		if(!sysInfo.cocoapodVer) {
-			this.$logger.warn("WARNING: CocoaPod is not installed or is not configured properly.");
-			this.$logger.out("You will not be able to build your projects for iOS if they contain plugin with CocoaPod file." + EOL
-				+ "To be able to build such projects, verify that you have installed CocoaPod.");
-			result = true;
-		}
-
-		if(sysInfo.cocoapodVer && semver.lt(sysInfo.cocoapodVer, DoctorService.MIN_SUPPORTED_POD_VERSION)) {
-			this.$logger.warn(`WARNING: CocoaPod version is lower than ${DoctorService.MIN_SUPPORTED_POD_VERSION}`);
-			this.$logger.out("You will not be able to build your projects for iOS if they contain plugin with CocoaPod file." + EOL
-				+ `To be able to build such projects, verify that you have at least ${DoctorService.MIN_SUPPORTED_POD_VERSION} version installed.`);
-			result = true;
-		}
-
 		let androidToolsIssues = this.$androidToolsInfo.validateInfo().wait();
-		return result || androidToolsIssues;
+		let javaVersionIssue = this.$androidToolsInfo.validateJavacVersion(sysInfo.javacVersion).wait();
+		return result || androidToolsIssues || javaVersionIssue;
 	}
 
 	private printPackageManagerTip() {


### PR DESCRIPTION
* Remove requirement to have `<android-sdk>/tools` and `<android-sdk>/platform-tools` directories to your PATH - use them based on ANDROID_HOME variable.
* Based on the above point - replace all calls to `android` directly with correct path to the `android` executable.
* Remove requirement for JAVA added in your PATH - validate it by using JAVA_HOME.
* Improve error messages when ANDROID_HOME is not set - for example warning about missing compile SDK will inform you in case ANDROID_HOME is not set.
* Improve ANDROID_HOME checks - validate that directories like "extras", "tools", "platform-tools" exist (at least on of them).
* Validate JAVA version in doctor command.
* Sometimes `build-tools` directories are not called with version(`22.0.1`), but have the name: `build-tools-22.0.1` - make sure we will be able to use such dirs
* Skip cocoapods warnings on Linux and Windows (for `tns doctor` command).