### PR TITLE
Add check for Podfile before preparing platform

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -221,7 +221,7 @@ export class PlatformService implements IPlatformService {
 				_.each(this.$pluginsService.getAllInstalledPlugins().wait(), (pluginData: IPluginData) => {
 					if (this.$fs.exists(path.join(pluginData.pluginPlatformsFolderPath(platform), "Podfile")).wait() &&
 						!this.$sysInfo.getSysInfo(this.$staticConfig.pathToPackageJson).wait().cocoapodVer) {
-						this.$errors.failWithoutHelp(`${pluginData.name} has Podfile and you don't have Cocoapods installed or it is not configured correctly. Please install Cocoapods and configure it correctly.`);
+						this.$errors.failWithoutHelp(`${pluginData.name} has Podfile and you don't have Cocoapods installed or it is not configured correctly. Please verify Cocoapods can work on your machine.`);
 					}
 				});
 			}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -32,7 +32,9 @@ export class PlatformService implements IPlatformService {
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $hostInfo: IHostInfo,
 		private $xmlValidator: IXmlValidator,
-		private $npm: INodePackageManager) { }
+		private $npm: INodePackageManager,
+		private $sysInfo: ISysInfo,
+		private $staticConfig: Config.IStaticConfig) { }
 
 	public addPlatforms(platforms: string[]): IFuture<void> {
 		return (() => {
@@ -47,7 +49,7 @@ export class PlatformService implements IPlatformService {
 	}
 
 	private addPlatform(platformParam: string): IFuture<void> {
-		return(() => {
+		return (() => {
 			let [platform, version] = platformParam.split("@");
 
 			this.validatePlatform(platform);
@@ -77,7 +79,7 @@ export class PlatformService implements IPlatformService {
 				pathToSave: path.join(this.$projectData.platformsDir, platform)
 			};
 
-			if(this.$options.frameworkPath) {
+			if (this.$options.frameworkPath) {
 				packageToInstall = this.$options.frameworkPath;
 			} else {
 				packageToInstall = platformData.frameworkPackageName;
@@ -92,7 +94,7 @@ export class PlatformService implements IPlatformService {
 				frameworkDir = path.resolve(frameworkDir);
 
 				this.addPlatformCore(platformData, frameworkDir).wait();
-			} catch(err) {
+			} catch (err) {
 				this.$fs.deleteDirectory(platformPath).wait();
 				throw err;
 			} finally {
@@ -110,7 +112,7 @@ export class PlatformService implements IPlatformService {
 			let isFrameworkPathDirectory = false,
 				isFrameworkPathNotSymlinkedFile = false;
 
-			if(this.$options.frameworkPath) {
+			if (this.$options.frameworkPath) {
 				let frameworkPathStats = this.$fs.getFsStats(this.$options.frameworkPath).wait();
 				isFrameworkPathDirectory = frameworkPathStats.isDirectory();
 				isFrameworkPathNotSymlinkedFile = !this.$options.symlink && frameworkPathStats.isFile();
@@ -122,7 +124,7 @@ export class PlatformService implements IPlatformService {
 			let pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
 			platformData.platformProjectService.createProject(path.resolve(sourceFrameworkDir), installedVersion, pathToTemplate).wait();
 
-			if(isFrameworkPathDirectory || isFrameworkPathNotSymlinkedFile) {
+			if (isFrameworkPathDirectory || isFrameworkPathNotSymlinkedFile) {
 				// Need to remove unneeded node_modules folder
 				// One level up is the runtime module and one above is the node_modules folder.
 				this.$fs.deleteDirectory(path.join(frameworkDir, "../../")).wait();
@@ -134,8 +136,8 @@ export class PlatformService implements IPlatformService {
 
 			this.applyBaseConfigOption(platformData).wait();
 
-			let frameworkPackageNameData: any = {version: installedVersion};
-			if(customTemplateOptions) {
+			let frameworkPackageNameData: any = { version: installedVersion };
+			if (customTemplateOptions) {
 				frameworkPackageNameData.template = customTemplateOptions.selectedTemplate;
 			}
 			this.$projectDataService.setValue(platformData.frameworkPackageName, frameworkPackageNameData).wait();
@@ -145,14 +147,14 @@ export class PlatformService implements IPlatformService {
 
 	private getPathToPlatformTemplate(selectedTemplate: string, frameworkPackageName: string): IFuture<any> {
 		return (() => {
-			if(!selectedTemplate) {
+			if (!selectedTemplate) {
 				// read data from package.json's nativescript key
 				// check the nativescript.tns-<platform>.template value
 				let nativescriptPlatformData = this.$projectDataService.getValue(frameworkPackageName).wait();
 				selectedTemplate = nativescriptPlatformData && nativescriptPlatformData.template;
 			}
 
-			if(selectedTemplate) {
+			if (selectedTemplate) {
 				let tempDir = temp.mkdirSync("platform-template");
 				try {
 					/*
@@ -166,7 +168,7 @@ export class PlatformService implements IPlatformService {
 					 */
 					let pathToTemplate = this.$npm.install(selectedTemplate, tempDir).wait()[0][1];
 					return { selectedTemplate, pathToTemplate };
-				} catch(err) {
+				} catch (err) {
 					this.$logger.trace("Error while trying to install specified template: ", err);
 					this.$errors.failWithoutHelp(`Unable to install platform template ${selectedTemplate}. Make sure the specified value is valid.`);
 				}
@@ -177,8 +179,8 @@ export class PlatformService implements IPlatformService {
 	}
 
 	public getInstalledPlatforms(): IFuture<string[]> {
-		return(() => {
-			if(!this.$fs.exists(this.$projectData.platformsDir).wait()) {
+		return (() => {
+			if (!this.$fs.exists(this.$projectData.platformsDir).wait()) {
 				return [];
 			}
 
@@ -209,9 +211,19 @@ export class PlatformService implements IPlatformService {
 			//We need dev-dependencies here, so before-prepare hooks will be executed correctly.
 			try {
 				this.$pluginsService.ensureAllDependenciesAreInstalled().wait();
-			} catch(err) {
+			} catch (err) {
 				this.$logger.trace(err);
 				this.$errors.failWithoutHelp(`Unable to install dependencies. Make sure your package.json is valid and all dependencies are correct. Error is: ${err.message}`);
+			}
+
+			// Need to check if any plugin requires Cocoapods to be installed.
+			if (platform === "ios") {
+				_.each(this.$pluginsService.getAllInstalledPlugins().wait(), (pluginData: IPluginData) => {
+					if (this.$fs.exists(path.join(pluginData.pluginPlatformsFolderPath(platform), "Podfile")).wait() &&
+						!this.$sysInfo.getSysInfo(this.$staticConfig.pathToPackageJson).wait().cocoapodVer) {
+						this.$errors.failWithoutHelp(`${pluginData.name} has Podfile and you don't have Cocoapods installed or it is not configured correctly. Please install Cocoapods and configure it correctly.`);
+					}
+				});
 			}
 
 			return this.preparePlatformCore(platform).wait();
@@ -250,23 +262,23 @@ export class PlatformService implements IPlatformService {
 			}
 
 			let hasTnsModulesInAppFolder = this.$fs.exists(path.join(appSourceDirectoryPath, constants.TNS_MODULES_FOLDER_NAME)).wait();
-			if(hasTnsModulesInAppFolder && this.$projectData.dependencies && this.$projectData.dependencies[constants.TNS_CORE_MODULES_NAME]) {
+			if (hasTnsModulesInAppFolder && this.$projectData.dependencies && this.$projectData.dependencies[constants.TNS_CORE_MODULES_NAME]) {
 				this.$logger.warn("You have tns_modules dir in your app folder and tns-core-modules in your package.json file. Tns_modules dir in your app folder will not be used and you can safely remove it.");
-				sourceFiles = sourceFiles.filter(source => !minimatch(source, `**/${constants.TNS_MODULES_FOLDER_NAME}/**`, {nocase: true}));
+				sourceFiles = sourceFiles.filter(source => !minimatch(source, `**/${constants.TNS_MODULES_FOLDER_NAME}/**`, { nocase: true }));
 			}
 
 			// verify .xml files are well-formed
 			this.$xmlValidator.validateXmlFiles(sourceFiles).wait();
 
 			// Remove .ts and .js.map files
-			constants.LIVESYNC_EXCLUDED_FILE_PATTERNS.forEach(pattern => sourceFiles = sourceFiles.filter(file => !minimatch(file, pattern, {nocase: true})));
+			constants.LIVESYNC_EXCLUDED_FILE_PATTERNS.forEach(pattern => sourceFiles = sourceFiles.filter(file => !minimatch(file, pattern, { nocase: true })));
 			let copyFileFutures = sourceFiles.map(source => {
-										let destinationPath = path.join(appDestinationDirectoryPath, path.relative(appSourceDirectoryPath, source));
-										if (this.$fs.getFsStats(source).wait().isDirectory()) {
-											return this.$fs.createDirectory(destinationPath);
-										}
-										return this.$fs.copyFile(source, destinationPath);
-									});
+				let destinationPath = path.join(appDestinationDirectoryPath, path.relative(appSourceDirectoryPath, source));
+				if (this.$fs.getFsStats(source).wait().isDirectory()) {
+					return this.$fs.createDirectory(destinationPath);
+				}
+				return this.$fs.copyFile(source, destinationPath);
+			});
 			Future.wait(copyFileFutures);
 
 			// Copy App_Resources to project root folder
@@ -290,7 +302,7 @@ export class PlatformService implements IPlatformService {
 					// Clean target node_modules folder. Not needed when bundling.
 					this.$broccoliBuilder.cleanNodeModules(tnsModulesDestinationPath, platform);
 				}
-			} catch(error) {
+			} catch (error) {
 				this.$logger.debug(error);
 				shell.rm("-rf", appDir);
 				this.$errors.failWithoutHelp(`Processing node_modules failed. ${error}`);
@@ -340,7 +352,7 @@ export class PlatformService implements IPlatformService {
 		}).future<void>()();
 	}
 
-	public copyLastOutput(platform: string, targetPath: string, settings: {isForDevice: boolean}): IFuture<void> {
+	public copyLastOutput(platform: string, targetPath: string, settings: { isForDevice: boolean }): IFuture<void> {
 		return (() => {
 			let packageFile: string;
 			platform = platform.toLowerCase();
@@ -351,13 +363,13 @@ export class PlatformService implements IPlatformService {
 			} else {
 				packageFile = this.getLatestApplicationPackageForEmulator(platformData).wait().packageName;
 			}
-			if(!packageFile || !this.$fs.exists(packageFile).wait()) {
+			if (!packageFile || !this.$fs.exists(packageFile).wait()) {
 				this.$errors.failWithoutHelp("Unable to find built application. Try 'tns build %s'.", platform);
 			}
 
 			this.$fs.ensureDirectoryExists(path.dirname(targetPath)).wait();
 
-			if(this.$fs.exists(targetPath).wait() && this.$fs.getFsStats(targetPath).wait().isDirectory()) {
+			if (this.$fs.exists(targetPath).wait() && this.$fs.getFsStats(targetPath).wait().isDirectory()) {
 				let sourceFileName = path.basename(packageFile);
 				this.$logger.trace(`Specified target path: '${targetPath}' is directory. Same filename will be used: '${sourceFileName}'.`);
 				targetPath = path.join(targetPath, sourceFileName);
@@ -389,7 +401,7 @@ export class PlatformService implements IPlatformService {
 		return (() => {
 			_.each(platforms, platformParam => {
 				let [platform, version] = platformParam.split("@");
-				if(this.isPlatformInstalled(platform).wait()) {
+				if (this.isPlatformInstalled(platform).wait()) {
 					this.updatePlatform(platform, version).wait();
 				} else {
 					this.addPlatform(platformParam).wait();
@@ -414,7 +426,7 @@ export class PlatformService implements IPlatformService {
 			this.ensurePlatformInstalled(platform).wait();
 			let platformData = this.$platformsData.getPlatformData(platform);
 
-			this.$devicesService.initialize({platform: platform, deviceId: this.$options.device}).wait();
+			this.$devicesService.initialize({ platform: platform, deviceId: this.$options.device }).wait();
 			let packageFile: string = null;
 
 			let action = (device: Mobile.IDevice): IFuture<void> => {
@@ -494,7 +506,7 @@ export class PlatformService implements IPlatformService {
 	}
 
 	public validatePlatform(platform: string): void {
-		if(!platform) {
+		if (!platform) {
 			this.$errors.fail("No platform specified.");
 		}
 
@@ -519,7 +531,7 @@ export class PlatformService implements IPlatformService {
 
 	public ensurePlatformInstalled(platform: string): IFuture<void> {
 		return (() => {
-			if(!this.isPlatformInstalled(platform).wait()) {
+			if (!this.isPlatformInstalled(platform).wait()) {
 				this.addPlatform(platform).wait();
 			}
 		}).future<void>()();
@@ -551,13 +563,13 @@ export class PlatformService implements IPlatformService {
 			let packages = _.filter(candidates, candidate => {
 				return _.contains(validPackageNames, candidate);
 			}).map(currentPackage => {
-					currentPackage = path.join(buildOutputPath, currentPackage);
+				currentPackage = path.join(buildOutputPath, currentPackage);
 
-					return {
-						packageName: currentPackage,
-						time: this.$fs.getFsStats(currentPackage).wait().mtime
-					};
-				});
+				return {
+					packageName: currentPackage,
+					time: this.$fs.getFsStats(currentPackage).wait().mtime
+				};
+			});
 
 			return packages;
 		}).future<IApplicationPackage[]>()();
@@ -598,17 +610,17 @@ export class PlatformService implements IPlatformService {
 			newVersion = (cachedPackageData && cachedPackageData.version) || newVersion;
 
 			let canUpdate = platformData.platformProjectService.canUpdatePlatform(currentVersion, newVersion).wait();
-			if(canUpdate) {
-				if(!semver.valid(newVersion)) {
+			if (canUpdate) {
+				if (!semver.valid(newVersion)) {
 					this.$errors.fail("The version %s is not valid. The version should consists from 3 parts separated by dot.", newVersion);
 				}
 
-				if(semver.gt(currentVersion, newVersion)) { // Downgrade
+				if (semver.gt(currentVersion, newVersion)) { // Downgrade
 					let isUpdateConfirmed = this.$prompter.confirm(`You are going to downgrade to runtime v.${newVersion}. Are you sure?`, () => false).wait();
-					if(isUpdateConfirmed) {
+					if (isUpdateConfirmed) {
 						this.updatePlatformCore(platformData, currentVersion, newVersion, canUpdate).wait();
 					}
-				} else if(semver.eq(currentVersion, newVersion)) {
+				} else if (semver.eq(currentVersion, newVersion)) {
 					this.$errors.fail("Current and new version are the same.");
 				} else {
 					this.updatePlatformCore(platformData, currentVersion, newVersion, canUpdate).wait();
@@ -623,9 +635,9 @@ export class PlatformService implements IPlatformService {
 	private updatePlatformCore(platformData: IPlatformData, currentVersion: string, newVersion: string, canUpdate: boolean): IFuture<void> {
 		return (() => {
 			let update = platformData.platformProjectService.updatePlatform(currentVersion, newVersion, canUpdate, this.addPlatform.bind(this), this.removePlatforms.bind(this)).wait();
-			if(update) {
+			if (update) {
 				// Remove old framework files
-				let oldFrameworkData =  this.getFrameworkFiles(platformData, currentVersion).wait();
+				let oldFrameworkData = this.getFrameworkFiles(platformData, currentVersion).wait();
 
 				_.each(oldFrameworkData.frameworkFiles, file => {
 					let fileToDelete = path.join(platformData.projectRoot, file);
@@ -659,7 +671,7 @@ export class PlatformService implements IPlatformService {
 
 				// Update .tnsproject file
 				this.$projectDataService.initialize(this.$projectData.projectDir);
-				this.$projectDataService.setValue(platformData.frameworkPackageName, {version: newVersion}).wait();
+				this.$projectDataService.setValue(platformData.frameworkPackageName, { version: newVersion }).wait();
 
 				this.$logger.out("Successfully updated to version ", newVersion);
 			}
@@ -690,7 +702,7 @@ export class PlatformService implements IPlatformService {
 
 	private applyBaseConfigOption(platformData: IPlatformData): IFuture<void> {
 		return (() => {
-			if(this.$options.baseConfig) {
+			if (this.$options.baseConfig) {
 				let newConfigFile = path.resolve(this.$options.baseConfig);
 				this.$logger.trace(`Replacing '${platformData.configurationFilePath}' with '${newConfigFile}'.`);
 				this.$fs.copyFile(newConfigFile, platformData.configurationFilePath).wait();

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -51,6 +51,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("npmInstallationManager", {});
 	testInjector.register("lockfile", LockFile);
 	testInjector.register("prompter", {});
+	testInjector.register("sysInfo", {});
 	testInjector.register("androidProjectService", {});
 	testInjector.register("iOSProjectService", {});
 	testInjector.register("devicesService", {});

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -102,6 +102,7 @@ function createTestInjector() {
 	testInjector.register('devicesService', {});
 	testInjector.register('projectDataService', stubs.ProjectDataService);
 	testInjector.register('prompter', {});
+	testInjector.register('sysInfo', {});
 	testInjector.register('commands-service', CommandsServiceLib.CommandsService);
 	testInjector.registerCommand("platform|add", PlatformAddCommandLib.AddPlatformCommand);
 	testInjector.registerCommand("platform|remove", PlatformRemoveCommandLib.RemovePlatformCommand);

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -38,6 +38,7 @@ function createTestInjector() {
 	testInjector.register('androidEmulatorServices', {});
 	testInjector.register('projectDataService', stubs.ProjectDataService);
 	testInjector.register('prompter', {});
+	testInjector.register('sysInfo', {});
 	testInjector.register('lockfile', stubs.LockFile);
 	testInjector.register("commandsService", {
 		tryExecuteCommand: () => { /* intentionally left blank */ }


### PR DESCRIPTION
When preparing iOS need to check if any plugin requires Cocoapods to be installed and configured correctly. If plugin contains Podfile in the platforms/ios directory and Cocoapods is not installed or not configured correctly the platform prepare should fail.
This fixes https://github.com/NativeScript/nativescript-cli/issues/1734

When preparing iOS and merging xcconfig files if the project requires xcodeproj to be used (Cocoapods version < 1.0.0 and Xcode version >= 7.3) need to check if xcodeproj is available and fail if it's not.