### PR TITLE
Implement `tns publish ios`

### DIFF
--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -36,6 +36,12 @@ Command | Description
 [plugin](lib-management/plugin.html) | Lets you manage the plugins for your project.
 [livesync](project/testing/livesync.html) | Synchronizes the latest changes in your project to devices.
 
+## Publishing Commands
+Command | Description
+---|---
+[appstore](project/publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](project/publishing/appstore-upload.html) | Uploads project to iTunes Connect.
+
 ## Device Commands
 Command | Description
 ---|---

--- a/docs/man_pages/project/testing/build-android.md
+++ b/docs/man_pages/project/testing/build-android.md
@@ -48,6 +48,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -25,6 +25,8 @@ Builds the project for iOS and produces an `APP` or `IPA` that you can manually 
 
 Command | Description
 ----------|----------
+[appstore](../../publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](../../publishing/appstore-upload.html) | Uploads project to iTunes Connect.
 [build android](build-android.html) | Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 [build](build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
 [debug android](debug-android.html) | Debugs your project on a connected Android device or in a native emulator.
@@ -41,6 +43,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/build.md
+++ b/docs/man_pages/project/testing/build.md
@@ -10,9 +10,9 @@ Builds the project for Android <% if(isMacOS) { %>or iOS <% } %>and produces an 
 <% if((isConsole && isMacOS) || isHtml) { %>### Attributes
 `<Platform>` is the target mobile platform for which you want to build your project. You can set the following target platforms.
 * `android` - Builds the project for Android and produces an `APK` that you can manually deploy on device or in the native emulator.
-* `ios` - Builds the project for iOS and produces an `APP` or `IPA` that you can manually deploy in the iOS Simulator or on device, respectively.<% } %> 
+* `ios` - Builds the project for iOS and produces an `APP` or `IPA` that you can manually deploy in the iOS Simulator or on device, respectively.<% } %>
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Command Limitations
 
 * You can run `$ tns build ios` only on OS X systems.
@@ -21,6 +21,8 @@ Builds the project for Android <% if(isMacOS) { %>or iOS <% } %>and produces an 
 
 Command | Description
 ----------|----------
