### PR TITLE
Include linting of unit tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
 		tslint: {
 			build: {
 				files: {
-					src: ["lib/**/*.ts", "test/**/*.ts", "!lib/common/node_modules/**/*.ts", "!lib/common/messages/**/*.ts", "lib/common/test/unit-tests/**/*.ts", "definitions/**/*.ts", "!lib/**/*.d.ts" , "!test/**/*.ts"]
+					src: ["lib/**/*.ts", "test/**/*.ts", "!lib/common/node_modules/**/*.ts", "!lib/common/messages/**/*.ts", "lib/common/test/unit-tests/**/*.ts", "definitions/**/*.ts", "!lib/**/*.d.ts" , "!test/**/*.d.ts"]
 				},
 				options: {
 					configuration: grunt.file.readJSON("./tslint.json")

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -259,7 +259,6 @@ describe("Npm support tests", () => {
 
 	it("Ensures that tns_modules absent when bundling", () => {
 		let fs = testInjector.resolve("fs");
-		let lockfile = testInjector.resolve("lockfile");
 		let options = testInjector.resolve("options");
 		let tnsModulesFolderPath = path.join(appDestinationFolderPath, "app", "tns_modules");
 

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -264,16 +264,16 @@ describe('Platform Service Tests', () => {
 
 			platformService = testInjector.resolve("platformService");
 			let options : IOptions = testInjector.resolve("options");
-			options.release = release; 
+			options.release = release;
 			platformService.preparePlatform(platformToTest).wait();
-			
+
 			let test1FileName = platformToTest.toLowerCase() === "ios" ? "test1.js" : "test2.js";
 			let test2FileName = platformToTest.toLowerCase() === "ios" ? "test2.js" : "test1.js";
 
 			// Asserts that the files in app folder are process as platform specific
 			assert.isTrue(fs.exists(path.join(appDestFolderPath, "app", test1FileName)).wait());
 			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test1-js")).wait());
-			
+
 			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", test2FileName)).wait());
 			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test2-js")).wait());
 
@@ -293,7 +293,7 @@ describe('Platform Service Tests', () => {
 		it("should process only files in app folder when preparing for Android platform", () => {
 			testPreparePlatform("Android");
 		});
-		
+
 		it("should process only files in app folder when preparing for iOS platform", () => {
 			testPreparePlatform("iOS", true);
 		});

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -382,8 +382,7 @@ describe("Project Service Tests", () => {
 					return (() => {
 						if (incorrectInputsCount < incorrectInputsLimit) {
 							incorrectInputsCount++;
-						}
-						else {
+						} else {
 							hasPromptedForString = true;
 
 							return validProjectName;


### PR DESCRIPTION
Allow linter for unit tests and fix all errors.

Add public method in liveSyncService that should be used to delete files when LiveSync operation is in progress.
This way, when user deletes file in Proton, the application will call `liveSyncService.deleteFiles` method for it and it will be removed from device.