### PR TITLE
Fixed: tns emulate --device id not working

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -123,3 +123,5 @@ $injector.requireCommand("update", "./commands/update");
 
 $injector.require("iOSLogFilter", "./services/ios-log-filter");
 $injector.require("projectChangesService", "./services/project-changes-service");
+
+$injector.require("emulatorPlatformService", "./services/emulator-platform-service");

--- a/lib/commands/devices.ts
+++ b/lib/commands/devices.ts
@@ -1,10 +1,16 @@
 export class DevicesCommand implements ICommand {
 
-	constructor(private $stringParameter: ICommandParameter) {}
+	constructor(
+		private $stringParameter: ICommandParameter,
+		private $emulatorPlatformService: IEmulatorPlatformService,
+		private $options: IOptions) {}
 
 	public allowedParameters: ICommandParameter[] = [this.$stringParameter];
 
 	public execute(args: string[]): IFuture<void> {
+		if (this.$options.availableDevices) {
+			return this.$emulatorPlatformService.listAvailableEmulators(args[0]);
+		}
 		return $injector.resolveCommand("device").execute(args);
 	}
 }

--- a/lib/definitions/emulator-platform-service.d.ts
+++ b/lib/definitions/emulator-platform-service.d.ts
@@ -1,0 +1,16 @@
+interface IEmulatorInfo {
+    name: string;
+    version: string;
+    platform: string;
+    id: string;
+    type: string;
+    isRunning?: boolean;
+}
+
+interface IEmulatorPlatformService {
+    listAvailableEmulators(platform: string): IFuture<void>;
+    getEmulatorInfo(platform: string, nameOfId: string): IFuture<IEmulatorInfo>;
+    getiOSEmulators(): IFuture<IEmulatorInfo[]>;
+    getAndroidEmulators(): IFuture<IEmulatorInfo[]>;
+    startEmulator(info: IEmulatorInfo): IFuture<void>;
+}

