### PR TITLE
Fix livesync of TypeScript projects

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -53,11 +53,12 @@ class LiveSyncService implements ILiveSyncService {
 			let platformData = this.$platformsData.getPlatformData(platformLowerCase);
 			this.ensureAndroidFrameworkVersion(platformData).wait();
 
-			let liveSyncData = {
+			let liveSyncData: ILiveSyncData = {
 				platform: platform,
 				appIdentifier:  this.$projectData.projectId,
 				projectFilesPath: path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME),
 				syncWorkingDirectory: path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME),
+				excludedProjectDirsAndFiles: ["**/*.js.map", "**/*.ts"]
 			};
 			this.$liveSyncServiceBase.sync(liveSyncData).wait();
 		}).future<void>()();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {


### PR DESCRIPTION
Pass .js.map and .ts as excluded patterns for livesync.
Fix livesync of TypeScript projects - make sure gaze does not trigger any livesync logic in case the file that's changed is excluded via any pattern from livesync data.
Currently when .ts file is change, gaze detects changes for .ts, .js and .js.map files and fails as only .js files exist in platforms dir.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1499