### PR TITLE
Update npm version to latest 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mute-stream": "0.0.5",
     "node-inspector": "https://github.com/NativeScript/node-inspector/tarball/v0.7.4.0",
     "node-uuid": "1.4.3",
-    "npm": "2.6.1",
+    "npm": "2.14.12",
     "open": "0.0.5",
     "osenv": "0.1.3",
     "plist": "1.1.0",


### PR DESCRIPTION
Update npm version to latest 2.x as the old one (2.6.1) has some bugs that prevent us from using git urls, installing some plugins, etc.