### PR TITLE
node_modules is not watched by default

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -39,7 +39,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			bundle: { type: OptionType.Boolean },
 			all: { type: OptionType.Boolean },
 			teamId: { type: OptionType.String },
-			syncAllFiles: { type: OptionType.Boolean, default: true },
+			syncAllFiles: { type: OptionType.Boolean, default: false },
 			liveEdit: { type: OptionType.Boolean },
 			chrome: { type: OptionType.Boolean },
 			clean: { type: OptionType.Boolean },

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -3,6 +3,8 @@ import * as helpers from "../../common/helpers";
 import * as path from "path";
 import * as semver from "semver";
 import * as fiberBootstrap from "../../common/fiber-bootstrap";
+import { NodeModulesDependenciesBuilder } from "../../tools/node-modules/node-modules-dependencies-builder";
+
 let choki = require("chokidar");
 
 class LiveSyncService implements ILiveSyncService {
@@ -117,7 +119,19 @@ class LiveSyncService implements ILiveSyncService {
 
 	private partialSync(syncWorkingDirectory: string, onChangedActions: ((event: string, filePath: string, dispatcher: IFutureDispatcher) => void )[]): void {
 		let that = this;
-		let pattern = ["app", "package.json", "node_modules"];
+		let dependenciesBuilder = this.$injector.resolve(NodeModulesDependenciesBuilder, {});
+		let productionDependencies = dependenciesBuilder.getProductionDependencies(this.$projectData.projectDir);
+		let pattern = ["app"];
+
+		if(this.$options.syncAllFiles) {
+			pattern.push("package.json");
+
+			// watch only production node_module/packages same one prepare uses
+			for(let index in productionDependencies) {
+				pattern.push("node_modules/" + productionDependencies[index].name);
+			}
+		}
+
 		let watcher = choki.watch(pattern, { ignoreInitial: true, cwd: syncWorkingDirectory }).on("all", (event: string, filePath: string) => {
 			fiberBootstrap.run(() => {
 				that.$dispatcher.dispatch(() => (() => {


### PR DESCRIPTION
If you want to watch for changes in node_modules or package.json a --sync-all-files or --syncAllFiles flag needs to be passed. By default only the app/ folder is being watched during any livesync.

Furthermore even with the --syncAllFiles flag enabled only production dependencies will be watched and livesynced.