### PR TITLE
delete all unnecessary keys from app/package.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,17 +7,23 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Launch Program (Node 6+)",
-			"program": "${workspaceRoot}/lib/nativescript-cli.js",
-			"cwd": "${workspaceRoot}",
+			"cwd": "${workspaceRoot}/scratch",
 			"sourceMaps": true,
-			// define the arguments that you would like to pass to CLI, for example
-			// "args": [ "build", "android", "--justlaunch" ]
-			"args": [
+			"name": "Launch CLI (Node 6+)",
+			"program": "${workspaceRoot}/lib/nativescript-cli.js",
 
-			]
+			// example commands
+			"args": [ "create", "cliapp"]
+			// "args": [ "platform", "add", "android@1.3.0", "--path", "cliapp"]
+			// "args": [ "platform", "remove", "android", "--path", "cliapp"]
+			// "args": [ "plugin", "add", "nativescript-barcodescanner", "--path", "cliapp"]
+			// "args": [ "plugin", "remove", "nativescript-barcodescanner", "--path", "cliapp"]
+			// "args": [ "build", "android", "--path", "cliapp"]
+			// "args": [ "run", "android", "--path", "cliapp"]
+			// "args": [ "debug", "android", "--path", "cliapp"]
+			// "args": [ "livesync", "android", "--path", "cliapp"]
+			// "args": [ "livesync", "android", "--watch", "--path", "cliapp"]
 		},
-
 		{
 			// in case you want to debug a single test, modify it's code to be `it.only(...` instead of `it(...`
 			"type": "node",
@@ -34,7 +40,7 @@
 				"--harmony"
 			],
 			"request": "launch",
-			"name": "Launch Program (Node 4, Node 5)",
+			"name": "Launch CLI (Node 4, Node 5)",
 			"program": "${workspaceRoot}/lib/nativescript-cli.js",
 			"cwd": "${workspaceRoot}",
 			"sourceMaps": true,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -21,6 +21,8 @@ export class PackageVersion {
 	static LATEST = "latest";
 }
 
