### PR TITLE
Fixed: debug > stopApplication not working correctly on Android emulator

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -18,7 +18,10 @@
 
 					this.debugService.debugStop().wait();
 
-					let applicationId = deviceAppData.device.isEmulator ? projectData.projectName : deviceAppData.appIdentifier;
+					let applicationId = deviceAppData.appIdentifier;
+					if (deviceAppData.device.isEmulator && deviceAppData.platform.toLowerCase() === this.$devicePlatformsConstants.iOS.toLowerCase()) {
+						applicationId = projectData.projectName;
+					}
 					deviceAppData.device.applicationManager.stopApplication(applicationId).wait();
 
 					this.debugService.debug().wait();


### PR DESCRIPTION
The current logic in debug commnad changes the argument passed to stopApplication method from applicationId to projectName when using emulator. This behavior is correct in iOS, but it fails on Android. This fix corrects the issue.