### PR TITLE
Fixed: livesync + debug syncs wrong files on Android

### DIFF
--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -171,7 +171,7 @@ class AndroidDebugService implements IDebugService {
 
 	private startAppWithDebugger(packageFile: string, packageName: string): IFuture<void> {
 		return (() => {
-			if (!this.$options.emulator) {
+			if (!this.$options.emulator && !this.$config.debugLivesync) {
 				this.device.applicationManager.uninstallApplication(packageName).wait();
 				this.device.applicationManager.installApplication(packageFile).wait();
 			}


### PR DESCRIPTION
1. Create a new {N} project.
2. Run `tns livesync android --watch`.
3. Do some changes in XML and JS files.
4. Stop tns process.
5. Open Visual Studio Code and start `Sync on Android` action.
6. Change JS file - you will see that the JS file is correct, but the XML one is not.
7. Change XML file - you will see that the XML file is correct, but the JS file is not.

Should be merged on top of #1985
