### PR TITLE
added missing action so debug is enabled right after the first command

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -107,7 +107,7 @@ class LiveSyncService implements ILiveSyncService {
 			watchForChangeActions.push((event: string, filePath: string, dispatcher: IFutureDispatcher) =>
 				service.partialSync(event, filePath, dispatcher, applicationReloadAction));
 
-			await service.fullSync();
+			await service.fullSync(applicationReloadAction);
 		}
 
 		if (this.$options.watch && !this.$options.justlaunch) {


### PR DESCRIPTION
_Problem:_
When the command `tns debug android` is ran the expected behavior is
* application is started
* debug is started
* link is shown to the user so that he can open it in chrome and start debugging

Currently the debugger is not started and link is not shown

_Solution:_
While refactoring an argument was forgotten, and this causes the behavior described above.
* added forgotten argument (`applicationReloadAction`) in [this line](https://github.com/NativeScript/nativescript-cli/blob/c851b88c98ec53a00a589eea9a90a8e971f2afd8/lib/services/livesync/livesync-service.ts#L110) and everything is working as expected.

ping @rosen-vladimirov 