### PR TITLE
Add a --bundle option that disables node_modules -> tns_modules update.

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -80,6 +80,7 @@ interface IOptions extends ICommonOptions {
 	keyStorePath: string;
 	linkTo: string;
 	ng: boolean;
+	bundle: boolean;
 	platformTemplate: string;
 	port: Number;
 	production: boolean;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -37,6 +37,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			baseConfig: { type: OptionType.String },
 			platformTemplate: { type: OptionType.String },
 			ng: {type: OptionType.Boolean },
+			bundle: {type: OptionType.Boolean },
 			all: {type: OptionType.Boolean }
 		},
 		path.join($hostInfo.isWindows ? process.env.AppData : path.join(osenv.home(), ".local/share"), ".nativescript-cli"),

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -280,11 +280,16 @@ export class PlatformService implements IPlatformService {
 
 			platformData.platformProjectService.prepareProject().wait();
 
-			// Process node_modules folder
 			let appDir = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 			try {
 				let tnsModulesDestinationPath = path.join(appDir, constants.TNS_MODULES_FOLDER_NAME);
-				this.$broccoliBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime).wait();
+				if (!this.$options.bundle) {
+					// Process node_modules folder
+					this.$broccoliBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime).wait();
+				} else {
+					// Clean target node_modules folder. Not needed when bundling.
+					this.$broccoliBuilder.cleanNodeModules(tnsModulesDestinationPath, platform);
+				}
 			} catch(error) {
 				this.$logger.debug(error);
 				shell.rm("-rf", appDir);

--- a/lib/tools/broccoli/broccoli.d.ts
+++ b/lib/tools/broccoli/broccoli.d.ts
@@ -154,6 +154,7 @@ interface BroccoliNode {
 interface IBroccoliBuilder {
    getChangedNodeModules(outputPath: string, platform: string, lastModifiedTime?: Date): IFuture<any>;
    prepareNodeModules(outputPath: string, platform: string, lastModifiedTime?: Date): IFuture<void>;
+   cleanNodeModules(outputPath: string, platform: string): void;
 }
 
 interface IDiffResult {

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -232,6 +232,28 @@ describe("Npm support tests", () => {
 		let scopedDependencyPath = path.join(tnsModulesFolderPath, "@reactivex", "rxjs");
 		assert.isTrue(fs.exists(scopedDependencyPath).wait());
 	});
+
+	it("Ensures that tns_modules absent when bundling", () => {
+		let fs = testInjector.resolve("fs");
+		let options = testInjector.resolve("options");
+		let tnsModulesFolderPath = path.join(appDestinationFolderPath, "app", "tns_modules");
+
+		try {
+			options.bundle = false;
+			preparePlatform(testInjector).wait();
+			assert.isTrue(fs.exists(tnsModulesFolderPath).wait(), "tns_modules created first");
+
+			options.bundle = true;
+			preparePlatform(testInjector).wait();
+			assert.isFalse(fs.exists(tnsModulesFolderPath).wait(), "tns_modules deleted when bundling");
+
+			options.bundle = false;
+			preparePlatform(testInjector).wait();
+			assert.isTrue(fs.exists(tnsModulesFolderPath).wait(), "tns_modules recreated");
+		} finally {
+			options.bundle = false;
+		}
+	});
 });
 
 describe("Flatten npm modules tests", () => {


### PR DESCRIPTION
Delete `<platform/app>/tns_modules`, if present, and make sure we restore it
on subsequent runs without the `--bundle` option set.

Ping @rosen-vladimirov 