### PR TITLE
Fix App Resources copying operation

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -285,11 +285,11 @@ export class PlatformService implements IPlatformService {
 		return (() => {
 			let platformData = this.$platformsData.getPlatformData(platform);
 			let appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-			let appResourcesDestination = platformData.platformProjectService.getAppResourcesDestinationDirectoryPath().wait();
-			this.$fs.ensureDirectoryExists(appResourcesDestination).wait(); // Should be deleted
 			let appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
 			if (this.$fs.exists(appResourcesDirectoryPath).wait()) {
 				platformData.platformProjectService.prepareAppResources(appResourcesDirectoryPath).wait();
+				let appResourcesDestination = platformData.platformProjectService.getAppResourcesDestinationDirectoryPath().wait();
+				this.$fs.ensureDirectoryExists(appResourcesDestination).wait();
 				shell.cp("-Rf", path.join(appResourcesDirectoryPath, platformData.normalizedPlatformName, "*"), appResourcesDestination);
 				this.$fs.deleteDirectory(appResourcesDirectoryPath).wait();
 			}


### PR DESCRIPTION
[`prepareAppResources`](https://github.com/NativeScript/nativescript-cli/compare/buhov/fix-app-resources?expand=1#diff-513fe963f5d821a1cdb167ea91d70f1cR290) deletes the `appResourcesDestination` folder so we need to create it after its removal. This is needed because after [updating `shelljs`](https://github.com/NativeScript/nativescript-cli/pull/2243) [copying to non-existing destination](https://github.com/NativeScript/nativescript-cli/compare/buhov/fix-app-resources?expand=1#diff-513fe963f5d821a1cdb167ea91d70f1cL293) doesn't create the destination path.