### PR TITLE
Enable using localhost as ip for tests

### DIFF
--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -157,7 +157,7 @@ class TestExecutionService implements ITestExecutionService {
 	private generateConfig(port: string, options: any): string {
 		let nics = os.networkInterfaces();
 		let ips = Object.keys(nics)
-			.map(nicName => nics[nicName].filter((binding: any) => binding.family === 'IPv4' && !binding.internal)[0])
+			.map(nicName => nics[nicName].filter((binding: any) => binding.family === 'IPv4')[0])
 			.filter(binding => binding)
 			.map(binding => binding.address);
 


### PR DESCRIPTION
When using iOS Simulator we need the localhost enabled as ip for karma. This does not break the Android tests, so enable it for all configurations.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1612

> NOTE: Merge after 1.7.0 is released