### PR TITLE
Fix unit test runner

### DIFF
--- a/lib/services/karma-execution.ts
+++ b/lib/services/karma-execution.ts
@@ -1,0 +1,15 @@
+///<reference path="../.d.ts"/>
+
+"use strict";
+
+import * as path from "path";
+
+process.on("message", (data: any) => {
+	if(data.karmaConfig) {
+		let pathToKarma = path.join(data.karmaConfig.projectDir, 'node_modules/karma'),
+			KarmaServer = require(path.join(pathToKarma, 'lib/server')),
+			karma = new KarmaServer(data.karmaConfig);
+
+		karma.start();
+	}
+});


### PR DESCRIPTION
Fix the following issues in unit test runner:
* Tests cannot start when application is not installed on device
* Karma does not start when there are no .js files in app dir (initial state of TypeScript projects).
* `tns test <platform> --watch` is not working for TypeScript projects
* `tns test <platform> --debug-brk` does not debug.


### Implementation details
Change the way unit-tests are started. The current code was:
1) Start karma server
2) When start method of `karma-nativescript-launcher` is called, it spawns new CLI process (calls `tns dev-test` command with some arguments).
3) The new CLI process writes down some files in `node_modules/nativescript-unit-test-runner`
4) The new CLI process prepares the project.
5) The new CLI process changes the entry point of the application to point to nativescript-unit-test-runner's main-page.
6) The new CLI process calls livesync-base which should restart the application.
7) In case `--watch` option is used, karma launcher will listen for `file_list_modified` event and spawn new CLI process to run the tests.

Problems were in all the steps. New way:
1) When `tns test <platform>` is called, first step is to prepare the project.
2) Initialize devices service, so we are sure all devices are detected.
3) Prepare livesync data - here we set canExecuteFastSync to false, so any change will restart the application and tests will be started again.
4) Fork new process, which should start karma server.
5) When `karma-nativescript-launcher`'s start method is called in the forked process, it will send required information to current CLI process.
6) CLI process receives the data and writes the required files in `node_modules/nativescript-unit-test-runner`.
7) CLI process calls livesync. In case --debug-brk is specified, debugService is called instead.
8) karma-nativescript-launcher no longer listens for `file-list-modified` event. CLI is alreday doing this (livesync logic).
9) Entry point of application is change by `nativescript-unit-test-runner` via after-prepare hook.

The new behavior depends on the livesync - when app is not installed on the device, it will be installed. In case `--watch` is used, livesync will detect changes, prepare the project and restart the app - this will start the tests again.

### Problem
With this change `tns dev-test` command will stop working. As I consider it not usable, I've decided to skip its fixing for later.

Related PRs:
https://github.com/NativeScript/nativescript-unit-test-runner/pull/2
https://github.com/NativeScript/karma-nativescript-launcher/pull/23

Fixes https://github.com/NativeScript/nativescript-cli/issues/1513