### PR TITLE
Rollback package.json if plugin installation fails

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -17,7 +17,8 @@ export class NodePackageManager implements INodePackageManager {
 			config["ignore-scripts"] = true;
 		}
 
-		let jsonContentBefore = this.$fs.readJson(path.join(pathToSave, "package.json"));
+		let packageJsonPath = path.join(pathToSave, "package.json");
+		let jsonContentBefore = this.$fs.readJson(packageJsonPath);
 		let dependenciesBefore = _.keys(jsonContentBefore.dependencies).concat(_.keys(jsonContentBefore.devDependencies));
 
 		let flags = this.getFlagsString(config, true);
@@ -47,6 +48,8 @@ export class NodePackageManager implements INodePackageManager {
 				this.$logger.warn(err.message);
 			} else {
 				// All other errors should be handled by the caller code.
+				// Revert package.json contents to preserve valid state
+				this.$fs.writeJson(packageJsonPath, jsonContentBefore);
 				throw err;
 			}
 		}

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -3,12 +3,9 @@ import * as semver from "semver";
 import * as constants from "./constants";
 
 export class NpmInstallationManager implements INpmInstallationManager {
-	private static NPM_LOAD_FAILED = "Failed to retrieve data from npm. Please try again a little bit later.";
-
 	constructor(private $npm: INodePackageManager,
 		private $childProcess: IChildProcess,
 		private $logger: ILogger,
-		private $errors: IErrors,
 		private $options: IOptions,
 		private $fs: IFileSystem,
 		private $staticConfig: IStaticConfig) {
@@ -35,7 +32,6 @@ export class NpmInstallationManager implements INpmInstallationManager {
 	}
 
 	public async install(packageName: string, projectDir: string, opts?: INpmInstallOptions): Promise<any> {
-
 		try {
 			let packageToInstall = this.$options.frameworkPath || packageName;
 			let pathToSave = projectDir;
@@ -45,7 +41,8 @@ export class NpmInstallationManager implements INpmInstallationManager {
 			return await this.installCore(packageToInstall, pathToSave, version, dependencyType);
 		} catch (error) {
 			this.$logger.debug(error);
-			this.$errors.fail("%s. Error: %s", NpmInstallationManager.NPM_LOAD_FAILED, error);
+
+			throw new Error(error);
 		}
 	}
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -91,9 +91,10 @@ export class PlatformService implements IPlatformService {
 		}
 
 		let spinner = new clui.Spinner("Installing " + packageToInstall);
+		let projectDir = this.$projectData.projectDir;
 		try {
 			spinner.start();
-			let downloadedPackagePath = await this.$npmInstallationManager.install(packageToInstall, this.$projectData.projectDir, npmOptions);
+			let downloadedPackagePath = await this.$npmInstallationManager.install(packageToInstall, projectDir, npmOptions);
 			let frameworkDir = path.join(downloadedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME);
 			frameworkDir = path.resolve(frameworkDir);
 


### PR DESCRIPTION
Implement rollback of package.json contents of project if npm installation fails for whatever reason during installation of a NS plugin or platform.

Addresses #2487 