### PR TITLE
Shorten setup scripts links

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ You can install and run the NativeScript CLI on Windows, OS X or Linux.
 ### Setup Script
 To quickly set up your system for the latest NativeScript CLI, paste the following PowerShell script in the **Command Prompt** and hit `Enter`:
 ```cmd
-@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+@powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"
 ```
 
 Alternatively, your can paste the following PowerShell setup script in a **Windows PowerShell console** and hit `Enter`:
 ```PowerShell
-start-process -FilePath PowerShell.exe -Verb Runas -Wait -ArgumentList "-NoProfile -ExecutionPolicy Bypass -Command iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+start-process -FilePath PowerShell.exe -Verb Runas -Wait -ArgumentList "-NoProfile -ExecutionPolicy Bypass -Command iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"
 ```
 > Both scripts require that you have **.NET 4.0 or later** installed on your system. You can download .NET 4.6.1 from this [link](http://go.microsoft.com/fwlink/?LinkId=671729).
 
@@ -143,7 +143,7 @@ android update sdk --filter tools,platform-tools,android-23,build-tools-23.0.2,s
 ### Setup Script
 To quickly set up your system for the latest NativeScript CLI, paste the following Ruby script in the **Terminal** and hit `Enter`:
 ```Shell
-sudo ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
+sudo ruby -e "$(curl -fsSL https://www.nativescript.org/setup/mac)"
 ```
 
 ### Manual Setup

--- a/setup/native-script.ps1
+++ b/setup/native-script.ps1
@@ -2,9 +2,9 @@
 # A PowerShell script to set up Windows machine for NativeScript development
 # NOTE: The script requires at least a version 4.0 .NET framework installed
 # To run it inside a COMMAND PROMPT against the production branch (only one supported with self-elevation) use
-# @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+# @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"
 # To run it inside a WINDOWS POWERSHELL console against the production branch (only one supported with self-elevation) use
-# start-process -FilePath PowerShell.exe -Verb Runas -Wait -ArgumentList "-NoProfile -ExecutionPolicy Bypass -Command iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1'))"
+# start-process -FilePath PowerShell.exe -Verb Runas -Wait -ArgumentList "-NoProfile -ExecutionPolicy Bypass -Command iex ((new-object net.webclient).DownloadString('https://www.nativescript.org/setup/win'))"
 
 # Check if latest .NET framework installed is at least 4
 $dotNetVersions = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP' -recurse | Get-ItemProperty -name Version,Release -EA 0 | Where { $_.PSChildName -match '^(?!S)\p{L}'} | Select Version

--- a/setup/native-script.rb
+++ b/setup/native-script.rb
@@ -2,7 +2,7 @@
 
 # A script to setup developer's workstation for developing with NativeScript
 # To run it against PRODUCTION branch (only one supported with self-elevation) use
-# sudo ruby -e "$(curl -fsSL https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb)"
+# sudo ruby -e "$(curl -fsSL https://www.nativescript.org/setup/mac)"
 
 # Only the user can manually download and install Xcode from App Store
 unless Process.uid == 0


### PR DESCRIPTION
Where necessary, shorten:
* https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.rb to https://www.nativescript.org/setup/mac
* https://raw.githubusercontent.com/NativeScript/nativescript-cli/production/setup/native-script.ps1 to https://www.nativescript.org/setup/win

The shorthands actually redirect to the longer urls.

Only the urls which are used for starting the scripts have been shortened. I prefer we keep the urls in the code unchanged.