### PR TITLE
Extract tns-core-modules on root level of tns_modules

### DIFF
--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -30,6 +30,11 @@ export class TnsModulesCopy {
 				Future.wait(deleteFilesFutures);
 
 				shelljs.rm("-rf", path.join(tnsCoreModulesResourcePath, "node_modules"));
+
+				// TODO: The following two lines are necessary to temporarily work around hardcoded 
+				// path dependencies in iOS livesync logic. Should be addressed ASAP
+				shelljs.cp("-Rf", path.join(tnsCoreModulesResourcePath, "*"), this.outputRoot);
+				shelljs.rm("-rf", tnsCoreModulesResourcePath);
 			}
 		}
 	}


### PR DESCRIPTION
This PR aims to partially revert changes made in #2152 such that `tns-core-modules` submodules will once again be copied directly into `tns_modules`.

@hdeshev @dtopuzov 