### PR TITLE
Plamen5kov/respect shelljserrors

### DIFF
--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -3,6 +3,7 @@ import * as fiber from "fibers";
 import Future = require("fibers/future");
 import * as shelljs from "shelljs";
 shelljs.config.silent = true;
+shelljs.config.fatal = true;
 import {installUncaughtExceptionListener} from "./common/errors";
 installUncaughtExceptionListener(process.exit);
 

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -12,7 +12,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	private static VALUES_DIRNAME = "values";
 	private static VALUES_VERSION_DIRNAME_PREFIX = AndroidProjectService.VALUES_DIRNAME + "-v";
 	private static ANDROID_PLATFORM_NAME = "android";
-	private static MIN_RUNTIME_VERSION_WITH_GRADLE = "1.3.0";
+	private static MIN_RUNTIME_VERSION_WITH_GRADLE = "1.5.0";
 	private static REQUIRED_DEV_DEPENDENCIES = [
 		{ name: "babel-traverse", version: "^6.4.5" },
 		{ name: "babel-types", version: "^6.4.5" },
@@ -118,10 +118,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			}
 			this.copy(this.platformData.projectRoot, frameworkDir, "build.gradle settings.gradle gradle.properties build-tools", "-Rf");
 
-			if (this.useGradleWrapper(frameworkDir)) {
-				this.copy(this.platformData.projectRoot, frameworkDir, "gradle", "-R");
-				this.copy(this.platformData.projectRoot, frameworkDir, "gradlew gradlew.bat", "-f");
-			}
+			this.copy(this.platformData.projectRoot, frameworkDir, "gradle", "-R");
+			this.copy(this.platformData.projectRoot, frameworkDir, "gradlew gradlew.bat", "-f");
 
 			this.cleanResValues(targetSdkVersion, frameworkVersion);
 
@@ -156,11 +154,6 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			});
 
 		}).future<any>()();
-	}
-
-	private useGradleWrapper(frameworkDir: string): boolean {
-		let gradlew = path.join(frameworkDir, "gradlew");
-		return this.$fs.exists(gradlew);
 	}
 
 	private cleanResValues(targetSdkVersion: number, frameworkVersion: string): void {
@@ -228,7 +221,6 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 	public updatePlatform(currentVersion: string, newVersion: string, canUpdate: boolean, addPlatform?: Function, removePlatforms?: (platforms: string[]) => IFuture<void>): IFuture<boolean> {
 		return (() => {
-			// TODO: plamen5kov: drop support for project older than 1.3.0(MIN_RUNTIME_VERSION_WITH_GRADLE)
 			if (semver.eq(newVersion, AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE)) {
 				let platformLowercase = this.platformData.normalizedPlatformName.toLowerCase();
 				removePlatforms([platformLowercase.split("@")[0]]).wait();
@@ -249,7 +241,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 					buildOptions.unshift("--debug");
 				}
 				buildOptions.unshift("buildapk");
-				let gradleBin = this.useGradleWrapper(projectRoot) ? path.join(projectRoot, "gradlew") : "gradle";
+				let gradleBin = path.join(projectRoot, "gradlew");
 				if (this.$hostInfo.isWindows) {
 					gradleBin += ".bat"; // cmd command line parsing rules are weird. Avoid issues with quotes. See https://github.com/apache/cordova-android/blob/master/bin/templates/cordova/lib/builders/GradleBuilder.js for another approach
 				}
@@ -399,7 +391,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			buildOptions.unshift("clean");
 
 			let projectRoot = this.platformData.projectRoot;
-			let gradleBin = this.useGradleWrapper(projectRoot) ? path.join(projectRoot, "gradlew") : "gradle";
+			let gradleBin = path.join(projectRoot, "gradlew");
 			if (this.$hostInfo.isWindows) {
 				gradleBin += ".bat";
 			}

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -119,12 +119,9 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			}
 		}).future<void>()();
 	}
