### PR TITLE
Deprecate support for Node.js 0.12.x

### DIFF
--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -1,6 +1,6 @@
 let node = require("../package.json").engines.node;
 // this call must be first to avoid requiring c++ dependencies
-require("./common/verify-node-version").verifyNodeVersion(node, "NativeScript", "2.2.0");
+require("./common/verify-node-version").verifyNodeVersion(node, "NativeScript", "2.5.0");
 
 require("./bootstrap");
 import * as fiber from "fibers";


### PR DESCRIPTION
Deprecate support for Node.js 0.12.x as it will not be supported after 2016 by Node.js Foundation.

Implements: https://github.com/NativeScript/nativescript-cli/issues/2164 