### PR TITLE
Revert strict check for JAVA_HOME

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -156,63 +156,28 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		}).future<boolean>()();
 	}
 
-	public validateJava(javacVersion: string, options?: {showWarningsAsErrors: boolean}): IFuture<boolean> {
+	public validateJavacVersion(installedJavaVersion: string, options?: {showWarningsAsErrors: boolean}): IFuture<boolean> {
 		return ((): boolean => {
+			let hasProblemWithJavaVersion = false;
 			if(options) {
 				this.showWarningsAsErrors = options.showWarningsAsErrors;
 			}
-
-			let helpfulMessage = "You will not be able to build your projects for Android." + EOL
+			let additionalMessage = "You will not be able to build your projects for Android." + EOL
 				+ "To be able to build for Android, verify that you have installed The Java Development Kit (JDK) and configured it according to system requirements as" + EOL +
 				" described in https://github.com/NativeScript/nativescript-cli#system-requirements.";
-
-			let hasProblemWithJavaHome = this.validateJavaHome(helpfulMessage).wait();
-			let hasProblemWithJavaVersion: boolean;
-			if(!hasProblemWithJavaHome) {
-				hasProblemWithJavaVersion = this.validateJavacVersion(javacVersion, helpfulMessage);
-			}
-
-			return hasProblemWithJavaHome || hasProblemWithJavaVersion;
-		}).future<boolean>()();
-	}
-
-	private validateJavaHome(helpfulMessage: string): IFuture<boolean> {
-		return ((): boolean => {
-			let hasProblemWithJavaHome = false;
-			let javaHome = process.env.JAVA_HOME;
-
-			if(javaHome) {
-				// validate jarsigner as it does not exist in JRE, but is mandatory for JDK and Android Runtime
-				let jarSigner = path.join(javaHome, "bin", "jarsigner");
-				let childProcessResult = this.$childProcess.spawnFromEvent(jarSigner, [], "close", {}, { throwError: false }).wait();
-				this.$logger.trace(`Result of calling jarsigner from path: ${jarSigner}:`, childProcessResult);
-				if(childProcessResult.stderr || childProcessResult.exitCode !== 0) {
-					hasProblemWithJavaHome = true;
-					this.printMessage("JAVA_HOME environment variable points to incorrect path. Make sure it points to the installation directory of JDK.", helpfulMessage);
+			let matchingVersion = (installedJavaVersion || "").match(AndroidToolsInfo.VERSION_REGEX);
+			if(matchingVersion && matchingVersion[1]) {
+				if(semver.lt(matchingVersion[1], AndroidToolsInfo.MIN_JAVA_VERSION)) {
+					hasProblemWithJavaVersion = true;
+					this.printMessage(`Javac version ${installedJavaVersion} is not supported. You have to install at least ${AndroidToolsInfo.MIN_JAVA_VERSION}.`, additionalMessage);
 				}
 			} else {
-				hasProblemWithJavaHome = true;
-				this.printMessage("JAVA_HOME environment variable is not set.", helpfulMessage);
-			}
-
-			return hasProblemWithJavaHome;
-		}).future<boolean>()();
-	}
-
-	private validateJavacVersion(installedJavaVersion: string, helpfulMessage: string): boolean {
-		let hasProblemWithJavaVersion = false;
-		let matchingVersion = (installedJavaVersion || "").match(AndroidToolsInfo.VERSION_REGEX);
-		if(matchingVersion && matchingVersion[1]) {
-			if(semver.lt(matchingVersion[1], AndroidToolsInfo.MIN_JAVA_VERSION)) {
 				hasProblemWithJavaVersion = true;
-				this.printMessage(`Javac version ${installedJavaVersion} is not supported. You have to install at least ${AndroidToolsInfo.MIN_JAVA_VERSION}.`, helpfulMessage);
+				this.printMessage("Error executing command 'javac'. Make sure you have installed The Java Development Kit (JDK) and set JAVA_HOME environment variable.", additionalMessage);
 			}
-		} else {
-			hasProblemWithJavaVersion = true;
-			this.printMessage("Error executing command 'javac'. Make sure you have installed The Java Development Kit (JDK) and set JAVA_HOME environment variable.", helpfulMessage);
-		}
 
-		return hasProblemWithJavaVersion;
+			return hasProblemWithJavaVersion;
+		}).future<boolean>()();
 	}
 
 	public getPathToAdbFromAndroidHome(): IFuture<string> {

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -161,12 +161,12 @@ interface IAndroidToolsInfo {
 	validateInfo(options?: {showWarningsAsErrors: boolean, validateTargetSdk: boolean}): IFuture<boolean>;
 
 	/**
-	 * Validates the information about required JAVA version and JAVA_HOME.
-	 * @param {string} javacVersion The JAVA version that will be checked.
+	 * Validates the information about required JAVA version.
+	 * @param {string} installedJavaVersion The JAVA version that will be checked.
 	 * @param {any} options Defines if the warning messages should treated as error.
 	 * @return {boolean} True if there are detected issues, false otherwise.
 	 */
-	validateJava(javacVersion: string, options?: {showWarningsAsErrors: boolean}): IFuture<boolean>;
+	validateJavacVersion(installedJavaVersion: string, options?: {showWarningsAsErrors: boolean}): IFuture<boolean>;
 
 	/**
 	 * Returns the path to `android` executable. It should be `$ANDROID_HOME/tools/android`.

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -88,7 +88,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 			// this call will fail in case `android` is not set correctly.
 			this.$androidToolsInfo.getPathToAndroidExecutable({showWarningsAsErrors: true}).wait();
-			this.$androidToolsInfo.validateJava(this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait().javacVersion, {showWarningsAsErrors: true}).wait();
+			this.$androidToolsInfo.validateJavacVersion(this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait().javacVersion, {showWarningsAsErrors: true}).wait();
 		}).future<void>()();
 	}
 

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -88,8 +88,7 @@ class DoctorService implements IDoctorService {
 		}
 
 		let androidToolsIssues = this.$androidToolsInfo.validateInfo().wait();
-		let javaVersionIssue = this.$androidToolsInfo.validateJava(sysInfo.javacVersion).wait();
-
+		let javaVersionIssue = this.$androidToolsInfo.validateJavacVersion(sysInfo.javacVersion).wait();
 		let doctorResult = result || androidToolsIssues || javaVersionIssue;
 
 		if(!configOptions || configOptions.trackResult) {


### PR DESCRIPTION
Due to change in runtime, we do not need strict check for JAVA_HOME, so revert the logic introduced yesterday.