### PR TITLE
don't add platform after tns platform clean is ran

### DIFF
--- a/lib/commands/platform-clean.ts
+++ b/lib/commands/platform-clean.ts
@@ -6,7 +6,6 @@ export class CleanCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		this.$platformService.removePlatforms(args);
-		await this.$platformService.addPlatforms(args);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -399,7 +399,7 @@ describe('Platform Service Tests', () => {
 				assert.isFalse(isCommandExecuted);
 			});
 
-			it("will call removePlatform and addPlatform on the platformService passing the provided platforms", async () => {
+			it("will call removePlatform on the platformService passing the provided platforms", async () => {
 				let platformActions: { action: string, platforms: string[] }[] = [];
 				testInjector.registerCommand("platform|clean", CleanCommand);
 				let cleanCommand = testInjector.resolveCommand("platform|clean");
@@ -408,17 +408,10 @@ describe('Platform Service Tests', () => {
 					platformActions.push({ action: "removePlatforms", platforms });
 				};
 
-				platformService.addPlatforms = async (platforms: string[]) => {
-
-					platformActions.push({ action: "addPlatforms", platforms });
-
-				};
-
 				await cleanCommand.execute(["ios"]);
 
 				let expectedPlatformActions = [
 					{ action: "removePlatforms", platforms: ["ios"] },
-					{ action: "addPlatforms", platforms: ["ios"] },
 				];
 
 				assert.deepEqual(platformActions, expectedPlatformActions, "Expected `remove ios`, `add ios` calls to the platformService.");


### PR DESCRIPTION
see more info [here](https://github.com/NativeScript/nativescript-cli/issues/2496).
In short when `tns platform clean <platform>` is ran, the command will now only clean the platform, instead of removing it and then adding the latest platform package.