### PR TITLE
Fixed: the app is recompiled always when first time livesync 

### DIFF
--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -73,8 +73,8 @@ class AndroidLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<
 
 	public afterInstallApplicationAction(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<boolean> {
 		return (() => {
-			this.deviceHashService.uploadHashFileToDevice(localToDevicePaths).wait();
-			return false;
+			 this.deviceHashService.uploadHashFileToDevice(localToDevicePaths).wait();
+			 return false;
 		}).future<boolean>()();
 	}
 

--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -71,8 +71,11 @@ class AndroidLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<
 		}).future<void>()();
 	}
 
-	public afterInstallApplicationAction(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<void> {
-		return this.deviceHashService.uploadHashFileToDevice(localToDevicePaths);
+	public afterInstallApplicationAction(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<boolean> {
+		return (() => {
+			this.deviceHashService.uploadHashFileToDevice(localToDevicePaths).wait();
+			return false;
+		}).future<boolean>()();
 	}
 
 	private getDeviceRootPath(appIdentifier: string): string {

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -20,11 +20,11 @@ class IOSLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<Mobi
 	}
 
 	public afterInstallApplicationAction(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<boolean> {
-		return (() => {
-			return this.$options.watch;
-		}).future<boolean>()();
-	}
-	
+ 		return (() => {
+ 			return this.$options.watch;
+ 		}).future<boolean>()();
+ 	}
+
 	public removeFiles(appIdentifier: string, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<void> {
 		return (() => {
 			_.each(localToDevicePaths, localToDevicePathData => this.device.fileSystem.deleteFile(localToDevicePathData.getDevicePath(), appIdentifier));

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -19,6 +19,12 @@ class IOSLiveSyncService extends liveSyncServiceBaseLib.LiveSyncServiceBase<Mobi
 		super(_device, $liveSyncProvider);
 	}
 
+	public afterInstallApplicationAction(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<boolean> {
+		return (() => {
+			return this.$options.watch;
+		}).future<boolean>()();
+	}
+	
 	public removeFiles(appIdentifier: string, localToDevicePaths: Mobile.ILocalToDevicePathData[]): IFuture<void> {
 		return (() => {
 			_.each(localToDevicePaths, localToDevicePathData => this.device.fileSystem.deleteFile(localToDevicePathData.getDevicePath(), appIdentifier));

--- a/lib/services/livesync/livesync-service-base.ts
+++ b/lib/services/livesync/livesync-service-base.ts
@@ -7,8 +7,13 @@ export abstract class LiveSyncServiceBase<T extends Mobile.IDevice> {
 		private $liveSyncProvider: ILiveSyncProvider) { }
 
 	public refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], forceExecuteFullSync: boolean): IFuture<void> {
-		let canExecuteFastSync = !forceExecuteFullSync && localToDevicePaths &&
-			_.each(localToDevicePaths, localToDevicePath => this.$liveSyncProvider.canExecuteFastSync(localToDevicePath.getLocalPath(), deviceAppData.platform));
+		let canExecuteFastSync = !forceExecuteFullSync && localToDevicePaths !== undefined;
+		for (let localToDevicePath of localToDevicePaths) {
+			if (!this.$liveSyncProvider.canExecuteFastSync(localToDevicePath.getLocalPath(), deviceAppData.platform)) {
+				canExecuteFastSync = false;
+				break;
+			}
+		}
 		if (canExecuteFastSync) {
 			return this.reloadPage(deviceAppData);
 		}


### PR DESCRIPTION
When the application is installed on device for the first time with the livesync command, it always recompiles the app e.g:

tns livesync ios --watch