### PR TITLE
Include custom platform template when using tns init

### DIFF
--- a/lib/services/init-service.ts
+++ b/lib/services/init-service.ts
@@ -47,7 +47,9 @@ export class InitService implements IInitService {
 				projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE]["id"] = this.getProjectId().wait();
 
 				if (this.$options.frameworkName && this.$options.frameworkVersion) {
-					projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE][this.$options.frameworkName] = this.buildVersionData(this.$options.frameworkVersion);
+					let currentPlatformData = projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE][this.$options.frameworkName] || {};
+
+					projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE][this.$options.frameworkName] = _.extend(currentPlatformData, this.buildVersionData(this.$options.frameworkVersion));
 				} else {
 					let $platformsData = this.$injector.resolve("platformsData");
 					_.each($platformsData.platformsNames, platform => {


### PR DESCRIPTION
When the `tns-<platform>` key in the package.json of nativescript project has custom template the template key must be kept and the version key should be added. When the --framework-name and --framework-version are passed as arguments.