### PR TITLE
Fixed: .nsbuildinfo/.nslivesyncinfo files should be app specific

### DIFF
--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -223,7 +223,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 		if (deviceAppData.device.deviceInfo.platform.toLowerCase() === this.$devicePlatformsConstants.Android.toLowerCase()) {
 			deviceRootPath = path.dirname(deviceRootPath);
 		}
-		let deviceFilePath = path.join(deviceRootPath, livesyncInfoFileName);
+		let deviceFilePath = path.join(deviceRootPath, livesyncInfoFileName + this.$projectData.projectId);
 		return deviceFilePath;
 	}
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -498,7 +498,7 @@ export class PlatformService implements IPlatformService {
 		if (device.deviceInfo.platform.toLowerCase() === this.$devicePlatformsConstants.Android.toLowerCase()) {
 			deviceRootPath = path.dirname(deviceRootPath);
 		}
-		return path.join(deviceRootPath, buildInfoFileName);
+		return path.join(deviceRootPath, buildInfoFileName + this.$projectData.projectId);
 	}
 
 	private getDeviceBuildInfo(device: Mobile.IDevice): IFuture<IBuildInfo> {


### PR DESCRIPTION
Currently .nsbuildinfo and .nslivesyncinfo files were written in global device folder instead of app specific folders. This will cause issues when deploying different {N} apps on the same device. Currently we can't write those files in app sandbox folder. This commit adds the app id as a  suffix to the corresponding file. We will continue searching for a better solution.