### PR TITLE
Fix failing android build command by forcing use of gradle

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -445,10 +445,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			if (!this._canUseGradle) {
 				if (!frameworkVersion) {
 					this.$projectDataService.initialize(this.$projectData.projectDir);
-					frameworkVersion = this.$projectDataService.getValue(this.platformData.frameworkPackageName).wait().version;
+					let frameworkInfoInProjectFile = this.$projectDataService.getValue(this.platformData.frameworkPackageName).wait();
+					frameworkVersion = frameworkInfoInProjectFile && frameworkInfoInProjectFile.version;
 				}
 
-				this._canUseGradle = semver.gte(frameworkVersion, AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE);
+				this._canUseGradle = !frameworkVersion || semver.gte(frameworkVersion, AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE);
 			}
 
 			return this._canUseGradle;


### PR DESCRIPTION
When there's `platforms/android` directory, but in package.json there's no entry in `nativescript` for android platform, calling `tns build android` or any build related command will fail with error:
`Cannot read property 'version' of undefined`
The reason is that we are trying to check the version in package.json and check if it allows us to use gradle (previously Android builds required Ant).
Prevent the error and force using gradle in such case.

NOTE: The issue can be reproduced when working in new repository and you've added the platforms directory to `.gitignore` file. After adding android platform, you'll notice changes in your package.json. Instead of commiting them, I've called `git reset --hard` which removed them from package.json, but I still have the platforms directory.