### PR TITLE
Add support for different templates

### DIFF
--- a/lib/commands/create-project.ts
+++ b/lib/commands/create-project.ts
@@ -26,13 +26,14 @@ export class CreateProjectCommand implements ICommand {
 	constructor(private $projectService: IProjectService,
 		private $errors: IErrors,
 		private $logger: ILogger,
-		private $projectNameValidator: IProjectNameValidator) { }
+		private $projectNameValidator: IProjectNameValidator,
+		private $options: ICommonOptions) { }
 
 	public enableHooks = false;
 
 	execute(args: string[]): IFuture<void> {
 		return (() => {
-			this.$projectService.createProject(args[0]).wait();
+			this.$projectService.createProject(args[0], this.$options.template).wait();
 		}).future<void>()();
 	}
 

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -1,6 +1,6 @@
 
 interface IProjectService {
-	createProject(projectName: string): IFuture<void>;
+	createProject(projectName: string, selectedTemplate?: string): IFuture<void>;
 }
 
 interface IProjectData {
@@ -22,8 +22,24 @@ interface IProjectDataService {
 	removeDependency(dependencyName: string): IFuture<void>;
 }
 
+/**
+ * Describes working with templates.
+ */
 interface IProjectTemplatesService {
+	/**
+	 * Defines the path where unpacked default template can be found.
+	 */
 	defaultTemplatePath: IFuture<string>;
+
+	/**
+	 * Prepares template for project creation.
+	 * In case templateName is not provided, use defaultTemplatePath.
+	 * In case templateName is a special word, validated from us (for ex. typescript), resolve the real template name and add it to npm cache.
+	 * In any other cases try to `npm install` the specified templateName to temp directory.
+	 * @param {string} templateName The name of the template.
+	 * @return {string} Path to the directory where extracted template can be found.
+	 */
+	prepareTemplate(templateName: string): IFuture<string>;
 }
 
 interface IPlatformProjectServiceBase {

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -18,7 +18,8 @@ export class NpmInstallationManager implements INpmInstallationManager {
 	private packageSpecificDirectories: IStringDictionary = {
 		"tns-android": constants.PROJECT_FRAMEWORK_FOLDER_NAME,
 		"tns-ios": constants.PROJECT_FRAMEWORK_FOLDER_NAME,
-		"tns-template-hello-world": constants.APP_RESOURCES_FOLDER_NAME
+		"tns-template-hello-world": constants.APP_RESOURCES_FOLDER_NAME,
+		"tns-template-hello-world-ts": constants.APP_RESOURCES_FOLDER_NAME
 	};
 
 	constructor(private $npm: INodePackageManager,

--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -1,13 +1,101 @@
 ///<reference path="../.d.ts"/>
 "use strict";
+import * as path from "path";
+import * as temp from "temp";
+import * as constants from "../constants";
+import {EOL} from "os";
+temp.track();
 
 export class ProjectTemplatesService implements IProjectTemplatesService {
-	private static NPM_DEFAULT_TEMPLATE_NAME = "tns-template-hello-world";
+	private static RESERVED_TEMPLATE_NAMES: IStringDictionary = {
+		"default": "tns-template-hello-world",
+		"tsc": "tns-template-hello-world-ts",
+		"typescript": "tns-template-hello-world-ts"
+	};
 
-	public constructor(private $npmInstallationManager: INpmInstallationManager) { }
+	public constructor(private $errors: IErrors,
+						private $fs: IFileSystem,
+						private $logger: ILogger,
+						private $npm: INodePackageManager,
+						private $npmInstallationManager: INpmInstallationManager) { }
 
 	public get defaultTemplatePath(): IFuture<string> {
-		return this.$npmInstallationManager.install(ProjectTemplatesService.NPM_DEFAULT_TEMPLATE_NAME);
+		return this.prepareNativeScriptTemplate(ProjectTemplatesService.RESERVED_TEMPLATE_NAMES["default"]);
+	}
+
+	public prepareTemplate(originalTemplateName: string): IFuture<string> {
+		return ((): string => {
+			let realTemplatePath: string;
+			if(originalTemplateName) {
+				let templateName = originalTemplateName.toLowerCase();
+
+				// support <reserved_name>@<version> syntax
+				let [name, version] = templateName.split("@");
+				if(ProjectTemplatesService.RESERVED_TEMPLATE_NAMES[name]) {
+					realTemplatePath = this.prepareNativeScriptTemplate(ProjectTemplatesService.RESERVED_TEMPLATE_NAMES[name], version).wait();
+				} else {
+					let tempDir = temp.mkdirSync("nativescript-template-dir");
+					try {
+						// Use the original template name, specified by user as it may be case-sensitive.
+						this.$npm.install(originalTemplateName, tempDir, {production: true, silent: true}).wait();
+					} catch(err) {
+						this.$logger.trace(err);
+						this.$errors.failWithoutHelp(`Unable to use template ${originalTemplateName}. Make sure you've specified valid name, github URL or path to local dir.` +
+													`${EOL}Error is: ${err.message}.`);
+					}
+
+					realTemplatePath = this.getTemplatePathFromTempDir(tempDir).wait();
+				}
+			} else {
+				realTemplatePath = this.defaultTemplatePath.wait();
+			}
+
+			if(realTemplatePath) {
+				this.$fs.deleteDirectory(path.join(realTemplatePath, constants.NODE_MODULES_FOLDER_NAME)).wait();
+				return realTemplatePath;
+			}
+
+			this.$errors.failWithoutHelp("Unable to find the template in temp directory. " +
+				`Please open an issue at https://github.com/NativeScript/nativescript-cli/issues and send the output of the same command executed with --log trace.`);
+		}).future<string>()();
+	}
+
+	/**
+	 * Install verified NativeScript template in the npm cache.
+	 * The "special" here is that npmInstallationManager will check current CLI version and will instal best matching version of the template.
+	 * For example in case CLI is version 10.12.8, npmInstallationManager will try to find latest 10.12.x version of the template.
+	 * @param {string} templateName The name of the verified NativeScript template.
+	 * @param {string} version The version of the template specified by user.
+	 * @return {string} Path to the directory where the template is installed.
+	 */
+	private prepareNativeScriptTemplate(templateName: string, version?: string): IFuture<string> {
+		this.$logger.trace(`Using NativeScript verified template: ${templateName} with version ${version}.`);
+		return this.$npmInstallationManager.install(templateName, {version: version});
+	}
+
+	private getTemplatePathFromTempDir(tempDir: string): IFuture<string> {
+		return ((): string => {
+			let templatePath: string;
+			let tempDirContents = this.$fs.readDirectory(tempDir).wait();
+			this.$logger.trace(`TempDir contents: ${tempDirContents}.`);
+
+			// We do not know the name of the package that will be installed, so after installation to temp dir,
+			// there should be node_modules dir there and its only subdir should be our package.
+			// In case there's some other dir instead of node_modules, consider it as our package.
+			if(tempDirContents && tempDirContents.length === 1) {
+				let tempDirSubdir = _.first(tempDirContents);
+				if(tempDirSubdir === constants.NODE_MODULES_FOLDER_NAME) {
+					let templateDirName = _.first(this.$fs.readDirectory(path.join(tempDir, constants.NODE_MODULES_FOLDER_NAME)).wait());
+					if(templateDirName) {
+						templatePath = path.join(tempDir, tempDirSubdir, templateDirName);
+					}
+				} else {
+					templatePath = path.join(tempDir, tempDirSubdir);
+				}
+			}
+
+			return templatePath;
+		}).future<string>()();
 	}
 }
 $injector.register("projectTemplatesService", ProjectTemplatesService);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mute-stream": "0.0.5",
     "node-inspector": "https://github.com/NativeScript/node-inspector/tarball/v0.7.4.0",
     "node-uuid": "1.4.3",
-    "npm": "2.6.1",
+    "npm": "2.14.12",
     "open": "0.0.5",
     "osenv": "0.1.3",
     "plist": "1.1.0",

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -187,7 +187,6 @@ describe("Project Service Tests", () => {
 			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", projectTemplatesService.prepareTemplate("default@1.4.0").wait()).wait();
 		});
 
-		/* Uncomment when tns-template-hello-world-ts is public
 		it("creates valid project from typescript template", () => {
 			let projectIntegrationTest = new ProjectIntegrationTest();
 			let tempFolder = temp.mkdirSync("projectTypescript");
@@ -213,7 +212,6 @@ describe("Project Service Tests", () => {
 			let projectTemplatesService: IProjectTemplatesService = projectIntegrationTest.testInjector.resolve("projectTemplatesService");
 			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", projectTemplatesService.prepareTemplate("tsc").wait()).wait();
 		});
-		*/
 
 		it("creates valid project from local directory template", () => {
 			let projectIntegrationTest = new ProjectIntegrationTest();

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -20,6 +20,7 @@ import * as helpers from "../lib/common/helpers";
 import {assert} from "chai";
 import {Options} from "../lib/options";
 import {HostInfo} from "../lib/common/host-info";
+import {ProjectTemplatesService} from "../lib/services/project-templates-service";
 
 let mockProjectNameValidator = {
 	validate: () => { return true; }
@@ -34,9 +35,9 @@ class ProjectIntegrationTest {
 		this.createTestInjector();
 	}
 
-	public createProject(projectName: string): IFuture<void> {
+	public createProject(projectName: string, template?: string): IFuture<void> {
 		let projectService = this.testInjector.resolve("projectService");
-		return projectService.createProject(projectName);
+		return projectService.createProject(projectName, template);
 	}
 
 	public getNpmPackagePath(packageName: string): IFuture<string> {
@@ -59,7 +60,7 @@ class ProjectIntegrationTest {
 		}).future<string>()();
 	}
 
-	public assertProject(tempFolder: string, projectName: string, appId: string): IFuture<void> {
+	public assertProject(tempFolder: string, projectName: string, appId: string, projectSourceDirectory?: string): IFuture<void> {
 		return (() => {
 			let fs: IFileSystem = this.testInjector.resolve("fs");
 			let projectDir = path.join(tempFolder, projectName);
@@ -67,7 +68,7 @@ class ProjectIntegrationTest {
 			let platformsDirectoryPath = path.join(projectDir, "platforms");
 			let tnsProjectFilePath = path.join(projectDir, "package.json");
 			let tnsModulesPath = path.join(projectDir, constants.NODE_MODULES_FOLDER_NAME, constants.TNS_CORE_MODULES_NAME);
-
+			let packageJsonContent = fs.readJson(tnsProjectFilePath).wait();
 			let options = this.testInjector.resolve("options");
 
 			assert.isTrue(fs.exists(appDirectoryPath).wait());
@@ -78,21 +79,38 @@ class ProjectIntegrationTest {
 			assert.isFalse(fs.isEmptyDir(appDirectoryPath).wait());
 			assert.isTrue(fs.isEmptyDir(platformsDirectoryPath).wait());
 
-			let actualAppId = fs.readJson(tnsProjectFilePath).wait()["nativescript"].id;
+			let actualAppId = packageJsonContent["nativescript"].id;
 			let expectedAppId = appId;
 			assert.equal(actualAppId, expectedAppId);
 
-			let tnsCoreModulesRecord = fs.readJson(tnsProjectFilePath).wait()["dependencies"][constants.TNS_CORE_MODULES_NAME];
+			let tnsCoreModulesRecord = packageJsonContent["dependencies"][constants.TNS_CORE_MODULES_NAME];
 			assert.isTrue(tnsCoreModulesRecord !== null);
 
-			let actualFiles = fs.enumerateFilesInDirectorySync(options.copyFrom);
-			let expectedFiles = fs.enumerateFilesInDirectorySync(appDirectoryPath);
+			let sourceDir = projectSourceDirectory || options.copyFrom;
 
-			assert.equal(actualFiles.length, expectedFiles.length);
-			_.each(actualFiles, file => {
-				let relativeToProjectDir = helpers.getRelativeToRootPath(options.copyFrom, file);
-				assert.isTrue(fs.exists(path.join(appDirectoryPath, relativeToProjectDir)).wait());
+			let expectedFiles = fs.enumerateFilesInDirectorySync(sourceDir);
+			let actualFiles = fs.enumerateFilesInDirectorySync(appDirectoryPath);
+			assert.isTrue(actualFiles.length >= (expectedFiles.length - 1), "Files in created project must be at least as files in app dir (without package.json).");
+			_.each(expectedFiles, file => {
+				let relativeToProjectDir = helpers.getRelativeToRootPath(sourceDir, file);
+				if(path.basename(file) === "package.json") {
+					assert.isFalse(fs.exists(path.join(appDirectoryPath, relativeToProjectDir)).wait());
+				} else {
+					assert.isTrue(fs.exists(path.join(appDirectoryPath, relativeToProjectDir)).wait());
+				}
 			});
+
+			// assert dependencies and devDependencies are copied from template to real project
+			let sourcePackageJsonContent = fs.readJson(path.join(sourceDir, "package.json")).wait();
+			let missingDeps = _.difference(_.keys(sourcePackageJsonContent.dependencies), _.keys(packageJsonContent.dependencies));
+			let missingDevDeps = _.difference(_.keys(sourcePackageJsonContent.devDependencies), _.keys(packageJsonContent.devDependencies));
+			assert.deepEqual(missingDeps, [], `All dependencies from template must be copied to project's package.json. Missing ones are: ${missingDeps.join(", ")}.`);
+			assert.deepEqual(missingDevDeps, [], `All devDependencies from template must be copied to project's package.json. Missing ones are: ${missingDevDeps.join(", ")}.`);
+
+			// assert App_Resources are prepared correctly
+			let appResourcesDir = path.join(appDirectoryPath, "App_Resources");
+			let appResourcesContents = fs.readDirectory(appResourcesDir).wait();
+			assert.deepEqual(appResourcesContents, ["Android", "iOS"], "Project's app/App_Resources must contain Android and iOS directories.");
 		}).future<void>()();
 	}
 
@@ -107,7 +125,7 @@ class ProjectIntegrationTest {
 		this.testInjector.register('logger', stubs.LoggerStub);
 		this.testInjector.register("projectService", ProjectServiceLib.ProjectService);
 		this.testInjector.register("projectHelper", ProjectHelperLib.ProjectHelper);
-		this.testInjector.register("projectTemplatesService", stubs.ProjectTemplatesService);
+		this.testInjector.register("projectTemplatesService", ProjectTemplatesService);
 		this.testInjector.register("projectNameValidator", mockProjectNameValidator);
 
 		this.testInjector.register("fs", FileSystem);
@@ -126,8 +144,15 @@ class ProjectIntegrationTest {
 
 describe("Project Service Tests", () => {
 	describe("project service integration tests", () => {
+		let pathToDefaultTemplate: string;
+		before(() => {
+			let projectIntegrationTest = new ProjectIntegrationTest();
+			let projectTemplatesService: IProjectTemplatesService = projectIntegrationTest.testInjector.resolve("projectTemplatesService");
+			pathToDefaultTemplate = projectTemplatesService.defaultTemplatePath.wait();
+		});
+
 		it("creates valid project from default template", () => {
-			let	projectIntegrationTest = new ProjectIntegrationTest();
+			let projectIntegrationTest = new ProjectIntegrationTest();
 			let tempFolder = temp.mkdirSync("project");
 			let projectName = "myapp";
 			let options = projectIntegrationTest.testInjector.resolve("options");
@@ -138,8 +163,106 @@ describe("Project Service Tests", () => {
 			projectIntegrationTest.createProject(projectName).wait();
 			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp").wait();
 		});
+
+		it("creates valid project from default template when --template default is specified", () => {
+			let projectIntegrationTest = new ProjectIntegrationTest();
+			let tempFolder = temp.mkdirSync("project");
+			let projectName = "myapp";
+			let options = projectIntegrationTest.testInjector.resolve("options");
+
+			options.path = tempFolder;
+			projectIntegrationTest.createProject(projectName, "default").wait();
+			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", pathToDefaultTemplate).wait();
+		});
+
+		it("creates valid project from default template when --template default@version is specified", () => {
+			let projectIntegrationTest = new ProjectIntegrationTest();
+			let tempFolder = temp.mkdirSync("project");
+			let projectName = "myapp";
+			let options = projectIntegrationTest.testInjector.resolve("options");
+
+			options.path = tempFolder;
+			let projectTemplatesService: IProjectTemplatesService = projectIntegrationTest.testInjector.resolve("projectTemplatesService");
+			projectIntegrationTest.createProject(projectName, "default@1.4.0").wait();
+			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", projectTemplatesService.prepareTemplate("default@1.4.0").wait()).wait();
+		});
+
+		/* Uncomment when tns-template-hello-world-ts is public
+		it("creates valid project from typescript template", () => {
+			let projectIntegrationTest = new ProjectIntegrationTest();
+			let tempFolder = temp.mkdirSync("projectTypescript");
+			let projectName = "myapp";
+			let options = projectIntegrationTest.testInjector.resolve("options");
+
+			options.path = tempFolder;
+			projectIntegrationTest.createProject(projectName, "typescript").wait();
+
+			let projectTemplatesService: IProjectTemplatesService = projectIntegrationTest.testInjector.resolve("projectTemplatesService");
+			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", projectTemplatesService.prepareTemplate("typescript").wait()).wait();
+		});
+
+		it("creates valid project from tsc template", () => {
+			let projectIntegrationTest = new ProjectIntegrationTest();
+			let tempFolder = temp.mkdirSync("projectTsc");
+			let projectName = "myapp";
+			let options = projectIntegrationTest.testInjector.resolve("options");
+
+			options.path = tempFolder;
+			projectIntegrationTest.createProject(projectName, "tsc").wait();
+
+			let projectTemplatesService: IProjectTemplatesService = projectIntegrationTest.testInjector.resolve("projectTemplatesService");
+			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", projectTemplatesService.prepareTemplate("tsc").wait()).wait();
+		});
+		*/
+
+		it("creates valid project from local directory template", () => {
+			let projectIntegrationTest = new ProjectIntegrationTest();
+			let tempFolder = temp.mkdirSync("projectLocalDir");
+			let projectName = "myapp";
+			let options = projectIntegrationTest.testInjector.resolve("options");
+
+			options.path = tempFolder;
+			let tempDir = temp.mkdirSync("template");
+			let fs: IFileSystem = projectIntegrationTest.testInjector.resolve("fs");
+			fs.writeJson(path.join(tempDir, "package.json"), {
+				name: "myCustomTemplate",
+				version: "1.0.0",
+				dependencies: {
+					"lodash": "3.10.1"
+				},
+				devDependencies: {
+					"minimist": "1.2.0"
+				}
+			}).wait();
+
+			projectIntegrationTest.createProject(projectName, tempDir).wait();
+			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", tempDir).wait();
+		});
+
+		it("creates valid project from tarball", () => {
+			let projectIntegrationTest = new ProjectIntegrationTest();
+			let tempFolder = temp.mkdirSync("projectLocalDir");
+			let projectName = "myapp";
+			let options = projectIntegrationTest.testInjector.resolve("options");
+
+			options.path = tempFolder;
+			projectIntegrationTest.createProject(projectName, "https://github.com/NativeScript/template-hello-world/tarball/master").wait();
+			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", pathToDefaultTemplate).wait();
+		});
+
+		it("creates valid project from git url", () => {
+			let projectIntegrationTest = new ProjectIntegrationTest();
+			let tempFolder = temp.mkdirSync("projectLocalDir");
+			let projectName = "myapp";
+			let options = projectIntegrationTest.testInjector.resolve("options");
+
+			options.path = tempFolder;
+			projectIntegrationTest.createProject(projectName, "https://github.com/NativeScript/template-hello-world.git").wait();
+			projectIntegrationTest.assertProject(tempFolder, projectName, "org.nativescript.myapp", pathToDefaultTemplate).wait();
+		});
+
 		it("creates valid project with specified id from default template", () => {
-			let	projectIntegrationTest = new ProjectIntegrationTest();
+			let projectIntegrationTest = new ProjectIntegrationTest();
 			let tempFolder = temp.mkdirSync("project1");
 			let projectName = "myapp";
 			let options = projectIntegrationTest.testInjector.resolve("options");

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -1,0 +1,134 @@
+/// <reference path=".d.ts" />
+"use strict";
+
+import {Yok} from "../lib/common/yok";
+import * as stubs from "./stubs";
+import {ProjectTemplatesService} from "../lib/services/project-templates-service";
+import * as assert from "assert";
+import Future = require("fibers/future");
+import * as path from "path";
+
+let isDeleteDirectoryCalledForNodeModulesDir = false;
+let expectedTemplatePath = "templatePath";
+let nativeScriptValidatedTemplatePath = "nsValidatedTemplatePath";
+
+function createTestInjector(configuration?: {shouldNpmInstallThrow: boolean, npmInstallationDirContents: string[], npmInstallationDirNodeModulesContents: string[]}): IInjector {
+	let injector = new Yok();
+	injector.register("errors", stubs.ErrorsStub);
+	injector.register("logger", stubs.LoggerStub);
+	injector.register("fs", {
+		readDirectory: (dirPath: string) => {
+			if(dirPath.toLowerCase().indexOf("node_modules") !== -1) {
+				return Future.fromResult(configuration.npmInstallationDirNodeModulesContents);
+			}
+			return Future.fromResult(configuration.npmInstallationDirContents);
+		},
+
+		deleteDirectory: (directory: string) => {
+			if(directory.indexOf("node_modules") !== -1) {
+				isDeleteDirectoryCalledForNodeModulesDir = true;
+			}
+			return Future.fromResult();
+		}
+
+	});
+	injector.register("npm", {
+		install: (packageName: string, pathToSave: string, config?: any) => {
+			return (() => {
+				if(configuration.shouldNpmInstallThrow) {
+					throw new Error("NPM install throws error.");
+				}
+
+				return "sample result";
+			}).future<any>()();
+		}
+	});
+
+	injector.register("npmInstallationManager", {
+		install: (packageName: string, options?: INpmInstallOptions) => {
+			return Future.fromResult(nativeScriptValidatedTemplatePath);
+		}
+	});
+
+	injector.register("projectTemplatesService", ProjectTemplatesService);
+
+	return injector;
+}
+
+describe("project-templates-service", () => {
+	let testInjector: IInjector;
+	let projectTemplatesService: IProjectTemplatesService;
+	beforeEach(() => {
+		isDeleteDirectoryCalledForNodeModulesDir = false;
+	});
+
+	describe("prepareTemplate", () => {
+		describe("throws error", () =>{
+			it("when npm install fails", () => {
+				testInjector = createTestInjector({shouldNpmInstallThrow: true, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: null});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				assert.throws(() => projectTemplatesService.prepareTemplate("invalidName").wait());
+			});
+
+			it("when after npm install the temp directory does not have any content", () => {
+				testInjector = createTestInjector({shouldNpmInstallThrow: false, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: null});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				assert.throws(() => projectTemplatesService.prepareTemplate("validName").wait());
+			});
+
+			it("when after npm install the temp directory has more than one subdir", () => {
+				testInjector = createTestInjector({shouldNpmInstallThrow: false, npmInstallationDirContents: ["dir1", "dir2"], npmInstallationDirNodeModulesContents: []});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				assert.throws(() => projectTemplatesService.prepareTemplate("validName").wait());
+			});
+
+			it("when after npm install the temp directory has only node_modules directory and there's nothing inside node_modules", () => {
+				testInjector = createTestInjector({shouldNpmInstallThrow: false, npmInstallationDirContents: ["node_modules"], npmInstallationDirNodeModulesContents: []});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				assert.throws(() => projectTemplatesService.prepareTemplate("validName").wait());
+			});
+		});
+
+		describe("returns correct path to template", () => {
+			it("when after npm install the temp directory has only one subdir and it is not node_modules", () =>{
+				testInjector = createTestInjector({shouldNpmInstallThrow: false, npmInstallationDirContents: [expectedTemplatePath], npmInstallationDirNodeModulesContents: []});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				let actualPathToTemplate = projectTemplatesService.prepareTemplate("validName").wait();
+				assert.strictEqual(path.basename(actualPathToTemplate), expectedTemplatePath);
+				assert.strictEqual(isDeleteDirectoryCalledForNodeModulesDir, true, "When correct path is returned, template's node_modules directory should be deleted.");
+			});
+
+			it("when after npm install the temp directory has only one subdir and it is node_modules", () =>{
+				testInjector = createTestInjector({shouldNpmInstallThrow: false, npmInstallationDirContents: ["node_modules"], npmInstallationDirNodeModulesContents: [expectedTemplatePath]});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				let actualPathToTemplate = projectTemplatesService.prepareTemplate("validName").wait();
+				assert.strictEqual(path.basename(actualPathToTemplate), expectedTemplatePath);
+				assert.strictEqual(isDeleteDirectoryCalledForNodeModulesDir, true, "When correct path is returned, template's node_modules directory should be deleted.");
+			});
+
+			it("when reserved template name is used", () =>{
+				testInjector = createTestInjector({shouldNpmInstallThrow: false, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: []});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				let actualPathToTemplate = projectTemplatesService.prepareTemplate("typescript").wait();
+				assert.strictEqual(path.basename(actualPathToTemplate), nativeScriptValidatedTemplatePath);
+				assert.strictEqual(isDeleteDirectoryCalledForNodeModulesDir, true, "When correct path is returned, template's node_modules directory should be deleted.");
+			});
+
+			it("when reserved template name is used (case-insensitive test)", () =>{
+				testInjector = createTestInjector({shouldNpmInstallThrow: false, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: []});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				let actualPathToTemplate = projectTemplatesService.prepareTemplate("tYpEsCriPT").wait();
+				assert.strictEqual(path.basename(actualPathToTemplate), nativeScriptValidatedTemplatePath);
+				assert.strictEqual(isDeleteDirectoryCalledForNodeModulesDir, true, "When correct path is returned, template's node_modules directory should be deleted.");
+			});
+
+			it("uses defaultTemplate when undefined is passed as parameter", () =>{
+				testInjector = createTestInjector({shouldNpmInstallThrow: false, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: []});
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+				let actualPathToTemplate = projectTemplatesService.prepareTemplate(undefined).wait();
+				assert.strictEqual(path.basename(actualPathToTemplate), nativeScriptValidatedTemplatePath);
+				assert.strictEqual(isDeleteDirectoryCalledForNodeModulesDir, true, "When correct path is returned, template's node_modules directory should be deleted.");
+			});
+		});
+	});
+});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -184,7 +184,7 @@ export class ErrorsStub implements IErrors {
 	}
 
 	failWithoutHelp(message: string, ...args: any[]): void {
-		throw new Error();
+		throw new Error(message);
 	}
 
 	beginCommand(action:() => IFuture<boolean>, printHelpCommand: () => IFuture<boolean>): IFuture<boolean> {
@@ -384,6 +384,10 @@ export class ProjectHelperStub implements IProjectHelper {
 
 export class ProjectTemplatesService implements IProjectTemplatesService {
 	get defaultTemplatePath(): IFuture<string> {
+		return Future.fromResult("");
+	}
+
+	prepareTemplate(templateName: string): IFuture<string> {
 		return Future.fromResult("");
 	}
 }


### PR DESCRIPTION
Add support for --template option when creating new project.
The value for `--template` can be anything that you can `npm install`. For example valid calls are:
* `tns create app1 --template tns-template-hello-world`
* `tns create app1 --template https://github.com/NativeScript/template-hello-world-ts/tarball/master`
* `tns create app1 --template ../myTemplate`
* `tns create app1 --template https://github.com/NativeScript/template-hello-world-ts.git`
* `tns create app1 --template https://github.com/NativeScript/template-hello-world-ts.git#master`

In case you use:
`tns create app1 --template typescript` or `tns create app1 --template tsc`, CLI will try to install `tns-template-hello-world-ts` template.
In case you use `tns create app1 --template typescript@1.2.0` we will install version 1.2.0 of `tns-template-hello-world-ts`.

When a custom template is used, CLI will extend its App_Resources with the ones from default template in case any of them is missing.

> NOTE: Updating npm version to latest 2.x as our current version (2.6.1) fails when trying to execute: `npm install https://github.com/nativescript/template-hello-world.git`
```
npm ERR! fetch failed https://github.com/nativescript/template-hello-world.git
npm WARN retry will retry, error on last attempt: Error: fetch failed with status code 406
npm ERR! fetch failed https://github.com/nativescript/template-hello-world.git
npm WARN retry will retry, error on last attempt: Error: fetch failed with status code 406
```

Implements https://github.com/NativeScript/nativescript-cli/issues/374 