### PR TITLE
Init command should not force tns-core-modules version

### DIFF
--- a/lib/services/init-service.ts
+++ b/lib/services/init-service.ts
@@ -60,7 +60,9 @@ export class InitService implements IInitService {
 				if(!dependencies) {
 					projectData.dependencies = Object.create(null);
 				}
-				projectData.dependencies[constants.TNS_CORE_MODULES_NAME] = this.getVersionData(constants.TNS_CORE_MODULES_NAME).wait()["version"];
+				// In case console is interactive and --force is not specified, do not read the version from package.json, show all available versions to the user.
+				let tnsCoreModulesVersionInPackageJson = this.useDefaultValue ? projectData.dependencies[constants.TNS_CORE_MODULES_NAME] : null;
+				projectData.dependencies[constants.TNS_CORE_MODULES_NAME] = this.$options.tnsModulesVersion || tnsCoreModulesVersionInPackageJson || this.getVersionData(constants.TNS_CORE_MODULES_NAME).wait()["version"];
 
 				this.$fs.writeJson(this.projectFilePath, projectData).wait();
 			} catch(err) {
@@ -106,7 +108,7 @@ export class InitService implements IInitService {
 			let data = this.$npm.view(packageName, "versions").wait();
 			let versions = _.filter(data[latestVersion].versions, (version: string) => semver.gte(version, InitService.MIN_SUPPORTED_FRAMEWORK_VERSIONS[packageName]));
 			if(versions.length === 1) {
-				this.$logger.info(`Only ${versions[0]} version is available for ${packageName} framework.`);
+				this.$logger.info(`Only ${versions[0]} version is available for ${packageName}.`);
 				return this.buildVersionData(versions[0]);
 			}
 			let sortedVersions = versions.sort(helpers.versionCompare).reverse();


### PR DESCRIPTION
Currently `tns init` command forces the application to use the default version of tns-core-modules.
For example in case your CLI is version 1.4.3, `tns init` in non-interactive terminal will set version 1.4.0 (latest 1.4.x) of tns-core-modules even in case you already have defined your version in your package.json
Use --tnsCoreModules option by default - if it is specified, it has highest priority.
In case the console is not interactive, check if package.json has entry in dependencies section for tns-core-modules and use it.
In case the console is interactive, show all available versions to the user and let him pick up the one he wants.
In case the console is not interactive and the package.json does not have entry for `tns-core-modules`, use the default logic.

Targeting release branch as this feature is required for AppBuilder integration.