### PR TITLE
Add baseConfig option

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -87,6 +87,7 @@ interface IOptions extends ICommonOptions {
 	compileSdk: number;
 	port: Number;
 	copyTo: string;
+	baseConfig: string;
 }
 
 interface IProjectFilesManager {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -34,6 +34,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			compileSdk: {type: OptionType.Number },
 			port: { type: OptionType.Number },
 			copyTo: { type: OptionType.String },
+			baseConfig: { type: OptionType.String }
 		},
 		path.join($hostInfo.isWindows ? process.env.LocalAppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),
 			$errors, $staticConfig);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -113,6 +113,11 @@ export class PlatformService implements IPlatformService {
 
 			let sourceFrameworkDir = isFrameworkPathDirectory && this.$options.symlink ? path.join(this.$options.frameworkPath, "framework") : frameworkDir;
 			platformData.platformProjectService.createProject(path.resolve(sourceFrameworkDir), installedVersion).wait();
+			if(this.$options.baseConfig) {
+				let newConfigFile = path.resolve(this.$options.baseConfig);
+				this.$logger.trace(`Replacing '${platformData.configurationFilePath}' with '${newConfigFile}'.`);
+				this.$fs.copyFile(newConfigFile, platformData.configurationFilePath).wait();
+			}
 
 			if(isFrameworkPathDirectory || isFrameworkPathNotSymlinkedFile) {
 				// Need to remove unneeded node_modules folder

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -114,7 +114,7 @@ export class PluginsService implements IPluginsService {
 			npmInstallationManager.addToCache(platformData.frameworkPackageName, frameworkVersion).wait();
 
 			let cachedPackagePath = npmInstallationManager.getCachedPackagePath(platformData.frameworkPackageName, frameworkVersion);
-			let cachedConfigurationFilePath = path.join(cachedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME, platformData.relativeToFrameworkConfigurationFilePath);
+			let cachedConfigurationFilePath =  this.$options.baseConfig ? path.resolve(this.$options.baseConfig) : path.join(cachedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME, platformData.relativeToFrameworkConfigurationFilePath);
 			let cachedConfigurationFileContent = this.$fs.readText(cachedConfigurationFilePath).wait();
 			this.$fs.writeFile(platformData.configurationFilePath, cachedConfigurationFileContent).wait();
 


### PR DESCRIPTION
Add baseConfig option that can be used to replace the default AndroidManifest.xml / Info.plist that is used for merge.
It should be passed to all build related commands. It can be passed to platform add command as well.

Required for AppBuilder integration.