### PR TITLE
Prepare plugins independently of node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_script:
 - npm install grunt
 - node_modules/.bin/grunt enableScripts:false
 - npm install
+- grunt rebuild
+- ./bin/nativescript error-reporting disable # force ~/.local dir creation -- some tests rely on it
+- ./bin/nativescript usage-reporting disable
 - npm test
 - node_modules/.bin/grunt enableScripts:true
 script:

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -5,8 +5,6 @@ interface IPluginsService {
 	prepare(pluginData: IDependencyData, platform: string): IFuture<void>;
 	getAllInstalledPlugins(): IFuture<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(): IFuture<void>;
-	afterPrepareAllPlugins(): IFuture<void>;
-	beforePrepareAllPlugins(): IFuture<void>;
 	getDependenciesFromPackageJson(): IFuture<IPackageJsonDepedenciesResult>
 }
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -290,13 +290,8 @@ export class PlatformService implements IPlatformService {
 			let appDir = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 			try {
 				let tnsModulesDestinationPath = path.join(appDir, constants.TNS_MODULES_FOLDER_NAME);
-				if (!this.$options.bundle) {
-					// Process node_modules folder
-					this.$nodeModulesBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime).wait();
-				} else {
-					// Clean target node_modules folder. Not needed when bundling.
-					this.$nodeModulesBuilder.cleanNodeModules(tnsModulesDestinationPath, platform);
-				}
+				// Process node_modules folder
+				this.$nodeModulesBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime).wait();
 			} catch (error) {
 				this.$logger.debug(error);
 				shell.rm("-rf", appDir);


### PR DESCRIPTION
- Extract dependency resolution from the node_modules copy code.
- Decouple plugin preparation from node_modules copying.
- Reuse resolved dependencies for plugin preparation.

Fixes #2110