### PR TITLE
Fix cocoapods check and add unit tests for doctor service

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -80,7 +80,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 			// this call will fail in case `android` is not set correctly.
 			this.$androidToolsInfo.getPathToAndroidExecutable().wait();
-			this.$androidToolsInfo.validateJavacVersion(this.$sysInfo.getSysInfo().wait().javacVersion, {showWarningsAsErrors: true}).wait();
+			this.$androidToolsInfo.validateJavacVersion(this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait().javacVersion, {showWarningsAsErrors: true}).wait();
 		}).future<void>()();
 	}
 

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -2,6 +2,7 @@
 "use strict";
 import {EOL} from "os";
 import * as semver from "semver";
+import * as path from "path";
 
 class DoctorService implements IDoctorService {
 	private static MIN_SUPPORTED_POD_VERSION = "0.38.2";
@@ -13,7 +14,7 @@ class DoctorService implements IDoctorService {
 
 	public printWarnings(): boolean {
 		let result = false;
-		let sysInfo = this.$sysInfo.getSysInfo().wait();
+		let sysInfo = this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait();
 
 		if (!sysInfo.adbVer) {
 			this.$logger.warn("WARNING: adb from the Android SDK is not installed or is not configured properly.");

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -2,23 +2,25 @@
 "use strict";
 
 import {SysInfoBase} from "./common/sys-info-base";
+import * as path from "path";
 
 export class SysInfo extends SysInfoBase {
 	constructor(protected $childProcess: IChildProcess,
 				protected $hostInfo: IHostInfo,
 				protected $iTunesValidator: Mobile.IiTunesValidator,
 				protected $logger: ILogger,
+				protected $winreg: IWinReg,
 				private $androidToolsInfo: IAndroidToolsInfo) {
-		super($childProcess, $hostInfo, $iTunesValidator, $logger);
+		super($childProcess, $hostInfo, $iTunesValidator, $logger, $winreg);
 	}
 
-	public getSysInfo(androidToolsInfo?: {pathToAdb: string, pathToAndroid: string}): IFuture<ISysInfoData> {
+	public getSysInfo(pathToPackageJson: string, androidToolsInfo?: {pathToAdb: string, pathToAndroid: string}): IFuture<ISysInfoData> {
 		return ((): ISysInfoData => {
 			let defaultAndroidToolsInfo = {
 				pathToAdb: this.$androidToolsInfo.getPathToAdbFromAndroidHome().wait(),
 				pathToAndroid: this.$androidToolsInfo.getPathToAndroidExecutable().wait()
 			};
-			return super.getSysInfo(androidToolsInfo || defaultAndroidToolsInfo).wait();
+			return super.getSysInfo(pathToPackageJson || path.join(__dirname, "..", "package.json"), androidToolsInfo || defaultAndroidToolsInfo).wait();
 		}).future<ISysInfoData>()();
 	}
 }


### PR DESCRIPTION
When cocoapods are not installed on Mac machine, doctor is failing.
Fix this by skipping match check in case pods are not installed.
Add basic unit tests for doctor service.

Add unit test for the failing cocoapods check.