### PR TITLE
Use AndroidManifest from App_Resources as full manifest

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -93,3 +93,4 @@ $injector.require("socketProxyFactory", "./device-sockets/ios/socket-proxy-facto
 $injector.require("iOSNotification", "./device-sockets/ios/notification");
 $injector.require("iOSSocketRequestExecutor", "./device-sockets/ios/socket-request-executor");
 $injector.require("messages", "./messages");
+$injector.require("xmlValidator", "./xml-validator");

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -184,3 +184,22 @@ interface IiOSSocketRequestExecutor {
 	executeLaunchRequest(device: Mobile.IiOSDevice, timeout: number, readyForAttachTimeout: number): IFuture<void>;
 	executeAttachRequest(device: Mobile.IiOSDevice, timeout: number): IFuture<void>;
 }
+
+/**
+ * Describes validation methods for XMLs.
+ */
+interface IXmlValidator {
+	/**
+	 * Checks the passed xml files for errors and if such exists, print them on the stdout.
+	 * @param {string[]} sourceFiles Files to be checked. Only the ones that ends with .xml are filtered.
+	 * @return {IFuture<boolean>} true in case there are no errors in specified files and false in case there's at least one error.
+	 */
+	validateXmlFiles(sourceFiles: string[]): IFuture<boolean>;
+
+	/**
+	 * Checks the passed xml file for errors and returns them as a result.
+	 * @param {string} sourceFile File to be checked.
+	 * @return {IFuture<string>} The errors detected (as a single string) or null in case there are no errors.
+	 */
+	getXmlFileErrors(sourceFile: string): IFuture<string>;
+}

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -76,6 +76,10 @@ interface IPlatformProjectService {
 	getAppResourcesDestinationDirectoryPath(): IFuture<string>;
 	deploy(deviceIdentifier: string): IFuture<void>;
 	processConfigurationFilesFromAppResources(): IFuture<void>;
+	/**
+	 * Ensures there is configuration file (AndroidManifest.xml, Info.plist) in app/App_Resources.
+	 */
+	ensureConfigurationFileInAppResources(): IFuture<void>;
 }
 
 interface IAndroidProjectPropertiesManager {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -400,7 +400,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		}).future<void>()();
 	}
 