-
+	//TODO: plamen5kov: revisit this method, might have unnecessary/obsolete logic
 	public interpolateData(): IFuture<void> {
 		return (() => {
-			let infoPlistFilePath = path.join(this.platformData.projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER, `${IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER}-Info.plist`);
-			this.interpolateConfigurationFile(infoPlistFilePath).wait();
-
 			let projectRootFilePath = path.join(this.platformData.projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER);
 			// Starting with NativeScript for iOS 1.6.0, the project Info.plist file resides not in the platform project,
 			// but in the hello-world app template as a platform specific resource.
@@ -156,9 +153,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	public interpolateConfigurationFile(configurationFilePath?: string): IFuture<void> {
-		return (() => {
-			shell.sed('-i', "__CFBUNDLEIDENTIFIER__", this.$projectData.projectId, configurationFilePath || this.platformData.configurationFilePath);
-		}).future<void>()();
+		return Future.fromResult();
 	}
 
 	public afterCreateProject(projectRoot: string): void {

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -139,9 +139,6 @@ export class ProjectService implements IProjectService {
 			this.$fs.createDirectory(appDestinationPath);
 
 			shelljs.cp('-R', path.join(appSourcePath, "*"), appDestinationPath);
-			// Copy hidden files.
-			//TODO: plamen5kov: don't copy hidden files, until we find a reason to do it
-			// shelljs.cp('-R', path.join(appSourcePath, ".*"), appDestinationPath);
 
 			this.$fs.createDirectory(path.join(projectDir, "platforms"));
 

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -140,7 +140,8 @@ export class ProjectService implements IProjectService {
 
 			shelljs.cp('-R', path.join(appSourcePath, "*"), appDestinationPath);
 			// Copy hidden files.
-			shelljs.cp('-R', path.join(appSourcePath, ".*"), appDestinationPath);
+			//TODO: plamen5kov: don't copy hidden files, until we find a reason to do it
+			// shelljs.cp('-R', path.join(appSourcePath, ".*"), appDestinationPath);
 
 			this.$fs.createDirectory(path.join(projectDir, "platforms"));
 

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -86,7 +86,7 @@ describe("Debugger tests", () => {
 		let androidProjectService: IPlatformProjectService = testInjector.resolve("androidProjectService");
 		let spawnFromEventCount = childProcess.spawnFromEventCount;
 		androidProjectService.beforePrepareAllPlugins().wait();
-		assert.isTrue(childProcess.lastCommand === "gradle");
+		assert.isTrue(childProcess.lastCommand.indexOf("gradle") !== -1);
 		assert.isTrue(childProcess.lastCommandArgs[0] === "clean");
 		assert.isTrue(spawnFromEventCount === 0);
 		assert.isTrue(spawnFromEventCount + 1 === childProcess.spawnFromEventCount);

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -124,6 +124,7 @@ function setupProject(dependencies?: any): IFuture<any> {
 		let appResourcesFolderPath = path.join(appFolderPath, "App_Resources");
 		fs.createDirectory(appResourcesFolderPath);
 		fs.createDirectory(path.join(appResourcesFolderPath, "Android"));
+		fs.createDirectory(path.join(appResourcesFolderPath, "Android", "mockdir"));
 		fs.createDirectory(path.join(appFolderPath, "tns_modules"));
 
 		// Creates platforms/android folder

--- a/test/test-bootstrap.ts
+++ b/test/test-bootstrap.ts
@@ -1,5 +1,6 @@
 import * as shelljs from "shelljs";
 shelljs.config.silent = true;
+shelljs.config.fatal = true;
 global._ = require("lodash");
 global.$injector = require("../lib/common/yok").injector;
 


### PR DESCRIPTION
This PR should allow shelljs errors to be fatal and interrupt the execution of any command if necessary. The current implementation has accounted for several places where, the errors are expected and are handled accordingly.
One more thing is the minimal project template support version is upped from `1.3.0` to `1.5.0`.

This PR should be merged after: https://github.com/telerik/mobile-cli-lib/pull/861