### PR TITLE
More setup fixes for Windows

### DIFF
--- a/setup/native-script.ps1
+++ b/setup/native-script.ps1
@@ -1,23 +1,33 @@
 
-# A Boxstarter script to set up Windows machine for NativeScript development
-# To run it against RELEASE branch (recommended) use
-# http://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/NativeScript/nativescript-cli/release/setup/native-script.ps1
-# To run it against MASTER branch (usually only developers of NativeScript need to) use
-# http://boxstarter.org/package/nr/url?https://raw.githubusercontent.com/NativeScript/nativescript-cli/master/setup/native-script.ps1
+# A PowerShell script to set up Windows machine for NativeScript development
+# To run it against the PRODUCTION branch (only one supported with self-elevation) use
+# @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))" 
+
+# Self-elevate
+$isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator")
+if (-not $isElevated) {
+    start-process -FilePath PowerShell.exe -NoProfile -ExecutionPolicy Bypass -Verb Runas -Wait -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+    exit 0
+}
+
+# Install Chocolately
+iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # install dependenciess with Chocolately
 
+write-host "To ensure consistent environment, this script will re-install all NativeScript dependencies."
+
 write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Google Chrome (required to debug NativeScript apps)"
-cinst googlechrome
+cinst googlechrome --force --yes
 
 write-host -BackgroundColor Black -ForegroundColor Yellow "Installing node.js"
-cinst nodejs.install -version 4.2.5
+cinst nodejs.install -version 4.2.6 --force --yes
 
 write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Java Development Kit"
-cinst jdk8
+cinst jdk8 --force --yes
 
 write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Android SDK"
-cinst android-sdk
+cinst android-sdk --force --yes
 
 # setup android sdk
 echo yes | cmd /c "$env:localappdata\Android\android-sdk\tools\android" update sdk --filter "tools,platform-tools,android-23" --all --no-ui
@@ -27,12 +37,14 @@ echo yes | cmd /c "$env:localappdata\Android\android-sdk\tools\android" update s
 
 if (!$env:ANDROID_HOME) {
     [Environment]::SetEnvironmentVariable("ANDROID_HOME", "$env:localappdata\Android\android-sdk", "User")
+    $env:ANDROID_HOME = "$env:localappdata\Android\android-sdk";
 }
 
 if (!$env:JAVA_HOME) {
 	$curVer = (Get-ItemProperty "HKLM:\SOFTWARE\JavaSoft\Java Development Kit").CurrentVersion
 	$javaHome = (Get-ItemProperty "HKLM:\Software\JavaSoft\Java Development Kit\$curVer").JavaHome
 	[Environment]::SetEnvironmentVariable("JAVA_HOME", $javaHome, "User")
+    $env:JAVA_HOME = $javaHome;
 }
 
 # install NativeScript CLI
@@ -43,6 +55,7 @@ $pathMachine = [Environment]::GetEnvironmentVariable("PATH", "Machine")
 $myPath = [Environment]::GetEnvironmentVariable("PATH")
 [Environment]::SetEnvironmentVariable("PATH", "$myPath;$oldPathUser;$pathMachine;$env:ProgramFiles\nodejs")
 
-cmd /c "npm" install -g nativescript
+npm install -g nativescript
 
 write-host -BackgroundColor Black -ForegroundColor Yellow "This script has modified your environment. You need to log off and log back on for the changes to take effect."
+pause

--- a/setup/native-script.ps1
+++ b/setup/native-script.ps1
@@ -21,7 +21,7 @@ write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Google Chr
 cinst googlechrome --force --yes
 
 write-host -BackgroundColor Black -ForegroundColor Yellow "Installing node.js"
-cinst nodejs.install -version 4.2.6 --force --yes
+cinst nodejs.install -version 4.3.0 --force --yes
 
 write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Java Development Kit"
 cinst jdk8 --force --yes
@@ -58,4 +58,5 @@ $myPath = [Environment]::GetEnvironmentVariable("PATH")
 npm install -g nativescript
 
 write-host -BackgroundColor Black -ForegroundColor Yellow "This script has modified your environment. You need to log off and log back on for the changes to take effect."
-pause
+Write-Host "Press any key to continue..."
+[void][System.Console]::ReadKey($true)


### PR DESCRIPTION
 - No longer uses BoxStarter, instead it is a plain PowerShell script
 - Force re-installation of dependencies
 - Can self-elevate when needed but in this case only PRODUCTION branch can be used

See https://github.com/NativeScript/nativescript-cli/issues/1429