### PR TITLE
Bash users with ~/.bash_profile don't pickup environment variable changes in ~/.profile

### DIFF
--- a/bin/nativescript
+++ b/bin/nativescript
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+source ~/.profile
 AB_DIR="`dirname \"$0\"`"
 node "$AB_DIR/nativescript.js" "$@"

--- a/bin/tns
+++ b/bin/tns
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+source ~/.profile
 AB_DIR="`dirname \"$0\"`"
 node "$AB_DIR/nativescript.js" "$@"


### PR DESCRIPTION
Per the man pages for bash, "it looks for `~/.bash_profile`, `~/.bash_login`, and `~/.profile`, in that order, and reads and executes commands from the **first** one that exists and is readable."

Since some users already have `~/.bash_profile` or `~/.bash_login`, the third file `~/.profile` is never picked up for them. The installation script writes the `ANDROID_HOME` and the `JAVA_HOME` environment variables to `~/.profile`, so the `bin/tns` and `bin/nativescript` executables should explicitly pull in those variables.

This may resolve issues related to #1097.