### PR TITLE
Fix warning when adding existing platform

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -55,7 +55,7 @@ export class PlatformService implements IPlatformService {
 			let platformPath = path.join(this.$projectData.platformsDir, platform);
 
 			if (this.$fs.exists(platformPath).wait()) {
-				this.$errors.fail("Platform %s already added", platform);
+				this.$errors.failWithoutHelp("Platform %s already added", platform);
 			}
 
 			let platformData = this.$platformsData.getPlatformData(platform);


### PR DESCRIPTION
Do not display help for platform add command when adding an existing platform to the project.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1526