### PR TITLE
Workaround Ctrl+C not exiting debug process

### DIFF
--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -20,6 +20,9 @@ fiber(() => {
 	let messages: IMessagesService = $injector.resolve("$messagesService");
 	messages.pathsToMessageJsonFiles = [/* Place client-specific json message file paths here */];
 
+	let processService: IProcessService = $injector.resolve("$processService");
+	processService.attachToProcessExitSignals(this, process.exit);
+
 	if (process.argv[2] === "completion") {
 		commandDispatcher.completeCommand().wait();
 	} else {


### PR DESCRIPTION
During `tns debug ios` command, Ctrl + C does not kill the proecss. It looks like there are still resources that do not allow the process to die.
Implement a workaround - call process.exit when SIGINT (Ctrl + C) is received. There's no guarantee that this will release the other resources. However CLI's process will definitely die and console will be released.
Code is based on this PR: https://github.com/telerik/mobile-cli-lib/pull/791