### PR TITLE
Add a target to the Podfile

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -689,13 +689,9 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			let pluginPodFilePath = path.join(pluginPlatformsFolderPath, "Podfile");
 
 			if(this.$fs.exists(pluginPodFilePath).wait()) {
-				if(!this.$fs.exists(this.projectPodFilePath).wait()) {
-					this.$fs.writeFile(this.projectPodFilePath, "use_frameworks!\n").wait();
-				}
-
 				let pluginPodFileContent = this.$fs.readText(pluginPodFilePath).wait();
-				let contentToWrite = this.buildPodfileContent(pluginPodFilePath, pluginPodFileContent);
-				this.$fs.appendFile(this.projectPodFilePath, contentToWrite).wait();
+				let contentToWrite = `use_frameworks!${os.EOL}${os.EOL}target "${this.$projectData.projectName}" do${os.EOL}${this.buildPodfileContent(pluginPodFilePath, pluginPodFileContent)}${os.EOL}end`;
+				this.$fs.writeFile(this.projectPodFilePath, contentToWrite).wait();
 
 				let project = this.createPbxProj();
 				project.updateBuildProperty("IPHONEOS_DEPLOYMENT_TARGET", "8.0");
@@ -747,7 +743,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				let projectPodFileContent = this.$fs.readText(this.projectPodFilePath).wait();
 				let contentToRemove= this.buildPodfileContent(pluginPodFilePath, pluginPodFileContent);
 				projectPodFileContent = helpers.stringReplaceAll(projectPodFileContent, contentToRemove, "");
-				if(projectPodFileContent.trim() === "use_frameworks!") {
+				if(projectPodFileContent.trim() === `use_frameworks!${os.EOL}${os.EOL}target "${this.$projectData.projectName}" do${os.EOL}${os.EOL}end`) {
 					this.$fs.deleteFile(this.projectPodFilePath).wait();
 				} else {
 					this.$fs.writeFile(this.projectPodFilePath, projectPodFileContent).wait();
@@ -811,10 +807,11 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				this.mergeXcconfigFiles(appResourcesXcconfigPath, this.pluginsReleaseXcconfigFilePath).wait();
 			}
 
-			let podFolder = path.join(this.platformData.projectRoot, "Pods/Target Support Files/Pods/");
+			let podFilesRootDirName = path.join("Pods", "Target Support Files", `Pods-${this.$projectData.projectName}`);
+			let podFolder = path.join(this.platformData.projectRoot, podFilesRootDirName);
 			if (this.$fs.exists(podFolder).wait()) {
-				this.mergeXcconfigFiles(path.join(this.platformData.projectRoot, "Pods/Target Support Files/Pods/Pods.debug.xcconfig"), this.pluginsDebugXcconfigFilePath).wait();
-				this.mergeXcconfigFiles(path.join(this.platformData.projectRoot, "Pods/Target Support Files/Pods/Pods.release.xcconfig"), this.pluginsReleaseXcconfigFilePath).wait();
+				this.mergeXcconfigFiles(path.join(this.platformData.projectRoot, podFilesRootDirName, `Pods-${this.$projectData.projectName}.debug.xcconfig`), this.pluginsDebugXcconfigFilePath).wait();
+				this.mergeXcconfigFiles(path.join(this.platformData.projectRoot, podFilesRootDirName, `Pods-${this.$projectData.projectName}.release.xcconfig`), this.pluginsReleaseXcconfigFilePath).wait();
 			}
 		}).future<void>()();
 	}

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -154,10 +154,12 @@ describe("Cocoapods support", () => {
 			assert.isTrue(fs.exists(projectPodfilePath).wait());
 
 			let actualProjectPodfileContent = fs.readText(projectPodfilePath).wait();
-			let expectedProjectPodfileContent = ["use_frameworks!",
+			let expectedProjectPodfileContent = ["use_frameworks!\n",
+				`target "${projectName}" do`,
 				`# Begin Podfile - ${pluginPodfilePath} `,
 				` ${pluginPodfileContent} `,
-				" # End Podfile \n"]
+				" # End Podfile \n",
+				"end"]
 				.join("\n");
 			assert.equal(actualProjectPodfileContent, expectedProjectPodfileContent);
 		});
@@ -221,10 +223,12 @@ describe("Cocoapods support", () => {
 			assert.isTrue(fs.exists(projectPodfilePath).wait());
 
 			let actualProjectPodfileContent = fs.readText(projectPodfilePath).wait();
-			let expectedProjectPodfileContent = ["use_frameworks!",
+			let expectedProjectPodfileContent = ["use_frameworks!\n",
+				`target "${projectName}" do`,
 				`# Begin Podfile - ${pluginPodfilePath} `,
 				` ${pluginPodfileContent} `,
-				" # End Podfile \n"]
+				" # End Podfile \n",
+				"end"]
 				.join("\n");
 			assert.equal(actualProjectPodfileContent, expectedProjectPodfileContent);
 


### PR DESCRIPTION
Trying to run `pod install` with CocoaPods 1.0.0 issues an error in case the Podfile doesn't reference a target. Add the project target to the Podfile.
Upon specifying target to the Podfile, however, the path to the Pods' .xcconfig file changes - reflect that change in code.
In addition, truncate and write the Podfile upon each prepare in order to avoid duplication and errors.

Is related to https://github.com/NativeScript/ios-runtime/pull/545
Fixes https://github.com/NativeScript/nativescript-cli/issues/1611

Ping @rosen-vladimirov 