### PR TITLE
Check if plugin consumes v8 symbols

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -86,7 +86,7 @@ interface IPlatformProjectService {
 	preparePluginNativeCode(pluginData: IPluginData, options?: any): IFuture<void>;
 	removePluginNativeCode(pluginData: IPluginData): IFuture<void>;
 	afterPrepareAllPlugins(): IFuture<void>;
-	beforePrepareAllPlugins(): IFuture<void>;
+	beforePrepareAllPlugins(dependencies?: IDictionary<IDependencyData>): IFuture<void>;
 	getAppResourcesDestinationDirectoryPath(): IFuture<string>;
 	deploy(deviceIdentifier: string): IFuture<void>;
 	processConfigurationFilesFromAppResources(): IFuture<void>;

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -393,8 +393,18 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		return Future.fromResult();
 	}
 
-	public beforePrepareAllPlugins(): IFuture<void> {
+	public beforePrepareAllPlugins(dependencies?: IDictionary<IDependencyData>): IFuture<void> {
 		if (!this.$config.debugLivesync) {
+			if (dependencies) {
+				let platformDir = path.join(this.$projectData.platformsDir, "android");
+				let buildDir = path.join(platformDir, "build-tools");
+				let checkV8dependants = path.join(buildDir, "check-v8-dependants.js");
+				if (this.$fs.exists(checkV8dependants).wait()) {
+					let stringifiedDependencies = JSON.stringify(dependencies);
+					this.spawn('node', [checkV8dependants, stringifiedDependencies, this.$projectData.platformsDir], { stdio: "inherit" }).wait();
+				}
+			}
+
 			let buildOptions = this.getBuildOptions();
 
 			buildOptions.unshift("clean");

--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -142,7 +142,8 @@ export class NpmPluginPrepare {
 			return;
 		}
 
-		this.$platformsData.getPlatformData(platform).platformProjectService.beforePrepareAllPlugins().wait();
+		this.$platformsData.getPlatformData(platform).platformProjectService.beforePrepareAllPlugins(dependencies).wait();
+
 		_.each(dependencies, dependency => {
 			let isPlugin = !!dependency.nativescript;
 			if (isPlugin) {


### PR DESCRIPTION
The PR introduces additional logic on beforePrepare in android builds to execute a node script that checks for dependencies consuming the public v8 API.

This is necessary in order to decide whether or not the optimized runtime package (stripped v8 symbols) should be used in the resulting APK.

@NativeScript/android-runtime 