### PR TITLE
Fixes time mismatch issues with prepare when using symlinks

### DIFF
--- a/lib/services/project-changes-info.ts
+++ b/lib/services/project-changes-info.ts
@@ -102,6 +102,10 @@ export class ProjectChangesInfo {
 			if (fileStats.mtime.getTime() > mtime) {
 				return true;
 			}
+			let lFileStats = this.$fs.getLsStats(filePath).wait();
+			if (lFileStats.mtime.getTime() > mtime) {
+				return true;
+			}
 			if (fileStats.isDirectory()) {
 				if (this.containsNewerFiles(filePath, skipDir, mtime)) {
 					return true;

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -121,6 +121,10 @@ export class FileSystemStub implements IFileSystem {
 		return undefined;
 	}
 
+	getLsStats(path: string): IFuture<IFsStats> {
+		return undefined;
+	}
+
 	isEmptyDir(directoryPath: string): IFuture<boolean> {
 		return Future.fromResult(true);
 	}


### PR DESCRIPTION
Steps to reproduce:
1. Clone nativescript and create `npm link` in tns-core-modules
2. Create a new {N} project
3. Run the project
4. Remove tns-core-modules folder from the project modules path
5. Execute `npm link tns-core-modules` 
6. Expected: the project should be prepared and build. Actual: both steps are skipped. 

Merge after:
https://github.com/telerik/mobile-cli-lib/pull/834