### PR TITLE
clean-app command installs the platform if not present.

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -326,6 +326,8 @@ export class PlatformService implements IPlatformService {
 
 	public cleanDestinationApp(platform: string): IFuture<void> {
 		return (() => {
+			this.ensurePlatformInstalled(platform).wait();
+
 			const appSourceDirectoryPath = path.join(this.$projectData.projectDir, constants.APP_FOLDER_NAME);
 			let platformData = this.$platformsData.getPlatformData(platform);
 			let appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);


### PR DESCRIPTION
This allows for easier documentation workflows when using webpack.