### PR TITLE
Fix livesynnc on iOS simulator-livesync

### DIFF
--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -26,7 +26,8 @@ class IOSLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<Mobi
 	}
 
 	protected restartApplication(deviceAppData: Mobile.IDeviceAppData): IFuture<void> {
-		return this.device.applicationManager.restartApplication(deviceAppData.appIdentifier, deviceAppData.appIdentifier.split(".")[2]);
+		let projectData: IProjectData = this.$injector.resolve("projectData");
+		return this.device.applicationManager.restartApplication(deviceAppData.appIdentifier, projectData.projectName);
 	}
 
 	protected reloadPage(deviceAppData: Mobile.IDeviceAppData): IFuture<void> {


### PR DESCRIPTION
When restarting the application if pacakgeId and folder name does not match the name of the application should be the projectName.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1532