### PR TITLE
Ignore scripts when checking CocoaPods

### DIFF
--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -109,7 +109,7 @@ class DoctorService implements IDoctorService {
 		let spinner = new clui.Spinner("Installing iOS runtime.");
 		try {
 			spinner.start();
-			this.$npm.install("tns-ios", projDir).wait();
+			this.$npm.install("tns-ios", projDir, { "ignore-scripts": true, production: true }).wait();
 			spinner.stop();
 			let iosDir = path.join(projDir, "node_modules", "tns-ios", "framework");
 			this.$fs.writeFile(


### PR DESCRIPTION
Install tns-ios with `--ignore-scripts` when the `$ tns doctor` verifies CocoaPods. Else the amount of text printed on the console is incomprehensible.
Ping @rosen-vladimirov @teobugslayer for a quick review