### PR TITLE
Do not install the CLI

### DIFF
--- a/setup/native-script.ps1
+++ b/setup/native-script.ps1
@@ -20,9 +20,6 @@ write-host "To ensure consistent environment, this script will re-install all Na
 write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Google Chrome (required to debug NativeScript apps)"
 cinst googlechrome --force --yes
 
-write-host -BackgroundColor Black -ForegroundColor Yellow "Installing node.js"
-cinst nodejs.install -version 4.3.0 --force --yes
-
 write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Java Development Kit"
 cinst jdk8 --force --yes
 
@@ -46,16 +43,6 @@ if (!$env:JAVA_HOME) {
 	[Environment]::SetEnvironmentVariable("JAVA_HOME", $javaHome, "User")
     $env:JAVA_HOME = $javaHome;
 }
-
-# install NativeScript CLI
-write-host -BackgroundColor Black -ForegroundColor Yellow "Installing NativeScript CLI"
-
-$oldPathUser = [Environment]::GetEnvironmentVariable("PATH", "User")
-$pathMachine = [Environment]::GetEnvironmentVariable("PATH", "Machine")
-$myPath = [Environment]::GetEnvironmentVariable("PATH")
-[Environment]::SetEnvironmentVariable("PATH", "$myPath;$oldPathUser;$pathMachine;$env:ProgramFiles\nodejs")
-
-npm install -g nativescript
 
 write-host -BackgroundColor Black -ForegroundColor Yellow "This script has modified your environment. You need to log off and log back on for the changes to take effect."
 Write-Host "Press any key to continue..."

--- a/setup/native-script.rb
+++ b/setup/native-script.rb
@@ -1,8 +1,8 @@
 # coding: utf-8
 
 # A script to setup developer's workstation for developing with NativeScript
-# To run it against RELEASE branch (recommended) use
-# ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/release/setup/native-script.rb)"
+# To run it against PRODUCTION branch (recommended) use
+# ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
 # To run it against MASTER branch (usually only developers of NativeScript need to) use
 # ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/master/setup/native-script.rb)"
 

--- a/setup/native-script.rb
+++ b/setup/native-script.rb
@@ -51,10 +51,4 @@ system('echo "export ANDROID_HOME=/usr/local/opt/android-sdk" >> ~/.profile')
 puts "Configuring your system for Android development... This might take some time, please, be patient."
 system "echo yes | /usr/local/opt/android-sdk/tools/android update sdk --filter tools,platform-tools,android-23,build-tools-23.0.2,extra-android-m2repository --all --no-ui"
 
-puts "Installing Node.js 4"
-system('brew install homebrew/versions/node4-lts')
-
-puts "Installing NativeScript CLI..."
-system "/usr/local/bin/npm install -g nativescript"
-
 puts "The ANDROID_HOME and JAVA_HOME environment variables have been added to your .profile. Restart the terminal to use them."


### PR DESCRIPTION
Focus these scripts on installing only the native platform dependencies.
The documentation will guide the user to install the CLI separately.

See https://github.com/NativeScript/NativeScript/issues/1556