### PR TITLE
Fix tns doctor command

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -126,9 +126,10 @@ interface IAndroidToolsInfo {
 	/**
 	 * Returns the path to `android` executable. It should be `$ANDROID_HOME/tools/android`.
 	 * In case ANDROID_HOME is not defined, check if `android` is part of $PATH.
+	 * @param {any} options Defines if the warning messages should treated as error.
 	 * @return {string} Path to the `android` executable.
 	 */
-	getPathToAndroidExecutable(): IFuture<string>;
+	getPathToAndroidExecutable(options?: {showWarningsAsErrors: boolean}): IFuture<string>;
 
 	/**
 	 * Gets the path to `adb` executable from ANDROID_HOME. It should be `$ANDROID_HOME/platform-tools/adb` in case it exists.

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -79,7 +79,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			this.validateProjectName(this.$projectData.projectName);
 
 			// this call will fail in case `android` is not set correctly.
-			this.$androidToolsInfo.getPathToAndroidExecutable().wait();
+			this.$androidToolsInfo.getPathToAndroidExecutable({showWarningsAsErrors: true}).wait();
 			this.$androidToolsInfo.validateJavacVersion(this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait().javacVersion, {showWarningsAsErrors: true}).wait();
 		}).future<void>()();
 	}


### PR DESCRIPTION
When ANDROID_HOME environment variable is not set, we call childProcess exec and spawn with undefined command.
This leads to "futures left behind" errors.
Make sure the commands will be executed only in case they are not undefined.
Also make sure that `tns prepare android` will fail immediately in case ANDROID_HOME is not set (currently it shows warning for ANDROID_HOME and shows error for compile SDK).

Related issue: https://github.com/NativeScript/nativescript-cli/issues/1242