### PR TITLE
Use monkey to start Android applications

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,6 @@
 import * as path from "path";
 import {StaticConfigBase} from "./common/static-config-base";
 import {ConfigBase} from "./common/config-base";
-import { startPackageActivityNames } from "./common/constants";
 
 export class Configuration extends ConfigBase implements IConfiguration { // User specific config
 	CI_LOGGER = false;
@@ -29,7 +28,6 @@ export class StaticConfig extends StaticConfigBase implements IStaticConfig {
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "TrackFeatureUsage";
 	public ERROR_REPORT_SETTING_NAME = "TrackExceptions";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";
-	public START_PACKAGE_ACTIVITY_NAME = startPackageActivityNames[this.CLIENT_NAME_ALIAS.toLowerCase()];
 	public INSTALLATION_SUCCESS_MESSAGE = "Installation successful. You are good to go. Connect with us on `http://twitter.com/NativeScript`.";
 
 	constructor($injector: IInjector) {


### PR DESCRIPTION
Use the monkey tool to start Android applications on device. This way we do not have to care about the startPackageActivity name and we can start the application in case a custom activity is used.
Remove unused code and variables.

Fixes https://github.com/NativeScript/nativescript-cli/issues/2028 