### PR TITLE
Fixed: Show error message when --device <device id> is invalid

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -458,6 +458,7 @@ export class PlatformService implements IPlatformService {
 		if (this.$options.availableDevices) {
 			return this.$emulatorPlatformService.listAvailableEmulators(platform);
 		}
+		this.$options.emulator = true;
 		if (this.$options.device) {
 			let info = this.$emulatorPlatformService.getEmulatorInfo(platform, this.$options.device).wait();
 			if (info) {
@@ -465,9 +466,17 @@ export class PlatformService implements IPlatformService {
 					this.$emulatorPlatformService.startEmulator(info).wait();
 				}
 				this.$options.device = null;
+			} else {
+				this.$devicesService.initialize({ platform: platform, deviceId: this.$options.device }).wait();
+				let found: Mobile.IDeviceInfo[] = [];
+				if (this.$devicesService.hasDevices) {
+					found = this.$devicesService.getDevices().filter((device:Mobile.IDeviceInfo) => device.identifier === this.$options.device);
+				}
+				if (found.length === 0) {
+					this.$errors.fail("Cannot find device with name: %s", this.$options.device);
+				}
 			}
 		}
-		this.$options.emulator = true;
 		this.deployPlatform(platform).wait();
 		return this.runPlatform(platform);
 	}


### PR DESCRIPTION
CLI should exit and show error message when using the following command:
`tns emulate android --device <device_id>`
and when device_id points to a non existing emulator.