### PR TITLE
Implement Android debugging with unix sockets redirection

### DIFF
--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -1,14 +1,11 @@
 ///<reference path="../.d.ts"/>
 "use strict";
-import * as helpers from "../common/helpers";
 import * as path from "path";
-import * as util from "util";
+import * as net from "net";
+import Future = require("fibers/future");
 
 class AndroidDebugService implements IDebugService {
-    private static ENV_DEBUG_IN_FILENAME = "envDebug.in";
-	private static ENV_DEBUG_OUT_FILENAME = "envDebug.out";
-    private static DEFAULT_NODE_INSPECTOR_URL = "http://127.0.0.1:8080/debug";
-    private static PACKAGE_EXTERNAL_DIR_TEMPLATE = "/sdcard/Android/data/%s/files/";
+	private static DEFAULT_NODE_INSPECTOR_URL = "http://127.0.0.1:8080/debug";
 
 	private _device: Mobile.IAndroidDevice = null;
 
@@ -19,13 +16,10 @@ class AndroidDebugService implements IDebugService {
 		private $logger: ILogger,
 		private $options: IOptions,
 		private $childProcess: IChildProcess,
-        private $mobileHelper: Mobile.IMobileHelper,
-        private $hostInfo: IHostInfo,
-        private $errors: IErrors,
-        private $opener: IOpener,
-        private $staticConfig: IStaticConfig,
-        private $utils: IUtils,
-        private $config: IConfiguration) { }
+		private $hostInfo: IHostInfo,
+		private $errors: IErrors,
+		private $opener: IOpener,
+		private $config: IConfiguration) { }
 
 	private get platform() { return "android"; }
 
@@ -43,14 +37,60 @@ class AndroidDebugService implements IDebugService {
 			: this.debugOnDevice();
 	}
 
