### PR TITLE
refactoring tns install to do only npm install

### DIFF
--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -1,6 +1,5 @@
 export class InstallCommand implements ICommand {
 	constructor(private $projectData: IProjectData,
-		private $projectDataService: IProjectDataService,
 		private $pluginsService: IPluginsService,
 		private $fs: IFileSystem,
 		private $stringParameter: ICommandParameter,
@@ -15,9 +14,7 @@ export class InstallCommand implements ICommand {
 	}
 
 	private installProjectDependencies(): IFuture<void> {
-		return (() => {
-			this.$pluginsService.ensureAllDependenciesAreInstalled().wait();
-		}).future<void>()();
+		return this.$pluginsService.ensureAllDependenciesAreInstalled();
 	}
 
 	private installModule(moduleName: string): IFuture<void> {

--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -1,12 +1,7 @@
-import {EOL} from "os";
-
 export class InstallCommand implements ICommand {
-	constructor(private $platformsData: IPlatformsData,
-		private $platformService: IPlatformService,
-		private $projectData: IProjectData,
+	constructor(private $projectData: IProjectData,
 		private $projectDataService: IProjectDataService,
 		private $pluginsService: IPluginsService,
-		private $logger: ILogger,
 		private $fs: IFileSystem,
 		private $stringParameter: ICommandParameter,
 		private $npm: INodePackageManager) { }
@@ -21,26 +16,7 @@ export class InstallCommand implements ICommand {
 
 	private installProjectDependencies(): IFuture<void> {
 		return (() => {
-			let error: string = "";
-
 			this.$pluginsService.ensureAllDependenciesAreInstalled().wait();
-
-			this.$projectDataService.initialize(this.$projectData.projectDir);
-			_.each(this.$platformsData.platformsNames, platform => {
-				let platformData = this.$platformsData.getPlatformData(platform);
-				let frameworkPackageData = this.$projectDataService.getValue(platformData.frameworkPackageName).wait();
-				if (frameworkPackageData && frameworkPackageData.version) {
-					try {
-						this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`]).wait();
-					} catch (err) {
-						error = `${error}${EOL}${err}`;
-					}
-				}
-			});
-
-			if (error) {
-				this.$logger.error(error);
-			}
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
`tns install` command no longer tries to add platform and only does npm install. Deprecate soon so only `npm install` is used. Before this command was doing `npm install` + `platform add`. This PR removes the `platform add` functionality and soon the whole command will be deprecated.

ping: @hdeshev 

