### PR TITLE
Fixed: There is an exception when stopping livesync --watch

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -148,7 +148,7 @@ class LiveSyncService implements ILiveSyncService {
 			});
 		});
 
-		this.$processService.attachToProcessExitSignals(this, gazeWatcher.close);
+		this.$processService.attachToProcessExitSignals(this, () => gazeWatcher.close());
 		this.$dispatcher.run();
 	}
 }


### PR DESCRIPTION
1. create a new {N} project.
2. start `tns livesync ios --watch`.
3. make a change.
4. try to stop tns process with Ctrl+C. You will see ugly exception.