### PR TITLE
Change the warning when creating project with name app

### DIFF
--- a/lib/commands/create-project.ts
+++ b/lib/commands/create-project.ts
@@ -3,33 +3,11 @@
 
 import * as constants from "../constants";
 
-export class ProjectCommandParameter implements ICommandParameter {
-	constructor(private $errors: IErrors,
-		private $logger: ILogger,
-		private $projectNameValidator: IProjectNameValidator) { }
-
-	mandatory = true;
-	validate(value: string): IFuture<boolean> {
-		return (() => {
-			if(!value) {
-				this.$errors.fail("You must specify <App name> when creating a new project.");
-			}
-
-			if (value.toUpperCase() === "APP") {
-				this.$logger.warn("You cannot build applications named 'app' in Xcode. Consider creating a project with different name.");
-			}
-
-			return this.$projectNameValidator.validate(value);
-		}).future<boolean>()();
-	}
-}
-
 export class CreateProjectCommand implements ICommand {
 	constructor(private $projectService: IProjectService,
 		private $errors: IErrors,
-		private $logger: ILogger,
-		private $projectNameValidator: IProjectNameValidator,
-		private $options: IOptions) { }
+		private $options: IOptions,
+		private $stringParameterBuilder: IStringParameterBuilder) { }
 
 	public enableHooks = false;
 
@@ -45,6 +23,7 @@ export class CreateProjectCommand implements ICommand {
 		}).future<void>()();
 	}
 
-	allowedParameters = [new ProjectCommandParameter(this.$errors, this.$logger, this.$projectNameValidator) ];
+	public allowedParameters: ICommandParameter[] = [this.$stringParameterBuilder.createMandatoryParameter("Project name cannot be empty.")];
 }
+
 $injector.registerCommand("create", CreateProjectCommand);

--- a/test/project-commands.ts
+++ b/test/project-commands.ts
@@ -4,6 +4,7 @@
 import { Yok } from "../lib/common/yok";
 import * as stubs from "./stubs";
 import { CreateProjectCommand } from "../lib/commands/create-project";
+import { StringParameterBuilder } from "../lib/common/command-params";
 import * as constants from "../lib/constants";
 import {assert} from "chai";
 
@@ -40,6 +41,7 @@ function createTestInjector() {
 		template: undefined
 	});
 	testInjector.register("createCommand", CreateProjectCommand);
+	testInjector.register("stringParameterBuilder", StringParameterBuilder);
 
 	return testInjector;
 }

--- a/test/project-name-service.ts
+++ b/test/project-name-service.ts
@@ -33,7 +33,7 @@ describe("Project Name Service Tests", () => {
 	let testInjector: IInjector;
 	let projectNameService: IProjectNameService;
 	let validProjectName = "valid";
-	let invalidProjectName = "1invalid";
+	let invalidProjectNames = ["1invalid", "app"];
 
 	beforeEach(() => {
 		testInjector = createTestInjector();
@@ -46,33 +46,35 @@ describe("Project Name Service Tests", () => {
 		assert.deepEqual(actualProjectName, validProjectName);
 	});
 
-	it("returns correct name when invalid name is entered several times and then valid name is entered", () => {
-		let prompter = testInjector.resolve("prompter");
-		prompter.confirm = (message: string): IFuture<boolean> => Future.fromResult(false);
+	_.each(invalidProjectNames, invalidProjectName => {
+		it(`returns correct name when "${invalidProjectName}" is entered several times and then valid name is entered`, () => {
+			let prompter = testInjector.resolve("prompter");
+			prompter.confirm = (message: string): IFuture<boolean> => Future.fromResult(false);
 
-		let incorrectInputsLimit = 5;
-		let incorrectInputsCount = 0;
+			let incorrectInputsLimit = 5;
+			let incorrectInputsCount = 0;
 
-		prompter.getString = (message: string): IFuture<string> => {
-			return (() => {
-				if (incorrectInputsCount < incorrectInputsLimit) {
-					incorrectInputsCount++;
+			prompter.getString = (message: string): IFuture<string> => {
+				return (() => {
+					if (incorrectInputsCount < incorrectInputsLimit) {
+						incorrectInputsCount++;
 
-					return invalidProjectName;
-				} else {
-					return validProjectName;
-				}
-			}).future<string>()();
-		};
+						return invalidProjectName;
+					} else {
+						return validProjectName;
+					}
+				}).future<string>()();
+			};
 
-		let actualProjectName = projectNameService.ensureValidName(invalidProjectName).wait();
+			let actualProjectName = projectNameService.ensureValidName(invalidProjectName).wait();
 
-		assert.deepEqual(actualProjectName, validProjectName);
-	});
+			assert.deepEqual(actualProjectName, validProjectName);
+		});
 
-	it("returns the invalid name when invalid name is entered and --force flag is present", () => {
-		let actualProjectName = projectNameService.ensureValidName(validProjectName, { force: true }).wait();
+		it(`returns the invalid name when "${invalidProjectName}" is entered and --force flag is present`, () => {
+			let actualProjectName = projectNameService.ensureValidName(validProjectName, { force: true }).wait();
 
-		assert.deepEqual(actualProjectName, validProjectName);
+			assert.deepEqual(actualProjectName, validProjectName);
+		});
 	});
 });


### PR DESCRIPTION
When creating project with name app a warning will appear and a prompt to create the project with name app or change the project name.

Implements the functionality described in https://github.com/NativeScript/nativescript-cli/issues/1203#issuecomment-203367786