### PR TITLE
Break CLI process when Node is not supported

### DIFF
--- a/bin/nativescript.js
+++ b/bin/nativescript.js
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
 
 "use strict";
+var path = require("path");
+var node = require("../package.json").engines.node;
+require(path.join(__dirname, "..", "lib", "common", "verify-node-version")).verifyNodeVersion(node, "NativeScript");
+
 require("../lib/nativescript-cli.js");

--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -1,7 +1,3 @@
-let node = require("../package.json").engines.node;
-// this call must be first to avoid requiring c++ dependencies
-require("./common/verify-node-version").verifyNodeVersion(node, "NativeScript", "2.5.0");
-
 require("./bootstrap");
 import * as fiber from "fibers";
 import Future = require("fibers/future");


### PR DESCRIPTION
NOTE: Merge **only after** https://github.com/telerik/mobile-cli-lib/pull/851 is merged 
EDIT: PR in common is merged, this one can be merged.

As old versions of Node.js cannot be used anymore (after transpiling to ES6), we should break the process when such case happens.
Use only var instead of let, const, as only var keyword is supported in Node.js 0.10.x

Part of https://github.com/NativeScript/nativescript-cli/issues/2204