### PR TITLE
Do not try to resolve hookArgs

### DIFF
--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -410,6 +410,8 @@ export class HooksServiceStub implements IHooksService {
 	executeAfterHooks(commandName: string): IFuture<void> {
 		return Future.fromResult();
 	}
+
+	hookArgsName = "hookArgs";
 }
 
 export class LockFile {


### PR DESCRIPTION
When we validate the hook arguments we try to resolve all of them but there is one argument which is not registered in the injector - hookArgs.
If some hook wants to use it we will try to resolve it and fail.
The solution is to skip the validation for the hookArgs argument.