### PR TITLE
Install ALL dependencies and devDependencies before prepare

### DIFF
--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -5,13 +5,6 @@ interface IPluginsService {
 	getAllInstalledPlugins(): IFuture<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(): IFuture<void>;
 	afterPrepareAllPlugins(): IFuture<void>;
-	/**
-	 * Installs all devDependencies of the project.
-	 * In case all of them are already installed, no operation will be executed.
-	 * In case any of them is missing, all of them will be installed.
-	 * @return {IFuture<void>}
-	 */
-	installDevDependencies(): IFuture<void>;
 }
 
 interface IPluginData extends INodeModuleData {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -158,8 +158,13 @@ export class PlatformService implements IPlatformService {
 		return (() => {
 			this.validatePlatform(platform);
 
-			//Install dev-dependencies here, so before-prepare hooks will be executed correctly.
-			this.$pluginsService.installDevDependencies().wait();
+			//We need dev-dependencies here, so before-prepare hooks will be executed correctly.
+			try {
+				this.$pluginsService.ensureAllDependenciesAreInstalled().wait();
+			} catch(err) {
+				this.$logger.trace(err);
+				this.$errors.failWithoutHelp(`Unable to install dependencies. Make sure your package.json is valid and all dependencies are correct. Error is: ${err.message}`);
+			}
 
 			this.preparePlatformCore(platform).wait();
 		}).future<void>()();
@@ -223,7 +228,6 @@ export class PlatformService implements IPlatformService {
 			// Process node_modules folder
 			let appDir = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 			try {
-				this.$pluginsService.ensureAllDependenciesAreInstalled().wait();
 				let tnsModulesDestinationPath = path.join(appDir, PlatformService.TNS_MODULES_FOLDER_NAME);
 				this.$broccoliBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime).wait();
 			} catch(error) {

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -49,8 +49,7 @@ function createTestInjector() {
 		},
 		ensureAllDependenciesAreInstalled: () => {
 			return Future.fromResult();
-		},
-		installDevDependencies: () => Future.fromResult()
+		}
 	});
 	testInjector.register("projectFilesManager", ProjectFilesManagerLib.ProjectFilesManager);
 	testInjector.register("hooksService", stubs.HooksServiceStub);


### PR DESCRIPTION
The old fix for installing only devDependencies before preparing the project has a problem:
`npm install <devPackagesNames>` does not respect the versions from the devDependencies section and always installs the latest versions.

We cannot use `npm install <devPackageName>@<version>` as we do not know if they are real versions or paths or even "frog legs".

There's a magical flag `--dev` which should allow you to do:
`npm install <devPackagesNames> --dev` and it will respect the versions from devDependencies. Unfortunately this flag forces recursive installation of devDependencies all down the tree of packages.

Of course npm has another rabbit in the hat - `--only=dev`. However I couldn't get it work at all.

So the only solution I could think about is to install all dependencies before preparing the project.