### PR TITLE
Transpile to ES6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,12 @@ results
 scratch/
 .idea/
 .settings/
-.vscode/
+.vscode/**
+!.vscode/launch.json
 test-reports.xml
 
 npm-debug.log
 node_modules
 docs/html
+
+!test-scripts/*.js

--- a/.npmignore
+++ b/.npmignore
@@ -21,6 +21,7 @@ lib/**/*.ts
 lib/**/*.js.map
 
 test/
+test-scripts/
 .vscode
 lib/common/test/
 coverage/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,70 @@
+{
+	// Use IntelliSense to learn about possible Node.js debug attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Program (Node 6+)",
+			"program": "${workspaceRoot}/lib/nativescript-cli.js",
+			"cwd": "${workspaceRoot}",
+			"sourceMaps": true,
+			// define the arguments that you would like to pass to CLI, for example
+			// "args": [ "build", "android", "--justlaunch" ]
+			"args": [
+
+			]
+		},
+
+		{
+			// in case you want to debug a single test, modify it's code to be `it.only(...` instead of `it(...`
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Tests (Node 6+)",
+			"program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+			"cwd": "${workspaceRoot}",
+			"sourceMaps": true
+		},
+
+		{
+			"type": "node",
+			"runtimeArgs": [
+				"--harmony"
+			],
+			"request": "launch",
+			"name": "Launch Program (Node 4, Node 5)",
+			"program": "${workspaceRoot}/lib/nativescript-cli.js",
+			"cwd": "${workspaceRoot}",
+			"sourceMaps": true,
+			// define the arguments that you would like to pass to CLI, for example
+			// "args": [ "build", "android", "--justlaunch" ]
+			"args": [
+
+			]
+		},
+
+		{
+			// in case you want to debug a single test, modify it's code to be `it.only(...` instead of `it(...`
+			"type": "node",
+			"runtimeArgs": [
+				"--harmony"
+			],
+			"request": "launch",
+			"name": "Launch Tests (Node 4, Node 5)",
+			"program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+			"cwd": "${workspaceRoot}",
+			"sourceMaps": true
+		},
+
+		{
+			"type": "node",
+			"request": "attach",
+			"name": "Attach to Process",
+			"port": 5858,
+			"sourceMaps": true
+		}
+
+	]
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,15 +28,7 @@ module.exports = function(grunt) {
 
 		pkg: grunt.file.readJSON("package.json"),
 		ts: {
-			options: {
-				target: 'es5',
-				module: 'commonjs',
-				sourceMap: true,
-				declaration: false,
-				removeComments: false,
-				noImplicitAny: true,
-				experimentalDecorators: true
-			},
+			options: grunt.file.readJSON("tsconfig.json").compilerOptions,
 
 			devlib: {
 				src: ["lib/**/*.ts", "!lib/common/node_modules/**/*.ts"],
@@ -131,7 +123,17 @@ module.exports = function(grunt) {
 		},
 
 		clean: {
-			src: ["test/**/*.js*", "lib/**/*.js*", "!lib/common/vendor/*.js", "!lib/common/**/*.json", "!lib/common/Gruntfile.js", "!lib/common/node_modules/**/*", "!lib/common/hooks/**/*.js", "!lib/common/bin/*.js", "*.tgz"]
+			src: ["test/**/*.js*",
+				"lib/**/*.js*",
+				"!test-scripts/**/*",
+				"!lib/common/vendor/*.js",
+				"!lib/common/**/*.json",
+				"!lib/common/Gruntfile.js",
+				"!lib/common/node_modules/**/*",
+				"!lib/common/hooks/**/*.js",
+				"!lib/common/bin/*.js",
+				"!lib/common/test-scripts/**/*",
+				"*.tgz"]
 		}
 	});
 

--- a/bin/nativescript
+++ b/bin/nativescript
@@ -1,4 +1,19 @@
 #!/bin/sh
 
 AB_DIR="`dirname \"$0\"`"
-node "$AB_DIR/nativescript.js" "$@"
+NODE_VERSION=`node --version`
+NODE4_VERSION_PREFIX="v4."
+NODE5_VERSION_PREFIX="v5."
+
+# check if Node.js version is 4.x.x or 5.x.x - both of them do not support some of required features
+# so we have to pass --harmony flag for them in order to enable spread opearator usage
+# Use POSIX substring parameter expansion, so the code will work on all shells.
+
+if [ "${NODE_VERSION#$NODE4_VERSION_PREFIX*}" != "$NODE_VERSION" -o "${NODE_VERSION#$NODE5_VERSION_PREFIX*}" != "$NODE_VERSION" ]
+then
+	# Node is 4.x.x or 5.x.x
+	node --harmony "$AB_DIR/nativescript.js" "$@"
+else
+	# Node is NOT 4.x.x or 5.x.x
+	node "$AB_DIR/nativescript.js" "$@"
+fi

--- a/bin/nativescript.cmd
+++ b/bin/nativescript.cmd
@@ -1,1 +1,18 @@
-@node %~dp0\nativescript.js %*
+@for /F "delims=" %%i IN ('@node --version') DO @set node_ver=%%i
+
+@echo %node_ver% | @findstr /b /c:"v4."
+@set is_node_4=%errorlevel%
+
+@echo %node_ver% | @findstr /b /c:"v5."
+@set is_node_5=%errorlevel%
+
+@set use_harmony_flag=0
+
+@if %is_node_4% == 0 @set use_harmony_flag=1
+@if %is_node_5% == 0 @set use_harmony_flag=1
+
+@if %use_harmony_flag% == 1 (
+	return @node --harmony %~dp0\nativescript.js %*
+) else (
+	@node %~dp0\nativescript.js %*
+)

--- a/bin/tns
+++ b/bin/tns
@@ -1,4 +1,19 @@
 #!/bin/sh
 
 AB_DIR="`dirname \"$0\"`"
-node "$AB_DIR/nativescript.js" "$@"
+NODE_VERSION=`node --version`
+NODE4_VERSION_PREFIX="v4."
+NODE5_VERSION_PREFIX="v5."
+
+# check if Node.js version is 4.x.x or 5.x.x - both of them do not support some of required features
+# so we have to pass --harmony flag for them in order to enable spread opearator usage
+# Use POSIX substring parameter expansion, so the code will work on all shells.
+
+if [ "${NODE_VERSION#$NODE4_VERSION_PREFIX*}" != "$NODE_VERSION" -o "${NODE_VERSION#$NODE5_VERSION_PREFIX*}" != "$NODE_VERSION" ]
+then
+	# Node is 4.x.x or 5.x.x
+	node --harmony "$AB_DIR/nativescript.js" "$@"
+else
+	# Node is NOT 4.x.x or 5.x.x
+	node "$AB_DIR/nativescript.js" "$@"
+fi

--- a/bin/tns.cmd
+++ b/bin/tns.cmd
@@ -1,1 +1,18 @@
-@node %~dp0\nativescript.js %*
+@for /F "delims=" %%i IN ('@node --version') DO @set node_ver=%%i
+
+@echo %node_ver% | @findstr /b /c:"v4."
+@set is_node_4=%errorlevel%
+
+@echo %node_ver% | @findstr /b /c:"v5."
+@set is_node_5=%errorlevel%
+
+@set use_harmony_flag=0
+
+@if %is_node_4% == 0 @set use_harmony_flag=1
+@if %is_node_5% == 0 @set use_harmony_flag=1
+
+@if %use_harmony_flag% == 1 (
+	return @node --harmony %~dp0\nativescript.js %*
+) else (
+	@node %~dp0\nativescript.js %*
+)

--- a/lib/device-sockets/ios/socket-request-executor.ts
+++ b/lib/device-sockets/ios/socket-request-executor.ts
@@ -13,8 +13,11 @@ export class IOSSocketRequestExecutor implements IiOSSocketRequestExecutor {
 		return (() => {
 			let npc = new iOSProxyServices.NotificationProxyClient(device, this.$injector);
 
-			let [alreadyConnected, readyForAttach, attachAvailable] = [this.$iOSNotification.alreadyConnected, this.$iOSNotification.readyForAttach, this.$iOSNotification.attachAvailable]
-				.map((notification) => this.$iOSNotificationService.awaitNotification(npc, notification, timeout));
+			let data = [this.$iOSNotification.alreadyConnected, this.$iOSNotification.readyForAttach, this.$iOSNotification.attachAvailable]
+				.map((notification) => this.$iOSNotificationService.awaitNotification(npc, notification, timeout)),
+				alreadyConnected = data[0],
+				readyForAttach = data[1],
+				attachAvailable = data[2];
 
 			npc.postNotificationAndAttachForData(this.$iOSNotification.attachAvailabilityQuery);
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -53,7 +53,9 @@ export class PlatformService implements IPlatformService {
 
 	private addPlatform(platformParam: string): IFuture<void> {
 		return (() => {
-			let [platform, version] = platformParam.split("@");
+			let data = platformParam.split("@"),
+				platform = data[0],
+				version = data[1];
 
 			this.validatePlatform(platform);
 
@@ -427,7 +429,10 @@ export class PlatformService implements IPlatformService {
 	public updatePlatforms(platforms: string[]): IFuture<void> {
 		return (() => {
 			_.each(platforms, platformParam => {
-				let [platform, version] = platformParam.split("@");
+				let data = platformParam.split("@"),
+					platform = data[0],
+					version = data[1];
+
 				if (this.isPlatformInstalled(platform).wait()) {
 					this.updatePlatform(platform, version).wait();
 				} else {

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -163,7 +163,7 @@ export class PluginsService implements IPluginsService {
 				.filter(dependencyName => _.startsWith(dependencyName, "@"))
 				.each(scopedDependencyDir => {
 					let contents = this.$fs.readDirectory(path.join(this.nodeModulesPath, scopedDependencyDir)).wait();
-					installedDependencies = installedDependencies.concat(...contents.map(dependencyName => `${scopedDependencyDir}/${dependencyName}`));
+					installedDependencies = installedDependencies.concat(contents.map(dependencyName => `${scopedDependencyDir}/${dependencyName}`));
 				});
 
 			let packageJsonContent = this.$fs.readJson(this.getPackageJsonFilePath()).wait();

--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -18,7 +18,10 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 				let templateName = originalTemplateName.toLowerCase();
 
 				// support <reserved_name>@<version> syntax
-				let [name, version] = templateName.split("@");
+				let data = templateName.split("@"),
+					name = data[0],
+					version = data[1];
+
 				if(constants.RESERVED_TEMPLATE_NAMES[name]) {
 					realTemplatePath = this.prepareNativeScriptTemplate(constants.RESERVED_TEMPLATE_NAMES[name], version, projectDir).wait();
 				} else {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "main": "./lib/nativescript-cli.js",
   "scripts": {
-    "test": "node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha",
+    "test": "node test-scripts/istanbul.js",
     "postinstall": "node postinstall.js",
     "preuninstall": "node preuninstall.js",
-    "mocha": "mocha",
+    "mocha": "node test-scripts/mocha.js",
     "tsc": "tsc",
     "test-watch": "node ./dev/tsc-to-mocha-watch.js"
   },
@@ -27,7 +27,6 @@
     "mobile"
   ],
   "dependencies": {
-    "bluebird": "2.9.34",
     "bplist-parser": "0.1.0",
     "bufferpack": "0.0.6",
     "bufferutil": "https://github.com/telerik/bufferutil/tarball/v1.0.1.4",
@@ -90,7 +89,7 @@
     "grunt-ts": "6.0.0-beta.3",
     "grunt-tslint": "3.3.0",
     "istanbul": "0.4.5",
-    "mocha": "2.5.3",
+    "mocha": "3.1.2",
     "mocha-fibers": "https://github.com/NativeScript/mocha-fibers.git",
     "mocha-typescript": "^1.0.4",
     "should": "7.0.2",

--- a/test-scripts/istanbul.js
+++ b/test-scripts/istanbul.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const childProcess = require("child_process");
+const path = require("path");
+const pathToIstanbul = path.join(__dirname, "..", "node_modules", "istanbul", "lib", "cli.js");
+const pathToMocha = path.join(__dirname, "..", "node_modules", "mocha", "bin", "_mocha");
+
+const istanbulArgs = [ pathToIstanbul, "cover", pathToMocha ];
+
+const nodeArgs = require("../lib/common/test-scripts/node-args").getNodeArgs();
+
+const args = nodeArgs.concat(istanbulArgs);
+
+const nodeProcess = childProcess.spawn("node", args, { stdio: "inherit"});
+nodeProcess.on("close", (code) => {
+	// We need this handler so if any test fails, we'll exit with same exit code as istanbul.
+	process.exit(code);
+});

--- a/test-scripts/mocha.js
+++ b/test-scripts/mocha.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const childProcess = require("child_process");
+const path = require("path");
+const pathToMocha = path.join(__dirname, "..", "node_modules", "mocha", "bin", "_mocha");
+
+const nodeArgs = require("../lib/common/test-scripts/node-args").getNodeArgs();
+
+const args = nodeArgs.concat(pathToMocha);
+
+const nodeProcess = childProcess.spawn("node", args, { stdio: "inherit"});
+nodeProcess.on("close", (code) => {
+	// We need this handler so if any test fails, we'll exit with same exit code as mocha.
+	process.exit(code);
+});

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -226,14 +226,14 @@ describe('Platform Service Tests', () => {
 		}
 
 		function testPreparePlatform(platformToTest: string, release?: boolean) {
-			let { tempFolder, appFolderPath, app1FolderPath, appDestFolderPath, appResourcesFolderPath } = prepareDirStructure();
+			let testDirData = prepareDirStructure();
 
 			// Add platform specific files to app and app1 folders
 			let platformSpecificFiles = [
 				"test1.ios.js", "test1-ios-js", "test2.android.js", "test2-android-js"
 			];
 
-			let destinationDirectories = [appFolderPath, app1FolderPath];
+			let destinationDirectories = [testDirData.appFolderPath, testDirData.app1FolderPath];
 
 			_.each(destinationDirectories, directoryPath => {
 				_.each(platformSpecificFiles, filePath => {
@@ -246,10 +246,10 @@ describe('Platform Service Tests', () => {
 			platformsData.platformsNames = ["ios", "android"];
 			platformsData.getPlatformData = (platform: string) => {
 				return {
-					appDestinationDirectoryPath: appDestFolderPath,
-					appResourcesDestinationDirectoryPath: appResourcesFolderPath,
+					appDestinationDirectoryPath: testDirData.appDestFolderPath,
+					appResourcesDestinationDirectoryPath: testDirData.appResourcesFolderPath,
 					normalizedPlatformName: platformToTest,
-					projectRoot: tempFolder,
+					projectRoot: testDirData.tempFolder,
 					platformProjectService: {
 						prepareProject: () => Future.fromResult(),
 						validate: () => Future.fromResult(),
@@ -266,7 +266,7 @@ describe('Platform Service Tests', () => {
 			};
 
 			let projectData = testInjector.resolve("projectData");
-			projectData.projectDir = tempFolder;
+			projectData.projectDir = testDirData.tempFolder;
 
 			platformService = testInjector.resolve("platformService");
 			let options : IOptions = testInjector.resolve("options");
@@ -277,18 +277,18 @@ describe('Platform Service Tests', () => {
 			let test2FileName = platformToTest.toLowerCase() === "ios" ? "test2.js" : "test1.js";
 
 			// Asserts that the files in app folder are process as platform specific
-			assert.isTrue(fs.exists(path.join(appDestFolderPath, "app", test1FileName)).wait());
-			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test1-js")).wait());
+			assert.isTrue(fs.exists(path.join(testDirData.appDestFolderPath, "app", test1FileName)).wait());
+			assert.isFalse(fs.exists(path.join(testDirData.appDestFolderPath, "app", "test1-js")).wait());
 
-			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", test2FileName)).wait());
-			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app", "test2-js")).wait());
+			assert.isFalse(fs.exists(path.join(testDirData.appDestFolderPath, "app", test2FileName)).wait());
+			assert.isFalse(fs.exists(path.join(testDirData.appDestFolderPath, "app", "test2-js")).wait());
 
 			// Asserts that the files in app1 folder aren't process as platform specific
-			assert.isFalse(fs.exists(path.join(appDestFolderPath, "app1")).wait(), "Asserts that the files in app1 folder aren't process as platform specific");
+			assert.isFalse(fs.exists(path.join(testDirData.appDestFolderPath, "app1")).wait(), "Asserts that the files in app1 folder aren't process as platform specific");
 
 			if (release) {
 				// Asserts that the files in tests folder aren't copied
-				assert.isFalse(fs.exists(path.join(appDestFolderPath, "tests")).wait(), "Asserts that the files in tests folder aren't copied");
+				assert.isFalse(fs.exists(path.join(testDirData.appDestFolderPath, "tests")).wait(), "Asserts that the files in tests folder aren't copied");
 			}
 		}
 
@@ -310,20 +310,20 @@ describe('Platform Service Tests', () => {
 
 		it("invalid xml is caught", () => {
 			require("colors");
-			let { tempFolder, appFolderPath, appDestFolderPath, appResourcesFolderPath } = prepareDirStructure();
+			let testDirData = prepareDirStructure();
 
 			// generate invalid xml
-			let fileFullPath = path.join(appFolderPath, "file.xml");
+			let fileFullPath = path.join(testDirData.appFolderPath, "file.xml");
 			fs.writeFile(fileFullPath, "<xml><unclosedTag></xml>").wait();
 
 			let platformsData = testInjector.resolve("platformsData");
 			platformsData.platformsNames = ["android"];
 			platformsData.getPlatformData = (platform: string) => {
 				return {
-					appDestinationDirectoryPath: appDestFolderPath,
-					appResourcesDestinationDirectoryPath: appResourcesFolderPath,
+					appDestinationDirectoryPath: testDirData.appDestFolderPath,
+					appResourcesDestinationDirectoryPath: testDirData.appResourcesFolderPath,
 					normalizedPlatformName: "Android",
-					projectRoot: tempFolder,
+					projectRoot: testDirData.tempFolder,
 					platformProjectService: {
 						prepareProject: () => Future.fromResult(),
 						validate: () => Future.fromResult(),
@@ -340,7 +340,7 @@ describe('Platform Service Tests', () => {
 			};
 
 			let projectData = testInjector.resolve("projectData");
-			projectData.projectDir = tempFolder;
+			projectData.projectDir = testDirData.tempFolder;
 
 			platformService = testInjector.resolve("platformService");
 			let oldLoggerWarner = testInjector.resolve("$logger").warn;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es6",
 		"module": "commonjs",
 		"sourceMap": true,
 		"declaration": false,


### PR DESCRIPTION
> NOTE: Merge only after https://github.com/telerik/mobile-cli-lib/pull/843 is merged

Add support for ES6 transpilation. Change dependency injection in order to match the `class` and `constructor` keywords.
Update istanbul to latest version as its previous versions do not support ES6.

Remove bluebird.d.ts as it conflicts with Promises from TypeScript's ES6 d.ts.
Remove bluebird as dependency - we will use native Promises from now on.

Add support for Node.js 4 and 5 - both versions have limited support for ES6 features, so in order to support them we have to:
 - pass --harmony flag to Node.js
 - do not use some features like default values of method arguments.
 - do not use spread operator - it's implementation in Node.js 4 is limited only to arrays. Even this implementation has issues. So use `.apply` instead of using spread operator. Remove all other usages of spread operator (for objects).

Add tests scripts for istanbul and mocha, as they both will need the `--harmony` flag as well, so we cannot execute them directly with Node.js 4 and 5. Instead we'll execute a custom script, that will start a new node process.

Introduce `test-scripts` directory with JavaScript executables to start the tests. Set them in package.json. They are required as when Node 4 or Node 5 is used, the tests will need `--harmony` flag as well.
Exclude `test-scripts` directory from npm package (add it to `.npmignore`) - users do not need these files.

Exclude `.vscode/launch.json` from `.gitignore` and add predefined launch configurations. They can be used for debugging CLI process and unit tests.

![nativescript_launch_configs_2](https://cloud.githubusercontent.com/assets/8351653/20652851/52d096e4-b50a-11e6-8aa4-6f8c292d6c4e.png)


Part of https://github.com/NativeScript/nativescript-cli/issues/2204 