### PR TITLE
Replace plugin variables in all Android .xml files

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -327,10 +327,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				this.$fs.ensureDirectoryExists(resourcesDestinationDirectoryPath).wait();
 				shell.cp("-Rf", path.join(pluginPlatformsFolderPath, "*"), resourcesDestinationDirectoryPath);
 
-				let pluginConfigurationFilePath = path.join(resourcesDestinationDirectoryPath, this.platformData.configurationFileName);
-				if (this.$fs.exists(pluginConfigurationFilePath).wait()) {
-					this.$pluginVariablesService.interpolate(pluginData, pluginConfigurationFilePath).wait();
-				}
+				let files = this.$fs.enumerateFilesInDirectorySync(resourcesDestinationDirectoryPath, file => this.$fs.getFsStats(file).wait().isDirectory() || path.extname(file) === ".xml");
+				_.each(files, file => {
+					this.$logger.trace(`Interpolate data for plugin file: ${file}`);
+					this.$pluginVariablesService.interpolate(pluginData, file).wait();
+				});
 			}
 
 			// Copy include.gradle file


### PR DESCRIPTION
In case a plugin has plugin variable, during project preparation CLI replaces the usage of the variable in plugin's AndroidManifest with the value set in the current project's package.json.
This is not enough, we have to set the variables in all plugin's .xml files, so the value could be used in resource and later read from the JAVA code.
Enumarate plugin's files and replace plugin variables in all .xml files.