+export let PackageJsonKeysToKeep : Array<String> = ["name", "main", "android", "version"];
+
 export class SaveOptions {
 	static PRODUCTION = "save";
 	static DEV = "save-dev";

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -76,9 +76,9 @@ export class ProjectService implements IProjectService {
 			try {
 				//TODO: plamen5kov: move copy of template and npm uninstall in prepareTemplate logic
 				this.createProjectCore(projectDir, appPath, projectId).wait();
-				let templatePackageJsonData = this.getDataFromJson(appPath).wait();
-				this.mergeProjectAndTemplateProperties(projectDir, templatePackageJsonData).wait(); //merging dependencies from template (dev && prod)
-				this.removeMergedDependencies(projectDir, templatePackageJsonData).wait();
+				let templatePackageJsonData = this.getDataFromJson(appPath);
+				this.mergeProjectAndTemplateProperties(projectDir, templatePackageJsonData); //merging dependencies from template (dev && prod)
+				this.removeMergedDependencies(projectDir, templatePackageJsonData);
 				this.$npm.install(projectDir, projectDir, { "ignore-scripts": this.$options.ignoreScripts }).wait();
 				selectedTemplate = selectedTemplate || "";
 				let templateName = (constants.RESERVED_TEMPLATE_NAMES[selectedTemplate.toLowerCase()] || selectedTemplate/*user template*/) || constants.RESERVED_TEMPLATE_NAMES["default"];
@@ -95,50 +95,44 @@ export class ProjectService implements IProjectService {
 		}).future<void>()();
 	}
 
-	private getDataFromJson(templatePath: string): IFuture<any> {
-		return (() => {
-			let templatePackageJsonPath = path.join(templatePath, constants.PACKAGE_JSON_FILE_NAME);
-			if(this.$fs.exists(templatePackageJsonPath)) {
-				let templatePackageJsonData = this.$fs.readJson(templatePackageJsonPath).wait();
-				return templatePackageJsonData;
-			} else {
-				this.$logger.trace(`Template ${templatePath} does not have ${constants.PACKAGE_JSON_FILE_NAME} file.`);
-			}
-			return null;
-		}).future<void>()();
+	private getDataFromJson(templatePath: string): any {
+		let templatePackageJsonPath = path.join(templatePath, constants.PACKAGE_JSON_FILE_NAME);
+		if(this.$fs.exists(templatePackageJsonPath)) {
+			let templatePackageJsonData = this.$fs.readJson(templatePackageJsonPath);
+			return templatePackageJsonData;
+		} else {
+			this.$logger.trace(`Template ${templatePath} does not have ${constants.PACKAGE_JSON_FILE_NAME} file.`);
+		}
+		return null;
 	}
 
-	private removeMergedDependencies(projectDir: string, templatePackageJsonData: any) : IFuture<void> {
-		return (() => {
-			let extractedTemplatePackageJsonPath = path.join(projectDir, constants.APP_FOLDER_NAME, constants.PACKAGE_JSON_FILE_NAME);
-			for(let key in templatePackageJsonData) {
-				if(constants.PackageJsonKeysToKeep.indexOf(key) === -1) {
-					delete templatePackageJsonData[key];
-				}
+	private removeMergedDependencies(projectDir: string, templatePackageJsonData: any) : void {
+		let extractedTemplatePackageJsonPath = path.join(projectDir, constants.APP_FOLDER_NAME, constants.PACKAGE_JSON_FILE_NAME);
+		for(let key in templatePackageJsonData) {
+			if(constants.PackageJsonKeysToKeep.indexOf(key) === -1) {
+				delete templatePackageJsonData[key];
 			}
+		}
 
-			this.$logger.trace("Deleting unnecessary information from template json.");
-			this.$fs.writeJson(extractedTemplatePackageJsonPath, templatePackageJsonData);
-		}).future<any>()();
+		this.$logger.trace("Deleting unnecessary information from template json.");
+		this.$fs.writeJson(extractedTemplatePackageJsonPath, templatePackageJsonData);
 	}
 
-	private mergeProjectAndTemplateProperties(projectDir: string, templatePackageJsonData: any): IFuture<void> {
-		return (() => {
-			if(templatePackageJsonData) {
-				let projectPackageJsonPath = path.join(projectDir, constants.PACKAGE_JSON_FILE_NAME);
-				let projectPackageJsonData = this.$fs.readJson(projectPackageJsonPath).wait();
-				this.$logger.trace("Initial project package.json data: ", projectPackageJsonData);
-				if(projectPackageJsonData.dependencies || templatePackageJsonData.dependencies) {
-					projectPackageJsonData.dependencies = this.mergeDependencies(projectPackageJsonData.dependencies, templatePackageJsonData.dependencies);
-				}
-
-				if (projectPackageJsonData.devDependencies || templatePackageJsonData.devDependencies) {
-					projectPackageJsonData.devDependencies = this.mergeDependencies(projectPackageJsonData.devDependencies, templatePackageJsonData.devDependencies);
-				}
-				this.$logger.trace("New project package.json data: ", projectPackageJsonData);
-				this.$fs.writeJson(projectPackageJsonPath, projectPackageJsonData);
+	private mergeProjectAndTemplateProperties(projectDir: string, templatePackageJsonData: any): void {
+		if(templatePackageJsonData) {
+			let projectPackageJsonPath = path.join(projectDir, constants.PACKAGE_JSON_FILE_NAME);
+			let projectPackageJsonData = this.$fs.readJson(projectPackageJsonPath);
+			this.$logger.trace("Initial project package.json data: ", projectPackageJsonData);
+			if(projectPackageJsonData.dependencies || templatePackageJsonData.dependencies) {
+				projectPackageJsonData.dependencies = this.mergeDependencies(projectPackageJsonData.dependencies, templatePackageJsonData.dependencies);
 			}
-		}).future<void>()();
+
+			if (projectPackageJsonData.devDependencies || templatePackageJsonData.devDependencies) {
+				projectPackageJsonData.devDependencies = this.mergeDependencies(projectPackageJsonData.devDependencies, templatePackageJsonData.devDependencies);
+			}
+			this.$logger.trace("New project package.json data: ", projectPackageJsonData);
+			this.$fs.writeJson(projectPackageJsonPath, projectPackageJsonData);
+		}
 	}
 
 	private mergeDependencies(projectDependencies: IStringDictionary, templateDependencies: IStringDictionary): IStringDictionary {


### PR DESCRIPTION
See [issue](https://github.com/NativeScript/nativescript-cli/issues/2301) for more info.

_Problem_
People get confused because there are two `package.json` files, one in the root folder and one in `app/` folder. The two `package.json` files have the same dependencies and devDependencies, which is the main reason for the confusion.

_Solution_ 
The solution discussed with @valentinstoychev was to keep the `app/package.json` as simple as possible, and if possible to add some comments to each key in the `app/package.json` to explain what is the purpose of it. Because there are no comments in the `.json` format, IMO it's best to describe the functionality in the documentation.

This PR is not final and is only one possible solution. We can decide we want to apply different solution to the problem later on after a discussion. This is simply an easy fix.

Currently we keep only the `name`, `main`, `version` and `android` keys in the `app/package.json` if anyone thinks we should exclude or include more keys, please comment this PR or [this](https://github.com/NativeScript/nativescript-cli/issues/2301) issue.