### PR TITLE
Fix installation of runtime with next tag

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -11,13 +11,12 @@ interface INodePackageManager {
 
 interface INpmInstallationManager {
 	getCacheRootPath(): string;
-	addToCache(packageName: string, version: string): IFuture<void>;
+	addToCache(packageName: string, version: string): IFuture<any>;
 	cacheUnpack(packageName: string, version: string, unpackTarget?: string): IFuture<void>;
 	install(packageName: string, options?: INpmInstallOptions): IFuture<string>;
 	getLatestVersion(packageName: string): IFuture<string>;
 	getLatestCompatibleVersion(packageName: string): IFuture<string>;
 	getCachedPackagePath(packageName: string, version: string): string;
-	addCleanCopyToCache(packageName: string, version: string): IFuture<void>;
 }
 
 interface INpmInstallOptions {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -212,10 +212,6 @@ export class NpmInstallationManagerStub implements INpmInstallationManager {
 		return undefined;
 	}
 
-	addCleanCopyToCache(packageName: string, version: string): IFuture<void> {
-		return undefined;
-	}
-
 	cacheUnpack(packageName: string, version: string): IFuture<void> {
 		return undefined;
 	}


### PR DESCRIPTION
Our npmInstallationManager is using the passed `next` string as a version and searches for directory called `next` in the npm cache.
Instead it should use the real version. Fix this by getting the result of npm call addToCache, which returns object with information about cached package.

With this change you can call:
```
tns platform add android@next
```

Fixes https://github.com/NativeScript/nativescript-cli/issues/1563