### PR TITLE
inherit verbose logging from --log trace command

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -252,8 +252,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		return (() => {
 			if (this.canUseGradle().wait()) {
 				let buildOptions = this.getBuildOptions();
+				if (this.$logger.getLevel() === "TRACE") {
+					buildOptions.unshift("--stacktrace");
+					buildOptions.unshift("--debug");
+				}
 				buildOptions.unshift("buildapk");
-
 				let gradleBin = this.useGradleWrapper(projectRoot) ? path.join(projectRoot, "gradlew") : "gradle";
 				if (this.$hostInfo.isWindows) {
 					gradleBin += ".bat"; // cmd command line parsing rules are weird. Avoid issues with quotes. See https://github.com/apache/cordova-android/blob/master/bin/templates/cordova/lib/builders/GradleBuilder.js for another approach


### PR DESCRIPTION
#### Problem: 
When a user runs a command using the `--log trace` we don't enable verbose logging for the gradle build. The current workaround was to ask the user to go to platforms android and run the same command that CLI runs but with two additional flags.

#### Solution
In order to enable our users to provide us with better logs of error while building an application, this PR uses the `--log trace` command to pass two additional debug flags to the gradle build.

#### Usage:
No difference in usage of commands.
e.g. `tns run android --log trace`

ping: @tzraikov @PanayotCankov @hdeshev 