### PR TITLE
Add list dependencies

### DIFF
--- a/docs/man_pages/lib-management/plugin-add.md
+++ b/docs/man_pages/lib-management/plugin-add.md
@@ -1,11 +1,11 @@
-plugin add 
+plugin add
 ==========
 
 Usage | Synopsis
 ------|-------
 General | `$ tns plugin add <Plugin>`
 
-<% if(isConsole) { %>Installs the specified plugin and any packages that it depends on.<% } %>  
+<% if(isConsole) { %>Installs the specified plugin and any packages that it depends on.<% } %>
 <% if(isHtml) { %>Installs the specified plugin and its dependencies in the local `node_modules` folder, adds it to the `dependencies` section in `package.json`, and prepares the plugin for all installed platforms. If you have not configured any platforms for the project, the NativeScript CLI will prepare the plugin when you add a platform. For more information about working with plugins, see [NativeScript Plugins](https://github.com/NativeScript/nativescript-cli/blob/master/PLUGINS.md).<% } %>
 
 ### Attributes
@@ -28,4 +28,6 @@ Command | Description
 ----------|----------
 [plugin](plugin.html) | Lets you manage the plugins for your project.
 [plugin remove](plugin-remove.html) | Uninstalls the specified plugin and its dependencies.
+[plugin find](plugin-find.html) | Finds NativeScript plugins in npm.
+[plugin search](plugin-search.html) | Finds NativeScript plugins in npm.
 <% } %>

--- a/docs/man_pages/lib-management/plugin-find.md
+++ b/docs/man_pages/lib-management/plugin-find.md
@@ -1,0 +1,29 @@
+plugin find
+==========
+
+Usage | Synopsis
+---|---
+General | `$ tns plugin find [<PluginName>] [--all] [--count <Count>]`
+
+Finds NativeScript plugins in npm.
+
+### Options
+* `--all` - Specifies that all results will be shown at once.
+* `--count` - Specifies the number of results to show at a time. If not set, the default value is 10. After showing the specified number of results, the CLI will prompt you to continue showing more results or to exit the operation.
+
+> **NOTE:** You cannot set --all and --count simultaneously.
+
+### Attributes
+* `<PluginName>` is the name of plugin that you want to find. When specified the search string in npm will be "`nativescript <PluginName>`".
+* `<Count>` is the number of the plugins to display.
+
+<% if(isHtml) { %>
+### Related Commands
+
+Command | Description
+----------|----------
+[plugin](plugin.html) | Lets you manage the plugins for your project.
+[plugin add](plugin-add.html) | Installs the specified plugin and its dependencies.
+[plugin remove](plugin-remove.html) | Uninstalls the specified plugin and its dependencies.
+[plugin search](plugin-search.html) | Finds NativeScript plugins in npm.
+<% } %>

--- a/docs/man_pages/lib-management/plugin-remove.md
+++ b/docs/man_pages/lib-management/plugin-remove.md
@@ -1,4 +1,4 @@
-plugin remove 
+plugin remove
 ==========
 
 Usage | Synopsis
@@ -12,11 +12,13 @@ General | `$ tns plugin remove <Plugin>`
 
 * `<Plugin>` is the name of the plugin as listed in its `package.json` file.
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
 ----------|----------
 [plugin](plugin.html) | Lets you manage the plugins for your project.
 [plugin add](plugin-add.html) | Installs the specified plugin and its dependencies.
+[plugin find](plugin-find.html) | Finds NativeScript plugins in npm.
+[plugin search](plugin-search.html) | Finds NativeScript plugins in npm.
 <% } %>

--- a/docs/man_pages/lib-management/plugin-search.md
+++ b/docs/man_pages/lib-management/plugin-search.md
@@ -1,0 +1,29 @@
+plugin search
+==========
+
+Usage | Synopsis
+---|---
+General | `$ tns plugin search [<PluginName>] [--all] [--count <Count>]`
+
+Finds NativeScript plugins in npm.
+
+### Options
+* `--all` - Specifies that all results will be shown at once.
+* `--count` - Specifies the number of results to show at a time. If not set, the default value is 10. After showing the specified number of results, the CLI will prompt you to continue showing more results or to exit the operation.
+
+> **NOTE:** You cannot set --all and --count simultaneously.
+
+### Attributes
+* `<PluginName>` is the name of plugin that you want to find. When specified the search string in npm will be "`nativescript <PluginName>`".
+* `<Count>` is the number of the plugins to display.
+
+<% if(isHtml) { %>
+### Related Commands
+
+Command | Description
+----------|----------
+[plugin](plugin.html) | Lets you manage the plugins for your project.
+[plugin add](plugin-add.html) | Installs the specified plugin and its dependencies.
+[plugin remove](plugin-remove.html) | Uninstalls the specified plugin and its dependencies.
+[plugin find](plugin-find.html) | Finds NativeScript plugins in npm.
+<% } %>

