### PR TITLE
Add check for xcodeproj ruby gem in doctor service

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ sudo ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/native
 * For iOS development
 	* [Latest Xcode][12]
 	* [Xcode command-line tools][12]
+	* [xcodeproj ruby gem][13]
 	* (Optional) [CocoaPods 0.38.2][CocoaPods 0.38.2]
 * For Android development
 	* [JDK 8][JDK 8] or a later stable official release
@@ -601,6 +602,7 @@ This software is licensed under the Apache 2.0 license, quoted <a href="LICENSE"
 [10]: http://developer.telerik.com/featured/nativescript-android/
 [11]: http://blogs.telerik.com/valentinstoychev/posts.aspx/14-06-12/announcing-nativescript---cross-platform-framework-for-building-native-mobile-applications
 [12]: https://developer.apple.com/xcode/downloads/
+[13]: https://rubygems.org/gems/xcodeproj/versions/0.28.2
 [Chocolatey]: https://chocolatey.org/
 [JDK 8]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
 [Android SDK 22]: http://developer.android.com/sdk/index.html

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -20,6 +20,7 @@ class DoctorService implements IDoctorService {
 		private $hostInfo: IHostInfo,
 		private $logger: ILogger,
 		private $progressIndicator: IProgressIndicator,
+		private $staticConfig: IStaticConfig,
 		private $sysInfo: ISysInfo,
 		private $childProcess: IChildProcess,
 		private $config: IConfiguration,
@@ -32,7 +33,7 @@ class DoctorService implements IDoctorService {
 	public printWarnings(configOptions?: { trackResult: boolean }): IFuture<boolean> {
 		return (() => {
 			let result = false;
-			let sysInfo = this.$sysInfo.getSysInfo(path.join(__dirname, "..", "..", "package.json")).wait();
+			let sysInfo = this.$sysInfo.getSysInfo(this.$staticConfig.pathToPackageJson).wait();
 
 			if (!sysInfo.adbVer) {
 				this.$logger.warn("WARNING: adb from the Android SDK is not installed or is not configured properly.");
@@ -61,6 +62,13 @@ class DoctorService implements IDoctorService {
 					this.$logger.warn("WARNING: Xcode is not installed or is not configured properly.");
 					this.$logger.out("You will not be able to build your projects for iOS or run them in the iOS Simulator." + EOL
 						+ "To be able to build for iOS and run apps in the native emulator, verify that you have installed Xcode." + EOL);
+					result = true;
+				}
+
+				if (!sysInfo.xcodeprojGemLocation) {
+					this.$logger.warn("WARNING: xcodeproj gem is not installed or is not configured properly.");
+					this.$logger.out("You will not be able to build your projects for iOS." + EOL
+						+ "To be able to build for iOS and run apps in the native emulator, verify that you have installed xcodeproj." + EOL);
 					result = true;
 				}
 

--- a/setup/native-script.rb
+++ b/setup/native-script.rb
@@ -108,6 +108,7 @@ end
 
 # the -p flag is set in order to ensure zero status code even if the directory exists
 execute("mkdir -p ~/.cocoapods", "There was a problem in creating ~/.cocoapods directory")
+install("xcodeproj", "Installing xcodeproj... This might take some time, please, be patient.", 'gem install xcodeproj -V', true)
 install("CocoaPods", "Installing CocoaPods... This might take some time, please, be patient.", 'gem install cocoapods -V', true)
 
 puts "Configuring your system for Android development... This might take some time, please, be patient."


### PR DESCRIPTION
This gem is required for creating xcsheme and merging xcconfig files with one another. iOS builds cannot be performed without it.
Update system requirements and setup script accordingly.

Merge after https://github.com/telerik/mobile-cli-lib/pull/648
Addresses https://github.com/NativeScript/nativescript-cli/issues/1674

Ping @rosen-vladimirov for code review