### PR TITLE
Fix doctor command for android and adb

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -180,7 +180,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 	public getPathToAdbFromAndroidHome(): IFuture<string> {
 		return (() => {
 			if(this.androidHome) {
-				let pathToAdb = path.join(this.androidHome, "platform-tools", "adb") + (this.$hostInfo.isWindows ? ".exe" : "");
+				let pathToAdb = path.join(this.androidHome, "platform-tools", "adb");
 				try {
 					this.$childProcess.execFile(pathToAdb, ["help"]).wait();
 					return pathToAdb;

--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -149,7 +149,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 				}
 			}
 
-			return detectedErrors || isAndroidHomeValid;
+			return detectedErrors || !isAndroidHomeValid;
 		}).future<boolean>()();
 	}
 
@@ -175,6 +175,24 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 
 			return hasProblemWithJavaVersion;
 		}).future<boolean>()();
+	}
+
+	public getPathToAdbFromAndroidHome(): IFuture<string> {
+		return (() => {
+			if(this.androidHome) {
+				let pathToAdb = path.join(this.androidHome, "platform-tools", "adb") + (this.$hostInfo.isWindows ? ".exe" : "");
+				try {
+					this.$childProcess.execFile(pathToAdb, ["help"]).wait();
+					return pathToAdb;
+				} catch (err) {
+					// adb does not exist, so ANDROID_HOME is not set correctly
+					// try getting default adb path (included in CLI package)
+					this.$logger.trace(`Error while executing '${pathToAdb} help'. Error is: ${err.message}`);
+				}
+			}
+
+			return null;
+		}).future<string>()();
 	}
 
 	/**

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -84,3 +84,4 @@ $injector.require("androidToolsInfo", "./android-tools-info");
 
 $injector.require("iosUsbLiveSyncServiceLocator", "./services/usb-livesync-service");
 $injector.require("androidUsbLiveSyncServiceLocator", "./services/usb-livesync-service");
+$injector.require("sysInfo", "./sys-info");

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -81,21 +81,8 @@ export class StaticConfig extends staticConfigBaseLibPath.StaticConfigBase imple
 	public getAdbFilePath(): IFuture<string> {
 		return (() => {
 			if(!this._adbFilePath) {
-				let androidHomeEnvVar = process.env.ANDROID_HOME;
-				if(androidHomeEnvVar) {
-					let pathToAdb = path.join(androidHomeEnvVar, "platform-tools", "adb");
-					let childProcess: IChildProcess = this.$injector.resolve("$childProcess");
-					try {
-						childProcess.execFile(pathToAdb, ["help"]).wait();
-						this._adbFilePath = pathToAdb;
-					} catch (err) {
-						// adb does not exist, so ANDROID_HOME is not set correctly
-						// try getting default adb path (included in CLI package)
-						super.getAdbFilePath().wait();
-					}
-				} else {
-					super.getAdbFilePath().wait();
-				}
+				let androidToolsInfo: IAndroidToolsInfo = this.$injector.resolve("androidToolsInfo");
+				this._adbFilePath = androidToolsInfo.getPathToAdbFromAndroidHome().wait() || super.getAdbFilePath().wait();
 			}
 
 			return this._adbFilePath;

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -127,9 +127,15 @@ interface IAndroidToolsInfo {
 	/**
 	 * Returns the path to `android` executable. It should be `$ANDROID_HOME/tools/android`.
 	 * In case ANDROID_HOME is not defined, check if `android` is part of $PATH.
-	 * @return {boolean} Path to the `android` executable.
+	 * @return {string} Path to the `android` executable.
 	 */
 	getPathToAndroidExecutable(): IFuture<string>;
