### PR TITLE
Don't code sign upon simulator build

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -199,7 +199,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 					"-sdk", "iphonesimulator",
 					"-arch", "i386",
 					"VALID_ARCHS=\"i386\"",
-					"CONFIGURATION_BUILD_DIR=" + path.join(projectRoot, "build", "emulator")
+					"CONFIGURATION_BUILD_DIR=" + path.join(projectRoot, "build", "emulator"),
+					"CODE_SIGN_IDENTITY="
 				]);
 			}
 


### PR DESCRIPTION
Apparently xcodebuild whith xcode 7.2 attempts to code sign the simulator build when CODE_SIGN_IDENTITY is set. This variable is set to `iPhone Developer` in the `build.xcconfig` generated.
For reasons beyond me though this code signing attempt fails with **CodeSign error: entitlements are required for product type 'Application' in SDK 'Simulator - iOS 9.2'. Your Xcode installation may be damaged.**
Explicitly setting code signing to **Don't code sign** effectively resolves the issue.
This eliminates https://github.com/NativeScript/nativescript-cli/issues/1428
Ping @rosen-vladimirov @teobugslayer 