### PR TITLE
Fix livesync --emulator when the app is not installed on the iOS simulator

### DIFF
--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -95,6 +95,12 @@ class TestExecutionService implements ITestExecutionService {
 
 						let localProjectRootPath = platform.toLowerCase() === "ios" ? platformData.appDestinationDirectoryPath : null;
 
+						let getApplicationPathForiOSSimulatorAction = (): IFuture<string> => {
+							return (() => {
+								return this.$platformService.getLatestApplicationPackageForEmulator(platformData).wait().packageName;
+							}).future<string>()();
+						};
+
 						let liveSyncData = {
 							platform: platform,
 							appIdentifier: this.$projectData.projectId,
@@ -104,6 +110,7 @@ class TestExecutionService implements ITestExecutionService {
 							platformSpecificLiveSyncServices: platformSpecificLiveSyncServices,
 							notInstalledAppOnDeviceAction: notInstalledAppOnDeviceAction,
 							notRunningiOSSimulatorAction: notRunningiOSSimulatorAction,
+							getApplicationPathForiOSSimulatorAction: getApplicationPathForiOSSimulatorAction,
 							localProjectRootPath: localProjectRootPath,
 							beforeBatchLiveSyncAction: beforeBatchLiveSyncAction,
 							shouldRestartApplication: (localToDevicePaths: Mobile.ILocalToDevicePathData[]) => Future.fromResult(!this.$options.debugBrk),

--- a/lib/services/usb-livesync-service.ts
+++ b/lib/services/usb-livesync-service.ts
@@ -83,7 +83,7 @@ export class UsbLiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncSer
 
 			let beforeBatchLiveSyncAction = (filePath: string): IFuture<string> => {
 				return (() => {
-					let projectFileInfo = this.getProjectFileInfo(filePath);
+					let projectFileInfo = this.getProjectFileInfo(filePath, platform);
 					let mappedFilePath = path.join(projectFilesPath, path.relative(path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME), projectFileInfo.onDeviceName));
 
 					// Handle files that are in App_Resources/<platform>

--- a/lib/services/usb-livesync-service.ts
+++ b/lib/services/usb-livesync-service.ts
@@ -148,6 +148,12 @@ export class UsbLiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncSer
 				});
 			};
 
+			let getApplicationPathForiOSSimulatorAction = (): IFuture<string> => {
+				return (() => {
+					return this.$platformService.getLatestApplicationPackageForEmulator(platformData).wait().packageName;
+				}).future<string>()();
+			};
+
 			let liveSyncData = {
 				platform: platform,
 				appIdentifier: this.$projectData.projectId,
@@ -157,6 +163,7 @@ export class UsbLiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncSer
 				platformSpecificLiveSyncServices: platformSpecificLiveSyncServices,
 				notInstalledAppOnDeviceAction: notInstalledAppOnDeviceAction,
 				notRunningiOSSimulatorAction: notRunningiOSSimulatorAction,
+				getApplicationPathForiOSSimulatorAction: getApplicationPathForiOSSimulatorAction,
 				localProjectRootPath: localProjectRootPath,
 				beforeLiveSyncAction: beforeLiveSyncAction,
 				beforeBatchLiveSyncAction: beforeBatchLiveSyncAction,


### PR DESCRIPTION
Fixes https://github.com/NativeScript/nativescript-cli/issues/1225 and https://github.com/NativeScript/nativescript-cli/issues/824