### PR TITLE
Fix device log for API 23

### DIFF
--- a/lib/providers/device-log-provider.ts
+++ b/lib/providers/device-log-provider.ts
@@ -3,7 +3,9 @@
 
 export class DeviceLogProvider implements Mobile.IDeviceLogProvider {
 	//sample line is "I/Web Console(    4438): Received Event: deviceready at file:///storage/emulated/0/Icenium/com.telerik.TestApp/js/index.js:48"
-	private static LINE_REGEX = /.\/(.+?)\s*\(\s*(\d+?)\): (.*)/;
+	private static LINE_REGEX = /.\/(.+?)\s*\(\s*\d+?\): (.*)/;
+	// sample line is "11-23 12:39:07.310  1584  1597 I art     : Background sticky concurrent mark sweep GC freed 21966(1780KB) AllocSpace objects, 4(80KB) LOS objects, 77% free, 840KB/3MB, paused 4.018ms total 158.629ms"
+	private static API_LEVEL_23_LINE_REGEX = /.+?\s+?(?:[A-Z]\s+?)([A-Za-z ]+?)\s+?\: (.*)/;
 
 	constructor(private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $logger: ILogger) { }
@@ -25,15 +27,12 @@ export class DeviceLogProvider implements Mobile.IDeviceLogProvider {
 
 	private getConsoleLogFromLine(lineText: String): any {
 		let acceptedTags = ["chromium", "Web Console", "JS"];
-		let match = lineText.match(DeviceLogProvider.LINE_REGEX);
-		if (match) {
-			if(acceptedTags.indexOf(match[1]) !== -1) {
-				return {tag: match[1], message: match[3]};
-			}
-		} else if (_.any(acceptedTags, (tag: string) => { return lineText.indexOf(tag) !== -1; })) {
-			return {message: match[3]};
+		let match = lineText.match(DeviceLogProvider.LINE_REGEX) || lineText.match(DeviceLogProvider.API_LEVEL_23_LINE_REGEX);
+		if (match && acceptedTags.indexOf(match[1].trim()) !== -1) {
+			return {tag: match[1].trim(), message: match[2]};
 		}
-		return null;
+		let matchingTag = _.any(acceptedTags, (tag: string) => { return lineText.indexOf(tag) !== -1; });
+		return matchingTag ? { message: lineText } : null;
 	}
 }
 $injector.register("deviceLogProvider", DeviceLogProvider);


### PR DESCRIPTION
When the Android is using API Level 23, the device log is in different format and our current code fails.
Use new regex for API Level 23 and fix the incorrect code that was failing.