### PR TITLE
Fixed: Livesync+Debug on Android not working when there are changes in tns-core-modules

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -41,6 +41,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $projectTemplatesService: IProjectTemplatesService,
 		private $xmlValidator: IXmlValidator,
+		private $config: IConfiguration,
 		private $npm: INodePackageManager) {
 		super($fs, $projectData, $projectDataService);
 		this._androidProjectPropertiesManagers = Object.create(null);
@@ -405,16 +406,18 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	public beforePrepareAllPlugins(): IFuture<void> {
-		let buildOptions = this.getBuildOptions();
-		buildOptions.unshift("clean");
+		if (!this.$config.debugLivesync) {
+			let buildOptions = this.getBuildOptions();
 
-		let projectRoot = this.platformData.projectRoot;
-		let gradleBin = this.useGradleWrapper(projectRoot) ? path.join(projectRoot, "gradlew") : "gradle";
-		if (this.$hostInfo.isWindows) {
-			gradleBin += ".bat";
+			buildOptions.unshift("clean");
+
+			let projectRoot = this.platformData.projectRoot;
+			let gradleBin = this.useGradleWrapper(projectRoot) ? path.join(projectRoot, "gradlew") : "gradle";
+			if (this.$hostInfo.isWindows) {
+				gradleBin += ".bat";
+			}
+			this.spawn(gradleBin, buildOptions, { stdio: "inherit", cwd: this.platformData.projectRoot }).wait();
 		}
-		this.spawn(gradleBin, buildOptions, { stdio: "inherit", cwd: this.platformData.projectRoot }).wait();
-
 		return Future.fromResult();
 	}
 

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -78,6 +78,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	testInjector.register("xmlValidator", XmlValidator);
+	testInjector.register("config", StaticConfigLib.Configuration);
 
 	return testInjector;
 }

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -33,6 +33,7 @@ import {DeviceAppDataProvider} from "../lib/providers/device-app-data-provider";
 import {MobilePlatformsCapabilities} from "../lib/mobile-platforms-capabilities";
 import {DevicePlatformsConstants} from "../lib/common/mobile/device-platforms-constants";
 import { XmlValidator } from "../lib/xml-validator";
+import StaticConfigLib = require("../lib/config");
 import * as path from "path";
 import * as temp from "temp";
 temp.track();
@@ -99,6 +100,7 @@ function createTestInjector() {
 		defaultTemplate: future.fromResult("")
 	});
 	testInjector.register("xmlValidator", XmlValidator);
+	testInjector.register("config", StaticConfigLib.Configuration);
 
 	return testInjector;
 }


### PR DESCRIPTION
## The issue:

1. Create a new {N} project.
2. Open it in Visual Studio Code. Run debug with "Sync on Android". This will start livesync and then debug.
3. Make a change in tns-core-modules. 
4. Run "Sync on Android" again. It will fail. This happens because the prepareProject called by livesync service will clean the android build folder with all apks. It is required by the debug service that is called after livesync.

## Proposal:

In that situation we change only the js file and therefore it is not necessary to clean the whole build folder.  We could check whether the change is in platforms folder of particular module.  It so, we should clean the project. If not, it is safe to skip the clean process. 