### PR TITLE
Fix --baseConfig option

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -299,10 +299,10 @@ export class PlatformService implements IPlatformService {
 			// Process configurations files from App_Resources
 			platformData.platformProjectService.processConfigurationFilesFromAppResources().wait();
 
+			this.applyBaseConfigOption(platformData).wait();
+
 			// Replace placeholders in configuration files
 			platformData.platformProjectService.interpolateConfigurationFile().wait();
-
-			this.applyBaseConfigOption(platformData).wait();
 
 			this.$logger.out("Project successfully prepared");
 			return true;


### PR DESCRIPTION
Apply --baseConfig before replacing placeholders in manifest. This way when there are placeholders in the file passed as `--baseConfig`, they will be replaced correctly.