### PR TITLE
Collect all warnings upon pod installing

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -516,15 +516,12 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			let podTool = this.$config.USE_POD_SANDBOX ? "sandbox-pod" : "pod";
 			let childProcess = this.$childProcess.spawnFromEvent(podTool,  ["install"], "close", { cwd: this.platformData.projectRoot, stdio: ['pipe', process.stdout, 'pipe'] }).wait();
 			if (childProcess.stderr) {
-				let warnings = childProcess.stderr.match(/(\u001b\[(?:\d*;){0,5}\d*m[\s\S]+?\u001b\[(?:\d*;){0,5}\d*m)|(\[!\].*?\n)/g);
+				let warnings = childProcess.stderr.match(/(\u001b\[(?:\d*;){0,5}\d*m[\s\S]+?\u001b\[(?:\d*;){0,5}\d*m)|(\[!\].*?\n)|(.*?warning.*)/gi);
 				_.each(warnings, (warning: string) => {
 					this.$logger.warnWithLabel(warning.replace("\n", ""));
 				});
 
-				// HACK for silencing irrelevant linking warnings when pod installing on
-				// El Capitan with cocoa pods version 0.38.2
-				// Reference https://github.com/CocoaPods/CocoaPods/issues/4302
-				let errors = childProcess.stderr.replace(/dyld: warning, LC_RPATH @executable_path.*?@executable_path/g, "");
+				let errors = childProcess.stderr;
 				_.each(warnings, warning => {
 					errors = errors.replace(warning, "");
 				});


### PR DESCRIPTION
Leftover warnings printed on the stderr are considered errors and as a result fail the `$ tns prepare ios` command. Make a more general regex for catching warnings.
Ping @Mitko-Kerezov @Fatme 