### PR TITLE
clean-up after release build in android to prevent runtime errors

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -163,6 +163,12 @@ interface IPlatformProjectService {
 	 * @returns {void}
 	 */
 	ensureConfigurationFileInAppResources(): void;
+
+	/**
+	 * Removes build artifacts specific to the platform
+	 * @returns {void}
+	 */
+	cleanProject(projectRoot: string, options: string[]): IFuture<void>
 }
 
 interface IAndroidProjectPropertiesManager {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -410,7 +410,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		return Future.fromResult();
 	}
 
-	private cleanProject(projectRoot: string, options: string[]): IFuture<void> {
+	public cleanProject(projectRoot: string, options: string[]): IFuture<void> {
 		return (() => {
 			options.unshift("clean");
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -653,8 +653,13 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 				this.platformData.configurationFileName
 			);
 	}
+
 	public ensureConfigurationFileInAppResources(): void {
 		return null;
+	}
+
+	public cleanProject(projectRoot: string, options: string[]): IFuture<void> {
+		return Future.fromResult();
 	}
 
 	private mergeInfoPlists(): IFuture<void> {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -217,6 +217,16 @@ export class PlatformService implements IPlatformService {
 			this.ensurePlatformInstalled(platform).wait();
 			let changesInfo = this.$projectChangesService.checkForChanges(platform);
 			if (changesInfo.hasChanges) {
+				// android build artifacts need to be cleaned up when switching from release to debug builds
+				if (platform.toLowerCase() === "android") {
+					let previousPrepareInfo = this.$projectChangesService.getPrepareInfo(platform);
+					// clean up prepared plugins when not building for release
+					if (previousPrepareInfo && previousPrepareInfo.release !== this.$options.release) {
+						let platformData = this.$platformsData.getPlatformData(platform);
+						platformData.platformProjectService.cleanProject(platformData.projectRoot, []).wait();
+					}
+				}
+
 				this.preparePlatformCore(platform, changesInfo).wait();
 				this.$projectChangesService.savePrepareInfo(platform);
 			} else {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -338,6 +338,9 @@ export class PlatformProjectServiceStub implements IPlatformProjectService {
 	ensureConfigurationFileInAppResources(): void {
 		return null;
 	}
+	cleanProject(projectRoot: string, options: string[]): IFuture<void> {
+		return Future.fromResult();
+	}
 }
 
 export class ProjectDataService implements IProjectDataService {


### PR DESCRIPTION
If app's built with the `--release` option, the settings are recorded in `.nsprepareinfo` in the `platforms/android` directory. If the file is present, and follow up builds are not built in release, then the project directory is cleaned manually to ensure that no build artifacts specific to just release (like the android snapshot binaries) are packaged into the debug application.

File changes:
- exposed an android-specific private method as public to the `IPlatformProjectService` and created a stub on the ios side.
- added conditions to clean the build directories on prepare when targeting `android`

**Addresses** https://github.com/NativeScript/nativescript-cli/issues/2443