### PR TITLE
Improve Setup Scripts

### DIFF
--- a/setup/mac-startup-shell-script.sh
+++ b/setup/mac-startup-shell-script.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"

--- a/setup/native-script.ps1
+++ b/setup/native-script.ps1
@@ -1,30 +1,76 @@
 
 # A PowerShell script to set up Windows machine for NativeScript development
-# To run it against the PRODUCTION branch (only one supported with self-elevation) use
-# @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))" 
+# NOTE: The scripts requires at least a version 4.0 .NET framework installed
+# To run it inside a COMMAND PROMPT against the production branch (only one supported with self-elevation) use
+# @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+# To run it inside a WINDOWS POWERSHELL console against the production branch (only one supported with self-elevation) use
+# iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))
+
+# Check if latest .NET framework installed is at least 4
+$dotNetVersions = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP' -recurse | Get-ItemProperty -name Version,Release -EA 0 | Where { $_.PSChildName -match '^(?!S)\p{L}'} | Select Version
+$latestDotNetVersion = $dotNetVersions.GetEnumerator() | Sort-Object Version | Select-Object -Last 1
+$latestDotNetMajorNumber = $latestDotNetVersion.Version.Split(".")[0]
+if ($latestDotNetMajorNumber -lt 4) {
+	Write-Host -ForegroundColor Red "To run this script, you need .NET 4.0 or later installed"
+	if ((Read-Host "Do you want to open Microsoft Download Center (y/n)") -eq 'y') {
+		Start-Process -FilePath "https://www.microsoft.com/en-us/download/search.aspx?q=.net%20framework&p=0&r=10&t=&s=Relevancy~Descending"
+	}
+
+	exit 1
+}
 
 # Self-elevate
 $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator")
 if (-not $isElevated) {
-    start-process -FilePath PowerShell.exe -NoProfile -ExecutionPolicy Bypass -Verb Runas -Wait -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
-    exit 0
+	start-process -FilePath PowerShell.exe -Verb Runas -Wait -ArgumentList "-NoProfile -ExecutionPolicy Bypass -Command iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+	exit 0
 }
 
+# Help with installing other dependencies
+$script:answer = ""
+function Install($programName, $message, $script, $shouldExit) {
+	if ($script:answer -ne "a") {
+		Write-Host -ForegroundColor Green "Allow the script to install $($programName)?"
+		Write-Host "Tip: Note that if you type a you won't be prompted for subsequent installations"
+		do {
+			$script:answer = (Read-Host "(Y)es/(N)o/(A)ll").ToLower()
+		} until ($script:answer -eq "y" -or $script:answer -eq "n" -or $script:answer -eq "a")
+
+		if ($script:answer -eq "n") {
+			Write-Host -ForegroundColor Yellow "You have chosen not to install $($programName). Some features of NativeScript may not work correctly if you haven't already installed it"
+			return
+		}
+	}
+
+	Write-Host $message
+	Invoke-Expression($script)
+	if ($LASTEXITCODE -ne 0) {
+		Write-Host -ForegroundColor Yellow "WARNING: $($programName) not installed"
+	}
+}
+
+function Pause {
+	Write-Host "Press any key to continue..."
+	[void][System.Console]::ReadKey($true)
+}
+
+# Actually installing all other dependencies
 # Install Chocolately
-iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+Install "Chocolately(It's mandatory for the rest of the script)" "Installing Chocolately" "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
 
-# install dependenciess with Chocolately
+if ((Get-Command "cinst" -ErrorAction SilentlyContinue) -eq $null) {
+	Write-Host -ForegroundColor Red "Chocolatey is not installed or not configured properly. Download it from https://chocolatey.org/, install, set it up and run this script again."
+	Pause
+	exit 1
+}
 
-write-host "To ensure consistent environment, this script will re-install all NativeScript dependencies."
+# Install dependenciess with Chocolately
 
-write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Google Chrome (required to debug NativeScript apps)"
-cinst googlechrome --force --yes
+Install "Google Chrome" "Installing Google Chrome (required to debug NativeScript apps)" "cinst googlechrome --force --yes"
 
-write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Java Development Kit"
-cinst jdk8 --force --yes
+Install "Java Development Kit" "Installing Java Development Kit" "cinst jdk8 --force --yes"
 
