### PR TITLE
Fix unit test runner on Windows

### DIFF
--- a/docs/man_pages/project/testing/dev-test-android.md
+++ b/docs/man_pages/project/testing/dev-test-android.md
@@ -1,0 +1,31 @@
+test android
+==========
+
+Usage | Synopsis
+------|-------
+Run tests on all connected devices | `$ tns test android [--watch] [--debug-brk]`
+Run tests on a selected device | `$ tns test android --device <Device ID> [--watch] [--debug-brk]`
+
+Runs the tests in your project on connected Android devices and running native emulators.<% if(isConsole) { %> Your project must already be configured for unit testing by running `$ tns test init`.<% } %>
+
+### Options
+* `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device and tests are re-run.
+* `--device` - Specifies the serial number or the index of the connected device on which to run the tests. To list all connected devices, grouped by platform, run `$ tns device`
+* `--debug-brk` - Runs the tests under the debugger. The debugger will break just before your tests are executed, so you have a chance to place breakpoints.
+
+### Attributes
+* `<Device ID>` is the device index or identifier as listed by `$ tns device`
+
+<% if(isHtml) { %>
+### Prerequisites
+
+* Verify that [you have configured your project for unit testing](test-init.html).
+* Verify that [you have stored your unit tests in `app` &#8594; `tests`](http://docs.nativescript.org/testing).
+* Verify that [you have configured your system and devices properly](http://docs.nativescript.org/testing).
+
+### Related Commands
+Command | Description
+--------|------------
+[test init](test-init.html) | Configures your project for unit testing with a selected framework.
+[test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
+<% } %>

--- a/docs/man_pages/project/testing/dev-test-ios.md
+++ b/docs/man_pages/project/testing/dev-test-ios.md
@@ -1,0 +1,36 @@
+test ios
+==========
+
+Usage | Synopsis
+------|-------
+Run tests on all connected devices | `$ tns test ios [--watch] [--debug-brk]`
+Run tests on a selected device | `$ tns test ios --device <Device ID> [--watch] [--debug-brk]`
+Run tests in the iOS Simulator | `$ tns test ios --emulator [--watch] [--debug-brk]`
+
+Runs the tests in your project on connected iOS devices or the iOS Simulator.<% if(isConsole && isMacOS) { %> Your project must already be configured for unit testing by running `$ tns test init`.<% } %>
+
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help test ios`<% } %> 
+
+<% if((isConsole && isMacOS) || isHtml) { %>
+### Options
+* `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device and tests are re-ran.
+* `--device` - Specifies the serial number or the index of the connected device on which you want to run tests. To list all connected devices, grouped by platform, run `$ tns device`. You cannot set `--device` and `--emulator` simultaneously.
+* `--emulator` - Runs tests on the iOS Simulator. You cannot set `--device` and `--emulator` simultaneously.
+* `--debug-brk` - Runs the tests under the debugger. The debugger will break just before your tests are executed, so you have a chance to place breakpoints.
+
+### Attributes
+* `<Device ID>` is the device index or identifier as listed by `$ tns device`<% } %>
+
+<% if(isHtml) { %>
+### Prerequisites
+
+* Verify that [you have configured your project for unit testing](test-init.html).
+* Verify that [you have stored your unit tests in `app` &#8594; `tests`](http://docs.nativescript.org/testing).
+* Verify that [you have configured your system and devices properly](http://docs.nativescript.org/testing).
+
+### Related Commands
+Command | Description
+--------|------------
+[test init](test-init.html) | Configures your project for unit testing with a selected framework.
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
+<% } %>

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -32,7 +32,8 @@ class TestExecutionService implements ITestExecutionService {
 		private $config: IConfiguration,
 		private $logger: ILogger,
 		private $fs: IFileSystem,
-		private $options: IOptions) {
+		private $options: IOptions,
+		private $pluginsService: IPluginsService) {
 	}
 
 	public startTestRunner(platform: string) : IFuture<void> {
@@ -133,6 +134,7 @@ class TestExecutionService implements ITestExecutionService {
 	public startKarmaServer(platform: string): IFuture<void> {
 		return (() => {
 			platform = platform.toLowerCase();
+			this.$pluginsService.ensureAllDependenciesAreInstalled().wait();
 			let pathToKarma = path.join(this.$projectData.projectDir, 'node_modules/karma');
 			let KarmaServer = require(path.join(pathToKarma, 'lib/server'));
 			if (platform === 'ios' && this.$options.emulator) {

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -6,6 +6,7 @@ import * as constants from "../constants";
 import * as path from 'path';
 import Future = require('fibers/future');
 import * as os from 'os';
+import * as fiberBootstrap from "../common/fiber-bootstrap";
 
 interface IKarmaConfigOptions {
 	debugBrk: boolean;
@@ -37,81 +38,95 @@ class TestExecutionService implements ITestExecutionService {
 	public startTestRunner(platform: string) : IFuture<void> {
 		return (() => {
 			this.$options.justlaunch = true;
+			let blockingOperationFuture = new Future<void>();
+			process.on('message', (launcherConfig: any) => {
+				fiberBootstrap.run(() => {
+					try {
+						let platformData = this.$platformsData.getPlatformData(platform.toLowerCase());
+						let projectDir = this.$projectData.projectDir;
 
-			let platformData = this.$platformsData.getPlatformData(platform.toLowerCase());
-			let projectDir = this.$projectData.projectDir;
+						let projectFilesPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 
-			let projectFilesPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+						let configOptions: IKarmaConfigOptions = JSON.parse(launcherConfig);
+						this.$options.debugBrk = configOptions.debugBrk;
+						this.$options.debugTransport = configOptions.debugTransport;
+						let configJs = this.generateConfig(configOptions);
+						this.$fs.writeFile(path.join(projectDir, TestExecutionService.CONFIG_FILE_NAME), configJs).wait();
 
-			let configOptions: IKarmaConfigOptions = JSON.parse(this.$fs.readStdin().wait());
-			this.$options.debugBrk = configOptions.debugBrk;
-			this.$options.debugTransport = configOptions.debugTransport;
-			let configJs = this.generateConfig(configOptions);
-			this.$fs.writeFile(path.join(projectDir, TestExecutionService.CONFIG_FILE_NAME), configJs).wait();
+						let socketIoJsUrl = `http://localhost:${this.$options.port}/socket.io/socket.io.js`;
+						let socketIoJs = this.$httpClient.httpRequest(socketIoJsUrl).wait().body;
+						this.$fs.writeFile(path.join(projectDir, TestExecutionService.SOCKETIO_JS_FILE_NAME), socketIoJs).wait();
 
-			let socketIoJsUrl = `http://localhost:${this.$options.port}/socket.io/socket.io.js`;
-			let socketIoJs = this.$httpClient.httpRequest(socketIoJsUrl).wait().body;
-			this.$fs.writeFile(path.join(projectDir, TestExecutionService.SOCKETIO_JS_FILE_NAME), socketIoJs).wait();
+						this.$platformService.preparePlatform(platform).wait();
+						this.detourEntryPoint(projectFilesPath).wait();
 
-			this.$platformService.preparePlatform(platform).wait();
-			this.detourEntryPoint(projectFilesPath).wait();
+						let watchGlob = path.join(projectDir, constants.APP_FOLDER_NAME);
 
-			let watchGlob = path.join(projectDir, constants.APP_FOLDER_NAME);
+						let platformSpecificLiveSyncServices: IDictionary<any> = {
+							android: (_device: Mobile.IDevice, $injector: IInjector): IPlatformSpecificLiveSyncService => {
+								return $injector.resolve(this.$androidUsbLiveSyncServiceLocator.factory, {_device: _device});
+							},
+							ios: (_device: Mobile.IDevice, $injector: IInjector) => {
+								return $injector.resolve(this.$iosUsbLiveSyncServiceLocator.factory, {_device: _device});
+							}
+						};
 
-			let platformSpecificLiveSyncServices: IDictionary<any> = {
-				android: (_device: Mobile.IDevice, $injector: IInjector): IPlatformSpecificLiveSyncService => {
-					return $injector.resolve(this.$androidUsbLiveSyncServiceLocator.factory, {_device: _device});
-				},
-				ios: (_device: Mobile.IDevice, $injector: IInjector) => {
-					return $injector.resolve(this.$iosUsbLiveSyncServiceLocator.factory, {_device: _device});
-				}
-			};
+						let notInstalledAppOnDeviceAction = (device: Mobile.IDevice): IFuture<void> => {
+							return (() => {
+								this.$platformService.installOnDevice(platform).wait();
+								this.detourEntryPoint(projectFilesPath).wait();
+							}).future<void>()();
+						};
 
-			let notInstalledAppOnDeviceAction = (device: Mobile.IDevice): IFuture<void> => {
-				return (() => {
-					this.$platformService.installOnDevice(platform).wait();
-					this.detourEntryPoint(projectFilesPath).wait();
-				}).future<void>()();
-			};
+						let notRunningiOSSimulatorAction = (): IFuture<void> => {
+							return (() => {
+								this.$platformService.deployOnEmulator(this.$devicePlatformsConstants.iOS.toLowerCase()).wait();
+								this.detourEntryPoint(projectFilesPath).wait();
+							}).future<void>()();
+						};
 
-			let notRunningiOSSimulatorAction = (): IFuture<void> => {
-				return (() => {
-					this.$platformService.deployOnEmulator(this.$devicePlatformsConstants.iOS.toLowerCase()).wait();
-					this.detourEntryPoint(projectFilesPath).wait();
-				}).future<void>()();
-			};
+						let beforeBatchLiveSyncAction = (filePath: string): IFuture<string> => {
+							return (() => {
+								this.$platformService.preparePlatform(platform).wait();
+								return path.join(projectFilesPath, path.relative(path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME), filePath));
+							}).future<string>()();
+						};
 
