### PR TITLE
Fix live edit on device

### DIFF
--- a/lib/services/livesync/ios-device-livesync-service.ts
+++ b/lib/services/livesync/ios-device-livesync-service.ts
@@ -42,7 +42,6 @@ class IOSLiveSyncService implements IDeviceLiveSyncService {
 				return true;
 			}
 
-			let enableDebuggerMessage = `{ "method":"Debugger.enable","id":${++currentPageReloadId} }`;
 			if (this.device.isEmulator) {
 				this.$iOSEmulatorServices.postDarwinNotification(this.$iOSNotification.attachRequest).wait();
 				try {
@@ -59,7 +58,6 @@ class IOSLiveSyncService implements IDeviceLiveSyncService {
 			}
 
 			this.attachEventHandlers();
-			this.sendMessage(enableDebuggerMessage).wait();
 
 			return true;
  		}).future<boolean>()();
@@ -131,7 +129,7 @@ class IOSLiveSyncService implements IDeviceLiveSyncService {
 				let message = JSON.stringify({
 					method: "Debugger.setScriptSource",
 					params: {
-						scriptUrl: localToDevicePath.getDevicePath(),
+						scriptUrl: localToDevicePath.getRelativeToProjectBasePath(),
 						scriptSource: content
 					},
 					id: ++currentPageReloadId


### PR DESCRIPTION
In case of live edit on device, the getDevicePath does not return the absolute device path. So pass a relative path instead and the runtime would handle it.