### PR TITLE
Merge Info.plist from App_Resources and plugins into platforms/ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "open": "0.0.5",
     "osenv": "0.1.3",
     "plist": "1.1.0",
+    "plist-merge-patch": "0.0.9",
     "plistlib": "0.2.1",
     "progress-stream": "1.1.1",
     "prompt": "https://github.com/Icenium/prompt/tarball/master",

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -38,6 +38,7 @@ function createTestInjector(projectPath: string, projectName: string): IInjector
 	testInjector.register("staticConfig", ConfigLib.StaticConfig);
 	testInjector.register("projectDataService", {});
 	testInjector.register("prompter", {});
+	testInjector.register("devicePlatformsConstants", { iOS: "iOS" });
 	return testInjector;
 }
 


### PR DESCRIPTION
Solves the #1089 for iOS.

If the file `app/App_Resources/iOS/Info.plist` exists the new behavior is triggered, otherwise we should be backward compatible.

On prepare we will get that `Info.plist` and merge it with each `platforms/ios/Info.plist` file from all plugins that have one. The CFBundleIdentifier will be set to package.json's nativescript.id and the result will be written to `platforms/ios/<proj-id>/<proj-id>-Info.plist`.

The *App_Resources Info.plist* has higher priority than the *plugin Info.plists*.

To use the new feature the hello-world template or the CLI will have to bring in a full blown `app/App_Resources/iOS/Info.plist`.

To be followed up by:
 - https://github.com/NativeScript/template-hello-world/pull/37
 - https://github.com/NativeScript/template-hello-world-ts/pull/4