### PR TITLE
Fixed: Livesync not syncing on 2 devices when platform is not specified

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -54,6 +54,7 @@ class LiveSyncService implements ILiveSyncService {
 				liveSyncData.push(this.prepareLiveSyncData(platform));
 			} else {
 				this.$devicesService.initialize({ skipInferPlatform: true }).wait();
+				this.$devicesService.stopDeviceDetectionInterval().wait();
 				for(let installedPlatform of this.$platformService.getInstalledPlatforms().wait()) {
 					if (this.$devicesService.getDevicesForPlatform(installedPlatform).length === 0) {
 						this.$devicesService.startEmulator(installedPlatform).wait();


### PR DESCRIPTION
1. connect two devices (iOS and Android).
2. create a new project: `tns create testProject`
3. run `tns platform add ios` and `tns platform add android`
4. run `tns livesync`
5. only the Android device will be synced, there will be a random exception when syncing the iOS device.