### PR TITLE
Fixed autocomplete

### DIFF
--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -169,6 +169,10 @@ export class FileSystemStub implements IFileSystem {
 	renameIfExists(oldPath: string, newPath: string): IFuture<boolean> {
 		return undefined;
 	}
+
+	rm(options: string, ...files: string[]): void {
+		// Mock
+	}
 }
 
 export class ErrorsStub implements IErrors {


### PR DESCRIPTION
When path to node has spaces (C:\Program Files) the child process exec cannot run the command. Need to place it in "" to run it without errors.
Update FileSystemStub with new method from interface.