### PR TITLE
Fix livesync of platform/configuration specific files

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -65,7 +65,6 @@ interface IOptions extends ICommonOptions {
 	frameworkVersion: string;
 	copyFrom: string;
 	linkTo: string;
-	release: boolean;
 	emulator: boolean;
 	symlink: boolean;
 	forDevice: boolean;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -18,7 +18,6 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			frameworkVersion: { type: OptionType.String },
 			copyFrom: { type: OptionType.String },
 			linkTo: { type: OptionType.String  },
-			release: { type: OptionType.Boolean },
 			symlink: { type: OptionType.Boolean },
 			forDevice: { type: OptionType.Boolean },
 			client: { type: OptionType.Boolean, default: true},

--- a/lib/providers/project-files-provider.ts
+++ b/lib/providers/project-files-provider.ts
@@ -4,26 +4,33 @@
 import minimatch = require("minimatch");
 import * as constants from "../constants";
 import * as path from "path";
+import { ProjectFilesProviderBase } from "../common/services/project-files-provider-base";
 
-export class ProjectFilesProvider implements IProjectFilesProvider {
+export class ProjectFilesProvider extends ProjectFilesProviderBase {
 	constructor(private $platformsData: IPlatformsData,
-		private $projectData: IProjectData) { }
+		private $projectData: IProjectData,
+		$mobileHelper: Mobile.IMobileHelper,
+		$options:IOptions) {
+			super($mobileHelper, $options);
+	}
 
 	private static INTERNAL_NONPROJECT_FILES = [ "**/*.ts" ];
 
 	public mapFilePath(filePath: string, platform: string): string {
 		let platformData = this.$platformsData.getPlatformData(platform.toLowerCase());
 		let projectFilesPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-		let mappedFilePath = path.join(projectFilesPath, path.relative(path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME), filePath));
+		let parsedFilePath = this.getPreparedFilePath(filePath);
+		let mappedFilePath = path.join(projectFilesPath, path.relative(path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME), parsedFilePath));
 
 		let appResourcesDirectoryPath = path.join(constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME);
 		let platformSpecificAppResourcesDirectoryPath = path.join(appResourcesDirectoryPath, platformData.normalizedPlatformName);
-		if (filePath.indexOf(appResourcesDirectoryPath) > -1 && filePath.indexOf(platformSpecificAppResourcesDirectoryPath) === -1) {
+		if (parsedFilePath.indexOf(appResourcesDirectoryPath) > -1 && parsedFilePath.indexOf(platformSpecificAppResourcesDirectoryPath) === -1) {
 			return null;
 		}
-		if (filePath.indexOf(platformSpecificAppResourcesDirectoryPath) > -1) {
+
+		if (parsedFilePath.indexOf(platformSpecificAppResourcesDirectoryPath) > -1) {
 			let appResourcesRelativePath = path.relative(path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME,
-				platformData.normalizedPlatformName), filePath);
+				platformData.normalizedPlatformName), parsedFilePath);
 			mappedFilePath = path.join(platformData.platformProjectService.getAppResourcesDestinationDirectoryPath().wait(), appResourcesRelativePath);
 		}
 

--- a/test/project-files-provider.ts
+++ b/test/project-files-provider.ts
@@ -1,0 +1,92 @@
+/// <reference path=".d.ts" />
+"use strict";
+
+import { Yok } from "../lib/common/yok";
+import { ProjectFilesProvider } from "../lib/providers/project-files-provider";
+import { assert } from "chai";
+import * as path from "path";
+import Future = require("fibers/future");
+
+let projectDir = "projectDir",
+	appDestinationDirectoryPath = "appDestinationDirectoryPath",
+	appResourcesDestinationDirectoryPath = "appResourcesDestinationDirectoryPath",
+	appSourceDir = path.join(projectDir, "app");
+
+function createTestInjector(): IInjector {
+	let testInjector = new Yok();
+	testInjector.register("mobileHelper", {
+		platformNames: ["Android", "iOS"]
+	});
+
+	testInjector.register("platformsData", {
+		getPlatformData: (platform: string) => {
+			return {
+				appDestinationDirectoryPath: appDestinationDirectoryPath,
+				normalizedPlatformName: platform.toLowerCase(),
+				platformProjectService: {
+					getAppResourcesDestinationDirectoryPath: () => Future.fromResult(appResourcesDestinationDirectoryPath)
+				}
+			};
+		},
+	});
+
+	testInjector.register("projectData", {
+		projectDir: projectDir
+	});
+
+	testInjector.register("options", { release: false });
+
+	return testInjector;
+}
+
+describe("project-files-provider", () => {
+	let testInjector: IInjector,
+		projectFilesProvider: IProjectFilesProvider;
+
+	beforeEach(() => {
+		testInjector = createTestInjector();
+		projectFilesProvider = testInjector.resolve(ProjectFilesProvider);
+	});
+
+	describe("isFileExcluded", () => {
+		it("returns true for .ts files", () => {
+			assert.isTrue(projectFilesProvider.isFileExcluded("test.ts"));
+		});
+
+		it("returns false for .js files", () => {
+			assert.isFalse(projectFilesProvider.isFileExcluded("test.js"));
+		});
+	});
+
+	describe("mapFilePath", () => {
+		it("returns file path from prepared project when path from app dir is passed", () => {
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.js"), "android");
+			assert.deepEqual(mappedFilePath, path.join(appDestinationDirectoryPath, "app", "test.js"));
+		});
+
+		it("returns file path from prepared project when path from app/App_Resources/platform dir is passed", () => {
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "android", "test.js"), "android");
+			assert.deepEqual(mappedFilePath, path.join(appResourcesDestinationDirectoryPath, "test.js"));
+		});
+
+		it("returns null when path from app/App_Resources/android dir is passed and iOS platform is specified", () => {
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "android", "test.js"), "iOS");
+			assert.deepEqual(mappedFilePath, null);
+		});
+
+		it("returns null when path from app/App_Resources/ dir (not platform specific) is passed", () => {
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "test.js"), "android");
+			assert.deepEqual(mappedFilePath, null);
+		});
+
+		it("returns file path from prepared project when path from app dir is passed and it contains platform in its name", () => {
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.android.js"), "android");
+			assert.deepEqual(mappedFilePath, path.join(appDestinationDirectoryPath, "app", "test.js"));
+		});
+
+		it("returns file path from prepared project when path from app dir is passed and it contains configuration in its name", () => {
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.debug.js"), "android");
+			assert.deepEqual(mappedFilePath, path.join(appDestinationDirectoryPath, "app", "test.js"));
+		});
+	});
+});


### PR DESCRIPTION
Fix LiveSync of platform specific / configuration specific files. Currently mappedFilePath does not respect the platform/configuration name.
Add base class that can parse the files and return correct on device filename.
Add unit tests for the provider.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1313