### PR TITLE
Check Android platform dependencies when adding platform

### DIFF
--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -1,5 +1,6 @@
 ///<reference path="../.d.ts"/>
 "use strict";
+import {EOL} from "os";
 
 export class InstallCommand implements ICommand {
 	constructor(private $platformsData: IPlatformsData,
@@ -34,7 +35,7 @@ export class InstallCommand implements ICommand {
 					try {
 						this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`]).wait();
 					} catch (err) {
-						error += err;
+						error = `${error}${EOL}${err}`;
 					}
 				}
 			});


### PR DESCRIPTION
If the current project already have some of the Android platform dependencies installed the installed version should be checked. If the installed version satisfies the Android platform the CLI should not install this dependency, if not the CLI should throw error to inform the user about the current version and the required version.