### PR TITLE
Exit with non-zero code on test failures.

### DIFF
--- a/lib/services/karma-execution.ts
+++ b/lib/services/karma-execution.ts
@@ -8,7 +8,10 @@ process.on("message", (data: any) => {
 	if(data.karmaConfig) {
 		let pathToKarma = path.join(data.karmaConfig.projectDir, 'node_modules/karma'),
 			KarmaServer = require(path.join(pathToKarma, 'lib/server')),
-			karma = new KarmaServer(data.karmaConfig);
+			karma = new KarmaServer(data.karmaConfig, (exitCode: number) => {
+				//Exit with the correct exit code and signal the manager process.
+				process.exit(exitCode);
+			});
 
 		karma.start();
 	}


### PR DESCRIPTION
Propagate the Karma server exit code and correctly fail the `tns test` command.