### PR TITLE
Fix livesync for iOS

### DIFF
--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -14,7 +14,8 @@ class IOSLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<Mobi
 		private $iOSSocketRequestExecutor: IiOSSocketRequestExecutor,
 		private $iOSNotification: IiOSNotification,
 		private $iOSEmulatorServices: Mobile.IiOSSimulatorService,
-		private $injector: IInjector) {
+		private $injector: IInjector,
+		private $logger: ILogger) {
 			super(_device);
 		}
 
@@ -45,7 +46,12 @@ class IOSLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<Mobi
 	private sendPageReloadMessage(socket: net.Socket): void {
 		try {
 			this.sendPageReloadMessageCore(socket);
-		} finally {
+			socket.once("data", (data: NodeBuffer|string) => {
+				this.$logger.trace(`Socket sent data: ${data.toString()}`);
+				socket.destroy();
+			});
+		} catch(err) {
+			this.$logger.trace("Error while sending page reload:", err);
 			socket.destroy();
 		}
 	}


### PR DESCRIPTION
CLI is destroying the socket too early and so the runtime cannot handle the message that we've sent.
As a result livesync is not working sometimes.
When we sent message, the socket will always receive data as result. If it's error, the result will contain it.
In any case, we should destroy the socket when data is received.