### PR TITLE
Improved: The live sync successfull message appears twice in the code

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -21,8 +21,6 @@
 				return (() => {
 					let projectData: IProjectData = this.$injector.resolve("projectData");
 
-					this.$logger.info(`Successfully synced application ${deviceAppData.appIdentifier} on device ${deviceAppData.device.deviceInfo.identifier}.`);
-
 					this.debugService.debugStop().wait();
 
 					let applicationId = deviceAppData.appIdentifier;

--- a/lib/services/livesync/android-platform-livesync-service.ts
+++ b/lib/services/livesync/android-platform-livesync-service.ts
@@ -41,10 +41,12 @@ class AndroidPlatformLiveSyncService extends PlatformLiveSyncServiceBase {
 					}
 
 					if (postAction) {
+						this.finishLivesync(deviceAppData).wait();
 						return postAction(deviceAppData, localToDevicePaths).wait();
 					}
 
-					return afterSyncAction().wait();
+					afterSyncAction().wait();
+					this.finishLivesync(deviceAppData).wait();
 				}).future<void>()();
 			};
 			this.$devicesService.execute(action, canExecute).wait();

--- a/lib/services/livesync/ios-platform-livesync-service.ts
+++ b/lib/services/livesync/ios-platform-livesync-service.ts
@@ -37,10 +37,12 @@ class IOSPlatformLiveSyncService extends PlatformLiveSyncServiceBase {
 					}
 
 					if (postAction) {
+						this.finishLivesync(deviceAppData).wait();
 						return postAction(deviceAppData, localToDevicePaths).wait();
 					}
 
-					return afterSyncAction().wait();
+					afterSyncAction().wait();
+					this.finishLivesync(deviceAppData).wait();
 				}).future<void>()();
 			};
 			this.$devicesService.execute(action, canExecute).wait();

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -110,12 +110,7 @@ class LiveSyncService implements ILiveSyncService {
 			let watchForChangeActions: ((event: string, filePath: string, dispatcher: IFutureDispatcher) => void)[] = [];
 			_.each(liveSyncData, (dataItem) => {
 				let service = this.resolvePlatformLiveSyncBaseService(dataItem.platform, dataItem);
-
 				watchForChangeActions.push((event: string, filePath: string, dispatcher: IFutureDispatcher) => {
-					if (!applicationReloadAction) {
-						applicationReloadAction = (deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => service.refreshApplication(deviceAppData, localToDevicePaths);
-					}
-
 					service.partialSync(event, filePath, dispatcher, applicationReloadAction);
 				});
 				service.fullSync(applicationReloadAction).wait();


### PR DESCRIPTION
This is a follow-up PR to #1993. Currently the "Successfully synced application" message can be found in two files. This PR creates a single method called `finishLivesync` in `platform-livesync-service-base` which improves the code. Note that `livesync-service` is not the best place for such message because it is platform agnostic, the message however is not.