### PR TITLE
Fix help links in index page

### DIFF
--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -40,8 +40,8 @@ Command | Description
 ## Publishing Commands
 Command | Description
 ---|---
-[appstore](project/publishing/appstore.html) | Lists applications registered in iTunes Connect.
-[appstore upload](project/publishing/appstore-upload.html) | Uploads project to iTunes Connect.
+[appstore](publishing/appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](publishing/appstore-upload.html) | Uploads project to iTunes Connect.
 
 ## Device Commands
 Command | Description


### PR DESCRIPTION
The links to appstore and appstore upload must point to the publishing directory not to the project directory.