### PR TITLE
Add support for custom platform templates

### DIFF
--- a/docs/man_pages/project/configuration/platform-add.md
+++ b/docs/man_pages/project/configuration/platform-add.md
@@ -3,26 +3,28 @@ platform add
 
 Usage | Synopsis
 ------|-------
-Android latest runtime | `$ tns platform add android [--frameworkPath <File Path>] [--symlink] [--sdk <API Level>]`
-Android selected runtime | `$ tns platform add android[@<Version>] [--frameworkPath <File Path>] [--symlink] [--sdk <API Level>]`
-<% if (isMacOS) { %>iOS latest runtime | `$ tns platform add ios [--frameworkPath <File Path>] [--symlink]`
-iOS selected runtime | `$ tns platform add ios[@<Version>] [--frameworkPath <File Path>] [--symlink]`<% } %>
+Android latest runtime | `$ tns platform add android [--framework-path <File Path>] [--symlink] [--sdk <API Level>] [--platform-template <Platform Template>]`
+Android selected runtime | `$ tns platform add android[@<Version>] [--framework-path <File Path>] [--symlink] [--sdk <API Level>] [--platform-template <Platform Template>]`
+<% if (isMacOS) { %>iOS latest runtime | `$ tns platform add ios [--framework-path <File Path>] [--symlink]`
+iOS selected runtime | `$ tns platform add ios[@<Version>] [--framework-path <File Path>] [--symlink] [--platform-template <Platform Template>]`<% } %>
 
-Configures the current project to target the selected platform. <% if(isHtml) { %>When you add a target platform, the NativeScript CLI adds a corresponding platform-specific subdirectory under the platforms directory. This platform-specific directory contains the necessary files to let you build your project for the target platform.<% } %> 
+Configures the current project to target the selected platform. <% if(isHtml) { %>When you add a target platform, the NativeScript CLI creates a corresponding platform-specific subdirectory under the platforms directory. This platform-specific directory contains the necessary files to let you build your project for the target platform.<% } %>
 
 ### Options
-* `--frameworkPath` - Sets the path to a NativeScript runtime for the specified platform that you want to use instead of the default runtime. If `--symlink` is specified, `<File Path>` must point to directory in which the runtime is already extracted. If `--symlink` is not specified, `<File Path>` must point to a valid npm package. 
+* `--framework-path` - Sets the path to a NativeScript runtime for the specified platform that you want to use instead of the default runtime. If `--symlink` is specified, `<File Path>` must point to directory in which the runtime is already extracted. If `--symlink` is not specified, `<File Path>` must point to a valid npm package.
 * `--symlink` - Creates a symlink to a NativeScript runtime for the specified platform that you want to use instead of the default runtime. If `--frameworkPath` is specified, creates a symlink to the specified directory. If `--frameworkPath` is not specified, creates a symlink to platform runtime installed with your current version of NativeScript.
 * `--sdk` - Sets the target Android SDK for the project.
