### PR TITLE
run command now can watch for changes

### DIFF
--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -10,6 +10,7 @@ Start an emulator and run the app inside it | `$ tns run android --emulator [<Em
 Runs your project on a connected Android device or in a native Android emulator, if configured. This is shorthand for prepare, build and deploy. While your app is running, prints the output from the application in the console.
 
 ### Options
+* `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device.
 * `--device` - Specifies a connected device on which to run the app.
 * `--emulator` - If set, runs the app in a native emulator for the target platform, if configured. When set, you can also set any other valid combination of emulator options as listed by `$ tns help emulate android`.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build. When set, you must also specify the `--key-store-*` options.

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -14,6 +14,7 @@ Runs your project on a connected iOS device or in the iOS Simulator, if configur
 <% if(isHtml) { %>> <% } %>IMPORTANT: Before building for iOS device, verify that you have configured a valid pair of certificate and provisioning profile on your OS X system. <% if(isHtml) { %>For more information, see [Obtaining Signing Identities and Downloading Provisioning Profiles](https://developer.apple.com/library/mac/recipes/xcode_help-accounts_preferences/articles/obtain_certificates_and_provisioning_profiles.html).<% } %>
 
 ### Options
+* `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device.
 * `--device` - Specifies a connected device on which to run the app.
 * `--emulator` - If set, runs the app in a native emulator for the target platform, if configured. When set, you can also set any other valid combination of emulator options as listed by `$ tns help emulate ios`. You cannot use `--device` and `--emulator` simultaneously.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -1,15 +1,23 @@
 export class RunCommandBase {
-	constructor(private $platformService: IPlatformService) { }
+	constructor(private $platformService: IPlatformService,
+		private $usbLiveSyncService: ILiveSyncService,
+		protected $options: IOptions) { }
 
 	public executeCore(args: string[], buildConfig?: IBuildConfig): IFuture<void> {
-		return this.$platformService.runPlatform(args[0], buildConfig);
+		if (this.$options.watch) {
+			return this.$usbLiveSyncService.liveSync(args[0]);
+		} else {
+			return this.$platformService.runPlatform(args[0], buildConfig);
+		}
 	}
 }
 
 export class RunIosCommand extends RunCommandBase implements ICommand {
 	constructor($platformService: IPlatformService,
-		private $platformsData: IPlatformsData) {
-		super($platformService);
+		private $platformsData: IPlatformsData,
+		$usbLiveSyncService: ILiveSyncService,
+		$options: IOptions) {
+		super($platformService, $usbLiveSyncService, $options);
 	}
 
 	public allowedParameters: ICommandParameter[] = [];
@@ -23,9 +31,10 @@ $injector.registerCommand("run|ios", RunIosCommand);
 export class RunAndroidCommand extends RunCommandBase implements ICommand {
 	constructor($platformService: IPlatformService,
 		private $platformsData: IPlatformsData,
-				private $options: IOptions,
-				private $errors: IErrors) {
-			super($platformService);
+		$usbLiveSyncService: ILiveSyncService,
+		$options: IOptions,
+		private $errors: IErrors) {
+		super($platformService, $usbLiveSyncService, $options);
 	}
 
 	public allowedParameters: ICommandParameter[] = [];


### PR DESCRIPTION
You can do now:
`tns run android|ios --watch`
instead of
`tns livesync android|ios --watch`

Related to https://github.com/NativeScript/nativescript-cli/issues/1366