### PR TITLE
Fix livesync for ios devices

### DIFF
--- a/lib/providers/livesync-provider.ts
+++ b/lib/providers/livesync-provider.ts
@@ -12,13 +12,22 @@ export class LiveSyncProvider implements ILiveSyncProvider {
 
 	private static FAST_SYNC_FILE_EXTENSIONS = [".css", ".xml"];
 
+	private platformSpecificLiveSyncServicesCache: IDictionary<any> = {};
 	public get platformSpecificLiveSyncServices(): IDictionary<any> {
 		return {
 			android: (_device: Mobile.IDevice, $injector: IInjector): IPlatformLiveSyncService => {
-				return $injector.resolve(this.$androidLiveSyncServiceLocator.factory, {_device: _device});
+				if(!this.platformSpecificLiveSyncServicesCache[_device.deviceInfo.identifier]) {
+					this.platformSpecificLiveSyncServicesCache[_device.deviceInfo.identifier] = $injector.resolve(this.$androidLiveSyncServiceLocator.factory, {_device: _device});
+				}
+
+				return this.platformSpecificLiveSyncServicesCache[_device.deviceInfo.identifier];
 			},
 			ios: (_device: Mobile.IDevice, $injector: IInjector) => {
-				return $injector.resolve(this.$iosLiveSyncServiceLocator.factory, {_device: _device});
+				if(!this.platformSpecificLiveSyncServicesCache[_device.deviceInfo.identifier]) {
+					this.platformSpecificLiveSyncServicesCache[_device.deviceInfo.identifier] = $injector.resolve(this.$iosLiveSyncServiceLocator.factory, {_device: _device});
+				}
+
+				return this.platformSpecificLiveSyncServicesCache[_device.deviceInfo.identifier];
 			}
 		};
 	}


### PR DESCRIPTION
Currently we are creating new instance of the AndroidLiveSyncService and IOSLiveSyncService. When `--watch` option is used, CLI gets new instance for each change of a file. This leads to opening new socket every single time. The second changed file leads to process exit as the inspector runtime logic is triggered many times.
Fix this by caching the instances per device.