### PR TITLE
Cherry pick fixes from release

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -38,7 +38,7 @@ export class NodePackageManager implements INodePackageManager {
 			}
 		}
 		try {
-			let spawnResult: ISpawnResult = await this.$childProcess.spawnFromEvent(this.getNpmExecutableName(), params, "close", { cwd: pwd });
+			let spawnResult: ISpawnResult = await this.$childProcess.spawnFromEvent(this.getNpmExecutableName(), params, "close", { cwd: pwd, stdio: "inherit" });
 			this.$logger.out(spawnResult.stdout);
 		} catch (err) {
 			if (err.message && err.message.indexOf("EPEERINVALID") !== -1) {

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -140,6 +140,7 @@ class LiveSyncService implements ILiveSyncService {
 				try {
 					filePath = path.join(syncWorkingDirectory, filePath);
 					for (let i = 0; i < onChangedActions.length; i++) {
+						that.$logger.trace(`Event '${event}' triggered for path: '${filePath}'`);
 						await onChangedActions[i](event, filePath, that.$dispatcher);
 					}
 				} catch (err) {

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -58,9 +58,9 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 			return;
 		}
 
-		if (event === "add" || event === "change") {
+		if (event === "add" || event === "addDir"|| event === "change") {
 			this.batchSync(filePath, dispatcher, afterFileSyncAction);
-		} else if (event === "unlink") {
+		} else if (event === "unlink" || event === "unlinkDir") {
 			await this.syncRemovedFile(filePath, afterFileSyncAction);
 		}
 	}

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -22,7 +22,8 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 		private $projectFilesProvider: IProjectFilesProvider,
 		private $platformService: IPlatformService,
 		private $projectChangesService: IProjectChangesService,
-		private $liveSyncProvider: ILiveSyncProvider) {
+		private $liveSyncProvider: ILiveSyncProvider,
+		private $fs: IFileSystem) {
 		this.liveSyncData = _liveSyncData;
 	}
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -211,6 +211,9 @@ export class PlatformService implements IPlatformService {
 
 		await this.ensurePlatformInstalled(platform);
 		let changesInfo = this.$projectChangesService.checkForChanges(platform);
+
+		this.$logger.trace("Changes info in prepare platform:", changesInfo);
+
 		if (changesInfo.hasChanges) {
 			await this.preparePlatformCore(platform, changesInfo);
 			this.$projectChangesService.savePrepareInfo(platform);

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -179,7 +179,7 @@ export class ProjectChangesService implements IProjectChangesService {
 
 			let fileStats = this.$fs.getFsStats(filePath);
 
-			let changed = fileStats.mtime.getTime() > this._outputProjectMtime || fileStats.ctime.getTime() > this._outputProjectMtime
+			let changed = fileStats.mtime.getTime() > this._outputProjectMtime || fileStats.ctime.getTime() > this._outputProjectMtime;
 
 			if (!changed) {
 				let lFileStats = this.$fs.getLsStats(filePath);

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -176,12 +176,16 @@ export class ProjectChangesService implements IProjectChangesService {
 			if (filePath === skipDir) {
 				continue;
 			}
+
 			let fileStats = this.$fs.getFsStats(filePath);
-			let changed = fileStats.mtime.getTime() > this._outputProjectMtime;
+
+			let changed = fileStats.mtime.getTime() > this._outputProjectMtime || fileStats.ctime.getTime() > this._outputProjectMtime
+
 			if (!changed) {
 				let lFileStats = this.$fs.getLsStats(filePath);
-				changed = lFileStats.mtime.getTime() > this._outputProjectMtime;
+				changed = lFileStats.mtime.getTime() > this._outputProjectMtime || lFileStats.ctime.getTime() > this._outputProjectMtime;
 			}
+
 			if (changed) {
 				if (processFunc) {
 					this._newFiles++;
@@ -193,6 +197,7 @@ export class ProjectChangesService implements IProjectChangesService {
 					return true;
 				}
 			}
+
 			if (fileStats.isDirectory()) {
 				if (this.containsNewerFiles(filePath, skipDir, processFunc)) {
 					return true;


### PR DESCRIPTION
Cherry-pick multiple fixes from release branch:

### Fix livesync when directories are modified
In case you try adding/removing directories in your `app` dir, `chokidar` (the file system watcher that we are using now instead of `gaze`) raises `addDir`/`unlinkDir` events.
However we do not have handles for these events, so we do not execute anything. After that, when we add a file in the newly created dir, `chokidar` sends `add` event, we handle it and try to process the file.
This works fine for iOS and Android devices, but it does not work at all for iOS Simulator, as we have not transferred the new directory to `platforms` dir.
Add required handles for `addDir` and `unlinkDir` methods.

Also currently there's a problem when already existing directory is renamed. In this case its modified time (`mtime`) is not changed, so the projectChangesService disregards the change and doesn't transfer it to `platforms` dir. After that, in case you modify any file inside the renamed dir, you'll see ENOENT error. In order to fix this, check the time of last status change (`ctime`) of the directory/file.

### 	LiveSync only existing files during `--watch`
During `--watch`, when a change is detected, the project is prepared and after that we are trying to move the prepared file (from `platforms/<platform>/...` dir) to the device.
However some plugins modify the content of the `platforms` directory on afterPrepare. For example `nativescript-dev-sass` allows you to use `.scss` files, on `beforePrepare` they are "transpiled" to `.css` files.
After that, on `afterPrepare` the plugin itself removes the file from `platforms/<platform>/...` dir.
CLI detects the change in `.scss` file, prepares the project (which moves the `.scss` file to `platforms` dir) and after that tries to move it from `platforms` to the device. During the last step, the `.scss` file is already removed from `platforms` directory, so our code fails.
Meanwhile, the `beforePrepare` hook of the plugin has created/modified the `.css` file inside `app` dir. This will trigger new iteration, where the file will be sent to device.

In order to fix the error when the `.scss` file is modified, we'll execute livesync only if the modified files exist in `platforms` dir.


### 	Pass current stdio to npm install process
Whenever CLI spawns `npm install <smth>`, we do not set stdin and stdout
of the spawned process. This way in case any of the npm scripts executed
during install requires input from user, it cannot be handled in any
way.

So pass the current stdin and stdout to the spawned npm process. This
way in case a postinstall script is executed and it requires input from
user, the users will be able to enter required information in the same
place where `tns` command has been executed (same terminal).

This fixes postinstall execution of `nativescript-plugin-firebase`.