### PR TITLE
Update TypeScript to 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-shell": "1.3.0",
-    "grunt-ts": "6.0.0-beta.3",
+    "grunt-ts": "6.0.0-beta.6",
     "grunt-tslint": "3.3.0",
     "istanbul": "0.4.5",
     "mocha": "3.1.2",
@@ -96,7 +96,7 @@
     "mocha-typescript": "^1.0.4",
     "should": "7.0.2",
     "tslint": "3.15.1",
-    "typescript": "2.0.7"
+    "typescript": "2.1.4"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
 		"declaration": false,
 		"removeComments": false,
 		"noImplicitAny": true,
-		"experimentalDecorators": true
+		"experimentalDecorators": true,
+		"alwaysStrict": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
TypeScript 2.0 does not add "use strict"; in files which just declare class and does not export it. This breaks Node 4 because of the class keyword.