### PR TITLE
Remove node_modules when preparing nativescript plugins

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -131,6 +131,8 @@ export class PluginsService implements IPluginsService {
 				platformData.platformProjectService.preparePluginNativeCode(pluginData).wait();
 
 				shelljs.rm("-rf", path.join(pluginDestinationPath, pluginData.name, "platforms"));
+				// Remove node_modules of the plugin. The destination path should have flattened node_modules.
+				shelljs.rm("-rf", path.join(pluginDestinationPath, pluginData.name, constants.NODE_MODULES_FOLDER_NAME));
 
 				// Show message
 				this.$logger.out(`Successfully prepared plugin ${pluginData.name} for ${platform}.`);


### PR DESCRIPTION
When preparing nativescript plugins, we copy the whole directory to the native project.
This leads to a problem that node_modules dir of such plugins is also copied, while it should be flattened.
CLI had already flatten it, but the copy of node_modules is never deleted and we receive `.aar` files in iOS projects for example.