### PR TITLE
Move settings into Roaming Windows profile

### DIFF
--- a/lib/services/analytics-settings-service.ts
+++ b/lib/services/analytics-settings-service.ts
@@ -18,7 +18,6 @@ class AnalyticsSettingsService implements IAnalyticsSettingsService {
 	}
 
 	public getPrivacyPolicyLink(): string {
-		// TODO: Replace with nativescript privacy-policy link, when such exists.
 		return "http://www.telerik.com/company/privacy-policy";
 	}
 }


### PR DESCRIPTION
See https://github.com/NativeScript/nativescript-cli/issues/1412

 - Change the default settings dir to be inside Roaming Windows profile
 - Move the existing file to its new location, if applicable
 - Remove the source comment which indicates that separate {N} provacy policy is needed - it is not