### PR TITLE
Fix debug android --emulator

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -16,6 +16,10 @@ export class DebugPlatformCommand implements ICommand {
 	canExecute(args: string[]): IFuture<boolean> {
 		return ((): boolean => {
 			this.$devicesService.initialize({ platform: this.debugService.platform, deviceId: this.$options.device }).wait();
+			if(this.$options.emulator) {
+				return true;
+			}
+
 			if(this.$devicesService.deviceCount === 0) {
 				this.$errors.failWithoutHelp("No devices detected. Connect a device and try again.");
 			} else if (this.$devicesService.deviceCount > 1) {
@@ -34,16 +38,6 @@ export class DebugIOSCommand extends DebugPlatformCommand {
 		$options: IOptions) {
 		super($iOSDebugService, $devicesService, $errors, $options);
 	}
-
-	canExecute(args: string[]): IFuture<boolean> {
-		return ((): boolean => {
-			if(this.$options.emulator) {
-				return true;
-			}
-
-			return super.canExecute(args).wait();
-		}).future<boolean>()();
-	}
 }
 $injector.registerCommand("debug|ios", DebugIOSCommand);
 
@@ -53,10 +47,6 @@ export class DebugAndroidCommand extends DebugPlatformCommand {
 		$errors: IErrors,
 		$options: IOptions) {
 		super($androidDebugService, $devicesService, $errors, $options);
-	}
-
-	canExecute(args: string[]): IFuture<boolean> {
-		return super.canExecute(args);
 	}
 }
 $injector.registerCommand("debug|android", DebugAndroidCommand);

--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -20,7 +20,8 @@ class AndroidDebugService implements IDebugService {
 		private $hostInfo: IHostInfo,
 		private $errors: IErrors,
 		private $opener: IOpener,
-		private $config: IConfiguration) { }
+		private $config: IConfiguration,
+		private $androidDeviceDiscovery: Mobile.IDeviceDiscovery) { }
 
 	public get platform() { return "android"; }
 
@@ -41,6 +42,10 @@ class AndroidDebugService implements IDebugService {
 	private debugOnEmulator(): IFuture<void> {
 		return (() => {
 			this.$platformService.deployOnEmulator(this.platform).wait();
+			// Assure we've detected the emulator as device
+			// For example in case deployOnEmulator had stated new emulator instance
+			// we need some time to detect it. Let's force detection.
+			this.$androidDeviceDiscovery.startLookingForDevices().wait();
 			this.debugOnDevice().wait();
 		}).future<void>()();
 	}


### PR DESCRIPTION
Fix `tns debug android --emulator`. There were two issues:
* With latest changes in master/release branch, when there's no android device detected and user executes `tns debug android --emulator` an error is raised - "Cannot find connected devices...". Fix this by returning true in command's canExecute method when `--emulator` is passed.
* When there's no running emulator, CLI tries to start it (android-debug-service, debugOnEmulator method). The emulator is started and after that we try to execute action on the started device.
However devicesService (in this case the androidDeviceDiscovery) had not reported yet the started emulator as a new device. So when device's service execute method is called, it checks if there are devices (still thinks there aren't) and tries to start emulator again.
The final result is that application starts on the device, but there's no debugger attached.
Fix this by forcing android device detection in debugOnEmulator method.

https://github.com/NativeScript/nativescript-cli/issues/1437