### PR TITLE
Execute batch sync when you live sync application with the --watch option

### DIFF
--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -14,8 +14,9 @@ class AndroidLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $options: IOptions,
 		private $injector: IInjector,
-		private $projectData: IProjectData) {
-		super(_device);
+		private $projectData: IProjectData,
+		$liveSyncProvider: ILiveSyncProvider) {
+		super(_device, $liveSyncProvider);
 	}
 
 	public restartApplication(deviceAppData: Mobile.IDeviceAppData): IFuture<void> {

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -14,9 +14,10 @@ class IOSLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<Mobi
 		private $iOSEmulatorServices: Mobile.IiOSSimulatorService,
 		private $injector: IInjector,
 		private $logger: ILogger,
-		private $options: IOptions) {
-			super(_device);
-		}
+		private $options: IOptions,
+		$liveSyncProvider: ILiveSyncProvider) {
+		super(_device, $liveSyncProvider);
+	}
 
 	public removeFiles(appIdentifier: string, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<void> {
 		return (() => {

--- a/lib/services/livesync/livesync-service-base.ts
+++ b/lib/services/livesync/livesync-service-base.ts
@@ -3,9 +3,12 @@ export abstract class LiveSyncServiceBase<T extends Mobile.IDevice> {
 		return <T>(this._device);
 	}
 
-	constructor(private _device: Mobile.IDevice) { }
+	constructor(private _device: Mobile.IDevice,
+		private $liveSyncProvider: ILiveSyncProvider) { }
 
-	public refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], canExecuteFastSync?: boolean): IFuture<void> {
+	public refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], forceExecuteFullSync: boolean): IFuture<void> {
+		let canExecuteFastSync = !forceExecuteFullSync && localToDevicePaths &&
+			_.all(localToDevicePaths, localToDevicePath => this.$liveSyncProvider.canExecuteFastSync(localToDevicePath.getLocalPath(), deviceAppData.platform));
 		if (canExecuteFastSync) {
 			return this.reloadPage(deviceAppData);
 		}

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -64,14 +64,7 @@ class TestExecutionService implements ITestExecutionService {
 						}
 						this.detourEntryPoint(projectFilesPath).wait();
 
-						let liveSyncData = {
-							platform: platform,
-							appIdentifier: this.$projectData.projectId,
-							projectFilesPath: projectFilesPath,
-							syncWorkingDirectory: path.join(projectDir, constants.APP_FOLDER_NAME)
-						};
-
-						this.$liveSyncServiceBase.sync(liveSyncData).wait();
+						this.liveSyncProject(platform);
 
 						if (this.$options.debugBrk) {
 							this.$logger.info('Starting debugger...');
@@ -233,8 +226,8 @@ class TestExecutionService implements ITestExecutionService {
 				platform: platform,
 				appIdentifier: this.$projectData.projectId,
 				projectFilesPath: projectFilesPath,
+				forceExecuteFullSync: true, // Always restart the application when change is detected, so tests will be rerun.
 				syncWorkingDirectory: path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME),
-				canExecuteFastSync: false, // Always restart the application when change is detected, so tests will be rerun.
 				excludedProjectDirsAndFiles: this.$options.release ? constants.LIVESYNC_EXCLUDED_FILE_PATTERNS : []
 			};
 


### PR DESCRIPTION
Remove the data.canExecuteFastSync. The check is made in the respective {N} service instead of in the base implementation