### PR TITLE
Use node.d.ts from @types

### DIFF
--- a/lib/definitions/ws.d.ts
+++ b/lib/definitions/ws.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Paul Loyd <https://github.com/loyd>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../common/definitions/node.d.ts" />
-
 declare module "ws" {
     import events = require('events');
     import http   = require('http');
@@ -69,21 +67,21 @@ declare module "ws" {
         addEventListener(method: string, listener?: () => void): void;
 
         // Events
-        on(event: 'error', cb: (err: Error) => void): WebSocket;
-        on(event: 'close', cb: (code: number, message: string) => void): WebSocket;
-        on(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
-        on(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
-        on(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
-        on(event: 'open', cb: () => void): WebSocket;
-        on(event: string, listener: () => void): WebSocket;
-        
-        addListener(event: 'error', cb: (err: Error) => void): WebSocket;
-        addListener(event: 'close', cb: (code: number, message: string) => void): WebSocket;
-        addListener(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
-        addListener(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
-        addListener(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): WebSocket;
-        addListener(event: 'open', cb: () => void): WebSocket;
-        addListener(event: string, listener: () => void): WebSocket;
+        on(event: 'error', cb: (err: Error) => void): this;
+        on(event: 'close', cb: (code: number, message: string) => void): this;
+        on(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): this;
+        on(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): this;
+        on(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): this;
+        on(event: 'open', cb: () => void): this;
+        on(event: string, listener: () => void): this;
+
+        addListener(event: 'error', cb: (err: Error) => void): this;
+        addListener(event: 'close', cb: (code: number, message: string) => void): this;
+        addListener(event: 'message', cb: (data: any, flags: {binary: boolean}) => void): this;
+        addListener(event: 'ping', cb: (data: any, flags: {binary: boolean}) => void): this;
+        addListener(event: 'pong', cb: (data: any, flags: {binary: boolean}) => void): this;
+        addListener(event: 'open', cb: () => void): this;
+        addListener(event: string, listener: () => void): this;
     }
 
     module WebSocket {
@@ -115,15 +113,15 @@ declare module "ws" {
                           upgradeHead: Buffer, callback: (client: WebSocket) => void): void;
 
             // Events
-            on(event: 'error', cb: (err: Error) => void): Server;
-            on(event: 'headers', cb: (headers: string[]) => void): Server;
-            on(event: 'connection', cb: (client: WebSocket) => void): Server;
-            on(event: string, listener: () => void): Server;
-            
-            addListener(event: 'error', cb: (err: Error) => void): Server;
-            addListener(event: 'headers', cb: (headers: string[]) => void): Server;
-            addListener(event: 'connection', cb: (client: WebSocket) => void): Server;
-            addListener(event: string, listener: () => void): Server;
+            on(event: 'error', cb: (err: Error) => void): this;
+            on(event: 'headers', cb: (headers: string[]) => void): this;
+            on(event: 'connection', cb: (client: WebSocket) => void): this;
+            on(event: string, listener: () => void): this;
+
+            addListener(event: 'error', cb: (err: Error) => void): this;
+            addListener(event: 'headers', cb: (headers: string[]) => void): this;
+            addListener(event: 'connection', cb: (client: WebSocket) => void): this;
+            addListener(event: string, listener: () => void): this;
         }
 
         export function createServer(options?: IServerOptions,

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
   "devDependencies": {
     "@types/chai": "3.4.34",
     "@types/chai-as-promised": "0.0.29",
+    "@types/lodash": "4.14.50",
+    "@types/node": "6.0.61",
     "@types/source-map": "0.5.0",
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -101,7 +101,7 @@ export class FileSystemStub implements IFileSystem {
 
 	openFile(filename: string): void { }
 
-	createReadStream(path: string, options?: { flags?: string; encoding?: string; fd?: string; mode?: number; bufferSize?: number }): any {
+	createReadStream(path: string, options?: { flags?: string; encoding?: string; fd?: number; mode?: number; bufferSize?: number }): any {
 		return undefined;
 	}
 

--- a/test/test-bootstrap.ts
+++ b/test/test-bootstrap.ts
@@ -1,13 +1,18 @@
 import * as shelljs from "shelljs";
+import { use } from "chai";
+
 shelljs.config.silent = true;
 shelljs.config.fatal = true;
-global._ = require("lodash");
-global.$injector = require("../lib/common/yok").injector;
-import { use } from "chai";
+
+const cliGlobal = <ICliGlobal>global;
+
+cliGlobal._ = require("lodash");
+cliGlobal.$injector = require("../lib/common/yok").injector;
+
 use(require("chai-as-promised"));
 
 $injector.register("analyticsService", {
-	trackException: (): {wait(): void} => {
+	trackException: (): { wait(): void } => {
 		return {
 			wait: () => undefined
 		};


### PR DESCRIPTION
Currently we are using `node.d.ts` from version `0.11.x`. In order to get latest updates, remove our own version of node.d.ts and use the one from `@types`. Use the version for Node 6.
Fix code according to new definitions. Introduce ICliGlobal interface in order to describe the global object that's used from CLI (we add some properties to the global object).
Add definition file for `xmlhttprequest` module.
Add definitions for Eqatec Analytics.
Modify `ws.d.ts` according to latest changes.