### PR TITLE
Speed-up grunt lint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,15 +59,15 @@ module.exports = function(grunt) {
 		},
 
 		tslint: {
-            build: {
-                files: {
-                    src: ["lib/**/*.ts", "test/**/*.ts", "!lib/common/node_modules/**/*.ts", "!lib/common/messages/**/*.ts", "lib/common/test/unit-tests/**/*.ts", "definitions/**/*.ts", "!**/*.d.ts"]
-                },
-                options: {
-                    configuration: grunt.file.readJSON("./tslint.json")
-                }
-            }
-        },
+			build: {
+				files: {
+					src: ["lib/**/*.ts", "test/**/*.ts", "!lib/common/node_modules/**/*.ts", "!lib/common/messages/**/*.ts", "lib/common/test/unit-tests/**/*.ts", "definitions/**/*.ts", "!lib/**/*.d.ts" , "!test/**/*.ts"]
+				},
+				options: {
+					configuration: grunt.file.readJSON("./tslint.json")
+				}
+			}
+		},
 
 		watch: {
 			devall: {


### PR DESCRIPTION
Currently `grunt lint` might take more than 2-3 minutes. The problem is in the src files passed.
In my case the scratch directory was around 2.5 GB and this was slowing down the linting, as we have included `!*.d.ts` files.
Make sure only lib and test directories are used when linting as our source code and tests are there.

Fixed mixed tabs and spaces in Gruntfile