### PR TITLE
Do not force LaunchScreen when adding AndroidManifest.xml in old projects

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -586,7 +586,16 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 					if (alreadyHasAndroidManifest) {
 						this.backupOriginalAndroidManifest(originalAndroidManifestFilePath).wait();
 					}
-					this.$fs.copyFile(templateAndroidManifest, originalAndroidManifestFilePath).wait();
+
+					let content = this.$fs.readText(templateAndroidManifest).wait();
+
+					// We do not want to force launch screens on old projects.
+					let themeMeta = `<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />`;
+					content = content
+						.replace(`\n\t\t\tandroid:theme="@style/LaunchScreenTheme">\n`, `>\n\t\t\t<!-- android:theme="@style/LaunchScreenTheme" -->\n`)
+						.replace(themeMeta, "<!-- " + themeMeta + " -->");
+
+					this.$fs.writeFile(originalAndroidManifestFilePath, content).wait();
 				} catch (e) {
 					this.$logger.trace(`Copying template's ${this.platformData.configurationFileName} failed. `, e);
 					this.revertBackupOfOriginalAndroidManifest(originalAndroidManifestFilePath).wait();


### PR DESCRIPTION
Some arcane projects have no AndroidManifest.xml in App_Resources. When we add the new AndroidManifets it requires LaunchScreenTheme resources. Since these project had no splashscreen when they were created we had decided that we do not want to force feed them splash screens and sanitize the theme attribute and default theme meta in the AndroidManifest when we are coping it from the default template.