### PR TITLE
Added check if project name starts with number when creating new proj…

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -12,6 +12,7 @@ $injector.require("androidProjectService", "./services/android-project-service")
 $injector.require("iOSProjectService", "./services/ios-project-service");
 
 $injector.require("projectTemplatesService", "./services/project-templates-service");
+$injector.require("projectNameService", "./services/project-name-service");
 $injector.require("tnsModulesService", "./services/tns-modules-service");
 
 $injector.require("platformsData", "./platforms-data");

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -159,7 +159,7 @@ interface IAndroidToolsInfo {
 	 * @param {any} options Defines if the warning messages should treated as error and if the targetSdk value should be validated as well.
 	 * @return {boolean} True if there are detected issues, false otherwise.
 	 */
-	validateInfo(options?: {showWarningsAsErrors: boolean, validateTargetSdk: boolean}): IFuture<boolean>;
+	validateInfo(options?: { showWarningsAsErrors: boolean, validateTargetSdk: boolean }): IFuture<boolean>;
 
 	/**
 	 * Validates the information about required JAVA version.
@@ -167,7 +167,7 @@ interface IAndroidToolsInfo {
 	 * @param {any} options Defines if the warning messages should treated as error.
 	 * @return {boolean} True if there are detected issues, false otherwise.
 	 */
-	validateJavacVersion(installedJavaVersion: string, options?: {showWarningsAsErrors: boolean}): IFuture<boolean>;
+	validateJavacVersion(installedJavaVersion: string, options?: { showWarningsAsErrors: boolean }): IFuture<boolean>;
 
 	/**
 	 * Returns the path to `android` executable. It should be `$ANDROID_HOME/tools/android`.
@@ -175,7 +175,7 @@ interface IAndroidToolsInfo {
 	 * @param {any} options Defines if the warning messages should treated as error.
 	 * @return {string} Path to the `android` executable.
 	 */
-	getPathToAndroidExecutable(options?: {showWarningsAsErrors: boolean}): IFuture<string>;
+	getPathToAndroidExecutable(options?: { showWarningsAsErrors: boolean }): IFuture<string>;
 
 	/**
 	 * Gets the path to `adb` executable from ANDROID_HOME. It should be `$ANDROID_HOME/platform-tools/adb` in case it exists.
@@ -255,4 +255,17 @@ interface IXmlValidator {
 	 * @return {IFuture<string>} The errors detected (as a single string) or null in case there are no errors.
 	 */
 	getXmlFileErrors(sourceFile: string): IFuture<string>;
+}
+
+/**
+ * Describes methods for project name.
+ */
+interface IProjectNameService {
+	/**
+	 * Ensures the passed project name is valid. If the project name is not valid prompts for actions.
+	 * @param {string} project name to be checked.
+	 * @param {IOptions} current command options.
+	 * @return {IFuture<strng>} returns the selected name of the project.
+	 */
+	ensureValidName(projectName: string, validateOptions?: {force: boolean}): IFuture<string>;
 }

--- a/lib/services/project-name-service.ts
+++ b/lib/services/project-name-service.ts
@@ -1,0 +1,59 @@
+"use strict";
+
+import { isInteractive } from "../common/helpers";
+
+export class ProjectNameService implements IProjectNameService {
+	constructor(private $projectNameValidator: IProjectNameValidator,
+		private $errors: IErrors,
+		private $logger: ILogger,
+		private $prompter: IPrompter) { }
+
+	public ensureValidName(projectName: string, validateOptions?: { force: boolean }): IFuture<string> {
+		return (() => {
+			if (validateOptions && validateOptions.force) {
+				return projectName;
+			}
+
+			if (!this.$projectNameValidator.validate(projectName)) {
+				return this.promptForNewName(projectName, validateOptions).wait();
+			}
+
+			if (!this.checkIfNameStartsWithLetter(projectName)) {
+				if (!isInteractive()) {
+					this.$errors.fail("The project name does not start with letter and will fail to build for Android. If You want to create project with this name add --force to the create command.");
+					return;
+				}
+
+				return this.promptForNewName(projectName, validateOptions).wait();
+			}
+
+			return projectName;
+		}).future<string>()();
+	}
+
+	private checkIfNameStartsWithLetter(projectName: string): boolean {
+		let startsWithLetterExpression = /^[a-zA-Z]/;
+		return startsWithLetterExpression.test(projectName);
+	}
+
+	private promptForNewName(projectName: string, validateOptions?: { force: boolean }): IFuture<string> {
+		return (() => {
+			if (this.promptForForceNameConfirm().wait()) {
+				return projectName;
+			}
+
+			let newProjectName = this.$prompter.getString("Enter the new project name:").wait();
+			return this.ensureValidName(newProjectName, validateOptions).wait();
+		}).future<string>()();
+	}
+
+	private promptForForceNameConfirm(): IFuture<boolean> {
+		return (() => {
+			this.$logger.warn("The project name does not start with letter and will fail to build for Android.");
+
+			return this.$prompter.confirm("Do you want to create the project with this name?").wait();
+		}).future<boolean>()();
+	}
+}
+
+$injector.register("projectNameService", ProjectNameService);

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -14,7 +14,7 @@ export class ProjectService implements IProjectService {
 		private $logger: ILogger,
 		private $projectDataService: IProjectDataService,
 		private $projectHelper: IProjectHelper,
-		private $projectNameValidator: IProjectNameValidator,
+		private $projectNameService: IProjectNameService,
 		private $projectTemplatesService: IProjectTemplatesService,
 		private $options: IOptions) { }
 
