### PR TITLE
Check XML files for well-formedness

### DIFF
--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -6,7 +6,9 @@ export class PrepareCommand implements ICommand {
 		private $platformCommandParameter: ICommandParameter) { }
 
 	execute(args: string[]): IFuture<void> {
-		return this.$platformService.preparePlatform(args[0]);
+		return (() => {
+			this.$platformService.preparePlatform(args[0]);
+		}).future<void>()();
 	}
 
 	allowedParameters = [this.$platformCommandParameter];

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -6,7 +6,7 @@ interface IPlatformService {
 	removePlatforms(platforms: string[]): IFuture<void>;
 	updatePlatforms(platforms: string[]): IFuture<void>;
 	runPlatform(platform: string, buildConfig?: IBuildConfig): IFuture<void>;
-	preparePlatform(platform: string): IFuture<void>;
+	preparePlatform(platform: string): IFuture<boolean>;
 	buildPlatform(platform: string, buildConfig?: IBuildConfig): IFuture<void>;
 	installOnDevice(platform: string, buildConfig?: IBuildConfig): IFuture<void>;
 	deployOnDevice(platform: string, buildConfig?: IBuildConfig): IFuture<void>;

--- a/lib/services/usb-livesync-service.ts
+++ b/lib/services/usb-livesync-service.ts
@@ -34,6 +34,7 @@ export class UsbLiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncSer
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $projectDataService: IProjectDataService,
 		private $prompter: IPrompter,
+		private $errors: IErrors,
 		$hostInfo: IHostInfo) {
 			super($devicesService, $mobileHelper, $localToDevicePathDataFactory, $logger, $options,
 				$deviceAppDataFactory, $fs, $dispatcher, $injector, $childProcess, $iOSEmulatorServices,
@@ -65,7 +66,9 @@ export class UsbLiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncSer
 				}
 			}
 
-			this.$platformService.preparePlatform(platform).wait();
+			if (!this.$platformService.preparePlatform(platform).wait()) {
+				this.$errors.failWithoutHelp("Verify that listed files are well-formed and try again the operation.");
+			}
 
 			let projectFilesPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 
@@ -121,7 +124,10 @@ export class UsbLiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncSer
 			let fastLiveSync = (filePath: string) => {
 				this.$dispatcher.dispatch(() => {
 					return (() => {
-						this.$platformService.preparePlatform(platform).wait();
+						if (!this.$platformService.preparePlatform(platform).wait()) {
+							this.$logger.out("Verify that listed files are well-formed and try again the operation.");
+							return;
+						}
 						let mappedFilePath = beforeBatchLiveSyncAction(filePath).wait();
 
 						if (this.shouldSynciOSSimulator(platform).wait()) {
@@ -177,7 +183,10 @@ export class UsbLiveSyncService extends usbLivesyncServiceBaseLib.UsbLiveSyncSer
 	}
 
 	protected preparePlatformForSync(platform: string) {
-		this.$platformService.preparePlatform(platform).wait();
+		if (!this.$platformService.preparePlatform(platform).wait()) {
+			this.$logger.out("Verify that listed files are well-formed and try again the operation.");
+			return;
+		}
 	}
 
 	private resolveUsbLiveSyncService(platform: string, device: Mobile.IDevice): IPlatformSpecificUsbLiveSyncService {


### PR DESCRIPTION
Check XML files for well-formedness. No validation is performed. The check should happen at least on build and livesync.

Whenever an invalid XML file is found:

  - for livesync --watch operation, warn the user, but do not break the CLI
  - for every other operation, abort it

Implementation detail: it happens actually on prepare.
See https://github.com/NativeScript/nativescript-cli/issues/1272