--- a/lib/services/emulator-platform-service.ts
+++ b/lib/services/emulator-platform-service.ts
@@ -1,0 +1,213 @@
+import * as path from "path";
+import * as fiberBootstrap from "../common/fiber-bootstrap";
+import { createTable } from "../common/helpers";
+import Future = require("fibers/future");
+
+export class EmulatorPlatformService implements IEmulatorPlatformService {
+
+    constructor(
+        private $mobileHelper: Mobile.IMobileHelper,
+        private $childProcess: IChildProcess,
+        private $devicesService: Mobile.IDevicesService,
+        private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+        private $dispatcher: IFutureDispatcher,
+        private $options: IOptions,
+        private $logger: ILogger) {}
+
+    public startEmulator(info: IEmulatorInfo): IFuture<void> {
+        if (!info.isRunning) {
+
+            if (this.$mobileHelper.isAndroidPlatform(info.platform)) {
+                this.$options.avd = this.$options.device;
+                this.$options.device = null;
+                let platformsData: IPlatformsData = $injector.resolve("platformsData");
+                let platformData = platformsData.getPlatformData(info.platform);
+                let emulatorServices = platformData.emulatorServices;
+                emulatorServices.checkAvailability();
+                emulatorServices.checkDependencies().wait();
+                emulatorServices.startEmulator().wait();
+                this.$options.avd = null;
+                return Future.fromResult();
+            }
+
+            if (this.$mobileHelper.isiOSPlatform(info.platform)) {
+                this.stopEmulator(info.platform).wait();
+                let future = new Future<void>();
+                this.$childProcess.exec(`open -a Simulator --args -CurrentDeviceUDID ${info.id}`).wait();
+                let timeoutFunc = () => {
+                    fiberBootstrap.run(() => {
+                        info = this.getEmulatorInfo("ios", info.id).wait();
+                        if (info.isRunning) {
+                            this.$devicesService.initialize({ platform: info.platform, deviceId: info.id }).wait();
+                            let device = this.$devicesService.getDeviceByIdentifier(info.id);
+                            device.applicationManager.checkForApplicationUpdates().wait();
+                            future.return();
+                            return;
+                        }
+                        setTimeout(timeoutFunc, 2000);
+                    });
+                };
+                timeoutFunc();
+                return future;
+            }
+        }
+
+        return Future.fromResult();
+    }
+
+    private stopEmulator(platform: string): IFuture<void> {
+        if (this.$mobileHelper.isiOSPlatform(platform)) {
+            return this.$childProcess.exec("pkill -9 -f Simulator");
+        }
+        return Future.fromResult();
+    }
+
+    public getEmulatorInfo(platform: string, idOrName: string): IFuture<IEmulatorInfo> {
+        return (() => {
+
+            if (this.$mobileHelper.isAndroidPlatform(platform)) {
+                let androidEmulators = this.getAndroidEmulators().wait();
+                let found = androidEmulators.filter((info:IEmulatorInfo) => info.id === idOrName);
+                if (found.length > 0) {
+                    return found[0];
+                }
+                this.$devicesService.initialize({platform: platform, deviceId: null, skipInferPlatform: true}).wait();
+                let info:IEmulatorInfo = null;
+                let action = (device:Mobile.IDevice) => {
+                    return (() => {
+                        if (device.deviceInfo.identifier === idOrName) {
+                            info = {
+                                id: device.deviceInfo.identifier,
+                                name: device.deviceInfo.displayName,
+                                version: device.deviceInfo.version,
+                                platform: "Android",
+                                type: "emulator",
+                                isRunning: true
+                            };
+                        }
+                    }).future<void>()();
+                };
+                this.$devicesService.execute(action, undefined, {allowNoDevices: true}).wait();
+                return info;
+            }
+
+            if (this.$mobileHelper.isiOSPlatform(platform)) {
+                let emulators = this.getiOSEmulators().wait();
+                let sdk: string = null;
+                let versionStart = idOrName.indexOf("(");
+                if (versionStart > 0) {
+                    sdk = idOrName.substring(versionStart+1, idOrName.indexOf(")", versionStart)).trim();
+                    idOrName = idOrName.substring(0, versionStart-1).trim();
+                }
+                let found = emulators.filter((info:IEmulatorInfo) => {
+                let sdkMatch = sdk ? info.version === sdk : true;
+                    return sdkMatch && info.id === idOrName || info.name === idOrName;
+                });
+                return found.length>0 ? found[0] : null;
+            }
+
+            return null;
+
+        }).future<IEmulatorInfo>()();
+    }
+
+    public listAvailableEmulators(platform: string): IFuture<void> {
+		return (() => {
+            let emulators: IEmulatorInfo[] = [];
+            if (!platform || this.$mobileHelper.isiOSPlatform(platform)) {
+                let iosEmulators = this.getiOSEmulators().wait();
+                if (iosEmulators) {
+                    emulators = emulators.concat(iosEmulators);
+                }
+			}
+            if (!platform || this.$mobileHelper.isAndroidPlatform(platform)) {
+                let androidEmulators = this.getAndroidEmulators().wait();
+                if (androidEmulators) {
+                    emulators = emulators.concat(androidEmulators);
+                }
+			}
+            this.outputEmulators("\nAvailable emulators", emulators);
+            this.$logger.out("\nConnected devices & emulators");
+            $injector.resolveCommand("device").execute(platform ? [platform] : []).wait();
+		}).future<void>()();
+    }
+
+    public getiOSEmulators(): IFuture<IEmulatorInfo[]> {
+        return (()=>{
+            let output = this.$childProcess.exec("xcrun simctl list --json").wait();
+            let list = JSON.parse(output);
+            let emulators: IEmulatorInfo[] = [];
+            for (let osName in list["devices"]) {
+                if (osName.indexOf("iOS") === -1) {
+                    continue;
+                }
+                let os = list["devices"][osName];
+                let version = this.parseiOSVersion(osName);
+                for (let device of os) {
+                    if (device["availability"] !== "(available)") {
+                        continue;
+                    }
+                    let emulatorInfo: IEmulatorInfo = {
+                        id: device["udid"],
+                        name: device["name"],
+                        isRunning: device["state"] === "Booted",
+                        type: "simulator",
+                        version: version,
+                        platform: "iOS"
+                    };
+                    emulators.push(emulatorInfo);
+                }
+            }
+            return emulators;
+        }).future<IEmulatorInfo[]>()();
+    }
+
+    public getAndroidEmulators(): IFuture<IEmulatorInfo[]> {
+        return (() => {
+            let androidPath = path.join(process.env.ANDROID_HOME, "tools", "android");
+            let text:string = this.$childProcess.exec(`${androidPath} list avd`).wait();
+            let notLoadedIndex = text.indexOf("The following");
+            if (notLoadedIndex > 0) {
+                text = text.substring(0, notLoadedIndex);
+            }
+            let textBlocks = text.split("---------");
+            let emulators: IEmulatorInfo[] = [];
+            for (let block of textBlocks) {
+                let lines = block.split("\n");
+                let info:IEmulatorInfo = { name: "", version: "", id: "",  platform: "Android", type: "Emulator" };
+                for (let line of lines) {
+                    if (line.indexOf("Target") >= 0) {
+                        info.version = line.substring(line.indexOf(":")+1).replace("Android", "").trim();
+                    }
+                    if (line.indexOf("Name") >= 0) {
+                        info.id = line.substring(line.indexOf(":")+1).trim();
+                    }
+                    if (line.indexOf("Device") >= 0) {
+                        info.name = line.substring(line.indexOf(":")+1).trim();
+                    }
+                    info.isRunning = false;
+                }
+                emulators.push(info);
+            }
+            return emulators;
+        }).future<IEmulatorInfo[]>()();
+    }
+
+    private parseiOSVersion(osName: string): string {
+        osName = osName.replace("com.apple.CoreSimulator.SimRuntime.iOS-", "");
+        osName = osName.replace(/-/g, ".");
+        osName = osName.replace("iOS", "");
+        osName = osName.trim();
+        return osName;
+    }
+
+    private outputEmulators(title: string, emulators: IEmulatorInfo[]) {
+        this.$logger.out(title);
+        let table: any = createTable(["Device Name", "Platform", "Version", "Device Identifier"], []);
+        for (let info of emulators) {
+            table.push([info.name, info.platform, info.version, info.id]);
+        }
+        this.$logger.out(table.toString());
+    }
+}
+$injector.register("emulatorPlatformService", EmulatorPlatformService);

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -79,7 +79,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("xmlValidator", XmlValidator);
 	testInjector.register("config", StaticConfigLib.Configuration);
 	testInjector.register("projectChangesService", ProjectChangesLib.ProjectChangesService);
