### PR TITLE
Add target to Podfile in tns doctor

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -11,6 +11,8 @@ $injector.require("projectService", "./services/project-service");
 $injector.require("androidProjectService", "./services/android-project-service");
 $injector.require("iOSProjectService", "./services/ios-project-service");
 
+$injector.require("cocoapodsService", "./services/cocoapods-service");
+
 $injector.require("projectTemplatesService", "./services/project-templates-service");
 $injector.require("projectNameService", "./services/project-name-service");
 $injector.require("tnsModulesService", "./services/tns-modules-service");

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -106,3 +106,19 @@ interface ITestExecutionService {
 	startKarmaServer(platform: string): IFuture<void>;
 }
 
+/**
+ * Describes a service used to facilitate communication with CocoaPods
+ */
+interface ICocoaPodsService {
+	/**
+	 * Get the header needed for the beginning of every Podfile
+	 * @param {string} targetName The name of the target (usually the same as the project's name).
+	 * @return {string} The header which needs to be placed at the beginning of a Podfile.
+	 */
+	getPodfileHeader(targetName: string): string;
+	/**
+	 * Get the footer needed for the end of every Podfile
+	 * @return {string} The footer which needs to be placed at the end of a Podfile.
+	 */
+	getPodfileFooter(): string;
+}

--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -1,0 +1,16 @@
+///<reference path="../.d.ts"/>
+"use strict";
+
+import {EOL} from "os";
+
+export class CocoaPodsService implements ICocoaPodsService {
+	public getPodfileHeader(targetName: string): string {
+		return `use_frameworks!${EOL}${EOL}target "${targetName}" do${EOL}`;
+	}
+
+	public getPodfileFooter(): string {
+		return `${EOL}end`;
+	}
+}
+
+$injector.register("cocoapodsService", CocoaPodsService);

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -7,6 +7,7 @@ import * as helpers from "../common/helpers";
 let clui = require("clui");
 
 class DoctorService implements IDoctorService {
+	private static PROJECT_NAME_PLACEHOLDER = "__PROJECT_NAME__";
 	private static MIN_SUPPORTED_POD_VERSION = "0.38.2";
 	private static DarwinSetupScriptLocation = path.join(__dirname, "..", "..", "setup", "mac-startup-shell-script.sh");
 	private static DarwinSetupDocsLink = "https://docs.nativescript.org/start/ns-setup-os-x";
@@ -17,6 +18,7 @@ class DoctorService implements IDoctorService {
 
 	constructor(private $analyticsService: IAnalyticsService,
 		private $androidToolsInfo: IAndroidToolsInfo,
+		private $cocoapodsService: ICocoaPodsService,
 		private $hostInfo: IHostInfo,
 		private $logger: ILogger,
 		private $progressIndicator: IProgressIndicator,
@@ -187,7 +189,7 @@ class DoctorService implements IDoctorService {
 			let iosDir = path.join(projDir, "node_modules", "tns-ios", "framework");
 			this.$fs.writeFile(
 				path.join(iosDir, "Podfile"),
-				"pod 'AFNetworking', '~> 1.0'\n"
+				`${this.$cocoapodsService.getPodfileHeader(DoctorService.PROJECT_NAME_PLACEHOLDER)}pod 'AFNetworking', '~> 1.0'${this.$cocoapodsService.getPodfileFooter()}`
 			).wait();
 
 			spinner.message("Verifying CocoaPods. This may take some time, please be patient.");
@@ -207,7 +209,7 @@ class DoctorService implements IDoctorService {
 				return true;
 			}
 
-			return !(this.$fs.exists(path.join(iosDir, "__PROJECT_NAME__.xcworkspace")).wait());
+			return !(this.$fs.exists(path.join(iosDir, `${DoctorService.PROJECT_NAME_PLACEHOLDER}.xcworkspace`)).wait());
 		} catch (err) {
 			this.$logger.trace(`verifyCocoaPods error: ${err}`);
 			return true;

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -27,6 +27,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	constructor($projectData: IProjectData,
 		$fs: IFileSystem,
 		private $childProcess: IChildProcess,
+		private $cocoapodsService: ICocoaPodsService,
 		private $errors: IErrors,
 		private $logger: ILogger,
 		private $iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
@@ -705,8 +706,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 					projectPodFileContent = this.$fs.exists(this.projectPodFilePath).wait() ? this.$fs.readText(this.projectPodFilePath).wait() : "";
 
 				if (!~projectPodFileContent.indexOf(pluginPodFilePreparedContent)) {
-					let podFileHeader = `use_frameworks!${os.EOL}${os.EOL}target "${this.$projectData.projectName}" do${os.EOL}`,
-						podFileFooter = `${os.EOL}end`;
+					let podFileHeader = this.$cocoapodsService.getPodfileHeader(this.$projectData.projectName),
+						podFileFooter = this.$cocoapodsService.getPodfileFooter();
 
 					if (_.startsWith(projectPodFileContent, podFileHeader)) {
 						projectPodFileContent = projectPodFileContent.substr(podFileHeader.length);

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -25,6 +25,7 @@ import {AndroidDeviceDiscovery} from "../lib/common/mobile/mobile-core/android-d
 import {PluginVariablesService} from "../lib/services/plugin-variables-service";
 import {PluginVariablesHelper} from "../lib/common/plugin-variables-helper";
 import {Utils} from "../lib/common/utils";
+import {CocoaPodsService} from "../lib/services/cocoapods-service";
 import { assert } from "chai";
 import temp = require("temp");
 temp.track();
@@ -48,6 +49,7 @@ function createTestInjector(projectPath: string, projectName: string): IInjector
 	testInjector.register("hostInfo", HostInfoLib.HostInfo);
 	testInjector.register("injector", testInjector);
 	testInjector.register("iOSEmulatorServices", {});
+	testInjector.register("cocoapodsService", CocoaPodsService);
 	testInjector.register("iOSProjectService", iOSProjectServiceLib.IOSProjectService);
 	testInjector.register("logger", LoggerLib.Logger);
 	testInjector.register("options", OptionsLib.Options);


### PR DESCRIPTION
CocoaPods 1.0.0 and later requires a target for which the Podfile will install. We already add such a target when preparing the Podfile for projects - extract logic and reuse it in the doctor service.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1741
Ping @rosen-vladimirov 