-write-host -BackgroundColor Black -ForegroundColor Yellow "Installing Android SDK"
-cinst android-sdk --force --yes
+Install "Android SDK" "Installing Android SDK" "cinst android-sdk --force --yes"
 
 # setup android sdk
 echo yes | cmd /c "$env:localappdata\Android\android-sdk\tools\android" update sdk --filter "tools,platform-tools,android-23" --all --no-ui
@@ -33,17 +79,16 @@ echo yes | cmd /c "$env:localappdata\Android\android-sdk\tools\android" update s
 # setup environment
 
 if (!$env:ANDROID_HOME) {
-    [Environment]::SetEnvironmentVariable("ANDROID_HOME", "$env:localappdata\Android\android-sdk", "User")
-    $env:ANDROID_HOME = "$env:localappdata\Android\android-sdk";
+	[Environment]::SetEnvironmentVariable("ANDROID_HOME", "$env:localappdata\Android\android-sdk", "User")
+	$env:ANDROID_HOME = "$env:localappdata\Android\android-sdk";
 }
 
 if (!$env:JAVA_HOME) {
 	$curVer = (Get-ItemProperty "HKLM:\SOFTWARE\JavaSoft\Java Development Kit").CurrentVersion
 	$javaHome = (Get-ItemProperty "HKLM:\Software\JavaSoft\Java Development Kit\$curVer").JavaHome
 	[Environment]::SetEnvironmentVariable("JAVA_HOME", $javaHome, "User")
-    $env:JAVA_HOME = $javaHome;
+	$env:JAVA_HOME = $javaHome;
 }
 
-write-host -BackgroundColor Black -ForegroundColor Yellow "This script has modified your environment. You need to log off and log back on for the changes to take effect."
-Write-Host "Press any key to continue..."
-[void][System.Console]::ReadKey($true)
+Write-Host -ForegroundColor Green "This script has modified your environment. You need to log off and log back on for the changes to take effect."
+Pause

--- a/setup/native-script.rb
+++ b/setup/native-script.rb
@@ -1,19 +1,23 @@
 # coding: utf-8
 
 # A script to setup developer's workstation for developing with NativeScript
-# To run it against PRODUCTION branch (recommended) use
-# ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
-# To run it against MASTER branch (usually only developers of NativeScript need to) use
-# ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/master/setup/native-script.rb)"
+# To run it against PRODUCTION branch (only one supported with self-elevation) use
+# sudo ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
 
 # Only the user can manually download and install Xcode from App Store
+unless Process.uid == 0
+  # Execute as root
+  puts "This scripts needs sudo permissions"
+  exec('sudo ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"')
+end
+
 puts "NativeScript requires Xcode."
 puts "If you do not have Xcode installed, download and install it from App Store and run it once to complete its setup."
 puts "Do you have Xcode installed? (y/n)"
 
 xcode = gets.chomp
 
-if xcode == "n" || xcode == "N"
+if xcode.downcase == "n"
   exit
 end
 
@@ -22,33 +26,75 @@ if !(`xcodebuild -version`.include? "version")
   exit
 end
 
-puts "You need to accept the Xcode license agreement to be able to use the Xcode command-line tools. (You might need to provide your password.)"
-system('sudo xcodebuild -license')
+puts "You need to accept the Xcode license agreement to be able to use the Xcode command-line tools."
+system('xcodebuild -license')
 
