### PR TITLE
AppBuilder fixes

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -22,6 +22,8 @@ export class Configuration extends ConfigBase implements IConfiguration { // Use
 $injector.register("config", Configuration);
 
 export class StaticConfig extends StaticConfigBase implements IStaticConfig {
+	public disableAnalytics = true;
+
 	public PROJECT_FILE_NAME = "package.json";
 	public CLIENT_NAME_KEY_IN_PROJECT_FILE = "nativescript";
 	public CLIENT_NAME = "tns";

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -417,7 +417,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	public ensureConfigurationFileInAppResources(): IFuture<void> {
 		return (() => {
 			let projectDir = this.$projectData.projectDir;
-			let infoPlistPath = path.join(projectDir, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME, this.platformData.normalizedPlatformName, this.platformData.configurationFileName);
+			let infoPlistPath = this.$options.baseConfig || path.join(projectDir, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME, this.platformData.normalizedPlatformName, this.platformData.configurationFileName);
 
 			if (!this.$fs.exists(infoPlistPath).wait()) {
 				// The project is missing Info.plist, try to populate it from the project template.
@@ -442,7 +442,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	private mergeInfoPlists(): IFuture<void> {
 		return (() => {
 			let projectDir = this.$projectData.projectDir;
-			let infoPlistPath = path.join(projectDir, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME, this.platformData.normalizedPlatformName, this.platformData.configurationFileName);
+			let infoPlistPath = this.$options.baseConfig || path.join(projectDir, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME, this.platformData.normalizedPlatformName, this.platformData.configurationFileName);
 			this.ensureConfigurationFileInAppResources().wait();
 
 			if (!this.$fs.exists(infoPlistPath).wait()) {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -296,10 +296,10 @@ export class PlatformService implements IPlatformService {
 			let excludedDirs = [constants.APP_RESOURCES_FOLDER_NAME];
 			this.$projectFilesManager.processPlatformSpecificFiles(directoryPath, platform, excludedDirs).wait();
 
+			this.applyBaseConfigOption(platformData).wait();
+
 			// Process configurations files from App_Resources
 			platformData.platformProjectService.processConfigurationFilesFromAppResources().wait();
-
-			this.applyBaseConfigOption(platformData).wait();
 
 			// Replace placeholders in configuration files
 			platformData.platformProjectService.interpolateConfigurationFile().wait();


### PR DESCRIPTION
Use baseConfig when merging Info.plist files.

Disable analytics in AppBuilder.