### PR TITLE
Kill the process for iOS Simulator logs on SIGINT

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "glob": "^7.0.3",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-sim-portable": "~1.3.0",
+    "ios-sim-portable": "~1.4.0",
     "lockfile": "1.0.1",
     "lodash": "4.13.1",
     "log4js": "0.6.26",


### PR DESCRIPTION
On some Mac OS machines, the process for reading iOS Simulator logs does not die when Ctrl + C is used. So CLI's process cannot die as well and Ctrl + Z should be used. However the processes for reading logs remain alive and zombies.
Make sure to kill the process on SIGINT, SIGTERM, etc. This way CLI's process should die as well.

Use new version of ios-sim-portable, where the child process is returned to the CLI, so we can kill it later.