### PR TITLE
Install devDependencies before prepare

### DIFF
--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -5,6 +5,13 @@ interface IPluginsService {
 	getAllInstalledPlugins(): IFuture<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(): IFuture<void>;
 	afterPrepareAllPlugins(): IFuture<void>;
+	/**
+	 * Installs all devDependencies of the project.
+	 * In case all of them are already installed, no operation will be executed.
+	 * In case any of them is missing, all of them will be installed.
+	 * @return {IFuture<void>}
+	 */
+	installDevDependencies(): IFuture<void>;
 }
 
 interface IPluginData extends INodeModuleData {
@@ -53,6 +60,7 @@ interface IPluginVariablesService {
 	 * @return {IFuture<string>}		returns the changed plugin configuration file content.
 	 */
 	getPluginVariablePropertyName(pluginData: IPluginData): string;
+
 }
 
 interface IPluginVariableData {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -154,11 +154,20 @@ export class PlatformService implements IPlatformService {
 		}).future<string[]>()();
 	}
 
-	@helpers.hook('prepare')
 	public preparePlatform(platform: string): IFuture<void> {
 		return (() => {
 			this.validatePlatform(platform);
 
+			//Install dev-dependencies here, so before-prepare hooks will be executed correctly.
+			this.$pluginsService.installDevDependencies().wait();
+
+			this.preparePlatformCore(platform).wait();
+		}).future<void>()();
+	}
+
+	@helpers.hook('prepare')
+	private preparePlatformCore(platform: string): IFuture<void> {
+		return (() => {
 			platform = platform.toLowerCase();
 			this.ensurePlatformInstalled(platform).wait();
 

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -185,6 +185,22 @@ export class PluginsService implements IPluginsService {
 		return this.executeForAllInstalledPlatforms(action);
 	}
 
+	public installDevDependencies(): IFuture<void> {
+		return (() => {
+			let installedDependencies = this.$fs.exists(this.nodeModulesPath).wait() ? this.$fs.readDirectory(this.nodeModulesPath).wait() : [];
+			let packageJsonContent = this.$fs.readJson(this.getPackageJsonFilePath()).wait();
+			let devDependencies = _.keys(packageJsonContent.devDependencies);
+			if(devDependencies.length && (this.$options.force || _.difference(devDependencies, installedDependencies).length)) {
+				let command = `npm install ${devDependencies.join(" ")}`;
+				if(this.$options.ignoreScripts) {
+					command += "--ignore-scripts";
+				}
+				this.$logger.trace(`Command for installing devDependencies is: '${command}'.`);
+				this.$childProcess.exec(command, { cwd: this.$projectData.projectDir }).wait();
+			}
+		}).future<void>()();
+	}
+
 	private get nodeModulesPath(): string {
 		return path.join(this.$projectData.projectDir, "node_modules");
 	}

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -49,7 +49,8 @@ function createTestInjector() {
 		},
 		ensureAllDependenciesAreInstalled: () => {
 			return Future.fromResult();
-		}
+		},
+		installDevDependencies: () => Future.fromResult()
 	});
 	testInjector.register("projectFilesManager", ProjectFilesManagerLib.ProjectFilesManager);
 	testInjector.register("hooksService", stubs.HooksServiceStub);


### PR DESCRIPTION
As our hooks (like typescript) are called before executing prepare method, we must be sure we have
all devDependencies installed in order to be able to execute before-prepare hooks.
This is mandatory for projects where typescript is enabled, but you do not have node_modules directory yet.

Steps to reproduce the bug:
1) `tns create app1`
2) `cd app1`
3) `tns install typescript`
4) `rm -rf node_modules`
5) `tns build android`
You'll see error:
```
Error: Cannot find module 'nativescript-dev-typescript/lib/before-prepare.js'
```