### PR TITLE
Exclude some dirs in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,10 @@
 		"target": "ES5",
 		"module": "commonjs",
 		"sourceMap": true
-	}
+	},
+	"exclude": [
+		"node_modules",
+		"scratch",
+		"coverage"
+	]
 }


### PR DESCRIPTION
In `tsconfig.json` we have to exclude `node_modules`, `coverage` and `scratch` dirs.
When they are huge (in my case scratch dir was 1.5 GB), TypeScript is not working at all in VS Code.