### PR TITLE
Print iOS Simulator device logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp": "3.9.0",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-sim-portable": "~1.0.19",
+    "ios-sim-portable": "~1.0.20",
     "lockfile": "1.0.1",
     "lodash": "3.10.0",
     "log4js": "0.6.26",


### PR DESCRIPTION
When using `tns run ios` and `tns livesync ios` for iOS Simulator, we exit the process immediately instead of printing device logs.