### PR TITLE
Verify JAVA_HOME is set correctly

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -160,12 +160,12 @@ interface IAndroidToolsInfo {
 	validateInfo(options?: {showWarningsAsErrors: boolean, validateTargetSdk: boolean}): IFuture<boolean>;
 
 	/**
-	 * Validates the information about required JAVA version.
-	 * @param {string} installedJavaVersion The JAVA version that will be checked.
+	 * Validates the information about required JAVA version and JAVA_HOME.
+	 * @param {string} javacVersion The JAVA version that will be checked.
 	 * @param {any} options Defines if the warning messages should treated as error.
 	 * @return {boolean} True if there are detected issues, false otherwise.
 	 */
-	validateJavacVersion(installedJavaVersion: string, options?: {showWarningsAsErrors: boolean}): IFuture<boolean>;
+	validateJava(javacVersion: string, options?: {showWarningsAsErrors: boolean}): IFuture<boolean>;
 
 	/**
 	 * Returns the path to `android` executable. It should be `$ANDROID_HOME/tools/android`.

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -88,7 +88,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 			// this call will fail in case `android` is not set correctly.
 			this.$androidToolsInfo.getPathToAndroidExecutable({showWarningsAsErrors: true}).wait();
-			this.$androidToolsInfo.validateJavacVersion(this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait().javacVersion, {showWarningsAsErrors: true}).wait();
+			this.$androidToolsInfo.validateJava(this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait().javacVersion, {showWarningsAsErrors: true}).wait();
 		}).future<void>()();
 	}
 

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -87,7 +87,7 @@ class DoctorService implements IDoctorService {
 		}
 
 		let androidToolsIssues = this.$androidToolsInfo.validateInfo().wait();
-		let javaVersionIssue = this.$androidToolsInfo.validateJavacVersion(sysInfo.javacVersion).wait();
+		let javaVersionIssue = this.$androidToolsInfo.validateJava(sysInfo.javacVersion).wait();
 		return result || androidToolsIssues || javaVersionIssue;
 	}
 


### PR DESCRIPTION
Our system requirements point that JAVA_HOME must be set, but `tns doctor` is not strict about this.
With version 1.7.0 of the runtime, `jarsigner` from $JAVA_HOME/bin/jarsigner will be called explicitly, so we must be sure JAVA_HOME is correct.
`jarsigner` does not exist in JRE, so add logic to call it in order to verify that the currently set JAVA_HOME is correct.
Validate the information in the following order:
1) Check if JAVA_HOME is set. In case it is not, you cannot build for Android (`tns build android` will fail before starting).
2) Check if JAVA_HOME is correct by executing JAVA_HOME/bin/jarsigner - in case it does not exist - fail
3) Check if the version of the JAVA is correct by calling JAVA_HOME/bin/javac -version and compare it with min required one. In case it's lower - fail.

`tns doctor` will print warning in case any of the above check fails. `tns build android` and any other Android related build operations will fail.