### PR TITLE
Treat tns-core-modules as a normal npm module

### DIFF
--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -30,11 +30,6 @@ export class TnsModulesCopy {
 				allFiles.filter(file => minimatch(file, matchPattern, { nocase: true })).map(file => this.$fs.deleteFile(file));
 
 				shelljs.rm("-rf", path.join(tnsCoreModulesResourcePath, "node_modules"));
-
-				// TODO: The following two lines are necessary to temporarily work around hardcoded
-				// path dependencies in iOS livesync logic. Should be addressed ASAP
-				shelljs.cp("-Rf", path.join(tnsCoreModulesResourcePath, "*"), this.outputRoot);
-				shelljs.rm("-rf", tnsCoreModulesResourcePath);
 			}
 		}
 	}


### PR DESCRIPTION
**Related to** https://github.com/NativeScript/nativescript-cli/pull/2156
The *temporary* logic for extracting every single piece of `tns-core-modules` at root level of `tns_modules` is removed as discussed back during the `2.4` release.

iOS livesync logic should in turn be revised, so we can ensure it doesn't break following these changes.