@@ -23,7 +23,8 @@ export class ProjectService implements IProjectService {
 			if (!projectName) {
 				this.$errors.fail("You must specify <App name> when creating a new project.");
 			}
-			this.$projectNameValidator.validate(projectName);
+
+			projectName = this.$projectNameService.ensureValidName(projectName, {force: this.$options.force}).wait();
 
 			let projectId = this.$options.appid || this.$projectHelper.generateDefaultAppId(projectName, constants.DEFAULT_APP_IDENTIFIER_PREFIX);
 

--- a/test/project-name-service.ts
+++ b/test/project-name-service.ts
@@ -1,0 +1,78 @@
+/// <reference path=".d.ts" />
+"use strict";
+
+import {Yok} from "../lib/common/yok";
+import {ProjectNameService} from "../lib/services/project-name-service";
+import {assert} from "chai";
+import {ErrorsStub, LoggerStub} from "./stubs";
+import Future = require("fibers/future");
+
+let mockProjectNameValidator = {
+	validate: () => true
+};
+
+let dummyString: string = "dummyString";
+
+function createTestInjector(): IInjector {
+	let testInjector: IInjector;
+
+	testInjector = new Yok();
+	testInjector.register("projectNameService", ProjectNameService);
+	testInjector.register("projectNameValidator", mockProjectNameValidator);
+	testInjector.register("errors", ErrorsStub);
+	testInjector.register("logger", LoggerStub);
+	testInjector.register("prompter", {
+		confirm: (message: string): IFuture<boolean> => Future.fromResult(true),
+		getString: (message: string): IFuture<string> => Future.fromResult(dummyString)
+	});
+
+	return testInjector;
+}
+
+describe("Project Name Service Tests", () => {
+	let testInjector: IInjector;
+	let projectNameService: IProjectNameService;
+	let validProjectName = "valid";
+	let invalidProjectName = "1invalid";
+
+	beforeEach(() => {
+		testInjector = createTestInjector();
+		projectNameService = testInjector.resolve("projectNameService");
+	});
+
+	it("returns correct name when valid name is entered", () => {
+		let actualProjectName = projectNameService.ensureValidName(validProjectName).wait();
+
+		assert.deepEqual(actualProjectName, validProjectName);
+	});
+
+	it("returns correct name when invalid name is entered several times and then valid name is entered", () => {
+		let prompter = testInjector.resolve("prompter");
+		prompter.confirm = (message: string): IFuture<boolean> => Future.fromResult(false);
+
+		let incorrectInputsLimit = 5;
+		let incorrectInputsCount = 0;
+
+		prompter.getString = (message: string): IFuture<string> => {
+			return (() => {
+				if (incorrectInputsCount < incorrectInputsLimit) {
+					incorrectInputsCount++;
+
+					return invalidProjectName;
+				} else {
+					return validProjectName;
+				}
+			}).future<string>()();
+		};
+
+		let actualProjectName = projectNameService.ensureValidName(invalidProjectName).wait();
+
+		assert.deepEqual(actualProjectName, validProjectName);
+	});
+
+	it("returns the invalid name when invalid name is entered and --force flag is present", () => {
+		let actualProjectName = projectNameService.ensureValidName(validProjectName, { force: true }).wait();
+
+		assert.deepEqual(actualProjectName, validProjectName);
+	});
+});


### PR DESCRIPTION
…ect.

Created project name service with method to ensure the project name does not start with number or if it starts with number the client is informed about the consequences when building for Android.
When invalid project name is entered the client gets warning about the problem and a prompt with choice to create the project with invalid name or to enter valid name.
Added integration tests for the prompts logic.

This fixes #1203
