### PR TITLE
Plamen5kov/fix for ios inspector

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -229,7 +229,7 @@ class IOSDebugService implements IDebugService {
 						this.$childProcess.exec(`tar -xf ${inspectorTgzPathInCache} -C ${pathToPackageInCache}`).wait();
 						this.$childProcess.exec(`npm install --prefix ${pathToUnzippedInspector}`).wait();
 					}
-
+					this.$logger.out("Using inspector from cache.");
 					inspectorPath = pathToUnzippedInspector;
 				}
 

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -215,9 +215,24 @@ class IOSDebugService implements IDebugService {
 		if (this.$options.client) {
 			return (() => {
 				let inspectorPath = path.join(this.$projectData.projectDir, "node_modules", inspectorNpmPackageName);
+
+				// local installation takes precedence over cache
 				if(!this.inspectorAlreadyInstalled(inspectorPath).wait()) {
-					inspectorPath = this.$npmInstallationManager.install(inspectorNpmPackageName, this.$projectData.projectDir, {dependencyType: "save-dev"}).wait();
+					let cachepath = this.$childProcess.exec("npm get cache").wait().trim();
+					let version = this.$npmInstallationManager.getLatestCompatibleVersion(inspectorNpmPackageName).wait();
+					let pathToPackageInCache = path.join(cachepath, inspectorNpmPackageName, version);
+					let pathToUnzippedInspector = path.join(pathToPackageInCache, "package");
+
+					if(!this.$fs.exists(pathToPackageInCache).wait()) {
+						this.$childProcess.exec(`npm cache add ${inspectorNpmPackageName}@${version}`).wait();
+						let inspectorTgzPathInCache = path.join(pathToPackageInCache, "package.tgz");
+						this.$childProcess.exec(`tar -xf ${inspectorTgzPathInCache} -C ${pathToPackageInCache}`).wait();
+						this.$childProcess.exec(`npm install --prefix ${pathToUnzippedInspector}`).wait();
+					}
+
+					inspectorPath = pathToUnzippedInspector;
 				}
+
 				let inspectorSourceLocation = path.join(inspectorPath, inspectorUiDir, "Main.html");
 				let inspectorApplicationPath = path.join(inspectorPath, inspectorAppName);
 


### PR DESCRIPTION
Because `tns-ios-inspector` package is too big, it's a good idea to save space and not install it locally for every project.
Behavior after this PR.

_How to use inspector from cache_:
`tns debug ios`

_How to use inspector locally from node_modules_:
`npm install tns-ios-inspector`
`tns debug ios`

ping: @hdeshev @tzraikov @dtopuzov
