### PR TITLE
Install platform-tools before tools in setup scripts

### DIFF
--- a/setup/native-script.ps1
+++ b/setup/native-script.ps1
@@ -99,8 +99,8 @@ if (!$env:JAVA_HOME) {
 # following commands are separated in case of having to answer to license agreements
 # the android tool will introduce a --accept-license option in subsequent releases
 $androidExecutable = [io.path]::combine($env:ANDROID_HOME, "tools", "android")
-echo y | cmd /c "$androidExecutable" update sdk --filter "tools" --all --no-ui
 echo y | cmd /c "$androidExecutable" update sdk --filter "platform-tools" --all --no-ui
+echo y | cmd /c "$androidExecutable" update sdk --filter "tools" --all --no-ui
 echo y | cmd /c "$androidExecutable" update sdk --filter "android-23" --all --no-ui
 echo y | cmd /c "$androidExecutable" update sdk --filter "build-tools-23.0.2" --all --no-ui
 echo y | cmd /c "$androidExecutable" update sdk --filter "extra-android-m2repository" --all --no-ui

--- a/setup/native-script.rb
+++ b/setup/native-script.rb
@@ -114,8 +114,8 @@ puts "Configuring your system for Android development... This might take some ti
 # Note that multiple license acceptances may be required, hence the multiple commands
 # the android tool will introduce a --accept-license option in subsequent releases
 android_executable = File.join(ENV["ANDROID_HOME"], "tools", "android")
-execute("echo y | #{android_executable} update sdk --filter tools --all --no-ui", "There seem to be some problems with the Android configuration")
 execute("echo y | #{android_executable} update sdk --filter platform-tools --all --no-ui", "There seem to be some problems with the Android configuration")
+execute("echo y | #{android_executable} update sdk --filter tools --all --no-ui", "There seem to be some problems with the Android configuration")
 execute("echo y | #{android_executable} update sdk --filter android-23 --all --no-ui", "There seem to be some problems with the Android configuration")
 execute("echo y | #{android_executable} update sdk --filter build-tools-23.0.2 --all --no-ui", "There seem to be some problems with the Android configuration")
 execute("echo y | #{android_executable} update sdk --filter extra-android-m2repository --all --no-ui", "There seem to be some problems with the Android configuration")


### PR DESCRIPTION
There are some cases where updating tools requires updating platform-tools and if the former is attempted before the latter the following error is raised:
`Skipping 'Android SKD Tools, revision 24.4.1'; it depends on 'Android SDK Platform-tools, revision 23.1 rc1' which was not installed`

Fix this by reversing order
Ping @rosen-vladimirov @teobugslayer 