### PR TITLE
Use https for submodule initialization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/common"]
 	path = lib/common
-	url = git@github.com:telerik/mobile-cli-lib.git
+	url = https://github.com/telerik/mobile-cli-lib.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,10 @@ language: node_js
 node_js:
 - '4'
 git:
-  submodules: false
+  submodules: true
 before_script:
-- sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-- git submodule update --init --recursive
 - npm install grunt
 - node_modules/.bin/grunt enableScripts:false
-- npm install
 - grunt rebuild
 - ./bin/nativescript error-reporting disable # force ~/.local dir creation -- some tests rely on it
 - ./bin/nativescript usage-reporting disable
@@ -44,5 +41,5 @@ deploy:
     email: nativescript@telerik.com
     on:
       branch: master
-    api_key: 
+    api_key:
       secure: Ugq6m/y4P5gF15zffYzTKhusn1Csu3ymYLdD+yXgyK3hek9Ms5PKTz4MKgPinlViRCBoQV2fGh0JsCikawIpmQyD+M+FRDKlP2GcXPhFmSN1wVEloxTCwe7H6m7Kl9mo+MJOTS0BN7waCc6yTJBJPxo5nwFgz+DT2srIYndA2h4=


### PR DESCRIPTION
At the moment the submodule is initialized via ssh. This way the command `git submodule update --init` will work only for users who have write access to mobile-cli-lib.
This also requires custom logic when travis is used. In current implementation, travis automatically calls `npm install` before executing the scripts, but at this point the submodule is not initialized yet (as we have declared submodules variable to false).
So the `npm install` executed by travis, will fail in case the postinstall script uses some code from the submodule.
In order to fix this two changes are applied:
 - change the sumodule to be used over https instead of ssh.
 - modify .travis.yml to use submodule correctly and remove two manual steps which are executed by travis by default, there's no need the execute them again.

NOTE: In case you have two-factor authentication, you'll not be able to commit to mobile-cli-lib over https. In this case you have to:
 - remove content of lib/common dir
 - clone over ssh: `$ git clone git@github.com:telerik/mobile-cli-lib.git .` (you must be inside lib/common dir).