### PR TITLE
Remove shelljs.config.fatal

### DIFF
--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -9,7 +9,6 @@ import * as fiber from "fibers";
 import Future = require("fibers/future");
 import * as shelljs from "shelljs";
 shelljs.config.silent = true;
-shelljs.config.fatal = true;
 import {installUncaughtExceptionListener} from "./common/errors";
 installUncaughtExceptionListener(process.exit);
 


### PR DESCRIPTION
When adding platform, CLI tries to copy some files from runtime to the native project.
When some of the files do not exist and `shelljs.config.fatal` is true, shelljs exits the process without warn.
Remove the option for the moment and consider better usage for it.

Original https://github.com/NativeScript/nativescript-cli/pull/1592