### PR TITLE
Fix support for Node.js 4

### DIFF
--- a/lib/services/ios-provision-service.ts
+++ b/lib/services/ios-provision-service.ts
@@ -17,7 +17,8 @@ export class IOSProvisionService {
 
 	public pick(uuidOrName: string): IFuture<mobileprovision.provision.MobileProvision> {
 		return (() => {
-			const { match } = this.queryProvisioningProfilesAndDevices().wait();
+			const match = this.queryProvisioningProfilesAndDevices().wait().match;
+
 			return match.eligable.find(prov => prov.UUID === uuidOrName)
 				|| match.eligable.find(prov => prov.Name === uuidOrName)
 				|| match.nonEligable.find(prov => prov.UUID === uuidOrName)
@@ -27,7 +28,9 @@ export class IOSProvisionService {
 
 	public list(): IFuture<void> {
 		return (() => {
-			const { devices, match } = this.queryProvisioningProfilesAndDevices().wait();
+			const data = this.queryProvisioningProfilesAndDevices().wait(),
+				devices = data.devices,
+				match = data.match;
 
 			function formatSupportedDeviceCount(prov: mobileprovision.provision.MobileProvision) {
 				if (devices.length > 0 && prov.Type === "Development") {


### PR DESCRIPTION
As the code is transpiled to ES6, spread operator from TypeScript is transpiled to spread operator in JavaScript.
However this usage is not available in Node.js 4:
```TypeScript
let { normalizedPropertyName, projectConfigurations } = this.validateUpdatePropertyInfo(propertyName, propertyValues, configurations);

// Replaced with:
let data = this.validateUpdatePropertyInfo(propertyName, propertyValues, configurations),
	normalizedPropertyName = data.normalizedPropertyName,
	projectConfigurations = data.projectConfigurations;
```

This is limitation of Node.js 4 itself. Spread operator is not available there (it's available only for arrays, i.e.
```JavaScript
const arr = [ 1, 2, 3 ]
console.log([ 0, ...arr ]);
	[ 0, 1, 2, 3 ]
```