-			let beforeBatchLiveSyncAction = (filePath: string): IFuture<string> => {
-				return (() => {
-					this.$platformService.preparePlatform(platform).wait();
-					return path.join(projectFilesPath, path.relative(path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME), filePath));
-				}).future<string>()();
-			};
+						let localProjectRootPath = platform.toLowerCase() === "ios" ? platformData.appDestinationDirectoryPath : null;
 
-			let localProjectRootPath = platform.toLowerCase() === "ios" ? platformData.appDestinationDirectoryPath : null;
+						let liveSyncData = {
+							platform: platform,
+							appIdentifier: this.$projectData.projectId,
+							projectFilesPath: projectFilesPath,
+							excludedProjectDirsAndFiles: constants.LIVESYNC_EXCLUDED_DIRECTORIES,
+							watchGlob: watchGlob,
+							platformSpecificLiveSyncServices: platformSpecificLiveSyncServices,
+							notInstalledAppOnDeviceAction: notInstalledAppOnDeviceAction,
+							notRunningiOSSimulatorAction: notRunningiOSSimulatorAction,
+							localProjectRootPath: localProjectRootPath,
+							beforeBatchLiveSyncAction: beforeBatchLiveSyncAction,
+							shouldRestartApplication: (localToDevicePaths: Mobile.ILocalToDevicePathData[]) => Future.fromResult(!this.$options.debugBrk),
+							canExecuteFastLiveSync: (filePath: string) => false,
+						};
 
