### PR TITLE
Fix double navigation when showing test results

### DIFF
--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -193,15 +193,20 @@ class TestExecutionService implements ITestExecutionService {
 				options: {
 					debugTransport: this.$options.debugTransport,
 					debugBrk: this.$options.debugBrk,
+					watch: !!this.$options.watch
 				}
 			},
 		};
+
 		if (this.$config.DEBUG || this.$logger.getLevel() === 'TRACE') {
 			karmaConfig.logLevel = 'DEBUG';
 		}
+
 		if (!this.$options.watch) {
+			// Setting singleRun to true will automatically start the tests when new browser (device in our case) is registered in karma.
 			karmaConfig.singleRun = true;
 		}
+
 		if (this.$options.debugBrk) {
 			karmaConfig.browserNoActivityTimeout = 1000000000;
 		}


### PR DESCRIPTION
When `tns test <platform>` is called and results are shown, the results page is refreshed as there's another navigation.
The problem is that CLI sets karma's `singleRun` option to true and also when browser is registered, `karma-nativescript-launcher` schedules execution of tests on the new browser.
In fact karma itself starts the tests on `browser register` event when the `singleRun` option is true. In our case we have double execution, so we receive the `execute` event two times (it's handled in `nativescript-unit-test-runner`).
We've handled the second execution to prevent tests running, but in fact, we should receive single `execute` event.
Fix this by passing watch option to `karma-nativescript-launcher`, where we'll not schedule new execution in case watch option is false. This way karma itself will start the tests as `singleRun` option is true.
This will fix the double navigation when showing test results.

Releated PR: https://github.com/NativeScript/karma-nativescript-launcher/pull/24
Fixes https://github.com/NativeScript/nativescript-cli/issues/1625