### PR TITLE
Print lldb output when attaching to the iOS Simulator with trace logging

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -1,6 +1,7 @@
 import * as iOSDevice from "../common/mobile/ios/device/ios-device";
 import * as net from "net";
 import * as path from "path";
+import * as log4js from "log4js";
 import {ChildProcess} from "child_process";
 import byline = require("byline");
 
@@ -124,7 +125,11 @@ class IOSDebugService implements IDebugService {
 				if (lineText && _.startsWith(lineText, this.$projectData.projectId)) {
 					let pid = _.trimStart(lineText, this.$projectData.projectId + ": ");
 					this._lldbProcess = this.$childProcess.spawn("lldb", [ "-p", pid]);
-				 	this._lldbProcess.stdin.write("process continue\n");
+					if (log4js.levels.TRACE.isGreaterThanOrEqualTo(this.$logger.getLevel())) {
+						this._lldbProcess.stdout.pipe(process.stdout);
+					}
+					this._lldbProcess.stderr.pipe(process.stderr);
+					this._lldbProcess.stdin.write("process continue\n");
 				} else {
 					process.stdout.write(line + "\n");
 				}


### PR DESCRIPTION
Merge with https://github.com/telerik/mobile-cli-lib/pull/840.

Can be useful when debugging connection issues.

Example output:
```
(lldb) process attach --pid 581
Process 581 stopped
* thread #1: tid = 0xa0c738, 0x00007fff661e7000 dyld`_dyld_start, stop reason = signal SIGSTOP
    frame #0: 0x00007fff661e7000 dyld`_dyld_start
dyld`_dyld_start:
->  0x7fff661e7000 <+0>: popq   %rdi
    0x7fff661e7001 <+1>: pushq  $0x0
    0x7fff661e7003 <+3>: movq   %rsp, %rbp
    0x7fff661e7006 <+6>: andq   $-0x10, %rsp

Executable module set to "/usr/lib/dyld".
Architecture set to: x86_64h-apple-ios.
```

ping @KristinaKoeva 