-	private mergeInfoPlists(): IFuture<void> {
+	public ensureConfigurationFileInAppResources(): IFuture<void> {
 		return (() => {
 			let projectDir = this.$projectData.projectDir;
 			let infoPlistPath = path.join(projectDir, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME, this.platformData.normalizedPlatformName, this.platformData.configurationFileName);
@@ -421,6 +421,15 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 					this.$logger.trace("Info.plist: app/App_Resources/iOS/Info.plist is missing but the template " + templateInfoPlist + " is missing too, can not upgrade Info.plist.");
 				}
 			}
+
+		}).future<void>()();
+	}
+
+	private mergeInfoPlists(): IFuture<void> {
+		return (() => {
+			let projectDir = this.$projectData.projectDir;
+			let infoPlistPath = path.join(projectDir, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME, this.platformData.normalizedPlatformName, this.platformData.configurationFileName);
+			this.ensureConfigurationFileInAppResources().wait();
 
 			if (!this.$fs.exists(infoPlistPath).wait()) {
 				this.$logger.trace("Info.plist: No app/App_Resources/iOS/Info.plist found, falling back to pre-1.6.0 Info.plist behavior.");

--- a/lib/xml-validator.ts
+++ b/lib/xml-validator.ts
@@ -1,0 +1,51 @@
+///<reference path=".d.ts"/>
+"use strict";
+
+import { EOL } from "os";
+
+export class XmlValidator implements IXmlValidator {
+	constructor(private $fs: IFileSystem,
+				private $logger: ILogger) { }
+
+	public validateXmlFiles(sourceFiles: string[]): IFuture<boolean> {
+		return (() => {
+			let xmlHasErrors = false;
+			sourceFiles
+				.filter(file => _.endsWith(file, ".xml"))
+				.forEach(file => {
+					let errorOutput = this.getXmlFileErrors(file).wait();
+					let hasErrors = !!errorOutput;
+					xmlHasErrors = xmlHasErrors || hasErrors;
+					if (hasErrors) {
+						this.$logger.warn(`${file} has syntax errors.`);
+						this.$logger.out(errorOutput);
+					}
+				});
+			return !xmlHasErrors;
+		}).future<boolean>()();
+	}
+
+	public getXmlFileErrors(sourceFile: string): IFuture<string> {
+		return ((): string => {
+			let errorOutput = "";
+			let fileContents = this.$fs.readText(sourceFile).wait();
+			let domErrorHandler = (level:any, msg:string) => {
+				errorOutput += level + EOL + msg + EOL;
+			};
+			this.getDomParser(domErrorHandler).parseFromString(fileContents, "text/xml");
+
+			return errorOutput || null;
+		}).future<string>()();
+	}
+
+	private getDomParser(errorHandler: (level:any, msg:string) => void): any {
+		let DomParser = require("xmldom").DOMParser;
+		let parser = new DomParser({
+			locator:{},
+			errorHandler: errorHandler
+		});
+
+		return parser;
+	}
+}
+$injector.register("xmlValidator", XmlValidator);

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -27,6 +27,7 @@ import {ProjectFilesProvider} from "../lib/providers/project-files-provider";
 import {DeviceAppDataProvider} from "../lib/providers/device-app-data-provider";
 import {MobilePlatformsCapabilities} from "../lib/mobile-platforms-capabilities";
 import {DevicePlatformsConstants} from "../lib/common/mobile/device-platforms-constants";
+import { XmlValidator } from "../lib/xml-validator";
 import Future = require("fibers/future");
 
 import path = require("path");
@@ -75,6 +76,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("deviceAppDataProvider", DeviceAppDataProvider);
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
+	testInjector.register("xmlValidator", XmlValidator);
 
 	return testInjector;
 }

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -20,6 +20,7 @@ import {ProjectFilesProvider} from "../lib/providers/project-files-provider";
 import {DeviceAppDataProvider} from "../lib/providers/device-app-data-provider";
 import {MobilePlatformsCapabilities} from "../lib/mobile-platforms-capabilities";
 import {DevicePlatformsConstants} from "../lib/common/mobile/device-platforms-constants";
+import { XmlValidator } from "../lib/xml-validator";
 
 let isCommandExecuted = true;
 
@@ -135,6 +136,7 @@ function createTestInjector() {
 	testInjector.register("deviceAppDataProvider", DeviceAppDataProvider);
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
+	testInjector.register("xmlValidator", XmlValidator);
 
 	return testInjector;
 }

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -19,6 +19,7 @@ import {ProjectFilesProvider} from "../lib/providers/project-files-provider";
 import {DeviceAppDataProvider} from "../lib/providers/device-app-data-provider";
 import {MobilePlatformsCapabilities} from "../lib/mobile-platforms-capabilities";
 import {DevicePlatformsConstants} from "../lib/common/mobile/device-platforms-constants";
+import { XmlValidator } from "../lib/xml-validator";
 
 require("should");
 let temp = require("temp");
@@ -69,6 +70,7 @@ function createTestInjector() {
 	testInjector.register("deviceAppDataProvider", DeviceAppDataProvider);
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
+	testInjector.register("xmlValidator", XmlValidator);
 
 	return testInjector;
 }
@@ -244,7 +246,8 @@ describe('Platform Service Tests', () => {
 						interpolateData: (projectRoot: string) => Future.fromResult(),
 						afterCreateProject: (projectRoot: string) => Future.fromResult(),
 						getAppResourcesDestinationDirectoryPath: () => Future.fromResult(""),
-						processConfigurationFilesFromAppResources: () => Future.fromResult()
+						processConfigurationFilesFromAppResources: () => Future.fromResult(),
+						ensureConfigurationFileInAppResources: () => Future.fromResult()
 					}
 				};
 			};
@@ -295,7 +298,8 @@ describe('Platform Service Tests', () => {
 						interpolateData: (projectRoot: string) => Future.fromResult(),
 						afterCreateProject: (projectRoot: string) => Future.fromResult(),
 						getAppResourcesDestinationDirectoryPath: () => Future.fromResult(""),
-						processConfigurationFilesFromAppResources: () => Future.fromResult()
+						processConfigurationFilesFromAppResources: () => Future.fromResult(),
+						ensureConfigurationFileInAppResources: () => Future.fromResult()
 					}
 				};
 			};
@@ -338,7 +342,8 @@ describe('Platform Service Tests', () => {
 						interpolateData: (projectRoot: string) => Future.fromResult(),
 						afterCreateProject: (projectRoot: string) => Future.fromResult(),
 						getAppResourcesDestinationDirectoryPath: () => Future.fromResult(""),
-						processConfigurationFilesFromAppResources: () => Future.fromResult()
+						processConfigurationFilesFromAppResources: () => Future.fromResult(),
+						ensureConfigurationFileInAppResources: () => Future.fromResult()
 					}
 				};
 			};

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -35,6 +35,7 @@ import {ProjectFilesProvider} from "../lib/providers/project-files-provider";
 import {DeviceAppDataProvider} from "../lib/providers/device-app-data-provider";
 import {MobilePlatformsCapabilities} from "../lib/mobile-platforms-capabilities";
 import {DevicePlatformsConstants} from "../lib/common/mobile/device-platforms-constants";
+import { XmlValidator } from "../lib/xml-validator";
 import * as path from "path";
 import * as temp from "temp";
 temp.track();
@@ -95,6 +96,10 @@ function createTestInjector() {
 	testInjector.register("deviceAppDataProvider", DeviceAppDataProvider);
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
+	testInjector.register("projectTemplatesService", {
+		defaultTemplate: future.fromResult("")
+	});
+	testInjector.register("xmlValidator", XmlValidator);
 
 	return testInjector;
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -348,6 +348,9 @@ export class PlatformProjectServiceStub implements IPlatformProjectService {
 	processConfigurationFilesFromAppResources(): IFuture<void> {
 		return Future.fromResult();
 	}
+	ensureConfigurationFileInAppResources(): IFuture<void> {
+		return Future.fromResult();
+	}
 }
 
 export class ProjectDataService implements IProjectDataService {


### PR DESCRIPTION
For iOS we'll have full Info.plist in app/App_Resources/iOS.
Currently for Android we allow placing a file, that will be merged with default AndroidManifest from the runtime.
Change the Android implementation, so now the AndroidManifest placed in app/App_Resources/Android will be the full one.
In such file is not present in user's project, extract it from default template.
In case there's already such file and it doesn't seems correct, rename it to old.AndroidManifest.xml, extract correct manifest from template and inform the user that he'll have to merge the files manually.