### PR TITLE
Fix upgrade of CLI

### DIFF
--- a/bin/nativescript.js
+++ b/bin/nativescript.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("./tns");


### PR DESCRIPTION
At the moment when you have CLI 2.4.x and you try installing newer version (2.5.x), installation fails with EEXIST error for bin/tns. The problem is that in 2.5.0 we've tried to simplify the files that we have in CLI's bin dir.
However `npm` acts a little bit strange to these changes. In NativeScript 2.4.x, when CLI is installed globally, npm makes symlink to CLI's `bin/nativescript.js` file. We've removed this file, and in version 2.5.x the symlink should point to `bin/tns` file. However during upgrade (when you have version 2.4.x or earlier installed globally) npm does not delete the symlink to `bin/nativescript.js` and later fails.
This can be fixed by manually uninstalling 2.4.x version and installing 2.5.x after that.
In order to allow upgrade to version 2.5.x when you already have earlier version installed, get back the `bin/nativescript.js` file. This way npm successfully creates the new symlink to `bin/tns`. We can delete the `bin/nativescript.js` in 2.6.x or later.

The problem is reproducible with specific npm versions, for example 3.10.10 works fine, but 3.10.8 throws the exception.