### PR TITLE
Fix the updating of changed node modules in platform folder

### DIFF
--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -48,6 +48,7 @@ interface IApplicationPackage {
 interface ILockFile {
 	lock(): IFuture<void>;
 	unlock(): IFuture<void>;
+	check(): IFuture<boolean>;
 }
 
 interface IOpener {

--- a/lib/definitions/lockfile.d.ts
+++ b/lib/definitions/lockfile.d.ts
@@ -3,6 +3,7 @@ declare module "lockfile" {
 	export function lockSync(lockFilename: string, lockParams: ILockSyncParams): void;
 	export function unlock(lockFilename: string, callback: (err: Error) => void): void;
 	export function unlockSync(lockFilename: string): void;
+	export function check(lockFilename: string, lockParams: ILockParams, callback: (err: Error, isLocked: boolean) => void): boolean;
 
 	interface ILockSyncParams {
 		retries: number;

--- a/lib/lockfile.ts
+++ b/lib/lockfile.ts
@@ -42,5 +42,18 @@ export class LockFile implements ILockFile {
 		});
 		return future;
 	}
+
+	public check(): IFuture<boolean> {
+		let future = new Future<boolean>();
+		lockfile.check(this.lockFilePath, LockFile.LOCK_PARAMS, (err: Error, isLocked: boolean) => {
+			if(err) {
+				future.throw(err);
+			} else {
+				future.return(isLocked);
+			}
+		});
+		return future;
+	}
 }
+
 $injector.register("lockfile", LockFile);

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -28,6 +28,7 @@ import {DeviceAppDataProvider} from "../lib/providers/device-app-data-provider";
 import {MobilePlatformsCapabilities} from "../lib/mobile-platforms-capabilities";
 import {DevicePlatformsConstants} from "../lib/common/mobile/device-platforms-constants";
 import { XmlValidator } from "../lib/xml-validator";
+import { LockFile } from "../lib/lockfile";
 import Future = require("fibers/future");
 
 import path = require("path");
@@ -48,7 +49,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("platformService", PlatformServiceLib.PlatformService);
 	testInjector.register("logger", stubs.LoggerStub);
 	testInjector.register("npmInstallationManager", {});
-	testInjector.register("lockfile", {});
+	testInjector.register("lockfile", LockFile);
 	testInjector.register("prompter", {});
 	testInjector.register("androidProjectService", {});
 	testInjector.register("iOSProjectService", {});
@@ -235,6 +236,7 @@ describe("Npm support tests", () => {
 
 	it("Ensures that tns_modules absent when bundling", () => {
 		let fs = testInjector.resolve("fs");
+		let lockfile = testInjector.resolve("lockfile");
 		let options = testInjector.resolve("options");
 		let tnsModulesFolderPath = path.join(appDestinationFolderPath, "app", "tns_modules");
 


### PR DESCRIPTION
When getting the stats for file from node_modules in the broccoli builder the event loop gets messed up from the Glob fiber and the cli fiber. That's why we need lock in the Glob fiber.