--- a/docs/man_pages/lib-management/plugin.md
+++ b/docs/man_pages/lib-management/plugin.md
@@ -1,4 +1,4 @@
-plugin 
+plugin
 ==========
 
 Usage | Synopsis
@@ -12,12 +12,16 @@ Lets you manage the plugins for your project.
 `<Command>` extends the `plugin` command. You can set the following values for this attribute.
 * `add` - Installs the specified plugin and its dependencies.
 * `remove` - Uninstalls the specified plugin and its dependencies.
+* `find` - Finds NativeScript plugins in npm.
+* `search` - Finds NativeScript plugins in npm.
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
 ----------|----------
 [plugin add](plugin-add.html) | Installs the specified plugin and its dependencies.
 [plugin remove](plugin-remove.html) | Uninstalls the specified plugin and its dependencies.
+[plugin find](plugin-find.html) | Finds NativeScript plugins in npm.
+[plugin search](plugin-search.html) | Finds NativeScript plugins in npm.
 <% } %>

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -77,6 +77,8 @@ $injector.require("broccoliPluginWrapper", "./tools/broccoli/broccoli-plugin-wra
 $injector.require("pluginVariablesService", "./services/plugin-variables-service");
 $injector.require("pluginsService", "./services/plugins-service");
 $injector.requireCommand("plugin|*list", "./commands/plugin/list-plugins");
+$injector.requireCommand("plugin|find", "./commands/plugin/find-plugins");
+$injector.requireCommand("plugin|search", "./commands/plugin/find-plugins");
 $injector.requireCommand("plugin|add", "./commands/plugin/add-plugin");
 $injector.requireCommand("plugin|remove", "./commands/plugin/remove-plugin");
 

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -76,6 +76,7 @@ $injector.require("broccoliPluginWrapper", "./tools/broccoli/broccoli-plugin-wra
 
 $injector.require("pluginVariablesService", "./services/plugin-variables-service");
 $injector.require("pluginsService", "./services/plugins-service");
+$injector.requireCommand("plugin|*list", "./commands/plugin/list-plugins");
 $injector.requireCommand("plugin|add", "./commands/plugin/add-plugin");
 $injector.requireCommand("plugin|remove", "./commands/plugin/remove-plugin");
 

--- a/lib/commands/plugin/find-plugins.ts
+++ b/lib/commands/plugin/find-plugins.ts
@@ -1,0 +1,100 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+import { createTable, isInteractive } from "../../common/helpers";
+import { NATIVESCRIPT_KEY_NAME } from "../../constants";
+import Future = require("fibers/future");
+
+export class FindPluginsCommand implements ICommand {
+	private static COUNT_OF_PLUGINS_TO_DISPLAY: number = 10;
+
+	constructor(private $pluginsService: IPluginsService,
+		private $errors: IErrors,
+		private $logger: ILogger,
+		private $prompter: IPrompter,
+		private $options: IOptions,
+		private $progressIndicator: IProgressIndicator) { }
+
+	execute(args: string[]): IFuture<void> {
+		return (() => {
+			let filter: string[] = this.prepareFilter(args);
+
+			let pluginsFuture: IFuture<IDictionary<any>> = this.$pluginsService.getAvailable(filter);
+			if (this.$options.json) {
+				this.$logger.out(JSON.stringify(pluginsFuture.wait()));
+				return;
+			}
+
+			this.$logger.printInfoMessageOnSameLine("Searching npm please be patient...");
+			this.$progressIndicator.showProgressIndicator(pluginsFuture, 500).wait();
+			let plugins: IDictionary<any> = pluginsFuture.get();
+
+			this.$logger.out("Available NativeScript plugins");
+			this.showPlugins(plugins).wait();
+		}).future<void>()();
+	}
+
+	canExecute(args: string[]): IFuture<boolean> {
+		return Future.fromResult(true);
+	}
+
+	public allowedParameters: ICommandParameter[] = [];
+
+	private showPlugins(plugins: IDictionary<any>): IFuture<void> {
+		return (() => {
+			let allPluginsNames: string[] = _.keys(plugins).sort();
+
+			let count: number = this.$options.count || FindPluginsCommand.COUNT_OF_PLUGINS_TO_DISPLAY;
+
+			if (!isInteractive() || this.$options.all) {
+				count = allPluginsNames.length;
+			}
+
+			let data: string[][] = [];
+
+			let pluginsToDisplay: string[] = allPluginsNames.splice(0, count);
+			let shouldDisplayMorePlugins: boolean = true;
+
+			do {
+				data = this.createTableCells(plugins, pluginsToDisplay);
+
+				let table: any = this.createPluginsTable(data);
+
+				this.$logger.out(table.toString());
+
+				pluginsToDisplay = allPluginsNames.splice(0, count);
+
+				if (!pluginsToDisplay || pluginsToDisplay.length < 1) {
+					return;
+				}
+
+				shouldDisplayMorePlugins = this.$prompter.confirm("Load more plugins?").wait();
+			} while (shouldDisplayMorePlugins);
+		}).future<void>()();
+	}
+
+	private createPluginsTable(data: string[][]): any {
+		let headers: string[] = ["Plugin", "Version", "Description"];
+
+		let table: any = createTable(headers, data);
+
+		return table;
+	}
+
+	private createTableCells(plugins: IDictionary<any>, pluginsToDisplay: string[]): string[][] {
+		return pluginsToDisplay.map(pluginName => {
+			let pluginDetails: any = plugins[pluginName];
+			return [pluginName, pluginDetails.version, pluginDetails.description || ""];
+		});
+	}
+
+	private prepareFilter(args: string[]): string[] {
+		return _(args || [])
+			.map(arg => arg.toLowerCase())
+			.concat(NATIVESCRIPT_KEY_NAME)
+			.uniq()
+			.value();
+	}
+
+}
+
+$injector.registerCommand(["plugin|find", "plugin|search"], FindPluginsCommand);

--- a/lib/commands/plugin/list-plugins.ts
+++ b/lib/commands/plugin/list-plugins.ts
@@ -1,0 +1,51 @@
+///<reference path="../../.d.ts"/>
+"use strict";
+
+import { createTable } from "../../common/helpers";
+
+export class ListPluginsCommand implements ICommand {
+	constructor(private $pluginsService: IPluginsService,
+		private $logger: ILogger,
+		private $options: IOptions) { }
+
+	allowedParameters: ICommandParameter[] = [];
+
+	public execute(args: string[]): IFuture<void> {
+		return (() => {
+			let installedPlugins: IPackageJsonDepedenciesResult = this.$pluginsService.getDependenciesFromPackageJson().wait();
+			let headers: string[] = ["Plugin", "Version"];
+			let dependenciesData: string[][] = [];
+			let devDependenciesData: string[][] = [];
+
+			_.each(installedPlugins.dependencies, (dependency: IBasePluginData) => {
+				dependenciesData.push([dependency.name, dependency.version]);
+			});
+
+			let dependenciesTable: any = createTable(headers, dependenciesData);
+			this.$logger.out("Dependencies");
+			this.$logger.out(dependenciesTable.toString());
+
+			if (installedPlugins.devDependencies && installedPlugins.devDependencies.length) {
+				_.each(installedPlugins.devDependencies, (dependency: IBasePluginData) => {
+					devDependenciesData.push([dependency.name, dependency.version]);
+				});
+
+				let devDependenciesTable: any = createTable(headers, devDependenciesData);
+
+				this.$logger.out("Dev Dependencies");
+				this.$logger.out(devDependenciesTable.toString());
+			} else {
+				this.$logger.out("There are no dev dependencies.");
+			}
+
+			let viewDependenciesCommand: string = "npm view <pluginName> grep dependencies".cyan.toString();
+			let viewDevDependenciesCommand: string = "npm view <pluginName> grep devDependencies".cyan.toString();
+
+			this.$logger.warn("NOTE:");
+			this.$logger.warn(`If you want to see the dependencies of installed plugin use ${viewDependenciesCommand}`);
+			this.$logger.warn(`If you want to see the dev dependencies of installed plugin use ${viewDevDependenciesCommand}`);
+		}).future<void>()();
+	}
+}
+
+$injector.registerCommand("plugin|*list", ListPluginsCommand);

--- a/lib/commands/plugin/list-plugins.ts
+++ b/lib/commands/plugin/list-plugins.ts
@@ -1,38 +1,30 @@
 ///<reference path="../../.d.ts"/>
 "use strict";
-
 import { createTable } from "../../common/helpers";
 
 export class ListPluginsCommand implements ICommand {
 	constructor(private $pluginsService: IPluginsService,
-		private $logger: ILogger,
-		private $options: IOptions) { }
+		private $logger: ILogger) { }
 
 	allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
 		return (() => {
 			let installedPlugins: IPackageJsonDepedenciesResult = this.$pluginsService.getDependenciesFromPackageJson().wait();
-			let headers: string[] = ["Plugin", "Version"];
-			let dependenciesData: string[][] = [];
-			let devDependenciesData: string[][] = [];
 
-			_.each(installedPlugins.dependencies, (dependency: IBasePluginData) => {
-				dependenciesData.push([dependency.name, dependency.version]);
-			});
+			let headers: string[] = ["Plugin", "Version"];
+			let dependenciesData: string[][] = this.createTableCells(installedPlugins.dependencies);
 
 			let dependenciesTable: any = createTable(headers, dependenciesData);
-			this.$logger.out("Dependencies");
+			this.$logger.out("Dependencies:");
 			this.$logger.out(dependenciesTable.toString());
 
 			if (installedPlugins.devDependencies && installedPlugins.devDependencies.length) {
-				_.each(installedPlugins.devDependencies, (dependency: IBasePluginData) => {
-					devDependenciesData.push([dependency.name, dependency.version]);
-				});
+				let devDependenciesData: string[][] = this.createTableCells(installedPlugins.devDependencies);
 
 				let devDependenciesTable: any = createTable(headers, devDependenciesData);
 
-				this.$logger.out("Dev Dependencies");
+				this.$logger.out("Dev Dependencies:");
 				this.$logger.out(devDependenciesTable.toString());
 			} else {
 				this.$logger.out("There are no dev dependencies.");
@@ -42,9 +34,13 @@ export class ListPluginsCommand implements ICommand {
 			let viewDevDependenciesCommand: string = "npm view <pluginName> grep devDependencies".cyan.toString();
 
 			this.$logger.warn("NOTE:");
-			this.$logger.warn(`If you want to see the dependencies of installed plugin use ${viewDependenciesCommand}`);
-			this.$logger.warn(`If you want to see the dev dependencies of installed plugin use ${viewDevDependenciesCommand}`);
+			this.$logger.warn(`If you want to check the dependencies of installed plugin use ${viewDependenciesCommand}`);
+			this.$logger.warn(`If you want to check the dev dependencies of installed plugin use ${viewDevDependenciesCommand}`);
 		}).future<void>()();
+	}
+
+	private createTableCells(items: IBasePluginData[]): string[][] {
+		return items.map(item => [item.name, item.version]);
 	}
 }
 

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -7,6 +7,7 @@ interface INodePackageManager {
 	cacheUnpack(packageName: string, version: string, unpackTarget?: string): IFuture<void>;
 	view(packageName: string, propertyName: string): IFuture<any>;
 	executeNpmCommand(npmCommandName: string, currentWorkingDirectory: string): IFuture<any>;
+	search(filter: string[], silent: boolean): IFuture<any>;
 }
 
 interface INpmInstallationManager {
@@ -58,6 +59,7 @@ interface ILiveSyncService {
 }
 
 interface IOptions extends ICommonOptions {
+	all: boolean;
 	baseConfig: string;
 	client: boolean;
 	compileSdk: number;
@@ -267,5 +269,5 @@ interface IProjectNameService {
 	 * @param {IOptions} current command options.
 	 * @return {IFuture<strng>} returns the selected name of the project.
 	 */
-	ensureValidName(projectName: string, validateOptions?: {force: boolean}): IFuture<string>;
+	ensureValidName(projectName: string, validateOptions?: { force: boolean }): IFuture<string>;
 }

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -5,6 +5,17 @@ interface IPluginsService {
 	getAllInstalledPlugins(): IFuture<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(): IFuture<void>;
 	afterPrepareAllPlugins(): IFuture<void>;
+	getDependenciesFromPackageJson(): IFuture<IPackageJsonDepedenciesResult>
+}
+
+interface IPackageJsonDepedenciesResult {
+	dependencies: IBasePluginData[],
+	devDependencies?: IBasePluginData[]
+}
+
+interface IBasePluginData {
+	name: string;
+	version: string;
 }
 
 interface IPluginData extends INodeModuleData {
@@ -14,9 +25,7 @@ interface IPluginData extends INodeModuleData {
 	pluginPlatformsFolderPath(platform: string): string;
 }
 
-interface INodeModuleData {
-	name: string;
-	version: string;
+interface INodeModuleData extends IBasePluginData {
 	fullPath: string;
 	isPlugin: boolean;
 	moduleInfo: any;

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -1,6 +1,7 @@
 interface IPluginsService {
 	add(plugin: string): IFuture<void>; // adds plugin by name, github url, local path and et.
 	remove(pluginName: string): IFuture<void>; // removes plugin only by name
+	getAvailable(filter: string[]): IFuture<IDictionary<any>>; // gets all available plugins
 	prepare(pluginData: IDependencyData, platform: string): IFuture<void>;
 	getAllInstalledPlugins(): IFuture<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(): IFuture<void>;

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -29,7 +29,7 @@ export class NodePackageManager implements INodePackageManager {
 		} else {
 			let future = new Future<void>();
 			npm.load(config, (err: Error) => {
-				if(err) {
+				if (err) {
 					future.throw(err);
 				} else {
 					future.return();
@@ -40,7 +40,7 @@ export class NodePackageManager implements INodePackageManager {
 	}
 
 	public install(packageName: string, pathToSave: string, config?: any): IFuture<any> {
-		if(this.$options.ignoreScripts) {
+		if (this.$options.ignoreScripts) {
 			config = config || {};
 			config["ignore-scripts"] = true;
 		}
@@ -49,7 +49,12 @@ export class NodePackageManager implements INodePackageManager {
 	}
 
 	public uninstall(packageName: string, config?: any, path?: string): IFuture<any> {
-		return this.loadAndExecute("uninstall", [[packageName]], { config, path});
+		return this.loadAndExecute("uninstall", [[packageName]], { config, path });
+	}
+
+	public search(filter: string[], silent: boolean): IFuture<any> {
+		let args = (<any[]>([filter] || [])).concat(silent);
+		return this.loadAndExecute("search", args);
 	}
 
 	public cache(packageName: string, version: string, config?: any): IFuture<IDependencyData> {
@@ -86,7 +91,7 @@ export class NodePackageManager implements INodePackageManager {
 				npm.prefix = oldNpmPath;
 			}
 
-			if(err) {
+			if (err) {
 				future.throw(err);
 			} else {
 				future.return(data);

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -37,7 +37,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			baseConfig: { type: OptionType.String },
 			platformTemplate: { type: OptionType.String },
 			ng: {type: OptionType.Boolean },
-			available: {type: OptionType.Boolean }
+			all: {type: OptionType.Boolean }
 		},
 		path.join($hostInfo.isWindows ? process.env.AppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),
 			$errors, $staticConfig);

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -36,7 +36,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			copyTo: { type: OptionType.String },
 			baseConfig: { type: OptionType.String },
 			platformTemplate: { type: OptionType.String },
-			ng: {type: OptionType.Boolean }
+			ng: {type: OptionType.Boolean },
+			available: {type: OptionType.Boolean }
 		},
 		path.join($hostInfo.isWindows ? process.env.AppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),
 			$errors, $staticConfig);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bufferutil": "https://github.com/telerik/bufferutil/tarball/v1.0.1.1",
     "byline": "4.2.1",
     "chalk": "1.1.0",
-    "cli-table": "https://github.com/telerik/cli-table/tarball/v0.3.1.1",
+    "cli-table": "https://github.com/telerik/cli-table/tarball/v0.3.1.2",
     "clui": "0.3.1",
     "colors": "1.1.2",
     "esprima": "2.7.0",


### PR DESCRIPTION
Add list plugins registered in package.json file when executing tns plugin in project.
Add plugin find command to list the nativescript plugins available in npm. The command has --all and --count flags to change the output format.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1231