-			let liveSyncData = {
-				platform: platform,
-				appIdentifier: this.$projectData.projectId,
-				projectFilesPath: projectFilesPath,
-				excludedProjectDirsAndFiles: constants.LIVESYNC_EXCLUDED_DIRECTORIES,
-				watchGlob: watchGlob,
-				platformSpecificLiveSyncServices: platformSpecificLiveSyncServices,
-				notInstalledAppOnDeviceAction: notInstalledAppOnDeviceAction,
-				notRunningiOSSimulatorAction: notRunningiOSSimulatorAction,
-				localProjectRootPath: localProjectRootPath,
-				beforeBatchLiveSyncAction: beforeBatchLiveSyncAction,
-				shouldRestartApplication: (localToDevicePaths: Mobile.ILocalToDevicePathData[]) => Future.fromResult(!this.$options.debugBrk),
-				canExecuteFastLiveSync: (filePath: string) => false,
-			};
+						this.$usbLiveSyncServiceBase.sync(liveSyncData).wait();
 
-			this.$usbLiveSyncServiceBase.sync(liveSyncData).wait();
+						if (this.$options.debugBrk) {
+							this.$logger.info('Starting debugger...');
+							let debugService: IDebugService = this.$injector.resolve(`${platform}DebugService`);
+							debugService.debugStart().wait();
+						}
+						blockingOperationFuture.return();
+					} catch(err) {
+						// send the error to the real future
+						blockingOperationFuture.throw(err);
+					}
+				});
+			});
 
-			if (this.$options.debugBrk) {
-				this.$logger.info('Starting debugger...');
-				let debugService: IDebugService = this.$injector.resolve(`${platform}DebugService`);
-				debugService.debugStart().wait();
-			}
+			// Tell the parent that we are ready to receive the data.
+			process.send("ready");
+			blockingOperationFuture.wait();
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
## Use fork instead of spawn for startTestRunner

In `karma-nativescript-launcher` we call startTestRunner through spawn.
Communication between karma launcher and tns is through stdin.
This is causing exception in buildMetadata step when gradle wrapper is used.
For some reason it throws error in java code.
So, replace the spawn with fork in the launcher. Modify `startTestRunner` to wait for message from parent process and send "ready" state to the parent.
After that the parent (karma-nativescript-launcher) sends configuration data and the `startTestRunner` will execute the actions.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1199


## Add help for dev-test-* commands

As the current workflow of unit-testing is:
1) user calls `tns test android`
2) CLI starts a new process in which `tns dev-test android` is called
3) In case the dev-test command fails, the error is caught in the child process and command help is printed on the terminal directly in it.
4) User receives message: `Unable to find command dev-test|android` (from the child process) as we do not have help for this commands.

Copy-paste the help fo test-android and test-ios commands and change the filenames so when the child process fails, it will print correct help.
Parent process will not fail as the error is caught inside the child, so there's no way to print the help twice.

Update common-lib to search dev-commands as well when searching for help pages.


## Make sure all dependencies are installed before starting karma
In case node_modules dir is deleted, `tns test <platform>` command will fail.
So ensure all dependencies are installed before starting karma server.

### Should be merged after:
* https://github.com/telerik/mobile-cli-lib/pull/529 - fix in common-lib
* https://github.com/NativeScript/karma-nativescript-launcher/pull/21 - fix in karma launcher - publish new version before merging this PR