### PR TITLE
Disable fast livesync with hook

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -56,6 +56,7 @@ interface IOpener {
 
 interface ILiveSyncService {
 	liveSync(platform: string): IFuture<void>;
+	forceExecuteFullSync: boolean;
 }
 
 interface IOptions extends ICommonOptions {


### PR DESCRIPTION
Add before livesync hook to be able to control the livesync data. Added property in livesync service to force full sync which will be passed to the livesync data.