### PR TITLE
Deprecate iOS deployment target check for frameworks

### DIFF
--- a/lib/definitions/xcode.d.ts
+++ b/lib/definitions/xcode.d.ts
@@ -23,5 +23,7 @@ declare module "xcode" {
         addToHeaderSearchPaths(options?: Options): void;
         removeFromHeaderSearchPaths(options?: Options): void;
         updateBuildProperty(key: string, value: any): void;
+
+        pbxXCBuildConfigurationSection(): any;
     }
 }

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -293,7 +293,8 @@ describe("Cocoapods support", () => {
 			};
 			iOSProjectService.createPbxProj = () => {
 				return {
-					updateBuildProperty: () => { return {}; }
+					updateBuildProperty: () => { return {}; },
+					pbxXCBuildConfigurationSection: () => { return {}; },
 				};
 			};
 			iOSProjectService.savePbxProj = (): IFuture<void> => Future.fromResult();
@@ -362,7 +363,8 @@ describe("Cocoapods support", () => {
 			};
 			iOSProjectService.createPbxProj = () => {
 				return {
-					updateBuildProperty: () => { return {}; }
+					updateBuildProperty: () => { return {}; },
+					pbxXCBuildConfigurationSection: () => { return {}; },
 				};
 			};
 			iOSProjectService.savePbxProj = (): IFuture<void> => Future.fromResult();


### PR DESCRIPTION
NativeScript for iOS 2.1 has a minimum one of 8.0.

ping @ivanbuhov 