### PR TITLE
Do not delete app's package.json

### DIFF
--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -77,9 +77,6 @@ export class ProjectService implements IProjectService {
 				//update dependencies and devDependencies of newly created project with data from template
 				this.mergeProjectAndTemplateProperties(projectDir, appPath).wait();
 				this.updateAppResourcesDir(appDirectory).wait();
-				// Delete app/package.json file, its just causing confusion.
-				// Also its dependencies and devDependencies are already merged in project's package.json.
-				this.$fs.deleteFile(path.join(projectDir, constants.APP_FOLDER_NAME, constants.PACKAGE_JSON_FILE_NAME)).wait();
 				this.$npm.install(projectDir, projectDir, { "ignore-scripts": this.$options.ignoreScripts }).wait();
 			} catch (err) {
 				this.$fs.deleteDirectory(projectDir).wait();

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -90,14 +90,11 @@ class ProjectIntegrationTest {
 
 			let expectedFiles = fs.enumerateFilesInDirectorySync(sourceDir);
 			let actualFiles = fs.enumerateFilesInDirectorySync(appDirectoryPath);
-			assert.isTrue(actualFiles.length >= (expectedFiles.length - 1), "Files in created project must be at least as files in app dir (without package.json).");
+			assert.isTrue(actualFiles.length >= expectedFiles.length, "Files in created project must be at least as files in app dir.");
 			_.each(expectedFiles, file => {
 				let relativeToProjectDir = helpers.getRelativeToRootPath(sourceDir, file);
-				if(path.basename(file) === "package.json") {
-					assert.isFalse(fs.exists(path.join(appDirectoryPath, relativeToProjectDir)).wait());
-				} else {
-					assert.isTrue(fs.exists(path.join(appDirectoryPath, relativeToProjectDir)).wait());
-				}
+				let filePathInApp = path.join(appDirectoryPath, relativeToProjectDir);
+				assert.isTrue(fs.exists(filePathInApp).wait(), `File ${filePathInApp} does not exist.`);
 			});
 
 			// assert dependencies and devDependencies are copied from template to real project


### PR DESCRIPTION
App's package.json contains information about application's entry point, so we should not delete it.