### PR TITLE
Android debugger unixsockets

### DIFF
--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -154,8 +154,8 @@ class AndroidDebugService implements IDebugService {
 
 	private attachDebugger(deviceId: string,packageName: string): void {
         
-        //let startDebuggerCommand = ["am", "broadcast", "-a", '\"${packageName}-debug\"', "--ez", "enable", "true"];
-        //this.device.adb.executeShellCommand(startDebuggerCommand).wait();
+        let startDebuggerCommand = ["am", "broadcast", "-a", '\"${packageName}-debug\"', "--ez", "enable", "true"];
+        this.device.adb.executeShellCommand(startDebuggerCommand).wait();
         
         var port = this.getForwardedLocalDebugPortForPackageName(deviceId, packageName);
         


### PR DESCRIPTION
This pull request is releated to the changes here #273. A help is needed to merge this into master and then investigate what issues there might be in app builder CLI. 

The long story short. The android debugger now uses named sockets instead of ports hence the code rewrite in adndroid-debug-service to accommodate for that.
Contact me directly in order to merge this successfully into the respected main branches. 