### PR TITLE
Fix native framework relative path calculation

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -674,7 +674,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 	}
 
 	private getLibSubpathRelativeToProjectPath(targetPath: string): string {
-		let frameworkPath = path.relative("platforms/ios", targetPath);
+		let frameworkPath = path.relative(this.platformData.projectRoot, targetPath);
 		return frameworkPath;
 	}
 

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -469,13 +469,13 @@ describe("Relative paths", () => {
 		it("checks for correct calculation of relative paths", () => {
 			let projectName = "projectDirectory";
 			let projectPath = temp.mkdirSync(projectName);
-			let subpath = "sub/path";
+			let subpath = path.join(projectPath, "sub/path");
 
 			let testInjector = createTestInjector(projectPath, projectName);
 			createPackageJson(testInjector, projectPath, projectName);
 			let iOSProjectService = testInjector.resolve("iOSProjectService");
 
 			let result = iOSProjectService.getLibSubpathRelativeToProjectPath(subpath);
-			assert.equal(result, path.join("../../", subpath));
+			assert.equal(result, "../../sub/path");
 		});
 });


### PR DESCRIPTION
Previously when adding a framework to the Xcode project the path was wrongly calculated when `--path` is used:

The correct one should be:
```
CFC86276F86A4C9B9A1EC768 /* TNSWidgets.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TNSWidgets.framework; path = "$(SRCROOT)/../../node_modules/tns-core-modules-widgets/platforms/ios/TNSWidgets.framework"; sourceTree = "<group>"; };
```