-
+	testInjector.register("emulatorPlatformService", stubs.EmulatorPlatformService);
 	return testInjector;
 }
 

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -141,7 +141,7 @@ function createTestInjector() {
 	testInjector.register("npm", {});
 	testInjector.register("childProcess", ChildProcessLib.ChildProcess);
 	testInjector.register("projectChangesService", ProjectChangesLib.ProjectChangesService);
-
+	testInjector.register("emulatorPlatformService", stubs.EmulatorPlatformService);
 	return testInjector;
 }
 

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -80,6 +80,7 @@ function createTestInjector() {
 	});
 	testInjector.register("childProcess", ChildProcessLib.ChildProcess);
 	testInjector.register("projectChangesService", ProjectChangesLib.ProjectChangesService);
+	testInjector.register("emulatorPlatformService", stubs.EmulatorPlatformService);
 
 	return testInjector;
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -660,3 +660,25 @@ export class PlatformServiceStub implements IPlatformService {
 		return Future.fromResult("");
 	}
 }
+
+export class EmulatorPlatformService implements IEmulatorPlatformService {
+	public listAvailableEmulators(platform: string): IFuture<void> {
+		return Future.fromResult();
+	}
+
+	public getEmulatorInfo(platform: string, nameOfId: string): IFuture<IEmulatorInfo> {
+		return Future.fromResult(null);
+	}
+
+    public getiOSEmulators(): IFuture<IEmulatorInfo[]> {
+		return Future.fromResult(null);
+	}
+
+    public getAndroidEmulators(): IFuture<IEmulatorInfo[]> {
+		return Future.fromResult(null);
+	}
+
+    public startEmulator(info: IEmulatorInfo): IFuture<void> {
+		return Future.fromResult();
+	}
+}


### PR DESCRIPTION
Fixed: Devices services not initialized! error when executing `tns emulate ios`
Fixed: cannot specify which emulator to start 