### PR TITLE
Track Feature usage in a separate Analytics project

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -27,6 +27,7 @@ export class StaticConfig extends StaticConfigBase implements IStaticConfig {
 	public CLIENT_NAME = "tns";
 	public CLIENT_NAME_ALIAS = "NativeScript";
 	public ANALYTICS_API_KEY = "5752dabccfc54c4ab82aea9626b7338e";
+	public ANALYTICS_FEATURE_USAGE_TRACKING_API_KEY = "9912cff308334c6d9ad9c33f76a983e3";
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "TrackFeatureUsage";
 	public ERROR_REPORT_SETTING_NAME = "TrackExceptions";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -8,7 +8,8 @@ let clui = require("clui");
 class DoctorService implements IDoctorService {
 	private static MIN_SUPPORTED_POD_VERSION = "0.38.2";
 
-	constructor(private $androidToolsInfo: IAndroidToolsInfo,
+	constructor(private $analyticsService: IAnalyticsService,
+		private $androidToolsInfo: IAndroidToolsInfo,
 		private $hostInfo: IHostInfo,
 		private $logger: ILogger,
 		private $progressIndicator: IProgressIndicator,
@@ -18,7 +19,7 @@ class DoctorService implements IDoctorService {
 		private $npm: INodePackageManager,
 		private $fs: IFileSystem) {	}
 
-	public printWarnings(): boolean {
+	public printWarnings(configOptions?: { trackResult: boolean }): boolean {
 		let result = false;
 		let sysInfo = this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait();
 
@@ -88,7 +89,14 @@ class DoctorService implements IDoctorService {
 
 		let androidToolsIssues = this.$androidToolsInfo.validateInfo().wait();
 		let javaVersionIssue = this.$androidToolsInfo.validateJava(sysInfo.javacVersion).wait();
-		return result || androidToolsIssues || javaVersionIssue;
+
+		let doctorResult = result || androidToolsIssues || javaVersionIssue;
+
+		if(!configOptions || configOptions.trackResult) {
+			this.$analyticsService.track("DoctorEnvironmentSetup", doctorResult ? "incorrect" : "correct").wait();
+		}
+
+		return doctorResult;
 	}
 
 	private printPackageManagerTip() {


### PR DESCRIPTION
As we need to track new users separately from existing ones, we have to track AcceptFeatureUsageTracking in a separate project.
Also track `InstallEnvironmentSetup` with values 'correct' and 'incorrect' - it will be tracked only on post-install of CLI and will report if user's environment is correct.
Track `DoctorEnvironmentSetup` with values 'correct' and 'incorrect'. On post-install this feature will not be tracked.