### PR TITLE
Replace plugin variables in all Android .xml files

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,6 +15,7 @@ export var LIVESYNC_EXCLUDED_DIRECTORIES = ["app_resources"];
 export var TESTING_FRAMEWORKS = ['jasmine', 'mocha', 'qunit'];
 export let TEST_RUNNER_NAME = "nativescript-unit-test-runner";
 export let LIVESYNC_EXCLUDED_FILE_PATTERNS = ["**/*.js.map", "**/*.ts"];
+export let XML_FILE_EXTENSION = ".xml";
 
 export class ReleaseType {
 	static MAJOR = "major";

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -327,10 +327,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				this.$fs.ensureDirectoryExists(resourcesDestinationDirectoryPath).wait();
 				shell.cp("-Rf", path.join(pluginPlatformsFolderPath, "*"), resourcesDestinationDirectoryPath);
 
-				let pluginConfigurationFilePath = path.join(resourcesDestinationDirectoryPath, this.platformData.configurationFileName);
-				if (this.$fs.exists(pluginConfigurationFilePath).wait()) {
-					this.$pluginVariablesService.interpolate(pluginData, pluginConfigurationFilePath).wait();
-				}
+				(this.$fs.enumerateFilesInDirectorySync(resourcesDestinationDirectoryPath, file => this.$fs.getFsStats(file).wait().isDirectory() || path.extname(file) === constants.XML_FILE_EXTENSION) || [])
+					.forEach(file => {
+						this.$logger.trace(`Interpolate data for plugin file: ${file}`);
+						this.$pluginVariablesService.interpolate(pluginData, file).wait();
+					});
 			}
 
 			// Copy include.gradle file

--- a/lib/xml-validator.ts
+++ b/lib/xml-validator.ts
@@ -2,6 +2,7 @@
 "use strict";
 
 import { EOL } from "os";
+import * as constants from "./constants";
 
 export class XmlValidator implements IXmlValidator {
 	constructor(private $fs: IFileSystem,
@@ -11,7 +12,7 @@ export class XmlValidator implements IXmlValidator {
 		return (() => {
 			let xmlHasErrors = false;
 			sourceFiles
-				.filter(file => _.endsWith(file, ".xml"))
+				.filter(file => _.endsWith(file, constants.XML_FILE_EXTENSION))
 				.forEach(file => {
 					let errorOutput = this.getXmlFileErrors(file).wait();
 					let hasErrors = !!errorOutput;


### PR DESCRIPTION
In case a plugin has plugin variable, during project preparation CLI replaces the usage of the variable in plugin's AndroidManifest with the value set in the current project's package.json.
This is not enough, we have to set the variables in all plugin's .xml files, so the value could be used in resource and later read from the JAVA code.
Enumarate plugin's files and replace plugin variables in all .xml files.

https://github.com/NativeScript/nativescript-cli/issues/1634