### PR TITLE
Pass current stdio to npm install process

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -45,7 +45,7 @@ export class NodePackageManager implements INodePackageManager {
 				}
 			}
 			try {
-				let spawnResult:ISpawnResult = this.$childProcess.spawnFromEvent(this.getNpmExecutableName(), params, "close", { cwd: pwd }).wait();
+				let spawnResult:ISpawnResult = this.$childProcess.spawnFromEvent(this.getNpmExecutableName(), params, "close", { cwd: pwd, stdio: "inherit" }).wait();
 				this.$logger.out(spawnResult.stdout);
 			} catch (err) {
 				if (err.message && err.message.indexOf("EPEERINVALID") !== -1) {


### PR DESCRIPTION
Whenever CLI spawns `npm install <smth>`, we do not set stdin and stdout
of the spawned process. This way in case any of the npm scripts executed
during install requires input from user, it cannot be handled in any
way.

So pass the current stdin and stdout to the spawned npm process. This
way in case a postinstall script is executed and it requires input from
user, the users will be able to enter required information in the same
place where `tns` command has been executed (same terminal).

This fixes postinstall execution of `nativescript-plugin-firebase`. Fixes #2521 