### PR TITLE
Add interpolation for app.gradle applicationId value in android projects

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -211,6 +211,10 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 			let gradleSettingsFilePath = path.join(this.platformData.projectRoot, "settings.gradle");
 			shell.sed('-i', /__PROJECT_NAME__/, this.getProjectNameFromId(), gradleSettingsFilePath);
+
+			// will replace applicationId in app/App_Resources/Android/app.gradle if it has not been edited by the user
+			let userAppGradleFilePath = path.join(this.$projectData.appResourcesDirectoryPath, this.$devicePlatformsConstants.Android, "app.gradle");
+			shell.sed('-i', /__PACKAGE__/, this.$projectData.projectId, userAppGradleFilePath);
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
Change `applicationId` field in `app.gradle` for android projects 
[Need to add a Grade Android.defaultConfig #454](https://github.com/NativeScript/android-runtime/issues/454)

ping: @rosen-vladimirov @enchev @Plamen5kov 