-# Install all other dependencies
-puts "Installing Homebrew... (You might need to provide your password.)"
-system('ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"')
+# Help with installing other dependencies
+$answer = ""
+
+def execute(script, warning_message, run_as_root = false)
+  if run_as_root
+    result = system(script)
+  else
+    result = system("sudo su " + ENV['SUDO_USER'] + " -c '" + script + "'")
+  end
+
+  if result.nil?
+    STDERR.puts "ERROR: " + script + " execution FAILED"
+    exit 1
+  end
+
+  unless result
+    STDERR.puts "WARNING: " + warning_message
+  end
+end
+
+def install(program_name, message, script, run_as_root = false, show_all_option = true)
+  if $answer != "a"
+    puts "Allow the script to install " + program_name + "?"
+    if show_all_option
+      puts "Note that if you type all you won't be prompted for subsequent installations"
+    end
+
+    loop do
+      puts show_all_option ? "(Y)es/(N)o/(A)ll" : "(Y)es/(N)o"
+      $answer = gets.chomp.downcase
+      is_answer_yn = $answer == "y" || $answer == "n"
+      break if show_all_option ? is_answer_yn || $answer == "a" : is_answer_yn
+    end
+
+    if $answer == "n"
+      puts "You have chosen not to install " + program_name + ". Some features of NativeScript may not work correctly if you haven't already installed it"
+      return
+    end
+  end
+
+  puts message
+  execute(script, program_name + " not installed", run_as_root)
+end
+
+# Actually installing all other dependencies
+install("Homebrew",	"Installing Homebrew...", 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</dev/null', false, false)
 
 if !(`brew --version`.include? "git revision")
   puts "Homebrew is not installed or not configured properly. Download it from http://brew.sh/, install, set it up and run this script again."
   exit
 end
 
-puts "Installing CocoaPods... This might take some time, please, be patient. (You might need to provide your password.)"
-system('sudo gem install cocoapods')
+install("Java SE Development Kit", "Installing the Java SE Development Kit... This might take some time, please, be patient. (You will be prompted for your password)", 'brew cask install java', false, false)
+execute('echo "export JAVA_HOME=$(/usr/libexec/java_home)" >> ~/.profile', "Unable to set JAVA_HOME")
 
-puts "Installing Homebrew Cask... (You might need to provide your password.)"
-system('brew install caskroom/cask/brew-cask')
+install("Android SDK", "Installing Android SDK", 'brew install android-sdk')
+execute('echo "export ANDROID_HOME=/usr/local/opt/android-sdk" >> ~/.profile', "Unable to set ANDROID_HOME")
 
-puts "Installing the Java SE Development Kit... This might take some time, please, be patient. (You might need to provide your password.)"
-system('brew cask install java')
-system('echo "export JAVA_HOME=$(/usr/libexec/java_home)" >> ~/.profile')
-
-puts "Installing Android SDK"
-system('brew install android-sdk')
-system('echo "export ANDROID_HOME=/usr/local/opt/android-sdk" >> ~/.profile')
+# the -p flag is set in order to ensure zero status code even if the directory exists
+execute("mkdir -p ~/.cocoapods", "There was a problem in creating ~/.cocoapods directory")
+install("CocoaPods", "Installing CocoaPods... This might take some time, please, be patient.", 'gem install cocoapods -V', true)
 
 puts "Configuring your system for Android development... This might take some time, please, be patient."
-system "echo yes | /usr/local/opt/android-sdk/tools/android update sdk --filter tools,platform-tools,android-23,build-tools-23.0.2,extra-android-m2repository --all --no-ui"
+# Note that multiple license acceptances may be required, hence the multiple y answers
+# the android tool will introduce a --accept-license option in subsequent releases
+execute("(for i in {1..5}; do echo y; sleep 4; done) | /usr/local/opt/android-sdk/tools/android update sdk --filter tools,platform-tools,android-23,build-tools-23.0.2,extra-android-m2repository --all --no-ui",
+	"There seem to be some problems with the Android configuration")
 
 puts "The ANDROID_HOME and JAVA_HOME environment variables have been added to your .profile. Restart the terminal to use them."


### PR DESCRIPTION
### Improve Setup Scripts:
#### Mac:
* Asking permission from user for every installation - this includes an `all` option for eliminating subsequent questions
* Improved error handling - warning upon non-zero exit code, error if the command execution fails
* Adding `-V` option for `sudo gem install cocoapods`. This triggers a verbose output
* Outputting multiple license acceptances for android tools
* Creating ~/.cocoapods directory in case it does not exist

#### Windows:
* Asking permission from user for every installation - this includes an `all` option for eliminating subsequent questions
* Improved error handling - warning upon non-zero exit code
* Initial check for latest .NET Framework installed - should be at least 4
* Check for correct Chocolatey installation
* Fixed the syntax in docs header on invoking the setup script from the command prompt
* Added example syntax in docs header for invoking the setup script from powershell itself

#### Doctor command:
* Upon detecting problems
  * Ask user whether to open up docs
  * Ask user whether to run setup script
* Both questions have **NO** as default for non-interactive consoles and **YES** in interactive

Addresses some parts of https://github.com/NativeScript/NativeScript/issues/1556

Ping @rosen-vladimirov and @teobugslayer 
