### PR TITLE
update node-fibers dependency, causing issues running tns

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "colors": "1.1.2",
     "esprima": "2.7.0",
     "ffi": "https://github.com/icenium/node-ffi/tarball/v2.0.0.1",
-    "fibers": "https://github.com/icenium/node-fibers/tarball/v1.0.6.3",
+    "fibers": "1.0.13",
     "filesize": "3.1.2",
     "gaze": "0.5.2",
     "glob": "^7.0.3",


### PR DESCRIPTION
Hi,

This is causing a lot of trouble to others users too. I update the dependency to the last version in the official githu repo.

This was my error:

```
[vns@localhost workspace]$ tns
/usr/lib/node_modules/nativescript/node_modules/fibers/fibers.js:16
	throw new Error('`'+ modPath+ '.node` is missing. Try reinstalling `node-fibers`?');
	^

Error: `/usr/lib/node_modules/nativescript/node_modules/fibers/bin/linux-x64-v8-4.6/fibers.node` is missing. Try reinstalling `node-fibers`?
    at Object.<anonymous> (/usr/lib/node_modules/nativescript/node_modules/fibers/fibers.js:16:8)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (/usr/lib/node_modules/nativescript/node_modules/fibers/future.js:2:13)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
```

it is looking for a not existent fibers install file:
/usr/lib/node_modules/nativescript/node_modules/fibers/bin/linux-x64-v8-4.6/fibers.node

this could also fix issue #1348