-	public debugOnEmulator(): IFuture<void> {
+	private debugOnEmulator(): IFuture<void> {
 		return (() => {
 			this.$platformService.deployOnEmulator(this.platform).wait();
 			this.debugOnDevice().wait();
 		}).future<void>()();
 	}
 
-	public debugOnDevice(): IFuture<void> {
+	private isPortAvailable(candidatePort: number): IFuture<boolean> {
+		let future = new Future<boolean>();
+		let server = net.createServer();
+		server.on("error", (err: Error) => {
+			future.return(false);
+		});
+		server.listen(candidatePort, (err: Error) => {
+			server.once("close", () => {
+				future.return(true);
+			});
+			server.close();
+		});
+
+		return future;
+	}
+
+	private getForwardedLocalDebugPortForPackageName(deviceId: string, packageName: string): IFuture<number> {
+		return (() => {
+			let port = -1;
+			let forwardsResult = this.device.adb.executeCommand(["forward", "--list"]).wait();
+
+			//matches 123a188909e6czzc tcp:40001 localabstract:org.nativescript.testUnixSockets-debug
+			let regexp = new RegExp(`(?:${deviceId} tcp:)([\\d]+)(?= localabstract:${packageName}-debug)`, "g");
+			let match = regexp.exec(forwardsResult);
+			if (match) {
+				port = parseInt(match[1]);
+			} else {
+				let candidatePort = 40000;
+				while (!this.isPortAvailable(candidatePort++).wait()) {
+					if (candidatePort > 65534) {
+						this.$errors.failWithoutHelp("Unable to find free local port.");
+					}
+				}
+				port = candidatePort;
+
+				this.unixSocketForward(port, packageName + "-debug").wait();
+			}
+
+			return port;
+		}).future<number>()();
+	}
+
+	private unixSocketForward(local: number, remote: string): IFuture<void> {
+		return this.device.adb.executeCommand(["forward", `tcp:${local.toString()}`, `localabstract:${remote}`]);
+	}
+
+	private debugOnDevice(): IFuture<void> {
 		return (() => {
 			let packageFile = "";
 
@@ -78,183 +118,102 @@ class AndroidDebugService implements IDebugService {
 	}
 
 	 private debugCore(device: Mobile.IAndroidDevice, packageFile: string, packageName: string): IFuture<void> {
-        return (() => {
+		return (() => {
 			this.device = device;
 
-            if (this.$options.getPort) {
-                this.printDebugPort(packageName).wait();
-            } else if (this.$options.start) {
-                this.attachDebugger(packageName);
-            } else if (this.$options.stop) {
-                this.detachDebugger(packageName).wait();
-            } else if (this.$options.debugBrk) {
-                this.startAppWithDebugger(packageFile, packageName).wait();
-            }
-        }).future<void>()();
-    }
+			if (this.$options.getPort) {
+				this.printDebugPort(device.deviceInfo.identifier, packageName).wait();
+			} else if (this.$options.start) {
+				this.attachDebugger(device.deviceInfo.identifier, packageName).wait();
+			} else if (this.$options.stop) {
+				this.detachDebugger(packageName).wait();
+			} else if (this.$options.debugBrk) {
+				this.startAppWithDebugger(packageFile, packageName).wait();
+			}
+		}).future<void>()();
+	}
 
-	private printDebugPort(packageName: string): IFuture<void> {
-        return (() => {
-            let res = this.device.adb.executeShellCommand(["am", "broadcast", "-a", packageName + "-GetDbgPort"]).wait();
-            this.$logger.info(res);
-        }).future<void>()();
-    }
+	private printDebugPort(deviceId: string, packageName: string): IFuture<void> {
+		return (() => {
+			let port = this.getForwardedLocalDebugPortForPackageName(deviceId, packageName).wait();
+			this.$logger.info(port);
+		}).future<void>()();
+	}
 
-	private attachDebugger(packageName: string): void {
-        let startDebuggerCommand = ["am", "broadcast", "-a", '\"${packageName}-Debug\"', "--ez", "enable", "true"];
-        let port = this.$options.debugPort;
+	private attachDebugger(deviceId: string, packageName: string): IFuture<void> {
+		return (() => {
+			let startDebuggerCommand = ["am", "broadcast", "-a", '\"${packageName}-debug\"', "--ez", "enable", "true"];
+			this.device.adb.executeShellCommand(startDebuggerCommand).wait();
 
-        if (port > 0) {
-            startDebuggerCommand.push("--ei", "debuggerPort", port.toString());
-            this.device.adb.executeShellCommand(startDebuggerCommand).wait();
-        } else {
-            let res = this.device.adb.executeShellCommand(["am", "broadcast", "-a", packageName + "-Debug", "--ez", "enable", "true"]).wait();
-            let match = res.match(/result=(\d)+/);
-            if (match) {
-                port = match[0].substring(7);
-            } else {
-                port = 0;
-            }
-        }
-        if ((0 < port) && (port < 65536)) {
-            this.tcpForward(port, port).wait();
-            this.startDebuggerClient(port).wait();
-            this.openDebuggerClient(AndroidDebugService.DEFAULT_NODE_INSPECTOR_URL + "?port=" + port);
-        } else {
-          this.$logger.info("Cannot detect debug port.");
-        }
-    }
+			let port = this.getForwardedLocalDebugPortForPackageName(deviceId, packageName).wait();
+			this.startDebuggerClient(port).wait();
+			this.openDebuggerClient(AndroidDebugService.DEFAULT_NODE_INSPECTOR_URL + "?port=" + port);
+		}).future<void>()();
+	}
 
-    private detachDebugger(packageName: string): IFuture<void> {
-        return this.device.adb.executeShellCommand(["am", "broadcast", "-a", `${packageName}-Debug`, "--ez", "enable", "false"]);
-    }
+	private detachDebugger(packageName: string): IFuture<void> {
+		return this.device.adb.executeShellCommand(["am", "broadcast", "-a", `${packageName}-debug`, "--ez", "enable", "false"]);
+	}
 
-    private startAppWithDebugger(packageFile: string, packageName: string): IFuture<void> {
-        return (() => {
-            if(!this.$options.emulator) {
-                this.device.applicationManager.uninstallApplication(packageName).wait();
-                this.device.applicationManager.installApplication(packageFile).wait();
-            }
-            this.debugStartCore().wait();
-        }).future<void>()();
-    }
+	private startAppWithDebugger(packageFile: string, packageName: string): IFuture<void> {
+		return (() => {
+			if(!this.$options.emulator) {
+				this.device.applicationManager.uninstallApplication(packageName).wait();
+				this.device.applicationManager.installApplication(packageFile).wait();
+			}
+			this.debugStartCore().wait();
+		}).future<void>()();
+	}
 
-    public debugStart(): IFuture<void> {
-        return (() => {
-            this.$devicesService.initialize({ platform: this.platform, deviceId: this.$options.device}).wait();
-            let action = (device: Mobile.IAndroidDevice): IFuture<void> => {
-                this.device = device;
-                return this.debugStartCore();
-            };
-            this.$devicesService.execute(action).wait();
-        }).future<void>()();
-    }
+	public debugStart(): IFuture<void> {
+		return (() => {
+			this.$devicesService.initialize({ platform: this.platform, deviceId: this.$options.device}).wait();
+			let action = (device: Mobile.IAndroidDevice): IFuture<void> => {
+				this.device = device;
+				return this.debugStartCore();
+			};
+			this.$devicesService.execute(action).wait();
+		}).future<void>()();
+	}
 
-    private debugStartCore(): IFuture<void> {
-        return (() => {
-            let packageName = this.$projectData.projectId;
-            let packageDir = util.format(AndroidDebugService.PACKAGE_EXTERNAL_DIR_TEMPLATE, packageName);
-            let envDebugOutFullpath = this.$mobileHelper.buildDevicePath(packageDir, AndroidDebugService.ENV_DEBUG_OUT_FILENAME);
+	private debugStartCore(): IFuture<void> {
+		return (() => {
+			let packageName = this.$projectData.projectId;
 
-            this.device.adb.executeShellCommand(["rm", `${envDebugOutFullpath}`]).wait();
-            this.device.adb.executeShellCommand(["mkdir", "-p", `${packageDir}`]).wait();
+			this.device.adb.executeShellCommand([`cat /dev/null > /data/local/tmp/${packageName}-debugbreak`]).wait();
 
-            let debugBreakPath = this.$mobileHelper.buildDevicePath(packageDir, "debugbreak");
-            this.device.adb.executeShellCommand([`cat /dev/null > ${debugBreakPath}`]).wait();
+			this.device.applicationManager.stopApplication(packageName).wait();
+			this.device.applicationManager.startApplication(packageName).wait();
 
-            this.device.applicationManager.stopApplication(packageName).wait();
-            this.device.applicationManager.startApplication(packageName).wait();
+			let localDebugPort = this.getForwardedLocalDebugPortForPackageName(this.device.deviceInfo.identifier, packageName).wait();
+			this.startDebuggerClient(localDebugPort).wait();
+			this.openDebuggerClient(AndroidDebugService.DEFAULT_NODE_INSPECTOR_URL + "?port=" + localDebugPort);
+		}).future<void>()();
+	}
 
-            let dbgPort = this.startAndGetPort(packageName).wait();
-            if (dbgPort > 0) {
-                this.tcpForward(dbgPort, dbgPort).wait();
-                this.startDebuggerClient(dbgPort).wait();
-                this.openDebuggerClient(AndroidDebugService.DEFAULT_NODE_INSPECTOR_URL + "?port=" + dbgPort);
-            }
-        }).future<void>()();
-    }
+	private startDebuggerClient(port: Number): IFuture<void> {
+		return (() => {
+			let nodeInspectorModuleFilePath = require.resolve("node-inspector");
+			let nodeInspectorModuleDir = path.dirname(nodeInspectorModuleFilePath);
+			let nodeInspectorFullPath = path.join(nodeInspectorModuleDir, "bin", "inspector");
+			this.$childProcess.spawn(process.argv[0], [nodeInspectorFullPath, "--debug-port", port.toString()], { stdio: "ignore", detached: true });
+		}).future<void>()();
+	}
 
-    private tcpForward(src: Number, dest: Number): IFuture<void> {
-        return this.device.adb.executeCommand(["forward", `tcp:${src.toString()}`, `tcp:${dest.toString()}`]);
-    }
-
-    private startDebuggerClient(port: Number): IFuture<void> {
-        return (() => {
-            let nodeInspectorModuleFilePath = require.resolve("node-inspector");
-            let nodeInspectorModuleDir = path.dirname(nodeInspectorModuleFilePath);
-            let nodeInspectorFullPath = path.join(nodeInspectorModuleDir, "bin", "inspector");
-            this.$childProcess.spawn(process.argv[0], [nodeInspectorFullPath, "--debug-port", port.toString()], { stdio: "ignore", detached: true });
-        }).future<void>()();
-    }
-
-    private openDebuggerClient(url: string): void {
-        let defaultDebugUI = "chrome";
-        if(this.$hostInfo.isDarwin) {
-            defaultDebugUI = "Google Chrome";
-        }
-        if(this.$hostInfo.isLinux) {
-            defaultDebugUI = "google-chrome";
-        }
+	private openDebuggerClient(url: string): void {
+		let defaultDebugUI = "chrome";
+		if(this.$hostInfo.isDarwin) {
+			defaultDebugUI = "Google Chrome";
+		}
+		if(this.$hostInfo.isLinux) {
+			defaultDebugUI = "google-chrome";
+		}
 
 		let debugUI = this.$config.ANDROID_DEBUG_UI || defaultDebugUI;
 		let child = this.$opener.open(url, debugUI);
 		if(!child) {
 			this.$errors.failWithoutHelp(`Unable to open ${debugUI}.`);
 		}
-    }
-
-    private checkIfRunning(packageName: string): boolean {
-        let packageDir = util.format(AndroidDebugService.PACKAGE_EXTERNAL_DIR_TEMPLATE, packageName);
-        let envDebugOutFullpath = packageDir + AndroidDebugService.ENV_DEBUG_OUT_FILENAME;
-        let isRunning = this.checkIfFileExists(envDebugOutFullpath).wait();
-        return isRunning;
-    }
-
-    private checkIfFileExists(filename: string): IFuture<boolean> {
-        return (() => {
-            let res = this.device.adb.executeShellCommand([`test -f ${filename} && echo 'yes' || echo 'no'`]).wait();
-            let exists = res.indexOf('yes') > -1;
-            return exists;
-        }).future<boolean>()();
-    }
-
-    private startAndGetPort(packageName: string): IFuture<number> {
-        return (() => {
-            let port = -1;
-			let timeout = this.$utils.getParsedTimeout(90);
-
-            let packageDir = util.format(AndroidDebugService.PACKAGE_EXTERNAL_DIR_TEMPLATE, packageName);
-            let envDebugInFullpath = packageDir + AndroidDebugService.ENV_DEBUG_IN_FILENAME;
-            this.device.adb.executeShellCommand(["rm", `${envDebugInFullpath}`]).wait();
-
-            let isRunning = false;
-            for (let i = 0; i < timeout; i++) {
-                helpers.sleep(1000 /* ms */);
-                isRunning = this.checkIfRunning(packageName);
-                if (isRunning) {
-                    break;
-                }
-            }
-
-            if (isRunning) {
-                this.device.adb.executeShellCommand([`cat /dev/null > ${envDebugInFullpath}`]).wait();
-
-                for (let i = 0; i < timeout; i++) {
-                    helpers.sleep(1000 /* ms */);
-                    let envDebugOutFullpath = packageDir + AndroidDebugService.ENV_DEBUG_OUT_FILENAME;
-                    let exists = this.checkIfFileExists(envDebugOutFullpath).wait();
-                    if (exists) {
-                        let res = this.device.adb.executeShellCommand(["cat", envDebugOutFullpath]).wait();
-                        let match = res.match(/PORT=(\d)+/);
-                        if (match) {
-                            port = parseInt(match[0].substring(5), 10);
-                            break;
-                        }
-                    }
-                }
-            }
-            return port;
-        }).future<number>()();
-    }
+	}
 }
 $injector.register("androidDebugService", AndroidDebugService);


### PR DESCRIPTION
This is cleaned-up version of https://github.com/NativeScript/nativescript-cli/pull/1227
To test it, you need this [runtime](http://nsbuild01.telerik.com/build/job/tns-android-PR/339/).

This pull request is releated to the changes [here](https://github.com/NativeScript/android-runtime/pull/273).

The android debugger now uses named sockets instead of ports hence the code rewrite in adndroid-debug-service to accommodate for that.
Contact @blagoev directly in order to merge this successfully into the respected main branches. 