### PR TITLE
Add devDependencies when adding Android platform

### DIFF
--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -40,8 +40,7 @@ export class BuildAndroidCommand extends BuildCommandBase implements  ICommand {
 	}
 
 	public execute(args: string[]): IFuture<void> {
-		let config = this.$options.staticBindings ? { runSbGenerator: true } : undefined;
-		return this.executeCore([this.$platformsData.availablePlatforms.Android], config);
+		return this.executeCore([this.$platformsData.availablePlatforms.Android]);
 	}
 
 	public allowedParameters: ICommandParameter[] = [];

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -9,8 +9,7 @@ export class DeployOnDeviceCommand implements ICommand {
 				private $mobileHelper: Mobile.IMobileHelper) { }
 
 	execute(args: string[]): IFuture<void> {
-		let config = this.$options.staticBindings ? { runSbGenerator: true } : undefined;
-		return this.$platformService.deployOnDevice(args[0], config);
+		return this.$platformService.deployOnDevice(args[0]);
 	}
 
 	public canExecute(args: string[]): IFuture<boolean> {

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -34,8 +34,7 @@ export class RunAndroidCommand extends RunCommandBase implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): IFuture<void> {
-		let config = this.$options.staticBindings ? { runSbGenerator: true } : undefined;
-		return this.executeCore([this.$platformsData.availablePlatforms.Android], config);
+		return this.executeCore([this.$platformsData.availablePlatforms.Android]);
 	}
 
 	public canExecute(args: string[]): IFuture<boolean> {

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -85,7 +85,6 @@ interface IOptions extends ICommonOptions {
 	port: Number;
 	production: boolean;
 	sdk: string;
-	staticBindings: boolean;
 	symlink: boolean;
 	tnsModulesVersion: string;
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -47,7 +47,6 @@ interface IPlatformProjectServiceBase {
 }
 
 interface IBuildConfig {
-	runSbGenerator?: boolean;
 	buildForDevice?: boolean;
 	architectures?: string[];
 }

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -30,7 +30,6 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			keyStoreAliasPassword: { type: OptionType.String },
 			ignoreScripts: {type: OptionType.Boolean },
 			tnsModulesVersion: { type: OptionType.String },
-			staticBindings: {type: OptionType.Boolean},
 			compileSdk: {type: OptionType.Number },
 			port: { type: OptionType.Number },
 			copyTo: { type: OptionType.String },

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -60,13 +60,11 @@ export class ProjectDataService implements IProjectDataService {
 		return (() => {
 			assert.ok(this.projectFilePath, "Initialize method of projectDataService is not called.");
 
-			if(!this.projectData) {
-				if(!this.$fs.exists(this.projectFilePath).wait()) {
-					this.$fs.writeFile(this.projectFilePath, null).wait();
-				}
-
-				this.projectData = this.$fs.readJson(this.projectFilePath).wait() || Object.create(null);
+			if(!this.$fs.exists(this.projectFilePath).wait()) {
+				this.$fs.writeFile(this.projectFilePath, null).wait();
 			}
+
+			this.projectData = this.$fs.readJson(this.projectFilePath).wait() || Object.create(null);
 		}).future<void>()();
 	}
 }


### PR DESCRIPTION
In order to support Static Binding Generation, we have to add some dev Dependencies to the project when platform Android is added.
As some of them do not work with Nodejs 0.x, we have to limit this functionality only to users who are using node 4.2.1 (the earliest version of 4.x that we support) or later.
Show warning in case the user has older node version.
Remove --staticBindings flag as it's turned on by default now.