### PR TITLE
Interpolate data in config files from App_Resources on prepare

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -323,7 +323,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	public processConfigurationFilesFromAppResources(): IFuture<void> {
-		return this.ensureConfigurationFileInAppResources();
+		return Future.fromResult();
 	}
 
 	private processResourcesFromPlugin(pluginData: IPluginData, pluginPlatformsFolderPath: string): IFuture<void> {
@@ -571,6 +571,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				return false;
 			}
 
+			this.interpolateConfigurationFile().wait();
 			return true;
 		}).future<boolean>()();
 	}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -192,6 +192,7 @@ export class PlatformService implements IPlatformService {
 			this.ensurePlatformInstalled(platform).wait();
 
 			let platformData = this.$platformsData.getPlatformData(platform);
+			platformData.platformProjectService.ensureConfigurationFileInAppResources().wait();
 			let appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 			let lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath).wait() ?
 				this.$fs.getFsStats(appDestinationDirectoryPath).wait().mtime : null;
@@ -264,6 +265,9 @@ export class PlatformService implements IPlatformService {
 
 			// Process configurations files from App_Resources
 			platformData.platformProjectService.processConfigurationFilesFromAppResources().wait();
+
+			// Replace placeholders in configuration files
+			platformData.platformProjectService.interpolateConfigurationFile().wait();
 
 			this.$logger.out("Project successfully prepared");
 			return true;

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -144,7 +144,9 @@ function setupProject(): IFuture<any> {
 					prepareAppResources: () => Future.fromResult(),
 					afterPrepareAllPlugins: () => Future.fromResult(),
 					getAppResourcesDestinationDirectoryPath: () => Future.fromResult(""),
-					processConfigurationFilesFromAppResources: () => Future.fromResult()
+					processConfigurationFilesFromAppResources: () => Future.fromResult(),
+					ensureConfigurationFileInAppResources: () => Future.fromResult(),
+					interpolateConfigurationFile: () => Future.fromResult()
 				}
 			};
 		};

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -247,7 +247,8 @@ describe('Platform Service Tests', () => {
 						afterCreateProject: (projectRoot: string) => Future.fromResult(),
 						getAppResourcesDestinationDirectoryPath: () => Future.fromResult(""),
 						processConfigurationFilesFromAppResources: () => Future.fromResult(),
-						ensureConfigurationFileInAppResources: () => Future.fromResult()
+						ensureConfigurationFileInAppResources: () => Future.fromResult(),
+						interpolateConfigurationFile: () => Future.fromResult()
 					}
 				};
 			};
@@ -299,7 +300,8 @@ describe('Platform Service Tests', () => {
 						afterCreateProject: (projectRoot: string) => Future.fromResult(),
 						getAppResourcesDestinationDirectoryPath: () => Future.fromResult(""),
 						processConfigurationFilesFromAppResources: () => Future.fromResult(),
-						ensureConfigurationFileInAppResources: () => Future.fromResult()
+						ensureConfigurationFileInAppResources: () => Future.fromResult(),
+						interpolateConfigurationFile: () => Future.fromResult()
 					}
 				};
 			};
@@ -343,7 +345,8 @@ describe('Platform Service Tests', () => {
 						afterCreateProject: (projectRoot: string) => Future.fromResult(),
 						getAppResourcesDestinationDirectoryPath: () => Future.fromResult(""),
 						processConfigurationFilesFromAppResources: () => Future.fromResult(),
-						ensureConfigurationFileInAppResources: () => Future.fromResult()
+						ensureConfigurationFileInAppResources: () => Future.fromResult(),
+						interpolateConfigurationFile: () => Future.fromResult()
 					}
 				};
 			};


### PR DESCRIPTION
Interpolate data in config files from App_Resources on prepare so `__PACKAGE__` and other placeholders will be replaced.
Ensure the file in the App_Resources is correct in the beginning of the prepare method and make sure all of the placeholders are interpolated after finishing the processing. The interpolating process will replace the placeholders in `platforms/<platform>` dir