+* `--platform-template` - Sets the platform template that will be used for the native application.
 
 ### Attributes
 * `<API Level>` is a valid Android API level. For example: 17, 19, MNC.<% if(isHtml) { %> For a complete list of the Android API levels and their corresponding Android versions, click [here](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#platform).<% } %>
 * `<File Path>` is the complete path to a valid npm package or a directory that contains a NativeScript runtime for the selected platform.
-* `<Version>` is any available version of the respective platform runtime published in npm. <% if(isHtml) { %>If `@<Version>` is not specified, the NativeScript CLI installs the latest stable runtime for the selected platform.  
-To list all available versions for Android, run `$ npm view tns-android versions`  
-To list only experimental versions for Android, run `$ npm view tns-android dist-tags`  
-To list all available versions for iOS, run `$ npm view tns-ios versions`  
-To list only experimental versions for iOS, run `$ npm view tns-ios dist-tags`  
+* `<Platform Template>` is a valid npm package, path to directory, .tgz or GitHub URL that contains a native Android or iOS template.
+* `<Version>` is any available version of the respective platform runtime published in npm. <% if(isHtml) { %>If `@<Version>` is not specified, the NativeScript CLI installs the latest stable runtime for the selected platform.
+To list all available versions for Android, run `$ npm view tns-android versions`
+To list only experimental versions for Android, run `$ npm view tns-android dist-tags`
+To list all available versions for iOS, run `$ npm view tns-ios versions`
+To list only experimental versions for iOS, run `$ npm view tns-ios dist-tags`
 
 ### Command Limitations
 

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -83,6 +83,7 @@ interface IOptions extends ICommonOptions {
 	port: Number;
 	copyTo: string;
 	baseConfig: string;
+	platformTemplate: string;
 }
 
 interface IInitService {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -69,7 +69,7 @@ interface IiOSBuildConfig extends IBuildConfig {
 interface IPlatformProjectService {
 	platformData: IPlatformData;
 	validate(): IFuture<void>;
-	createProject(frameworkDir: string, frameworkVersion: string): IFuture<void>;
+	createProject(frameworkDir: string, frameworkVersion: string, pathToTemplate?: string): IFuture<void>;
 	interpolateData(): IFuture<void>;
 	interpolateConfigurationFile(configurationFilePath?: string): IFuture<void>;
 	afterCreateProject(projectRoot: string): IFuture<void>;

--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -9,6 +9,7 @@ import * as fiber from "fibers";
 import Future = require("fibers/future");
 import * as shelljs from "shelljs";
 shelljs.config.silent = true;
+shelljs.config.fatal = true;
 import {installUncaughtExceptionListener} from "./common/errors";
 installUncaughtExceptionListener(process.exit);
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -34,7 +34,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			compileSdk: {type: OptionType.Number },
 			port: { type: OptionType.Number },
 			copyTo: { type: OptionType.String },
-			baseConfig: { type: OptionType.String }
+			baseConfig: { type: OptionType.String },
+			platformTemplate: { type: OptionType.String }
 		},
 		path.join($hostInfo.isWindows ? process.env.AppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),
 			$errors, $staticConfig);

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -92,7 +92,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		}).future<void>()();
 	}
 
-	public createProject(frameworkDir: string, frameworkVersion: string): IFuture<void> {
+	public createProject(frameworkDir: string, frameworkVersion: string, pathToTemplate?: string): IFuture<void> {
 		return (() => {
 			if(semver.lt(frameworkVersion, AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE)) {
 				this.$errors.failWithoutHelp(`The NativeScript CLI requires Android runtime ${AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE} or later to work properly.`);
@@ -111,7 +111,13 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			}
 
 			// These files and directories should not be symlinked as CLI is modifying them and we'll change the original values as well.
-			this.copy(this.platformData.projectRoot, frameworkDir, "src", "-R");
+			if(pathToTemplate) {
+				let mainPath = path.join(this.platformData.projectRoot, "src", "main");
+				this.$fs.createDirectory(mainPath).wait();
+				shell.cp("-R", path.join(path.resolve(pathToTemplate), "*"), mainPath);
+			} else {
+				this.copy(this.platformData.projectRoot, frameworkDir, "src", "-R");
+			}
 			this.copy(this.platformData.projectRoot, frameworkDir, "build.gradle settings.gradle gradle.properties", "-f");
 
 			if (this.useGradleWrapper(frameworkDir)) {

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -137,6 +137,7 @@ function createTestInjector() {
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	testInjector.register("xmlValidator", XmlValidator);
+	testInjector.register("npm", {});
 
 	return testInjector;
 }

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -71,6 +71,7 @@ function createTestInjector() {
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	testInjector.register("xmlValidator", XmlValidator);
+	testInjector.register("npm", {});
 
 	return testInjector;
 }


### PR DESCRIPTION
Add new option when adding platform: `--platform-template`. When it is
used, CLI will use the specified template instead of the default template
from the runtime. The path to the specified template will be saved in
project's package.json, so next time when platform is added, the same
template will be used.
In case when `--platform-template` is not passed, CLI will check the
package.json and if there's value for the template, it will be used.
Otherwise the default template from runtime will be used.