### PR TITLE
added beforePrepareAllPlugins

### DIFF
--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -6,6 +6,7 @@ interface IPluginsService {
 	getAllInstalledPlugins(): IFuture<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(): IFuture<void>;
 	afterPrepareAllPlugins(): IFuture<void>;
+	beforePrepareAllPlugins(): IFuture<void>;
 	getDependenciesFromPackageJson(): IFuture<IPackageJsonDepedenciesResult>
 }
 

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -86,6 +86,7 @@ interface IPlatformProjectService {
 	preparePluginNativeCode(pluginData: IPluginData, options?: any): IFuture<void>;
 	removePluginNativeCode(pluginData: IPluginData): IFuture<void>;
 	afterPrepareAllPlugins(): IFuture<void>;
+	beforePrepareAllPlugins(): IFuture<void>;
 	getAppResourcesDestinationDirectoryPath(): IFuture<string>;
 	deploy(deviceIdentifier: string): IFuture<void>;
 	processConfigurationFilesFromAppResources(): IFuture<void>;

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -401,6 +401,10 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	public afterPrepareAllPlugins(): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	public beforePrepareAllPlugins(): IFuture<void> {
 		let buildOptions = this.getBuildOptions();
 		buildOptions.unshift("clean");
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -774,6 +774,10 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 		}).future<void>()();
 	}
 
+	public beforePrepareAllPlugins(): IFuture<void> {
+		return Future.fromResult();
+	}
+
 	private getAllLibsForPluginWithFileExtension(pluginData: IPluginData, fileExtension: string): IFuture<string[]> {
 		let filterCallback = (fileName: string, pluginPlatformsFolderPath: string) => path.extname(fileName) === fileExtension;
 		return this.getAllNativeLibrariesForPlugin(pluginData, IOSProjectService.IOS_PLATFORM_NAME, filterCallback);

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -164,6 +164,14 @@ export class PluginsService implements IPluginsService {
 		return this.executeForAllInstalledPlatforms(action);
 	}
 
+	public beforePrepareAllPlugins(): IFuture<void> {
+		let action = (pluginDestinationPath: string, platform: string, platformData: IPlatformData) => {
+			return platformData.platformProjectService.beforePrepareAllPlugins();
+		};
+
+		return this.executeForAllInstalledPlatforms(action);
+	}
+
 	public getDependenciesFromPackageJson(): IFuture<IPackageJsonDepedenciesResult> {
 		return (() => {
 			let packageJson = this.$fs.readJson(this.getPackageJsonFilePath()).wait();

--- a/lib/tools/broccoli/node-modules-dest-copy.ts
+++ b/lib/tools/broccoli/node-modules-dest-copy.ts
@@ -69,8 +69,9 @@ export class DestCopy implements IBroccoliPlugin {
 				});
 			}
 		});
-
-		this.$pluginsService.beforePrepareAllPlugins().wait();
+		if (!_.isEmpty(this.dependencies)) {
+			this.$pluginsService.beforePrepareAllPlugins().wait();
+		}
 
 		_.each(this.dependencies, dependency => {
 			this.copyDependencyDir(dependency);

--- a/lib/tools/broccoli/node-modules-dest-copy.ts
+++ b/lib/tools/broccoli/node-modules-dest-copy.ts
@@ -31,6 +31,7 @@ export class DestCopy implements IBroccoliPlugin {
 	}
 
 	public rebuildChangedDirectories(changedDirectories: string[], platform: string): void {
+
 		_.each(changedDirectories, changedDirectoryAbsolutePath => {
 			if (!this.devDependencies[path.basename(changedDirectoryAbsolutePath)]) {
 				let pathToPackageJson = path.join(changedDirectoryAbsolutePath, constants.PACKAGE_JSON_FILE_NAME);
@@ -68,6 +69,8 @@ export class DestCopy implements IBroccoliPlugin {
 				});
 			}
 		});
+
+		this.$pluginsService.beforePrepareAllPlugins().wait();
 
 		_.each(this.dependencies, dependency => {
 			this.copyDependencyDir(dependency);

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -144,6 +144,7 @@ function setupProject(): IFuture<any> {
 					prepareProject: () => Future.fromResult(),
 					prepareAppResources: () => Future.fromResult(),
 					afterPrepareAllPlugins: () => Future.fromResult(),
+					beforePrepareAllPlugins: () => Future.fromResult(),
 					getAppResourcesDestinationDirectoryPath: () => Future.fromResult(""),
 					processConfigurationFilesFromAppResources: () => Future.fromResult(),
 					ensureConfigurationFileInAppResources: () => Future.fromResult(),

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -342,6 +342,9 @@ export class PlatformProjectServiceStub implements IPlatformProjectService {
 	afterPrepareAllPlugins(): IFuture<void> {
 		return Future.fromResult();
 	}
+	beforePrepareAllPlugins(): IFuture<void> {
+		return Future.fromResult();
+	}
 	deploy(deviceIdentifier: string): IFuture<void> {
 		return Future.fromResult();
 	}


### PR DESCRIPTION
Moved gradle clean command that executed in the wrong place (afterPrepareAllPlugins) to newly introduced: `beforePrepareAllPlugins`.

Had to introduce `beforePrepareAllPlugins` command for ios. In ios implementation is empty.

`grunt lint`: >> 253 files lint free.

ping: @rosen-vladimirov @PanayotCankov 
