### PR TITLE
Don't livesync tns_modules folder for iOS device

### DIFF
--- a/lib/providers/livesync-provider.ts
+++ b/lib/providers/livesync-provider.ts
@@ -65,7 +65,7 @@ export class LiveSyncProvider implements ILiveSyncProvider {
 				temp.track();
 				let tempZip = temp.path({prefix: "sync", suffix: ".zip"});
 				this.$logger.trace("Creating zip file: " + tempZip);
-				this.$childProcess.spawnFromEvent("zip", [ "-r", "-0", tempZip, "app" ], "close", { cwd: path.dirname(projectFilesPath) }).wait();
+				this.$childProcess.spawnFromEvent("zip", [ "-r", "-0", tempZip, "app", "-x", "app/tns_modules/*" ], "close", { cwd: path.dirname(projectFilesPath) }).wait();
 
 				deviceAppData.device.fileSystem.transferFiles(deviceAppData, [{
 					getLocalPath: () => tempZip,


### PR DESCRIPTION
This is done for performance improvements to avoid unarchiving Angular and NativeScript modules. At runtime the `tns_modules` from the deployed `ipa` bundle  will be used instead.

BTW, Livesync with `--watch` is not livesyncing `tns_modules` too, so at least this should be consistent now.

Related: https://github.com/NativeScript/ios-runtime/pull/611/files#diff-26b03154ad8867bf950c44b3bb6c9c86