### PR TITLE
Fix livesync --watch for ios devices

### DIFF
--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -49,8 +49,10 @@ class IOSLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<Mobi
 				}
 			 	this.$iOSEmulatorServices.postDarwinNotification(this.$iOSNotification.attachRequest).wait();
 			} else {
-				this.$iOSSocketRequestExecutor.executeAttachRequest(this.device, timeout).wait();
-				this.socket = this.device.connectToPort(IOSLiveSyncService.BACKEND_PORT);
+				if(!this.socket) {
+					this.$iOSSocketRequestExecutor.executeAttachRequest(this.device, timeout).wait();
+					this.socket = this.device.connectToPort(IOSLiveSyncService.BACKEND_PORT);
+				}
 				this.sendPageReloadMessage();
 			}
 		}).future<void>()();


### PR DESCRIPTION
Do not try creating the socket again when `--watch` is used. It's already created buddy, keep using it.