### PR TITLE
cli cleans android project when plugins are updated in anyway

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -423,6 +423,15 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	public afterPrepareAllPlugins(): IFuture<void> {
+
+		let projectRoot = this.platformData.projectRoot;
+
+		let gradleBin = this.useGradleWrapper(projectRoot) ? path.join(projectRoot, "gradlew") : "gradle";
+		if (this.$hostInfo.isWindows) {
+			gradleBin += ".bat";
+		}
+		this.spawn(gradleBin, ["clean"], { stdio: "inherit", cwd: this.platformData.projectRoot }).wait();
+
 		return Future.fromResult();
 	}
 


### PR DESCRIPTION
This PR does a gradle clean each time the plugins are updated in any way, for example on plugin remove / add. This prevents problems concerning the android build. This is done automatically so the user doesn't have to take care of cleaning the native project manually when there is a change that will affect the build.

related to: https://github.com/NativeScript/android-runtime/issues/459