### PR TITLE
Silent shelljs by default

### DIFF
--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -7,6 +7,8 @@ require("./common/verify-node-version").verifyNodeVersion(require("../package.js
 require("./bootstrap");
 import * as fiber from "fibers";
 import Future = require("fibers/future");
+import * as shelljs from "shelljs";
+shelljs.config.silent = true;
 import {installUncaughtExceptionListener} from "./common/errors";
 installUncaughtExceptionListener(process.exit);
 


### PR DESCRIPTION
Shelljs likes to report some warnings, which we do not want to show to our users.
So set it to silent mode by default. In case for any shelljs command you want to show the warnings, just set silent to false before executing it.

This will also fix some warnings that are currently shown when preparing plugins. (`cp - unable to find file...`).