### PR TITLE
fix for  #2460

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -110,7 +110,7 @@ export class PluginsService implements IPluginsService {
 		let appFolderExists = this.$fs.exists(path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME));
 		if (appFolderExists) {
 			this.preparePluginScripts(pluginData, platform);
-			this.preparePluginNativeCode(pluginData, platform);
+			await this.preparePluginNativeCode(pluginData, platform);
 
 			// Show message
 			this.$logger.out(`Successfully prepared plugin ${pluginData.name} for ${platform}.`);


### PR DESCRIPTION
Problem:
See more in this issue.
Because of the way promises are executed, a new project was created twice and was overridden twice with only one framework file being added each time. The proper implementation reads the previously changed .proj file and augments it with the new .framework file.

Fix for:  https://github.com/NativeScript/nativescript-cli/issues/2460