### PR TITLE
Pass -destination when building for iOS Simulator

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -30,6 +30,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		private $errors: IErrors,
 		private $logger: ILogger,
 		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
+		private $iOSSimResolver: Mobile.IiOSSimResolver,
 		private $options: IOptions,
 		private $injector: IInjector,
 		$projectDataService: IProjectDataService,
@@ -200,10 +201,10 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 				args = args.concat((buildConfig && buildConfig.architectures) || defaultArchitectures);
 			} else {
+				let currentSimulator = this.$iOSSimResolver.iOSSim.getRunningSimulator();
 				args = basicArgs.concat([
 					"-sdk", "iphonesimulator",
-					"-arch", "i386",
-					"VALID_ARCHS=\"i386\"",
+					"-destination", `platform=iOS Simulator,name=${this.$iOSSimResolver.iOSSim.getSimulatorName(currentSimulator && currentSimulator.name)}`,
 					"CONFIGURATION_BUILD_DIR=" + path.join(projectRoot, "build", "emulator"),
 					"CODE_SIGN_IDENTITY="
 				]);


### PR DESCRIPTION
Instead of passing architectures pass `-destination` parameter. This prevents a [bug in Xcode 7.2]( http://www.openradar.me/23857648)

This resolves https://github.com/NativeScript/nativescript-cli/issues/1606 and depends on https://github.com/telerik/ios-sim-portable/pull/57

Ping @rosen-vladimirov 