### PR TITLE
[iOS speciffic] Fix open app inspector command

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -214,7 +214,7 @@ class IOSDebugService implements IDebugService {
 	private openAppInspector(fileDescriptor: string): IFuture<void> {
 		if (this.$options.client) {
 			return (() => {
-				let inspectorPath = this.$npmInstallationManager.install(inspectorNpmPackageName, this.$projectData.projectDir).wait();
+				let inspectorPath = this.$npmInstallationManager.install(inspectorNpmPackageName, this.$projectData.projectDir, {dependencyType: "save-dev"}).wait();
 				let inspectorSourceLocation = path.join(inspectorPath, inspectorUiDir, "Main.html");
 				let inspectorApplicationPath = path.join(inspectorPath, inspectorAppName);
 


### PR DESCRIPTION
Open app inspector command installs tns-ios-inspector which needs to be saved in the package.json as a `normal` or a `dev` dependency, because we do a diff of the package json before and after the installation. 
If the newly installed package is not saved our diff logic doesn't work correctly

ping: @pkoleva @dtopuzov 