+[appstore](../../publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](../../publishing/appstore-upload.html) | Uploads project to iTunes Connect.
 [build android](build-android.html) | Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 [build ios](build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
 [debug android](debug-android.html) | Debugs your project on a connected Android device or in a native emulator.
@@ -37,6 +39,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/debug-android.md
+++ b/docs/man_pages/project/testing/debug-android.md
@@ -18,7 +18,7 @@ Debugs your project on a connected device, in a native emulator or in Genymotion
 * `--device` - Specifies a connected device on which to debug the app.
 * `--emulator` - Specifies that you want to debug the app in the native Android emulator from the Android SDK.
 * `--geny` - Specifies a Genymotion emulator on which you want to debug your app.
-* `--debug-brk` - Prepares, builds and deploys the application package on a device or in an emulator, launches the Chrome DevTools of your Chrome browser. 
+* `--debug-brk` - Prepares, builds and deploys the application package on a device or in an emulator, launches the Chrome DevTools of your Chrome browser.
 * `--start` - Attaches the debug tools to a deployed and running app.
 * `--stop` - Detaches the debug tools.
 * `--get-port` - Retrieves the port on which you are debugging your application.
@@ -26,11 +26,11 @@ Debugs your project on a connected device, in a native emulator or in Genymotion
 * `--timeout` - Sets the number of seconds that the NativeScript CLI will wait for the debugger to boot. If not set, the default timeout is 90 seconds.
 
 ### Attributes
-* `<Device ID>` is the index or name of the target device as listed by `$ tns device` 
+* `<Device ID>` is the index or name of the target device as listed by `$ tns device`
 * `<Port>` is an accessible port on the device to which you want to attach the debugging tools.
 * `<Emulator Options>` is any valid combination of options as listed by `$ tns help emulate android`
 * `<GenyName>` is the name of the Genymotion virtual device that you want to use as listed by `$ genyshell -c "devices list"`
- 
+
 <% if(isHtml) { %>
 ###Prerequisites
 
@@ -56,6 +56,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/debug-ios.md
+++ b/docs/man_pages/project/testing/debug-ios.md
@@ -8,9 +8,9 @@ Deploy in the iOS Simulator, run the app and stop at the first breakpoint | `$ t
 Attach the debug tools to a running app on device | `$ tns debug ios --start [--device <Device ID>] [--no-client]`
 Attach the debug tools to a running app in the iOS Simulator | `$ tns debug ios --start --emulator [<Emulator Options>] [--no-client]`
 
-Debugs your project on a connected device or in the iOS Simulator. <% if(isHtml) { %>Any debugging traffic is forwarded on port 8080 from the device to the local machine.<% } %> 
+Debugs your project on a connected device or in the iOS Simulator. <% if(isHtml) { %>Any debugging traffic is forwarded on port 8080 from the device to the local machine.<% } %>
 
-<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help debug ios`<% } %> 
+<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help debug ios`<% } %>
 
 <% if((isConsole && isMacOS) || isHtml) { %>
 <% if(isHtml) { %>> <% } %>IMPORTANT: Before building for iOS device, verify that you have configured a valid pair of certificate and provisioning profile on your OS X system. <% if(isHtml) { %>For more information, see [Obtaining Signing Identities and Downloading Provisioning Profiles](https://developer.apple.com/library/mac/recipes/xcode_help-accounts_preferences/articles/obtain_certificates_and_provisioning_profiles.html).<% } %>
@@ -25,8 +25,8 @@ Debugs your project on a connected device or in the iOS Simulator. <% if(isHtml)
 ### Attributes
 * `<Device ID>` is the index or name of the target device as listed by `$ tns device`
 * `<Emulator Options>` is any valid combination of options as listed by `$ tns help emulate ios`
-<% } %> 
-<% if(isHtml) { %> 
+<% } %>
+<% if(isHtml) { %>
 ### Prerequisite
 
 * If you want to debug in the iOS Simulator, you must have Xcode 6 or later installed on your system.
@@ -55,6 +55,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/debug.md
+++ b/docs/man_pages/project/testing/debug.md
@@ -3,7 +3,7 @@ debug
 
 Usage | Synopsis
 ---|---
-<% if((isConsole && isMacOS) || isHtml) { %>General | `$ tns debug <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ tns debug android`<% } %> 
+<% if((isConsole && isMacOS) || isHtml) { %>General | `$ tns debug <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ tns debug android`<% } %>
 
 Debugs your project on a connected device or in a native emulator. <% if(isMacOS) { %>You must specify the target platform on which you want to debug.<% } %>
 
@@ -37,6 +37,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/deploy.md
+++ b/docs/man_pages/project/testing/deploy.md
@@ -4,7 +4,7 @@ deploy
 Usage | Synopsis
 ---|---
 Deploy on Android | `$ tns deploy android [--device <Device ID>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release]`
-<% if(isMacOS) { %>Deploy on iOS | `$ tns deploy ios [--device <Device ID>] [--release]`<% } %> 
+<% if(isMacOS) { %>Deploy on iOS | `$ tns deploy ios [--device <Device ID>] [--release]`<% } %>
 
 Builds and deploys the project to a connected physical or virtual device. <% if(isMacOS) { %>You must specify the target platform on which you want to deploy.<% } %>
 
@@ -13,7 +13,7 @@ Builds and deploys the project to a connected physical or virtual device. <% if(
 
 ### Options for iOS
 * `--device` - Deploys the project on the specified connected physical or virtual device.
-* `--release` - If set, produces a release build. Otherwise, produces a debug build.<% } %> 
+* `--release` - If set, produces a release build. Otherwise, produces a debug build.<% } %>
 
 ### Options<% if(isMacOS) { %> for Android<% } %>
 * `--device` - Deploys the project on the specified connected physical or virtual device.
@@ -26,7 +26,7 @@ Builds and deploys the project to a connected physical or virtual device. <% if(
 ### Attributes
 * `<Device ID>` is the index or name of the target device as listed by `$ tns device`
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Command Limitations
 
 * You can run `$ tns deploy ios` only on OS X systems.
@@ -36,6 +36,8 @@ Builds and deploys the project to a connected physical or virtual device. <% if(
 
 Command | Description
 ----------|----------
+[appstore](../../publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](../../publishing/appstore-upload.html) | Uploads project to iTunes Connect.
 [build android](build-android.html) | Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 [build ios](build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
 [build](build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
@@ -52,6 +54,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/emulate-android.md
+++ b/docs/man_pages/project/testing/emulate-android.md
@@ -7,12 +7,12 @@ Run in the native emulator | `$ tns emulate android [--avd <Name>] [--path <Dire
 Run in Genymotion | `$ tns emulate android --geny <GenyName> [--path <Directory>] [--timeout <Seconds>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch]`
 Run in the default Android virtual device or in a currently running emulator | `$ tns emulate android [--path <Directory>] [--timeout <Seconds>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch]`
 
-Builds the specified project and runs it in the native emulator from the Android SDK or Genymotion. While your app is running, prints the output from the application in the console.<% if(isHtml) { %>If you do not select an Android virtual device (AVD) with the `--avd` option or a Genymotion virtual device with the `--geny` option, your app runs in the default AVD or a currently running emulator, if any. <% } %> 
+Builds the specified project and runs it in the native emulator from the Android SDK or Genymotion. While your app is running, prints the output from the application in the console.<% if(isHtml) { %>If you do not select an Android virtual device (AVD) with the `--avd` option or a Genymotion virtual device with the `--geny` option, your app runs in the default AVD or a currently running emulator, if any. <% } %>
 
 ### Options
 * `--path` - Specifies the directory that contains the project. If not specified, the project is searched for in the current directory and all directories above it.
 * `--avd` - Sets the Android virtual device on which you want to run your app. You can set only one device at a time. You cannot use `--avd` and `--geny` simultaneously.
-* `--geny` - Sets the Genymotion virtual device on which you want to run your app. You can set only one device at a time. You cannot use `--avd` and `--geny` simultaneously.      
+* `--geny` - Sets the Genymotion virtual device on which you want to run your app. You can set only one device at a time. You cannot use `--avd` and `--geny` simultaneously.
 * `--timeout` - Sets the number of seconds that the NativeScript CLI will wait for the virtual device to boot before quitting the operation and releasing the console. If not set, the default timeout is 120 seconds. To wait indefinitely, set 0.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build. When set, you must also specify the `--key-store-*` options.
 * `--key-store-path` - Specifies the file path to the keystore file (P12) which you want to use to code sign your APK. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
@@ -22,10 +22,10 @@ Builds the specified project and runs it in the native emulator from the Android
 * `--justlaunch` - If set, does not print the application output in the console.
 
 ### Attributes
-* `<Name>` is the name of the Android virtual device that you want to use as listed by `$ android list avd`  
-* `<GenyName>` is the name of the Genymotion virtual device that you want to use as listed by `$ genyshell -c "devices list"`  
+* `<Name>` is the name of the Android virtual device that you want to use as listed by `$ android list avd`
+* `<GenyName>` is the name of the Genymotion virtual device that you want to use as listed by `$ genyshell -c "devices list"`
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Prerequisites
 Before running your app in the Android emulator from the Android SDK, verify that your system meets the following requirements.
 * Verify that you have installed the Android SDK.
@@ -45,7 +45,7 @@ Before running your app in the Android emulator from the Android SDK, verify tha
 
 ### Command Limitations
 
-* You can run this command for one virtual device at a time. To test your app on multiple Android virtual devices, run `$ tns emulate android --avd <Name>` or `$ tns emulate android --geny <GenyName>` for each virtual device. 
+* You can run this command for one virtual device at a time. To test your app on multiple Android virtual devices, run `$ tns emulate android --avd <Name>` or `$ tns emulate android --geny <GenyName>` for each virtual device.
 * When the `--release` flag is set, you must also specify all `--key-store-*` options.
 
 ### Related Commands
@@ -68,6 +68,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/emulate-ios.md
+++ b/docs/man_pages/project/testing/emulate-ios.md
@@ -7,19 +7,19 @@ General | `$ tns emulate ios [--path <Directory>] [--device <Device Name>] [--av
 
 Builds the specified project and runs it in the native iOS Simulator.
 
-<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help emulate ios`<% } %> 
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help emulate ios`<% } %>
 
 <% if((isConsole && isMacOS) || isHtml) { %>### Options
 * `--available-devices` - Lists all available device type identifiers for the current Xcode.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 * `--path` - Specifies the directory that contains the project. If not specified, the project is searched for in the current directory and all directories above it.
 * `--device` - Specifies the name of the iOS Simulator device on which you want to run your app. To list the available iOS Simulator devices, run `$ tns emulate ios --available-devices`
-* `--timeout` - Sets the number of seconds that the NativeScript CLI will wait for the iOS Simulator to start before quitting the operation and releasing the console. The value must be a positive integer. If not set, the default timeout is 90 seconds. 
+* `--timeout` - Sets the number of seconds that the NativeScript CLI will wait for the iOS Simulator to start before quitting the operation and releasing the console. The value must be a positive integer. If not set, the default timeout is 90 seconds.
 
 ### Attributes
-* `<Device Name>` is the name of the iOS Simulator device on which you want to run your app as listed by `$ tns emulate ios --available-devices`<% } %> 
+* `<Device Name>` is the name of the iOS Simulator device on which you want to run your app as listed by `$ tns emulate ios --available-devices`<% } %>
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Prerequisites
 Before running the iOS Simulator, verify that you have met the following requirements.
 * You have installed Xcode. The version of Xcode must be compatible with the ios-sim-portable npm package on which the NativeScript CLI depends. For more information, visit [https://www.npmjs.org/package/ios-sim-portable](https://www.npmjs.org/package/ios-sim-portable).
@@ -48,6 +48,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/emulate.md
+++ b/docs/man_pages/project/testing/emulate.md
@@ -12,7 +12,7 @@ Builds and runs the project in the native emulator for the selected target platf
 * `android` - Builds the specified project and runs it in the native Android emulator.
 * `ios` - Builds the specified project and runs it in the native iOS Simulator.<% } %>
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
@@ -33,6 +33,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/livesync-android.md
+++ b/docs/man_pages/project/testing/livesync-android.md
@@ -5,7 +5,7 @@ Usage | Synopsis
 ------|-------
 General | `$ tns livesync android [--device <Device ID>] [--watch]`
 
-Synchronizes the latest changes in your project to Android devices. 
+Synchronizes the latest changes in your project to Android devices.
 
 ### Options
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device.
@@ -14,7 +14,7 @@ Synchronizes the latest changes in your project to Android devices.
 ### Attributes
 * `<Device ID>` is the device index or identifier as listed by `$ tns device`
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Command Limitations
 
 * You cannot run this command on Android 4.3 devices and on some Samsung devices.
@@ -38,6 +38,6 @@ Command | Description
 [run android](run-android.html) | Runs your project on a connected Android device or in a native Android emulator, if configured.
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/livesync-ios.md
+++ b/docs/man_pages/project/testing/livesync-ios.md
@@ -17,7 +17,7 @@ Synchronizes the latest changes in your project to iOS devices or the iOS Simula
 ### Attributes
 * `<Device ID>` is the device index or identifier as listed by `$ tns device`
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Command Limitations
 
 * You cannot set `--device` and `--emulator` simultaneously.
@@ -26,6 +26,8 @@ Synchronizes the latest changes in your project to iOS devices or the iOS Simula
 
 Command | Description
 ----------|----------
+[appstore](../../publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](../../publishing/appstore-upload.html) | Uploads project to iTunes Connect.
 [build android](build-android.html) | Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 [build ios](build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
 [build](build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
@@ -41,6 +43,6 @@ Command | Description
 [run android](run-android.html) | Runs your project on a connected Android device or in a native Android emulator, if configured.
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/livesync.md
+++ b/docs/man_pages/project/testing/livesync.md
@@ -9,10 +9,10 @@ Synchronizes the latest changes in your project to devices.
 
 ### Attributes
 `<Platform>` is the target mobile platform to which you want to synchronize your changes. <% if(isHtml) { %>If you have connected only Android or only iOS devices, you can omit setting the target platform. If you have connected devices of multiple platforms, you must specify the target platform. <% } %>You can set the following target platforms.
-* `android` - Synchronizes the latest changes in your project to connected Android devices. 
+* `android` - Synchronizes the latest changes in your project to connected Android devices.
 * `ios` - Synchronizes the latest changes in your project to connected iOS devices.
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Command Limitations
 
 * You cannot run this command on Android 4.3 devices and on some Samsung devices.
@@ -21,6 +21,8 @@ Synchronizes the latest changes in your project to devices.
 
 Command | Description
 ----------|----------
+[appstore](../../publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](../../publishing/appstore-upload.html) | Uploads project to iTunes Connect.
 [build android](build-android.html) | Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 [build ios](build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
 [build](build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
@@ -36,6 +38,6 @@ Command | Description
 [run android](run-android.html) | Runs your project on a connected Android device or in a native Android emulator, if configured.
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -10,20 +10,20 @@ Start an emulator and run the app inside it | `$ tns run android --emulator [<Em
 Runs your project on a connected Android device or in a native Android emulator, if configured. This is shorthand for prepare, build and deploy. While your app is running, prints the output from the application in the console.
 
 ### Options
-* `--device` - Specifies a connected device on which to run the app. 
-* `--emulator` - If set, runs the app in a native emulator for the target platform, if configured. When set, you can also set any other valid combination of emulator options as listed by `$ tns help emulate android`. 
+* `--device` - Specifies a connected device on which to run the app.
+* `--emulator` - If set, runs the app in a native emulator for the target platform, if configured. When set, you can also set any other valid combination of emulator options as listed by `$ tns help emulate android`.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build. When set, you must also specify the `--key-store-*` options.
 * `--key-store-path` - Specifies the file path to the keystore file (P12) which you want to use to code sign your APK. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-password` - Provides the password for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-alias` - Provides the alias for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-alias-password` - Provides the password for the alias specified with `--key-store-alias-password`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
-* `--justlaunch` - If set, does not print the application output in the console. 
+* `--justlaunch` - If set, does not print the application output in the console.
 
 ### Attributes
 * `<Device ID>` is the index or name of the target device as listed by `$ tns device android`
 * `<Emulator Options>` is any valid combination of options as listed by `$ tns help emulate android`
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Prerequisites:
 Before running your app in the Android emulator from the Android SDK, verify that your system meets the following requirements.
 * Verify that you have installed the Android SDK.
@@ -67,6 +67,6 @@ Command | Description
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -9,21 +9,21 @@ Start an emulator and run the app inside it | `$ tns run ios --emulator [<Emulat
 
 Runs your project on a connected iOS device or in the iOS Simulator, if configured. This is shorthand for prepare, build, and deploy. While your app is running, prints the output from the application in the console.
 
-<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help run ios`<% } %> 
-<% if((isConsole && isMacOS) || isHtml) { %> 
+<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help run ios`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>
 <% if(isHtml) { %>> <% } %>IMPORTANT: Before building for iOS device, verify that you have configured a valid pair of certificate and provisioning profile on your OS X system. <% if(isHtml) { %>For more information, see [Obtaining Signing Identities and Downloading Provisioning Profiles](https://developer.apple.com/library/mac/recipes/xcode_help-accounts_preferences/articles/obtain_certificates_and_provisioning_profiles.html).<% } %>
 
 ### Options
-* `--device` - Specifies a connected device on which to run the app. 
+* `--device` - Specifies a connected device on which to run the app.
 * `--emulator` - If set, runs the app in a native emulator for the target platform, if configured. When set, you can also set any other valid combination of emulator options as listed by `$ tns help emulate ios`. You cannot use `--device` and `--emulator` simultaneously.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 * `--justlaunch` - If set, does not print the application output in the console.
 
 ### Attributes
-* `<Device ID>` is the index or name of the target device as listed by `$ tns device ios` 
+* `<Device ID>` is the index or name of the target device as listed by `$ tns device ios`
 * `<Emulator Options>` is any valid combination of options as listed by `$ tns help emulate ios`
 <% } %>
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Prerequisites
 Before running the iOS Simulator, verify that you have met the following requirements.
 * You have installed Xcode. The version of Xcode must be compatible with the ios-sim-portable npm package on which the  NativeScript CLI depends. For more information, visit [https://www.npmjs.org/package/ios-sim-portable](https://www.npmjs.org/package/ios-sim-portable).
@@ -37,6 +37,8 @@ Before running the iOS Simulator, verify that you have met the following require
 
 Command | Description
 ----------|----------
+[appstore](../../publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](../../publishing/appstore-upload.html) | Uploads project to iTunes Connect.
 [build android](build-android.html) | Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 [build ios](build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
 [build](build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
@@ -53,6 +55,6 @@ Command | Description
 [run android](run-android.html) | Runs your project on a connected Android device or in a native Android emulator, if configured.
 [run](run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/project/testing/run.md
+++ b/docs/man_pages/project/testing/run.md
@@ -10,9 +10,9 @@ Runs your project on a connected device or in the native emulator for the select
 <% if((isConsole && isMacOS) || isHtml) { %>### Attributes
 `<Platform>` is the target mobile platform on which you want to run your project. You can set the following target platforms.
 * `android` - Runs your project on a connected Android device, in the native emulator or in Genymotion.
-* `ios` - Runs your project on a connected iOS device or in the iOS Simulator.<% } %> 
+* `ios` - Runs your project on a connected iOS device or in the iOS Simulator.<% } %>
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Command Limitations
 
 * You can run `$ tns run ios` only on OS X systems.
@@ -21,6 +21,8 @@ Runs your project on a connected device or in the native emulator for the select
 
 Command | Description
 ----------|----------
+[appstore](../../publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](../../publishing/appstore-upload.html) | Uploads project to iTunes Connect.
 [build android](build-android.html) | Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 [build ios](build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
 [build](build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
@@ -37,6 +39,6 @@ Command | Description
 [run android](run-android.html) | Runs your project on a connected Android device or in a native Android emulator, if configured.
 [run ios](run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
 [test init](test-init.html) | Configures your project for unit testing with a selected framework.
-[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators. 
+[test android](test-android.html) | Runs the tests in your project on Android devices or native emulators.
 [test ios](test-ios.html) | Runs the tests in your project on iOS devices or the iOS Simulator.
 <% } %>

--- a/docs/man_pages/publishing/appstore-upload.md
+++ b/docs/man_pages/publishing/appstore-upload.md
@@ -1,0 +1,40 @@
+appstore upload
+==========
+
+Usage | Synopsis
+---|---
+Build and upload package | `$ tns appstore upload [<Apple ID> [<Password> [<Mobile Provisioning Profile Identifier> [<Code Sign Identity>]]]]]`
+Upload package | `$ tns appstore upload [<Apple ID> [<Password>]] --ipa <Ipa File Path>`
+
+Uploads project to iTunes Connect. The command either issues a production build and uploads it to iTunes Connect, or uses an already built package to upload.
+
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help appstore upload`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>
+
+### Options
+* `--ipa` - If set, will use provided .ipa file instead of building the project.
+
+### Attributes
+* `<Apple ID>` and `<Password>` are your credentials for logging into iTunes Connect.
+* `<Mobile Provisioning Profile Identifier>` the identifier of the mobile provision(e.g. d5d40f61-b303-4fc8-aea3-fbb229a8171c) which will be used for building. This can easily be acquired through the iPhone Configuration Utility.
+* `<Code Sign Identity>` the code sign identity which will be used for building. You can set it to something generic like 'iPhone Distribution' to let the build automatically detect a code sign identity.
+
+<% if(isHtml) { %>
+### Command Limitations
+
+* You can run `$ tns appstore upload` only on OS X systems.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[appstore](appstore.html) | Lists applications registered in iTunes Connect.
+[build](../project/testing/build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
+[build ios](../project/testing/build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
+[deploy](../project/testing/deploy.html) | Builds and deploys the project to a connected physical or virtual device.
+[livesync](../project/testing/livesync.html) | Synchronizes the latest changes in your project to devices.
+[livesync ios](../project/testing/livesync-ios.html) | Synchronizes the latest changes in your project to iOS devices or the iOS Simulator.
+[run](../project/testing/run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
+[run ios](../project/testing/run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
+<% } %>
+<% } %>

--- a/docs/man_pages/publishing/appstore.md
+++ b/docs/man_pages/publishing/appstore.md
@@ -1,0 +1,31 @@
+appstore
+==========
+
+Usage | Synopsis
+---|---
+List applications | `$ tns appstore [<Apple ID> [<Password>]]`
+<% if((isConsole && isMacOS) || isHtml) { %>Upload | `$ tns appstore upload`<% } %>
+
+Lists all application records in iTunes Connect. The list contains name, version and bundle ID for each application record.
+
+### Attributes
+<% if(isHtml) { %>
+`<Apple ID>` and `<Password>` are your credentials for logging in iTunes Connect. If you do not provide them when running the command, the NativeScript CLI will prompt you to provide them.
+
+### Command Limitations
+
+* You can run `$ tns appstore upload` only on OS X systems.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[appstore upload](appstore-upload.html) | Uploads project to iTunes Connect.
+[build](../project/testing/build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
+[build ios](../project/testing/build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
+[deploy](../project/testing/deploy.html) | Builds and deploys the project to a connected physical or virtual device.
+[livesync](../project/testing/livesync.html) | Synchronizes the latest changes in your project to devices.
+[livesync ios](../project/testing/livesync-ios.html) | Synchronizes the latest changes in your project to iOS devices or the iOS Simulator.
+[run](../project/testing/run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
+[run ios](../project/testing/run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
+<% } %>

--- a/docs/man_pages/publishing/publish-ios.md
+++ b/docs/man_pages/publishing/publish-ios.md
@@ -1,0 +1,41 @@
+publish ios
+==========
+
+Usage | Synopsis
+---|---
+Build and upload package | `$ tns publish ios [<Apple ID> [<Password> [<Mobile Provisioning Profile Identifier> [<Code Sign Identity>]]]]]`
+Upload package | `$ tns publish ios [<Apple ID> [<Password>]] --ipa <Ipa File Path>`
+
+Uploads project to iTunes Connect. The command either issues a production build and uploads it to iTunes Connect, or uses an already built package to upload.
+
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help publish ios`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>
+
+### Options
+* `--ipa` - If set, will use provided .ipa file instead of building the project.
+
+### Attributes
+* `<Apple ID>` and `<Password>` are your credentials for logging into iTunes Connect.
+* `<Mobile Provisioning Profile Identifier>` the identifier of the mobile provision(e.g. d5d40f61-b303-4fc8-aea3-fbb229a8171c) which will be used for building. This can easily be acquired through the iPhone Configuration Utility.
+* `<Code Sign Identity>` the code sign identity which will be used for building. You can set it to something generic like 'iPhone Distribution' to let the build automatically detect a code sign identity.
+
+<% if(isHtml) { %>
+### Command Limitations
+
+* You can run `$ tns publish ios` only on OS X systems.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[appstore](appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](appstore-upload.html) | Uploads project to iTunes Connect.
+[build](../project/testing/build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
+[build ios](../project/testing/build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
+[deploy](../project/testing/deploy.html) | Builds and deploys the project to a connected physical or virtual device.
+[livesync](../project/testing/livesync.html) | Synchronizes the latest changes in your project to devices.
+[livesync ios](../project/testing/livesync-ios.html) | Synchronizes the latest changes in your project to iOS devices or the iOS Simulator.
+[run](../project/testing/run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
+[run ios](../project/testing/run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
+<% } %>
+<% } %>

--- a/docs/man_pages/publishing/publish.md
+++ b/docs/man_pages/publishing/publish.md
@@ -1,0 +1,30 @@
+publish
+==========
+
+Usage | Synopsis
+---|---
+General | `$ tns publish ios`
+
+Uploads project to an application store.
+
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help publish ios`<% } %>
+<% if(isHtml) { %>
+### Command Limitations
+
+* You can run `$ tns publish` only on OS X systems.
+* Currently, you can run `$ tns publish` to publish only iOS applications.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[appstore](appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](appstore-upload.html) | Uploads project to iTunes Connect.
+[build](../project/testing/build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
+[build ios](../project/testing/build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
+[deploy](../project/testing/deploy.html) | Builds and deploys the project to a connected physical or virtual device.
+[livesync](../project/testing/livesync.html) | Synchronizes the latest changes in your project to devices.
+[livesync ios](../project/testing/livesync-ios.html) | Synchronizes the latest changes in your project to iOS devices or the iOS Simulator.
+[run](../project/testing/run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
+[run ios](../project/testing/run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
+<% } %>

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -52,6 +52,11 @@ $injector.requireCommand("test|ios", "./commands/test");
 $injector.requireCommand("test|init", "./commands/test-init");
 $injector.requireCommand("dev-generate-help", "./commands/generate-help");
 
+$injector.requireCommand("appstore|*list", "./commands/appstore-list");
+$injector.requireCommand("appstore|upload", "./commands/appstore-upload");
+$injector.requireCommand("publish|ios", "./commands/appstore-upload");
+$injector.require("itmsTransporterService", "./services/itmstransporter-service");
+
 $injector.require("npm", "./node-package-manager");
 $injector.require("npmInstallationManager", "./npm-installation-manager");
 $injector.require("lockfile", "./lockfile");

--- a/lib/commands/appstore-list.ts
+++ b/lib/commands/appstore-list.ts
@@ -1,0 +1,44 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import { createTable } from "../common/helpers";
+import {StringCommandParameter} from "../common/command-params";
+
+export class ListiOSApps implements ICommand {
+	constructor(private $injector: IInjector,
+		private $itmsTransporterService: IITMSTransporterService,
+		private $logger: ILogger,
+		private $prompter: IPrompter,
+		private $stringParameterBuilder: IStringParameterBuilder) { }
+
+	public allowedParameters: ICommandParameter[] = [new StringCommandParameter(this.$injector), new StringCommandParameter(this.$injector)];
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			let username = args[0],
+				password = args[1];
+
+			if(!username) {
+				username = this.$prompter.getString("Apple ID", { allowEmpty: false }).wait();
+			}
+
+			if(!password) {
+				password = this.$prompter.getPassword("Apple ID password").wait();
+			}
+
+			let iOSApplications = this.$itmsTransporterService.getiOSApplications({username, password}).wait();
+
+			if (!iOSApplications || !iOSApplications.length) {
+				this.$logger.out("Seems you don't have any applications yet.");
+			} else {
+				let table: any = createTable(["Application Name", "Bundle Identifier", "Version"], iOSApplications.map(element => {
+					return [element.name, element.bundleId, element.version];
+				}));
+
+				this.$logger.out(table.toString());
+			}
+		}).future<void>()();
+	}
+}
+
+$injector.registerCommand("appstore|*list", ListiOSApps);

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -1,0 +1,67 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import {StringCommandParameter} from "../common/command-params";
+import * as path from "path";
+
+export class PublishIOS implements ICommand {
+	constructor(private $errors: IErrors,
+		private $fs: IFileSystem,
+		private $hostInfo: IHostInfo,
+		private $injector: IInjector,
+		private $itmsTransporterService: IITMSTransporterService,
+		private $logger: ILogger,
+		private $options: IOptions,
+		private $prompter: IPrompter,
+		private $stringParameterBuilder: IStringParameterBuilder) { }
+
+	public allowedParameters: ICommandParameter[] = [new StringCommandParameter(this.$injector), new StringCommandParameter(this.$injector),
+			new StringCommandParameter(this.$injector), new StringCommandParameter(this.$injector)];
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			let username = args[0],
+				password = args[1],
+				mobileProvisionIdentifier = args[2],
+				codeSignIdentity = args[3],
+				ipaFilePath = this.$options.ipa ? path.resolve(this.$options.ipa) : null;
+
+			if(!username) {
+				username = this.$prompter.getString("Apple ID", { allowEmpty: false }).wait();
+			}
+
+			if(!password) {
+				password = this.$prompter.getPassword("Apple ID password").wait();
+			}
+
+			if(!mobileProvisionIdentifier && !ipaFilePath) {
+				this.$logger.warn("No mobile provision identifier set. A default mobile provision will be used. You can set one in app/App_Resources/iOS/build.xcconfig");
+			}
+
+			if(!codeSignIdentity && !ipaFilePath) {
+				this.$logger.warn("No code sign identity set. A default code sign identity will be used. You can set one in app/App_Resources/iOS/build.xcconfig");
+			}
+
+			this.$options.release = true;
+			this.$itmsTransporterService.upload({
+				username,
+				password,
+				mobileProvisionIdentifier,
+				codeSignIdentity,
+				ipaFilePath,
+				verboseLogging: this.$logger.getLevel() === "TRACE"
+			}).wait();
+		}).future<void>()();
+	}
+
+	public canExecute(args: string[]): IFuture<boolean> {
+		return (() => {
+			if (!this.$hostInfo.isDarwin) {
+				this.$errors.failWithoutHelp("This command is only available on Mac OS X.");
+			}
+
+			return true;
+		}).future<boolean>()();
+	}
+}
+$injector.registerCommand(["publish|ios", "appstore|upload"], PublishIOS);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -25,3 +25,20 @@ export class ReleaseType {
 	static PREPATCH = "prepatch";
 	static PRERELEASE = "prerelease";
 }
+
+export class ITMSConstants {
+	static ApplicationMetadataFile = "metadata.xml";
+	static VerboseLoggingLevels = {
+		Informational: "informational",
+		Verbose: "detailed"
+	};
+	static iTMSExecutableName = "iTMSTransporter";
+	static iTMSDirectoryName = "itms";
+}
+
+class ItunesConnectApplicationTypesClass implements IiTunesConnectApplicationType {
+	public iOS = "iOS App";
+	public Mac = "Mac OS X App";
+}
+
+export let ItunesConnectApplicationTypes = new ItunesConnectApplicationTypesClass();

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -58,6 +58,7 @@ interface ILiveSyncService {
 }
 
 interface IOptions extends ICommonOptions {
+	ipa: string;
 	frameworkPath: string;
 	frameworkName: string;
 	framework: string;
@@ -86,6 +87,58 @@ interface IOptions extends ICommonOptions {
 
 interface IInitService {
 	initialize(): IFuture<void>;
+}
+
+/**
+ * Describes standard username/password type credentials.
+ */
+interface ICredentials {
+	username: string;
+	password: string;
+}
+
+/**
+ * Describes properties needed for uploading a package to iTunes Connect
+ */
+interface IITMSData extends ICredentials {
+	/**
+	 * The identifier of the mobile provision used for building. Note that this will override the same option set through .xcconfig files.
+	 * @type {string}
+	 */
+	mobileProvisionIdentifier?: string;
+	/**
+	 * The Code Sign Identity used for building. Note that this will override the same option set through .xcconfig files.
+	 * @type {string}
+	 */
+	codeSignIdentity?: string;
+	/**
+	 * Path to a .ipa file which will be uploaded. If set that .ipa will be used and no build will be issued.
+	 * @type {string}
+	 */
+	ipaFilePath?: string;
+	/**
+	 * Specifies whether the logging level of the itmstransporter command-line tool should be set to verbose.
+	 * @type {string}
+	 */
+	verboseLogging?: boolean;
+}
+
+/**
+ * Used for communicating with Xcode's iTMS Transporter tool.
+ */
+interface IITMSTransporterService {
+	/**
+	 * Uploads an .ipa package to iTunes Connect.
+	 * @param  {IITMSData}     data Data needed to upload the package
+	 * @return {IFuture<void>}
+	 */
+	upload(data: IITMSData): IFuture<void>;
+	/**
+	 * Queries Apple's content delivery API to get the user's registered iOS applications.
+	 * @param  {ICredentials}                               credentials Credentials for authentication with iTunes Connect.
+	 * @return {IFuture<IItunesConnectApplication[]>}          The user's iOS applications.
+	 */
+	getiOSApplications(credentials: ICredentials): IFuture<IiTunesConnectApplication[]>;
 }
 
 /**

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -52,6 +52,20 @@ interface IBuildConfig {
 	architectures?: string[];
 }
 
+/**
+ * Describes iOS-specific build configuration properties
+ */
+interface IiOSBuildConfig extends IBuildConfig {
+	/**
+	 * Identifier of the mobile provision which will be used for the build. If not set a provision will be selected automatically if possible.
+	 */
+	mobileProvisionIdentifier?: string;
+	/**
+	 * Code sign identity used for build. If not set iPhone Developer is used as a default when building for device.
+	 */
+	codeSignIdentity?: string;
+}
+
 interface IPlatformProjectService {
 	platformData: IPlatformData;
 	validate(): IFuture<void>;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -12,6 +12,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 		$staticConfig: IStaticConfig,
 		$hostInfo: IHostInfo) {
 		super({
+			ipa: { type: OptionType.String },
 			frameworkPath: { type: OptionType.String },
 			frameworkName: { type: OptionType.String },
 			framework: { type: OptionType.String },

--- a/lib/services/init-service.ts
+++ b/lib/services/init-service.ts
@@ -94,7 +94,7 @@ export class InitService implements IInitService {
 				return defaultAppId;
 			}
 
-			return this.$prompter.getString("Id:", () => defaultAppId).wait();
+			return this.$prompter.getString("Id:", { defaultAction: () => defaultAppId }).wait();
 		}).future<string>()();
 	}
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -157,7 +157,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		}).future<void>()();
 	}
 
-	public buildProject(projectRoot: string, buildConfig?: IBuildConfig): IFuture<void> {
+	public buildProject(projectRoot: string, buildConfig?: IiOSBuildConfig): IFuture<void> {
 		return (() => {
 			let basicArgs = [
 				"-configuration", this.$options.release ? "Release" : "Debug",
@@ -202,6 +202,14 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 					"CONFIGURATION_BUILD_DIR=" + path.join(projectRoot, "build", "emulator"),
 					"CODE_SIGN_IDENTITY="
 				]);
+			}
+
+			if (buildConfig && buildConfig.codeSignIdentity) {
+				args.push(`CODE_SIGN_IDENTITY=${buildConfig.codeSignIdentity}`);
+			}
+
+			if (buildConfig && buildConfig.mobileProvisionIdentifier) {
+				args.push(`PROVISIONING_PROFILE=${buildConfig.mobileProvisionIdentifier}`);
 			}
 
 			this.$childProcess.spawnFromEvent("xcodebuild", args, "exit", {cwd: this.$options, stdio: 'inherit'}).wait();

--- a/lib/services/itmstransporter-service.ts
+++ b/lib/services/itmstransporter-service.ts
@@ -1,0 +1,227 @@
+///<reference path="../.d.ts"/>
+"use strict";
+import * as path from "path";
+import * as temp from "temp";
+import {EOL} from "os";
+import {ITMSConstants} from "../constants";
+import {ItunesConnectApplicationTypes} from "../constants";
+import {quoteString} from "../common/helpers";
+
+export class ITMSTransporterService implements IITMSTransporterService {
+	private _itmsTransporterPath: string = null;
+	private _itunesConnectApplications: IiTunesConnectApplication[] = null;
+	private _bundleIdentifier: string = null;
+
+	constructor(private $bplistParser: IBinaryPlistParser,
+		private $childProcess: IChildProcess,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $errors: IErrors,
+		private $fs: IFileSystem,
+		private $hostInfo: IHostInfo,
+		private $httpClient: Server.IHttpClient,
+		private $injector: IInjector,
+		private $logger: ILogger,
+		private $staticConfig: IStaticConfig,
+		private $sysInfo: ISysInfo,
+		private $xcodeSelectService: IXcodeSelectService) { }
+
+	// This property was introduced due to the fact that the $platformService dependency
+	// ultimately tries to resolve the current project's dir and fails if not executed from within a project
+	private get $platformService(): IPlatformService {
+		return this.$injector.resolve("platformService");
+	}
+
+	private get $projectData(): IProjectData {
+		return this.$injector.resolve("projectData");
+	}
+
+	public upload(data: IITMSData): IFuture<void> {
+		return (() => {
+			if (!this.$hostInfo.isDarwin) {
+				this.$errors.failWithoutHelp("iOS publishing is only available on Mac OS X.");
+			}
+
+			temp.track();
+			let itmsTransporterPath = this.getITMSTransporterPath().wait(),
+				ipaFileName = "app.ipa",
+				itmsDirectory = temp.mkdirSync("itms-"),
+				innerDirectory = path.join(itmsDirectory, "mybundle.itmsp"),
+				ipaFileLocation = path.join(innerDirectory, ipaFileName),
+				platform = this.$devicePlatformsConstants.iOS,
+				forDevice = true,
+				iOSBuildConfig: IiOSBuildConfig = {
+					buildForDevice: forDevice,
+					mobileProvisionIdentifier: data.mobileProvisionIdentifier,
+					codeSignIdentity: data.codeSignIdentity
+				},
+				loggingLevel = data.verboseLogging ? ITMSConstants.VerboseLoggingLevels.Verbose : ITMSConstants.VerboseLoggingLevels.Informational,
+				bundleId = this.getBundleIdentifier(data.ipaFilePath).wait(),
+				iOSApplication = this.getiOSApplication(data.username, data.password, bundleId).wait();
+
+			this.$fs.createDirectory(innerDirectory).wait();
+
+			if (data.ipaFilePath) {
+				this.$fs.copyFile(data.ipaFilePath, ipaFileLocation).wait();
+			} else {
+				this.$platformService.buildPlatform(platform, iOSBuildConfig).wait();
+				this.$platformService.copyLastOutput(platform, ipaFileLocation, { isForDevice: forDevice }).wait();
+			}
+
+			let ipaFileHash = this.$fs.getFileShasum(ipaFileLocation, {algorithm: "md5"}).wait(),
+				ipaFileSize = this.$fs.getFileSize(ipaFileLocation).wait(),
+				metadata = this.getITMSMetadataXml(iOSApplication.adamId, ipaFileName, ipaFileHash, ipaFileSize);
+
+			this.$fs.writeFile(path.join(innerDirectory, ITMSConstants.ApplicationMetadataFile), metadata).wait();
+
+			this.$childProcess.spawnFromEvent(itmsTransporterPath, ["-m", "upload", "-f", itmsDirectory, "-u", quoteString(data.username), "-p", quoteString(data.password), "-v", loggingLevel], "close", { stdio: "inherit" }).wait();
+		}).future<void>()();
+	}
+
+	public getiOSApplications(credentials: ICredentials): IFuture<IiTunesConnectApplication[]> {
+		return ((): IiTunesConnectApplication[] => {
+			if (!this._itunesConnectApplications) {
+				let requestBody = this.getContentDeliveryRequestBody(credentials),
+					contentDeliveryResponse = this.$httpClient.httpRequest({
+							url: "https://contentdelivery.itunes.apple.com/WebObjects/MZLabelService.woa/json/MZITunesProducerService",
+							method: "POST",
+							body: requestBody
+						}).wait(),
+					contentDeliveryBody: IContentDeliveryBody = JSON.parse(contentDeliveryResponse.body);
+
+				if (!contentDeliveryBody.result.Success || !contentDeliveryBody.result.Applications) {
+					let errorMessage = ["Unable to connect to iTunes Connect"];
+					if (contentDeliveryBody.result.Errors && contentDeliveryBody.result.Errors.length) {
+						errorMessage = errorMessage.concat(contentDeliveryBody.result.Errors);
+					}
+
+					this.$errors.failWithoutHelp(errorMessage.join(EOL));
+				}
+
+				this._itunesConnectApplications = contentDeliveryBody.result.Applications.filter(app => app.type === ItunesConnectApplicationTypes.iOS);
+			}
+
+			return this._itunesConnectApplications;
+		}).future<IiTunesConnectApplication[]>()();
+	}
+
+	/**
+	 * Gets iTunes Connect application corresponding to the given bundle identifier.
+	 * @param  {string}                             username For authentication with iTunes Connect.
+	 * @param  {string}                             password For authentication with iTunes Connect.
+	 * @param  {string}                             bundleId Application's Bundle Identifier
+	 * @return {IFuture<IiTunesConnectApplication>}          The iTunes Connect application.
+	 */
+	private getiOSApplication(username: string, password: string, bundleId: string) : IFuture<IiTunesConnectApplication> {
+		return (():IiTunesConnectApplication => {
+			let iOSApplications = this.getiOSApplications({username, password}).wait();
+			if (!iOSApplications || !iOSApplications.length) {
+				this.$errors.failWithoutHelp(`Cannot find any registered applications for Apple ID ${username} in iTunes Connect.`);
+			}
+
+			let iOSApplication = _.find(iOSApplications, app => app.bundleId === bundleId);
+
+			if (!iOSApplication) {
+				this.$errors.failWithoutHelp(`Cannot find registered applications that match the specified identifier ${bundleId} in iTunes Connect.`);
+			}
+
+			return iOSApplication;
+		}).future<IiTunesConnectApplication>()();
+	}
+
+	/**
+	 * Gets the application's bundle identifier. If ipaFileFullPath is provided will extract the bundle identifier from the .ipa file.
+	 * @param  {string}          ipaFileFullPath Optional full path to .ipa file
+	 * @return {IFuture<string>}                 Application's bundle identifier.
+	 */
+	private getBundleIdentifier(ipaFileFullPath?: string): IFuture<string> {
+		return ((): string => {
+			if (!this._bundleIdentifier) {
+				if (!ipaFileFullPath) {
+					this._bundleIdentifier = this.$projectData.projectId;
+				} else {
+					if (!this.$fs.exists(ipaFileFullPath).wait() || path.extname(ipaFileFullPath) !== ".ipa") {
+						this.$errors.failWithoutHelp(`Cannot use specified ipa file ${ipaFileFullPath}. File either does not exist or is not an ipa file.`);
+					}
+
+					this.$logger.trace("--ipa set - extracting .ipa file to get app's bundle identifier");
+					temp.track();
+					let destinationDir = temp.mkdirSync("ipa-");
+					this.$fs.unzip(ipaFileFullPath, destinationDir).wait();
+					let plistObject = this.$bplistParser.parseFile(path.join(destinationDir, "Payload", "iossampleapp.app", "Info.plist")).wait();
+					let bundleId = plistObject && plistObject[0] && plistObject[0].CFBundleIdentifier;
+					if (!bundleId) {
+						this.$errors.failWithoutHelp(`Unable to determine bundle identifier from ${ipaFileFullPath}.`);
+					}
+
+					this.$logger.trace(`bundle identifier determined to be ${bundleId}`);
+					this._bundleIdentifier = bundleId;
+				}
+			}
+
+			return this._bundleIdentifier;
+		}).future<string>()();
+	}
+
+	private getITMSTransporterPath(): IFuture<string> {
+		return ((): string => {
+			if (!this._itmsTransporterPath) {
+				let xcodePath = this.$xcodeSelectService.getContentsDirectoryPath().wait(),
+					sysInfo = this.$sysInfo.getSysInfo(this.$staticConfig.pathToPackageJson).wait(),
+					xcodeVersionMatch = sysInfo.xcodeVer.match(/Xcode (.*)/),
+					result = path.join(xcodePath, "Applications", "Application Loader.app", "Contents");
+
+				if (xcodeVersionMatch && xcodeVersionMatch[1]) {
+					let [major, minor] = xcodeVersionMatch[1].split(".");
+					// iTMS Transporter's path has been modified in Xcode 6.3
+					// https://github.com/nomad/shenzhen/issues/243
+					if (+major <= 6 && +minor < 3) {
+						result = path.join(result, "MacOS");
+					}
+				}
+
+				this._itmsTransporterPath = path.join(result, ITMSConstants.iTMSDirectoryName, "bin", ITMSConstants.iTMSExecutableName);
+			}
+
+			if(!this.$fs.exists(this._itmsTransporterPath).wait()) {
+				this.$errors.failWithoutHelp('iTMS Transporter not found on this machine - make sure your Xcode installation is not damaged.');
+			}
+
+			return this._itmsTransporterPath;
+		}).future<string>()();
+	}
+
+	private getContentDeliveryRequestBody(credentials: ICredentials): string {
+		// All of those values except credentials are hardcoded
+		// Apple's content delivery API is very picky with handling requests
+		// and if only one of these ends up missing the API returns
+		// a response with 200 status code and an error
+		return JSON.stringify({
+					id: "1", // magic number
+					jsonrpc: "2.0",
+					method: "lookupSoftwareApplications",
+					params: {
+						Username: credentials.username,
+						Password: credentials.password,
+						Version: "2.9.1 (441)",
+						Application: "Application Loader",
+						OSIdentifier: "Mac OS X 10.8.5 (x86_64)"
+					}
+				});
+	}
+
+	private getITMSMetadataXml(appleId: string, ipaFileName: string, ipaFileHash: string, ipaFileSize: number): string {
+		return `<?xml version="1.0" encoding="UTF-8"?>
+<package version="software4.7" xmlns="http://apple.com/itunes/importer">
+    <software_assets apple_id="${appleId}">
+        <asset type="bundle">
+            <data_file>
+                <file_name>${ipaFileName}</file_name>
+                <checksum type="md5">${ipaFileHash}</checksum>
+                <size>${ipaFileSize}</size>
+            </data_file>
+        </asset>
+    </software_assets>
+</package>`;
+	}
+}
+$injector.register("itmsTransporterService", ITMSTransporterService);


### PR DESCRIPTION
The command has several parameters:
* **Apple ID** - **Mandatory** The application's Apple ID - it can be viewed at [iTunes Connect](https://itunesconnect.apple.com)
* **Username** - **Mandatory** Username for authentication with iTunes Connect
* **Password** - **Mandatory** Password for authentication with iTunes Connect
* **Mobile Provisioning Profile Identifier** - Mobile Provisioning Profile Identifier - it can easily be viewed with the iPhone Configuration Utility under the tab `Provisioning Profiles`
* **Code Sign Identity** - Code Sign Identity used for building. It can be set to something generic like *iPhone Distribution* in order to let Xcode decide the best match for a code signing identity.

This is only the iOS part of the implementation - `tns publish android` will be introduced in a subsequent pull request.

References: https://github.com/NativeScript/nativescript-cli/issues/1172
Merge after: https://github.com/telerik/mobile-cli-lib/pull/609

Ping @rosen-vladimirov and @ligaz for code review and @ikoevska for messaging and help :cat: 