### PR TITLE
Always clean plugin "platforms" subdir.

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -132,8 +132,6 @@ export class PluginsService implements IPluginsService {
 		}
 
 		if (!this.isPluginDataValidForPlatform(pluginData, platform).wait()) {
-			// Still clean up platform in case other platforms were supported.
-			shelljs.rm("-rf", path.join(pluginScriptsDestinationPath , pluginData.name, "platforms"));
 			return;
 		}
 
@@ -143,12 +141,9 @@ export class PluginsService implements IPluginsService {
 
 	private preparePluginNativeCode(pluginData: IPluginData, platform: string): void {
 		let platformData = this.$platformsData.getPlatformData(platform);
-		let pluginScriptsDestinationPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME, "tns_modules");
 
 		pluginData.pluginPlatformsFolderPath = (_platform: string) => path.join(pluginData.fullPath, "platforms", _platform);
 		platformData.platformProjectService.preparePluginNativeCode(pluginData).wait();
-		shelljs.rm("-rf", path.join(pluginScriptsDestinationPath , pluginData.name, "platforms"));
-
 	}
 
 	public ensureAllDependenciesAreInstalled(): IFuture<void> {

--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -50,6 +50,10 @@ export class TnsModulesCopy {
 
 			shelljs.mkdir("-p", targetDir);
 			shelljs.cp("-Rf", dependency.directory, targetDir);
+
+			//remove platform-specific files (processed separately by plugin services)
+			const targetPackageDir = path.join(targetDir, dependency.name);
+			shelljs.rm("-rf", path.join(targetPackageDir, "platforms"));
 		}
 	}
 }


### PR DESCRIPTION
No longer cleaning that up on plugin prepare only. Cleaning it up
every time we update tns_modules/<plugin> now.

Fixes an obscure issue introduced in #2194 -- not preparing plugins when building for an iOS device after preparing them for the simulator beforehand.