### PR TITLE
No debug break by default implementation added for iOS and Android

### DIFF
--- a/docs/man_pages/project/testing/debug-android.md
+++ b/docs/man_pages/project/testing/debug-android.md
@@ -1,6 +1,9 @@
 debug android
 ==========
 
+All you need to do to start debugging your app is to execute `tns debug android`. The NativeScript CLI will build, deploy, start your app, start Chrome DevTools and attach the debugger.
+* You cannot debug if there are multiple devices available (emulators and/or real devices). You need to have started only one device or emulator.
+
 Usage | Synopsis
 ---|---
 Deploy on device, run the app and stop at the first breakpoint | `$ tns debug android --debug-brk [--device <Device ID>] [--debug-port <port>] [--timeout <timeout>]`

--- a/docs/man_pages/project/testing/debug-ios.md
+++ b/docs/man_pages/project/testing/debug-ios.md
@@ -1,5 +1,7 @@
 debug ios
 ==========
+All you need to do to start debugging your app is to execute `tns debug ios`. The NativeScript CLI will build, deploy, start your app, start Chrome DevTools and attach the debugger.
+* You cannot debug if there are multiple devices available (emulators and/or real devices). You need to have started only one device or emulator.
 
 Usage | Synopsis
 ---|---


### PR DESCRIPTION
Related to https://github.com/NativeScript/nativescript-cli/issues/1376

When you call `tns debug ios|android` (no `--debug-brk`) now we will build, deploy and start the application and attach the debugger. You can debug normally by placing breakpoint(s) in desired file(s). If you want to break somewhere initially you can use `debugger` keyword in your code.

The `--debug-brk` switch is still working as before in case you want to use it (not sure for what reason).