### PR TITLE
Update ios-sim-portable to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "glob": "^7.0.3",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-sim-portable": "~1.0.24",
+    "ios-sim-portable": "~1.1.0",
     "lockfile": "1.0.1",
     "lodash": "3.10.0",
     "log4js": "0.6.26",


### PR DESCRIPTION
Update ios-sim-portable to latest version where support for Node.js 6.x.x is added. This version is exactly the same as 1.0.24.

