### PR TITLE
remove logic concerning app/tns_modules folder

### DIFF
--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -98,10 +98,7 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 
 			if (isNodeModulesModified && this.$fs.exists(absoluteOutputPath).wait()) {
 				let currentPreparedTnsModules = this.$fs.readDirectory(absoluteOutputPath).wait();
-				let tnsModulesPath = path.join(projectDir, constants.APP_FOLDER_NAME, constants.TNS_MODULES_FOLDER_NAME);
-				if (!this.$fs.exists(tnsModulesPath).wait()) {
-					tnsModulesPath = path.join(projectDir, constants.NODE_MODULES_FOLDER_NAME, constants.TNS_CORE_MODULES_NAME);
-				}
+				let tnsModulesPath = path.join(projectDir, constants.NODE_MODULES_FOLDER_NAME, constants.TNS_CORE_MODULES_NAME);
 				let tnsModulesInApp = this.$fs.readDirectory(tnsModulesPath).wait();
 				let modulesToDelete = _.difference(currentPreparedTnsModules, tnsModulesInApp);
 				_.each(modulesToDelete, moduleName => this.$fs.deleteDirectory(path.join(absoluteOutputPath, moduleName)).wait());


### PR DESCRIPTION
There is old logic concerning `app/tns_modules` folder that is obsolete and we need to remove all logic from cli.

related to: https://github.com/NativeScript/nativescript-cli/pull/2099/commits/1514f277d72d7443c5ef85966e6aa0b45943dcf0

@tzraikov @hdeshev 