### PR TITLE
Do not copy app files to platform dir if using --bundle

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -42,6 +42,8 @@ $injector.requireCommand("debug|ios", "./commands/debug");
 $injector.requireCommand("debug|android", "./commands/debug");
 
 $injector.requireCommand("prepare", "./commands/prepare");
+$injector.requireCommand("clean-app|ios", "./commands/clean-app");
+$injector.requireCommand("clean-app|android", "./commands/clean-app");
 $injector.requireCommand("build|ios", "./commands/build");
 $injector.requireCommand("build|android", "./commands/build");
 $injector.requireCommand("deploy", "./commands/deploy");

--- a/lib/commands/clean-app.ts
+++ b/lib/commands/clean-app.ts
@@ -1,0 +1,40 @@
+export class CleanAppCommandBase {
+	constructor(protected $options: IOptions,
+		private $platformService: IPlatformService) { }
+
+	execute(args: string[]): IFuture<void> {
+		let platform = args[0].toLowerCase();
+		return this.$platformService.cleanDestinationApp(platform);
+	}
+}
+
+export class CleanAppIosCommand extends CleanAppCommandBase implements  ICommand {
+	constructor(protected $options: IOptions,
+				private $platformsData: IPlatformsData,
+				$platformService: IPlatformService) {
+		super($options, $platformService);
+	}
+
+	public allowedParameters: ICommandParameter[] = [];
+
+	public execute(args: string[]): IFuture<void> {
+		return super.execute([this.$platformsData.availablePlatforms.iOS]);
+	}
+}
+$injector.registerCommand("clean-app|ios", CleanAppIosCommand);
+
+export class CleanAppAndroidCommand extends CleanAppCommandBase implements  ICommand {
+	constructor(protected $options: IOptions,
+				private $platformsData: IPlatformsData,
+				private $errors: IErrors,
+				$platformService: IPlatformService) {
+		super($options, $platformService);
+	}
+
+	public allowedParameters: ICommandParameter[] = [];
+
+	public execute(args: string[]): IFuture<void> {
+		return super.execute([this.$platformsData.availablePlatforms.Android]);
+	}
+}
+$injector.registerCommand("clean-app|android", CleanAppAndroidCommand);

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -7,6 +7,7 @@ interface IPlatformService {
 	updatePlatforms(platforms: string[]): IFuture<void>;
 	runPlatform(platform: string, buildConfig?: IBuildConfig): IFuture<void>;
 	preparePlatform(platform: string): IFuture<boolean>;
+	cleanDestinationApp(platform: string): IFuture<void>;
 	buildPlatform(platform: string, buildConfig?: IBuildConfig): IFuture<void>;
 	buildForDeploy(platform: string, buildConfig?: IBuildConfig): IFuture<void>;
 	installOnDevice(platform: string, buildConfig?: IBuildConfig): IFuture<void>;

--- a/lib/services/app-files-updater.ts
+++ b/lib/services/app-files-updater.ts
@@ -1,0 +1,86 @@
+import * as path from "path";
+import * as minimatch from "minimatch";
+import * as constants from "../constants";
+import Future = require("fibers/future");
+
+export class AppFilesUpdater {
+	constructor(
+		private appSourceDirectoryPath: string,
+		private appDestinationDirectoryPath: string,
+		public options: IOptions,
+		public fs: IFileSystem
+	) {
+	}
+
+	public updateApp(beforeCopyAction: (sourceFiles: string[]) => void): void {
+		this.cleanDestinationApp();
+		const sourceFiles = this.resolveAppSourceFiles();
+
+		beforeCopyAction(sourceFiles);
+		this.copyAppSourceFiles(sourceFiles);
+	}
+
+	public cleanDestinationApp(): void {
+		if (this.options.bundle) {
+			//Assuming an the bundle has updated the dest folder already.
+			//Skip cleaning up completely.
+			return;
+		}
+
+		// Delete the destination app in order to prevent EEXIST errors when symlinks are used.
+		let destinationAppContents = this.readDestinationDir();
+		destinationAppContents = destinationAppContents.filter(
+			(directoryName: string) => directoryName !== constants.TNS_MODULES_FOLDER_NAME);
+
+		_(destinationAppContents).each((directoryItem: string) => {
+			this.deleteDestinationItem(directoryItem);
+		});
+	}
+
+	protected readDestinationDir(): string[] {
+		if (this.fs.exists(this.appDestinationDirectoryPath).wait()) {
+			return this.fs.readDirectory(this.appDestinationDirectoryPath).wait();
+		} else {
+			return [];
+		}
+	}
+
+	protected deleteDestinationItem(directoryItem: string): void {
+		this.fs.deleteDirectory(path.join(this.appDestinationDirectoryPath, directoryItem)).wait();
+	}
+
+	protected readSourceDir(): string[] {
+		return this.fs.enumerateFilesInDirectorySync(this.appSourceDirectoryPath, null, { includeEmptyDirectories: true });
+	}
+
+	protected resolveAppSourceFiles(): string[] {
+		// Copy all files from app dir, but make sure to exclude tns_modules
+		let sourceFiles = this.readSourceDir();
+
+		if (this.options.release) {
+			let testsFolderPath = path.join(this.appSourceDirectoryPath, 'tests');
+			sourceFiles = sourceFiles.filter(source => source.indexOf(testsFolderPath) === -1);
+		}
+
+		// Remove .ts and .js.map files in release
+		if (this.options.release) {
+			constants.LIVESYNC_EXCLUDED_FILE_PATTERNS.forEach(pattern => sourceFiles = sourceFiles.filter(file => !minimatch(file, pattern, { nocase: true })));
+		}
+
+		if (this.options.bundle) {
+			sourceFiles = sourceFiles.filter(file => minimatch(file, "**/App_Resources/**", {nocase: true}));
+		}
+		return sourceFiles;
+	}
+
+	protected copyAppSourceFiles(sourceFiles: string[]): void {
+		let copyFileFutures = sourceFiles.map(source => {
+			let destinationPath = path.join(this.appDestinationDirectoryPath, path.relative(this.appSourceDirectoryPath, source));
+			if (this.fs.getFsStats(source).wait().isDirectory()) {
+				return this.fs.createDirectory(destinationPath);
+			}
+			return this.fs.copyFile(source, destinationPath);
+		});
+		Future.wait(copyFileFutures);
+	}
+}

--- a/test/app-files-updates.ts
+++ b/test/app-files-updates.ts
@@ -1,0 +1,82 @@
+import {assert} from "chai";
+import {AppFilesUpdater} from "../lib/services/app-files-updater";
+
+require("should");
+
+describe("App files cleanup", () => {
+	class CleanUpAppFilesUpdater extends AppFilesUpdater {
+		public deletedDestinationItems: string[] = [];
+
+		constructor(
+			public destinationFiles: string[],
+			options: any
+		) {
+			super("<source>", "<destination>", options, null);
+		}
+
+		public clean() {
+			this.cleanDestinationApp();
+		}
+
+		protected readDestinationDir(): string[] {
+			return this.destinationFiles;
+		}
+
+		protected deleteDestinationItem(directoryItem: string): void {
+			this.deletedDestinationItems.push(directoryItem);
+		}
+	}
+
+	it("cleans up entire app when not bundling", () => {
+		const updater = new CleanUpAppFilesUpdater([
+			"file1", "dir1/file2", "App_Resources/Android/blah.png"
+		], {bundle: false});
+		updater.clean();
+		assert.deepEqual(["file1", "dir1/file2", "App_Resources/Android/blah.png"], updater.deletedDestinationItems);
+	});
+
+	it("does not clean up destination when bundling", () => {
+		const updater = new CleanUpAppFilesUpdater([
+			"file1", "dir1/file2", "App_Resources/Android/blah.png"
+		], {bundle: true});
+		updater.clean();
+		assert.deepEqual([], updater.deletedDestinationItems);
+	});
+});
+
+describe("App files copy", () => {
+	class CopyAppFilesUpdater extends AppFilesUpdater {
+		public copiedDestinationItems: string[] = [];
+
+		constructor(
+			public sourceFiles: string[],
+			options: any
+		) {
+			super("<source>", "<destination>", options, null);
+		}
+
+		protected readSourceDir(): string[] {
+			return this.sourceFiles;
+		}
+
+		public copy(): void {
+			this.copiedDestinationItems = this.resolveAppSourceFiles();
+		}
+	}
+
+	it("copies all app files when not bundling", () => {
+		const updater = new CopyAppFilesUpdater([
+			"file1", "dir1/file2", "App_Resources/Android/blah.png"
+		], {bundle: false});
+		updater.copy();
+		assert.deepEqual(["file1", "dir1/file2", "App_Resources/Android/blah.png"], updater.copiedDestinationItems);
+	});
+
+	it("skips copying non-App_Resource files when bundling", () => {
+		const updater = new CopyAppFilesUpdater([
+			"file1", "dir1/file2", "App_Resources/Android/blah.png"
+		], {bundle: true});
+		updater.copy();
+		assert.deepEqual(["App_Resources/Android/blah.png"], updater.copiedDestinationItems);
+	});
+});

--- a/test/test-bootstrap.ts
+++ b/test/test-bootstrap.ts
@@ -4,7 +4,11 @@ global._ = require("lodash");
 global.$injector = require("../lib/common/yok").injector;
 
 $injector.register("analyticsService", {
-	trackException: (): IFuture<void> => undefined
+	trackException: (): {wait(): void} => {
+		return {
+			wait: () => undefined
+		};
+	}
 });
 
 // Converts the js callstack to typescript


### PR DESCRIPTION
Cleaning up the target app dir turned out to be a hairy issue here. There is no way to know if the target app dir has been prepared without `--bundle` before the current prepare step. If it has, it needs to be cleaned up, but if it hasn't... it's highly likely that a custom webpack process ran just before preparing the app, and we should not touch anything.

The solution I came up with is the following:
- implement app cleanup as a separate command
- change the workflow to manually invoke `tns clean-app android` before bundling
- run your bundle process (webpack, etc)
- then finish up with a `tns build` or a `tns run` command.

I moved app updates (clean/copy) to a separate class, and added unit tests. This PR also fixes the test failure crash due to trying to send the assertion exception details via our analytics service.

Fixes #2111 