### PR TITLE
Add warning for Node.js 0.10.x deprecation

### DIFF
--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -1,8 +1,9 @@
 ///<reference path=".d.ts"/>
 "use strict";
 
+let node = require("../package.json").engines.node;
 // this call must be first to avoid requiring c++ dependencies
-require("./common/verify-node-version").verifyNodeVersion(require("../package.json").engines.node);
+require("./common/verify-node-version").verifyNodeVersion(node, "NativeScript", "2.2.0");
 
 require("./bootstrap");
 import * as fiber from "fibers";


### PR DESCRIPTION
Warn users that support from version 0.10.x will be removed in version 2.2.0.