### PR TITLE
Do not consider App_Resources/Android as plugin

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -284,13 +284,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	public processConfigurationFilesFromAppResources(): IFuture<void> {
-		return (() => {
-			// Process androidManifest.xml from App_Resources
-			let manifestFilePath = path.join(this.$projectData.appResourcesDirectoryPath, this.platformData.normalizedPlatformName, this.platformData.configurationFileName);
-			if (this.$fs.exists(manifestFilePath).wait()) {
-				this.processResourcesFromPlugin("NativescriptAppResources", path.dirname(manifestFilePath)).wait();
-			}
-		}).future<void>()();
+		return Future.fromResult();
 	}
 
 	private processResourcesFromPlugin(pluginName: string, pluginPlatformsFolderPath: string): IFuture<void> {


### PR DESCRIPTION
Currently when `app/App_Resources/Android` contains AndroidManifest.xml or include.gradle, we treat the folder in a specail way and copy it on two places.
This will be handled from the runtime itself, so no need to do it anymore.

Related to https://github.com/NativeScript/android-runtime/pull/309