### PR TITLE
fix for #2460

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -430,7 +430,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	private async addFramework(frameworkPath: string): Promise<void> {
 		await this.validateFramework(frameworkPath);
 
-		let project = this.createPbxProj();
 		let frameworkName = path.basename(frameworkPath, path.extname(frameworkPath));
 		let frameworkBinaryPath = path.join(frameworkPath, frameworkName);
 		let isDynamic = _.includes((await this.$childProcess.spawnFromEvent("otool", ["-Vh", frameworkBinaryPath], "close")).stdout, " DYLIB ");
@@ -442,6 +441,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		}
 
 		let frameworkRelativePath = '$(SRCROOT)/' + this.getLibSubpathRelativeToProjectPath(frameworkPath);
+		let project = this.createPbxProj();
 		project.addFramework(frameworkRelativePath, frameworkAddOptions);
 		this.savePbxProj(project);
 


### PR DESCRIPTION
_Problem:_
See more in [this](https://github.com/NativeScript/nativescript-cli/issues/2460) issue.
Because of the way promises are executed, a new project was created twice and was overridden twice with only one framework file being added each time. The proper implementation reads the previously changed `.proj` file and augments it with the new `.framework` file.