+
+	/**
+	 * Gets the path to `adb` executable from ANDROID_HOME. It should be `$ANDROID_HOME/platform-tools/adb` in case it exists.
+	 * @return {string} Path to the `adb` executable. In case it does not exists, null is returned.
+	 */
+	getPathToAdbFromAndroidHome(): IFuture<string>;
 }
 
 /**

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -81,7 +81,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 			// this call will fail in case `android` is not set correctly.
 			this.$androidToolsInfo.getPathToAndroidExecutable().wait();
-			this.$androidToolsInfo.validateJavacVersion(this.$sysInfo.getSysInfo().javacVersion, {showWarningsAsErrors: true}).wait();
+			this.$androidToolsInfo.validateJavacVersion(this.$sysInfo.getSysInfo().wait().javacVersion, {showWarningsAsErrors: true}).wait();
 		}).future<void>()();
 	}
 

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -13,11 +13,7 @@ class DoctorService implements IDoctorService {
 
 	public printWarnings(): boolean {
 		let result = false;
-		let androidToolsInfo = {
-			pathToAdb: this.$androidToolsInfo.getPathToAdbFromAndroidHome().wait(),
-			pathToAndroid: this.$androidToolsInfo.getPathToAndroidExecutable().wait()
-		};
-		let sysInfo = this.$sysInfo.getSysInfo(androidToolsInfo);
+		let sysInfo = this.$sysInfo.getSysInfo().wait();
 
 		if (!sysInfo.adbVer) {
 			this.$logger.warn("WARNING: adb from the Android SDK is not installed or is not configured properly.");
@@ -65,16 +61,6 @@ class DoctorService implements IDoctorService {
 		} else {
 			this.$logger.out("NOTE: You can develop for iOS only on Mac OS X systems.");
 			this.$logger.out("To be able to work with iOS devices and projects, you need Mac OS X Mavericks or later." + EOL);
-		}
-
-		if(!sysInfo.javaVer) {
-			this.$logger.warn("WARNING: The Java Development Kit (JDK) is not installed or is not configured properly.");
-			this.$logger.out("You will not be able to work with the Android SDK and you might not be able" + EOL
-				+ "to perform some Android-related operations. To ensure that you can develop and" + EOL
-				+ "test your apps for Android, verify that you have installed the JDK as" + EOL
-				+ "described in http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html (for JDK 8)" + EOL
-				+ "or http://docs.oracle.com/javase/7/docs/webnotes/install/ (for JDK 7)." + EOL);
-			result = true;
 		}
 
 		let androidToolsIssues = this.$androidToolsInfo.validateInfo().wait();

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -13,7 +13,11 @@ class DoctorService implements IDoctorService {
 
 	public printWarnings(): boolean {
 		let result = false;
-		let sysInfo = this.$sysInfo.getSysInfo();
+		let androidToolsInfo = {
+			pathToAdb: this.$androidToolsInfo.getPathToAdbFromAndroidHome().wait(),
+			pathToAndroid: this.$androidToolsInfo.getPathToAndroidExecutable().wait()
+		};
+		let sysInfo = this.$sysInfo.getSysInfo(androidToolsInfo);
 
 		if (!sysInfo.adbVer) {
 			this.$logger.warn("WARNING: adb from the Android SDK is not installed or is not configured properly.");
@@ -59,9 +63,8 @@ class DoctorService implements IDoctorService {
 				result = true;
 			}
 		} else {
-			this.$logger.warn("WARNING: You can work with iOS only on Mac OS X systems.");
+			this.$logger.out("NOTE: You can develop for iOS only on Mac OS X systems.");
 			this.$logger.out("To be able to work with iOS devices and projects, you need Mac OS X Mavericks or later." + EOL);
-			result = true;
 		}
 
 		if(!sysInfo.javaVer) {

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -1,0 +1,25 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import {SysInfoBase} from "./common/sys-info-base";
+
+export class SysInfo extends SysInfoBase {
+	constructor(protected $childProcess: IChildProcess,
+				protected $hostInfo: IHostInfo,
+				protected $iTunesValidator: Mobile.IiTunesValidator,
+				protected $logger: ILogger,
+				private $androidToolsInfo: IAndroidToolsInfo) {
+		super($childProcess, $hostInfo, $iTunesValidator, $logger);
+	}
+
+	public getSysInfo(androidToolsInfo?: {pathToAdb: string, pathToAndroid: string}): IFuture<ISysInfoData> {
+		return ((): ISysInfoData => {
+			let defaultAndroidToolsInfo = {
+				pathToAdb: this.$androidToolsInfo.getPathToAdbFromAndroidHome().wait(),
+				pathToAndroid: this.$androidToolsInfo.getPathToAndroidExecutable().wait()
+			};
+			return super.getSysInfo(androidToolsInfo || defaultAndroidToolsInfo).wait();
+		}).future<ISysInfoData>()();
+	}
+}
+$injector.register("sysInfo", SysInfo);


### PR DESCRIPTION
Fix doctor command, which checks adb and android incorrectly. Pass correct paths for verification.
Also make sure "No issues were detected" is printed when there are no issues.