### PR TITLE
Fix build for Android with custom platform template

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -128,9 +128,9 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				this.$fs.createDirectory(mainPath).wait();
 				shell.cp("-R", path.join(path.resolve(pathToTemplate), "*"), mainPath);
 			} else {
-				this.copy(this.platformData.projectRoot, frameworkDir, "src build-tools", "-R");
+				this.copy(this.platformData.projectRoot, frameworkDir, "src", "-R");
 			}
-			this.copy(this.platformData.projectRoot, frameworkDir, "build.gradle settings.gradle gradle.properties", "-f");
+			this.copy(this.platformData.projectRoot, frameworkDir, "build.gradle settings.gradle gradle.properties build-tools", "-Rf");
 
 			if (this.useGradleWrapper(frameworkDir)) {
 				this.copy(this.platformData.projectRoot, frameworkDir, "gradle", "-R");


### PR DESCRIPTION
When you use custom platform template, we still need build-tools dir from the runtime. Copy it no matter of the platform template.