### PR TITLE
Do not copy .ts and .js.map files in real app

### DIFF
--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -161,7 +161,7 @@ function preparePlatform(testInjector: IInjector): IFuture<void> {
 
 describe("Npm support tests", () => {
 	let testInjector: IInjector, projectFolder: string, appDestinationFolderPath: string;
-	before(() => {
+	beforeEach(() => {
 		let projectSetup = setupProject().wait();
 		testInjector = projectSetup.testInjector;
 		projectFolder = projectSetup.projectFolder;


### PR DESCRIPTION
Currently all `.ts` and `.js.map` files are copied to `platforms/<platform>/...` etc.
We do not need them in the real application for the moment. So ignore them.
Also fix problem with ignoring `tests` directory during release build - we were preparing collection of files to be copied, but finally we copy the whole app dir.
From now on we'll respect the filtered collection.