### PR TITLE
Hide npm preuninstall errors

### DIFF
--- a/preuninstall.js
+++ b/preuninstall.js
@@ -2,8 +2,9 @@ var child_process = require("child_process");
 
 var child = child_process.exec("node bin/nativescript.js dev-preuninstall", function (error) {
 	if (error) {
+		// Some npm versions (3.0, 3.5.1, 3.7.3) remove the NativeScript node_modules before the preuninstall script is executed and the script can't find them (the preuninstall script is like postinstall script).
+		// The issue is described in the npm repository https://github.com/npm/npm/issues/8806 and it is not fixed in version 3.1.1 as commented in the conversation.
 		console.error("Failed to complete all pre-uninstall steps. ");
-		console.log(error);
 	}
 });
 


### PR DESCRIPTION
Due to issue in npm versions 3.0, 3.5.1, 3.7.3 (may be more 3.x versions) the NativeScript node_modules are removed before the preuninstall script is executed and it fails.
The issue is logged in the npm repository: https://github.com/npm/npm/issues/8806 but it is not fixed in version 3.1.1 as commented in the discusion.

Workaround for https://github.com/NativeScript/nativescript-cli/issues/1419