### PR TITLE
fix behavior with old templates

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -199,7 +199,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			try {
 				shell.sed('-i', /__PACKAGE__/, this.$projectData.projectId, userAppGradleFilePath);
 			} catch(e) {
-				this.$errors.failWithoutHelp(` Error: ${e}.\nIt's possible you're using an old template. You can try updating it and try again.`);
+				this.$logger.warn(`\n${e}.\nIt's possible you're using an old template.`);
 			}
 		}).future<void>()();
 	}

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -116,7 +116,13 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			} else {
 				this.copy(this.platformData.projectRoot, frameworkDir, "src", "-R");
 			}
-			this.copy(this.platformData.projectRoot, frameworkDir, "build.gradle settings.gradle gradle.properties build-tools", "-Rf");
+			this.copy(this.platformData.projectRoot, frameworkDir, "build.gradle settings.gradle build-tools", "-Rf");
+
+			try {
+				this.copy(this.platformData.projectRoot, frameworkDir, "gradle.properties", "-Rf");
+			} catch(e) {
+				this.$logger.warn(`\n${e}\nIt's possible, the final .apk file will contain all architectures instead of the ones described in the abiFilters!\nYou can fix this by using the latest android platform.`);
+			}
 
 			this.copy(this.platformData.projectRoot, frameworkDir, "gradle", "-R");
 			this.copy(this.platformData.projectRoot, frameworkDir, "gradlew gradlew.bat", "-f");

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -190,7 +190,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 			// will replace applicationId in app/App_Resources/Android/app.gradle if it has not been edited by the user
 			let userAppGradleFilePath = path.join(this.$projectData.appResourcesDirectoryPath, this.$devicePlatformsConstants.Android, "app.gradle");
-			shell.sed('-i', /__PACKAGE__/, this.$projectData.projectId, userAppGradleFilePath);
+			try {
+				shell.sed('-i', /__PACKAGE__/, this.$projectData.projectId, userAppGradleFilePath);
+			} catch(e) {
+				this.$errors.failWithoutHelp(` Error: ${e}.\nIt's possible you're using an old template. You can try updating it and try again.`);
+			}
 		}).future<void>()();
 	}
 


### PR DESCRIPTION
This PR is to help the users understand what needs to be done, when the template they're using is old.

When there's an old template with missing `app.gradle` there's an error on copy added a verbose log that helps the user take care of updating the template.

This present's an opportunity for a known issues page in the documentation, to which we can refer when we feel the need to.

@valentinstoychev @tsonevn 