### PR TITLE
Fix using of custom AndroidManifest.xml

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -533,7 +533,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 					isFileCorrect = !!(~fileContent.indexOf("android:minSdkVersion") && ~fileContent.indexOf("android:targetSdkVersion")
 						&& ~fileContent.indexOf("uses-permission") && ~fileContent.indexOf("<application")
 						&& ~fileContent.indexOf("<activity") && ~fileContent.indexOf("<intent-filter>")
-						&& ~fileContent.indexOf("android.intent.action.MAIN") && ~fileContent.indexOf("com.tns.ErrorReportActivity")
+						&& ~fileContent.indexOf("android.intent.action.MAIN")
 						&& ~fileContent.indexOf("android:versionCode")
 						&& !this.$xmlValidator.getXmlFileErrors(pathToAndroidManifest).wait());
 


### PR DESCRIPTION
In case user had edited his AndroidManifest.xml, he may have removed the com.tns.ErrorReportActivity. In this case, NativeScript CLI thinks that the AndroidManifest.xml is not correct, creates a backup for it and extracts the default one from the template.
Remove the check for `com.tns.ErrorReportActivity`.