### PR TITLE
Fix run on multiple devices

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -348,7 +348,8 @@ export class PlatformService implements IPlatformService {
 	public deployOnDevice(platform: string, buildConfig?: IBuildConfig): IFuture<void> {
 		return (() => {
 			this.installOnDevice(platform, buildConfig).wait();
-			this.$commandsService.tryExecuteCommand("device", ["run", this.$projectData.projectId]).wait();
+			let action = (device: Mobile.IDevice) => device.applicationManager.startApplication(this.$projectData.projectId);
+			this.$devicesService.execute(action).wait();
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
When multiple devices with same platform are attached, `tns run <platform>` command should start the app on all of them.
Currently the application is started, but the call to commandsService (device|run) command is failing as more than one device is attached.
Fix this by calling the correct method from the devicesService.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1177