### PR TITLE
Fixed: debug exits unexpected when using --chrome and --watch options

### DIFF
--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -117,7 +117,9 @@ export class SocketProxyFactory implements ISocketProxyFactory {
 
 			webSocket.on("close", () => {
 				this.$logger.info('Frontend socket closed!');
-				process.exit(0);
+				if (!this.$options.watch) {
+					process.exit(0);
+				}
 			});
 
 		});


### PR DESCRIPTION
Debug should stay connected and watch for changes when executing:
`tns debug ios --chrome --watch`