### PR TITLE
Fix plugin remove command for invalid plugins

### DIFF
--- a/lib/commands/plugin/remove-plugin.ts
+++ b/lib/commands/plugin/remove-plugin.ts
@@ -3,7 +3,9 @@
 
 export class RemovePluginCommand implements ICommand {
 	constructor(private $pluginsService: IPluginsService,
-		private $errors: IErrors) { }
+		private $errors: IErrors,
+		private $logger: ILogger,
+		private $projectData: IProjectData) { }
 
 	execute(args: string[]): IFuture<void> {
 		return this.$pluginsService.remove(args[0]);
@@ -15,9 +17,18 @@ export class RemovePluginCommand implements ICommand {
 				this.$errors.fail("You must specify plugin name.");
 			}
 
-			let installedPlugins = this.$pluginsService.getAllInstalledPlugins().wait();
+			let pluginNames: string[] = [];
+			try {
+				// try installing the plugins, so we can get information from node_modules about their native code, libs, etc.
+				let installedPlugins = this.$pluginsService.getAllInstalledPlugins().wait();
+				pluginNames = installedPlugins.map(pl => pl.name);
+			} catch(err) {
+				this.$logger.trace("Error while installing plugins. Error is:", err);
+				pluginNames =  _.keys(this.$projectData.dependencies);
+			}
+
 			let pluginName = args[0].toLowerCase();
-			if(!_.any(installedPlugins, (plugin: IPluginData) => plugin.name.toLowerCase() === pluginName)) {
+			if(!_.any(pluginNames, name => name.toLowerCase() === pluginName)) {
 				this.$errors.failWithoutHelp(`Plugin "${pluginName}" is not installed.`);
 			}
 

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -36,10 +36,10 @@ interface IPluginVariablesService {
 	savePluginVariablesInProjectFile(pluginData: IPluginData): IFuture<void>;
 	/**
 	 * Removes plugin variables from project package.json file.
-	 * @param  {IPluginData}		pluginData for the plugin.
+	 * @param  {string}		pluginName Name of the plugin.
 	 * @return {IFuture<void>}
 	 */
-	removePluginVariablesFromProjectFile(pluginData: IPluginData): IFuture<void>;
+	removePluginVariablesFromProjectFile(pluginName: string): IFuture<void>;
 	/**
 	 * Replaces all plugin variables with their corresponding values.
 	 * @param {IPluginData}		pluginData for the plugin.
@@ -59,10 +59,10 @@ interface IPluginVariablesService {
 	interpolate(pluginData: IPluginData, pluginConfigurationFilePath: string): IFuture<void>;
 	/**
 	 * Returns the
-	 * @param {IPluginData}		pluginData for the plugin.
+	 * @param {string}		pluginName for the plugin.
 	 * @return {IFuture<string>}		returns the changed plugin configuration file content.
 	 */
-	getPluginVariablePropertyName(pluginData: IPluginData): string;
+	getPluginVariablePropertyName(pluginName: string): string;
 
 }
 

--- a/lib/services/plugin-variables-service.ts
+++ b/lib/services/plugin-variables-service.ts
@@ -13,8 +13,8 @@ export class PluginVariablesService implements IPluginVariablesService {
 		private $prompter: IPrompter,
 		private $fs: IFileSystem) { }
 
-	public getPluginVariablePropertyName(pluginData: IPluginData): string {
-		return `${pluginData.name}-${PluginVariablesService.PLUGIN_VARIABLES_KEY}`;
+	public getPluginVariablePropertyName(pluginName: string): string {
+		return `${pluginName}-${PluginVariablesService.PLUGIN_VARIABLES_KEY}`;
 	}
 
 	public savePluginVariablesInProjectFile(pluginData: IPluginData): IFuture<void> {
@@ -29,14 +29,14 @@ export class PluginVariablesService implements IPluginVariablesService {
 
 			if(!_.isEmpty(values)) {
 				this.$projectDataService.initialize(this.$projectData.projectDir);
-				this.$projectDataService.setValue(this.getPluginVariablePropertyName(pluginData), values).wait();
+				this.$projectDataService.setValue(this.getPluginVariablePropertyName(pluginData.name), values).wait();
 			}
 		}).future<void>()();
 	}
 
-	public removePluginVariablesFromProjectFile(pluginData: IPluginData): IFuture<void> {
+	public removePluginVariablesFromProjectFile(pluginName: string): IFuture<void> {
 		this.$projectDataService.initialize(this.$projectData.projectDir);
-		return this.$projectDataService.removeProperty(this.getPluginVariablePropertyName(pluginData));
+		return this.$projectDataService.removeProperty(this.getPluginVariablePropertyName(pluginName));
 	}
 
 	public interpolatePluginVariables(pluginData: IPluginData, pluginConfigurationFilePath: string): IFuture<void> {
@@ -115,7 +115,7 @@ export class PluginVariablesService implements IPluginVariablesService {
 			variableData.name = pluginVariableName;
 
 			this.$projectDataService.initialize(this.$projectData.projectDir);
-			let pluginVariableValues = this.$projectDataService.getValue(this.getPluginVariablePropertyName(pluginData)).wait();
+			let pluginVariableValues = this.$projectDataService.getValue(this.getPluginVariablePropertyName(pluginData.name)).wait();
 			variableData.value = pluginVariableValues ? pluginVariableValues[pluginVariableName] : undefined;
 
 			return variableData;


### PR DESCRIPTION
When invalid plugin data is written in project's package.json, `tns plugin remove <name>` command fails.
In such cases `npm uninstall --save <name>` just removes the entry from package.json, so we should do the same.
By invalid data I mean invalid version (not existing version or path to non-existing file).

Plugin remove command's canExecute method is trying to install all plugins in order to get information about their native code, so it will be removed from `platforms` dir.
The installation fails when some plugin's data is invalid.
Catch the error and check package.json's dependencies instead.
Also make sure plugin variables data is removed from package.json when plugin is removed.
Currently it's been removed only when platform is added and plugin has native code.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1541