### PR TITLE
Add tracking for the project types that users are creating and working with

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -142,6 +142,14 @@ interface IPlatformService {
 	 * @returns {string} The contents of the file or null when there is no such file.
 	 */
 	readFile(device: Mobile.IDevice, deviceFilePath: string): Promise<string>;
+
+	/**
+	 * Sends information to analytics for current project type.
+	 * The information is sent once per process for each project.
+	 * In long living process, where the project may change, each of the projects will be tracked after it's being opened.
+	 * @returns {Promise<void>}
+	 */
+	trackProjectType(): Promise<void>;
 }
 
 interface IPlatformData {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -53,8 +53,10 @@ interface IProjectData {
 	projectFilePath: string;
 	projectId?: string;
 	dependencies: any;
+	devDependencies: IStringDictionary;
 	appDirectoryPath: string;
 	appResourcesDirectoryPath: string;
+	projectType: string;
 }
 
 interface IProjectDataService {

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -102,6 +102,8 @@ class LiveSyncService implements ILiveSyncService {
 
 	@helpers.hook('livesync')
 	private async liveSyncCore(liveSyncData: ILiveSyncData[], applicationReloadAction: (deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => Promise<void>): Promise<void> {
+		await this.$platformService.trackProjectType();
+
 		let watchForChangeActions: ((event: string, filePath: string, dispatcher: IFutureDispatcher) => Promise<void>)[] = [];
 
 		for (let dataItem of liveSyncData) {

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -79,6 +79,10 @@ function createTestInjector(): IInjector {
 	testInjector.register("config", StaticConfigLib.Configuration);
 	testInjector.register("projectChangesService", ProjectChangesLib.ProjectChangesService);
 	testInjector.register("emulatorPlatformService", stubs.EmulatorPlatformService);
+	testInjector.register("analyticsService", {
+		track: async () => undefined
+	});
+
 	return testInjector;
 }
 

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -136,6 +136,10 @@ function createTestInjector() {
 	testInjector.register("childProcess", ChildProcessLib.ChildProcess);
 	testInjector.register("projectChangesService", ProjectChangesLib.ProjectChangesService);
 	testInjector.register("emulatorPlatformService", stubs.EmulatorPlatformService);
+	testInjector.register("analyticsService", {
+		track: async () => undefined
+	});
+
 	return testInjector;
 }
 

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -76,6 +76,9 @@ function createTestInjector() {
 	testInjector.register("childProcess", ChildProcessLib.ChildProcess);
 	testInjector.register("projectChangesService", ProjectChangesLib.ProjectChangesService);
 	testInjector.register("emulatorPlatformService", stubs.EmulatorPlatformService);
+	testInjector.register("analyticsService", {
+		track: async () => undefined
+	});
 
 	return testInjector;
 }

--- a/test/project-data.ts
+++ b/test/project-data.ts
@@ -1,0 +1,77 @@
+import { ProjectData } from "../lib/project-data";
+import { Yok } from "../lib/common/yok";
+import { assert } from "chai";
+import * as stubs from "./stubs";
+import * as path from "path";
+
+describe("projectData", () => {
+	const createTestInjector = (): IInjector => {
+		const testInjector = new Yok();
+
+		testInjector.register("projectHelper", {
+			projectDir: null,
+			sanitizeName: (name: string) => name
+		});
+
+		testInjector.register("fs", {
+			exists: () => true,
+			readJson: (): any => null
+		});
+
+		testInjector.register("staticConfig", {
+			CLIENT_NAME_KEY_IN_PROJECT_FILE: "nativescript",
+			PROJECT_FILE_NAME: "package.json"
+		});
+
+		testInjector.register("errors", stubs.ErrorsStub);
+
+		testInjector.register("logger", stubs.LoggerStub);
+
+		testInjector.register("options", {});
+
+		testInjector.register("projectData", ProjectData);
+
+		return testInjector;
+	};
+
+	describe("projectType", () => {
+
+		const assertProjectType = (dependencies: any, devDependencies: any, expectedProjecType: string) => {
+			const testInjector = createTestInjector();
+			const fs = testInjector.resolve("fs");
+			fs.exists = (filePath: string) => filePath && path.basename(filePath) === "package.json";
+
+			fs.readJson = () => ({
+				nativescript: {},
+				dependencies: dependencies,
+				devDependencies: devDependencies
+			});
+
+			const projectHelper: IProjectHelper = testInjector.resolve("projectHelper");
+			projectHelper.projectDir = "projectDir";
+
+			const projectData: IProjectData = testInjector.resolve("projectData");
+			assert.deepEqual(projectData.projectType, expectedProjecType);
+		};
+
+		it("detects project as Angular when @angular/core exists as dependency", () => {
+			assertProjectType({ "@angular/core": "*" }, null, "Angular");
+		});
+
+		it("detects project as Angular when nativescript-angular exists as dependency", () => {
+			assertProjectType({ "nativescript-angular": "*" }, null, "Angular");
+		});
+
+		it("detects project as TypeScript when nativescript-dev-typescript exists as dependency", () => {
+			assertProjectType(null, { "nativescript-dev-typescript": "*" }, "Pure TypeScript");
+		});
+
+		it("detects project as TypeScript when typescript exists as dependency", () => {
+			assertProjectType(null, { "typescript": "*" }, "Pure TypeScript");
+		});
+
+		it("detects project as JavaScript when no other project type is detected", () => {
+			assertProjectType(null, null, "Pure JavaScript");
+		});
+	});
+});

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -154,8 +154,10 @@ describe("Project Service Tests", () => {
 				"readme": "dummy",
 				"repository": "dummy"
 			});
-			await npmInstallationManager.install("tns-template-hello-world", defaultTemplateDir, { dependencyType: "save" });
-			defaultTemplatePath = path.join(defaultTemplateDir, "node_modules", "tns-template-hello-world");
+
+			await npmInstallationManager.install(constants.RESERVED_TEMPLATE_NAMES["default"], defaultTemplateDir, { dependencyType: "save" });
+			defaultTemplatePath = path.join(defaultTemplateDir, "node_modules", constants.RESERVED_TEMPLATE_NAMES["default"]);
+
 			fs.deleteDirectory(path.join(defaultTemplatePath, "node_modules"));
 
 			let defaultSpecificVersionTemplateDir = temp.mkdirSync("defaultTemplateSpeciffic");
@@ -167,8 +169,10 @@ describe("Project Service Tests", () => {
 				"readme": "dummy",
 				"repository": "dummy"
 			});
-			await npmInstallationManager.install("tns-template-hello-world", defaultSpecificVersionTemplateDir, { version: "1.4.0", dependencyType: "save" });
-			defaultSpecificVersionTemplatePath = path.join(defaultSpecificVersionTemplateDir, "node_modules", "tns-template-hello-world");
+
+			await npmInstallationManager.install(constants.RESERVED_TEMPLATE_NAMES["default"], defaultSpecificVersionTemplateDir, { version: "1.4.0", dependencyType: "save" });
+			defaultSpecificVersionTemplatePath = path.join(defaultSpecificVersionTemplateDir, "node_modules", constants.RESERVED_TEMPLATE_NAMES["default"]);
+
 			fs.deleteDirectory(path.join(defaultSpecificVersionTemplatePath, "node_modules"));
 
 			let angularTemplateDir = temp.mkdirSync("angularTemplate");
@@ -180,8 +184,10 @@ describe("Project Service Tests", () => {
 				"readme": "dummy",
 				"repository": "dummy"
 			});
-			await npmInstallationManager.install("tns-template-hello-world-ng", angularTemplateDir, { dependencyType: "save" });
-			angularTemplatePath = path.join(angularTemplateDir, "node_modules", "tns-template-hello-world-ng");
+
+			await npmInstallationManager.install(constants.RESERVED_TEMPLATE_NAMES["angular"], angularTemplateDir, { dependencyType: "save" });
+			angularTemplatePath = path.join(angularTemplateDir, "node_modules", constants.RESERVED_TEMPLATE_NAMES["angular"]);
+
 			fs.deleteDirectory(path.join(angularTemplatePath, "node_modules"));
 
 			let typescriptTemplateDir = temp.mkdirSync("typescriptTemplate");
@@ -193,8 +199,10 @@ describe("Project Service Tests", () => {
 				"readme": "dummy",
 				"repository": "dummy"
 			});
-			await npmInstallationManager.install("tns-template-hello-world-ts", typescriptTemplateDir, { dependencyType: "save" });
-			typescriptTemplatePath = path.join(typescriptTemplateDir, "node_modules", "tns-template-hello-world-ts");
+
+			await npmInstallationManager.install(constants.RESERVED_TEMPLATE_NAMES["typescript"], typescriptTemplateDir, { dependencyType: "save" });
+			typescriptTemplatePath = path.join(typescriptTemplateDir, "node_modules", constants.RESERVED_TEMPLATE_NAMES["typescript"]);
+
 			fs.deleteDirectory(path.join(typescriptTemplatePath, "node_modules"));
 		});
 

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -114,6 +114,7 @@ class ProjectIntegrationTest {
 		this.testInjector.register("fs", FileSystem);
 		this.testInjector.register("projectDataService", ProjectDataServiceLib.ProjectDataService);
 		this.testInjector.register("staticConfig", StaticConfig);
+		this.testInjector.register("analyticsService", { track: async () => undefined });
 
 		this.testInjector.register("npmInstallationManager", NpmInstallationManager);
 		this.testInjector.register("npm", NpmLib.NodePackageManager);
@@ -436,6 +437,7 @@ function createTestInjector() {
 	testInjector.register("projectDataService", ProjectDataServiceLib.ProjectDataService);
 
 	testInjector.register("staticConfig", StaticConfig);
+	testInjector.register("analyticsService", { track: async () => undefined });
 
 	testInjector.register("npmInstallationManager", NpmInstallationManager);
 	testInjector.register("httpClient", HttpClientLib.HttpClient);

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -50,6 +50,8 @@ function createTestInjector(configuration?: { shouldNpmInstallThrow: boolean, np
 
 	injector.register("projectTemplatesService", ProjectTemplatesService);
 
+	injector.register("analyticsService", { track: async () => undefined });
+
 	return injector;
 }
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -235,6 +235,8 @@ export class ProjectDataStub implements IProjectData {
 	dependencies: any;
 	appDirectoryPath: string;
 	appResourcesDirectoryPath: string;
+	devDependencies: IStringDictionary;
+	projectType: string;
 }
 
 export class PlatformsDataStub implements IPlatformsData {
@@ -656,6 +658,10 @@ export class PlatformServiceStub implements IPlatformService {
 
 	public readFile(device: Mobile.IDevice, deviceFilePath: string): Promise<string> {
 		return Promise.resolve("");
+	}
+
+	public async trackProjectType(): Promise<void> {
+		return null;
 	}
 }
 


### PR DESCRIPTION
## Track from which template a project is created
Add tracking from which template a project is created. This will give us better picture of the usage of CLI and the types of projects that the users are creating.

## Track project type when deploy/run/livesync is executed  …
Track the project type (Angular, TypeScript, JavaScript) when any of the commands is executed:
* prepare
* deploy
* run
* livesync

This will allow us to better understand the type of projects that the users are building.

Implements https://github.com/NativeScript/nativescript-cli/issues/2478

This is cherry-pick of https://github.com/NativeScript/nativescript-cli/pull/2492