### PR TITLE
Call afterPrepareAllPlugins for the specific platform only

### DIFF
--- a/lib/tools/broccoli/node-modules-dest-copy.ts
+++ b/lib/tools/broccoli/node-modules-dest-copy.ts
@@ -26,7 +26,8 @@ export class DestCopy implements IBroccoliPlugin {
 		private platform: string,
 		private $fs: IFileSystem,
 		private $projectFilesManager: IProjectFilesManager,
-		private $pluginsService: IPluginsService
+		private $pluginsService: IPluginsService,
+		private $platformsData: IPlatformsData
 	) {
 		this.dependencies = Object.create(null);
 		this.devDependencies = this.getDevDependencies(projectDir);
@@ -93,7 +94,7 @@ export class DestCopy implements IBroccoliPlugin {
 	});
 
 	if(!_.isEmpty(this.dependencies)) {
-		this.$pluginsService.afterPrepareAllPlugins().wait();
+		this.$platformsData.getPlatformData(platform).platformProjectService.afterPrepareAllPlugins().wait();
 	}
   }
 


### PR DESCRIPTION
Instead of calling `afterPrepareAllPlugins` for all installed platforms.
Fixes https://github.com/NativeScript/nativescript-cli/issues/1027
Ping @rosen-vladimirov and @teobugslayer for a quick review.