### PR TITLE
Fixed: the app doesn't exit when using --release and --justlaunch

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -438,6 +438,9 @@ export class PlatformService implements IPlatformService {
 
 	public runPlatform(platform: string): IFuture<void> {
 		return (() => {
+			if (this.$options.justlaunch) {
+				this.$options.watch = false;
+			}
 			this.$logger.out("Starting...");
 			let action = (device: Mobile.IDevice) => {
 				return (() => {


### PR DESCRIPTION
The following command doesn't exit: `tns run ios --release --justlaunch` because of the watch option that is enabled by default.