### PR TITLE
tns-android/ios are installed as dev dependencies

### DIFF
--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -1,4 +1,5 @@
 import { EOL } from "os";
+import * as constants from "../constants";
 
 export class InstallCommand implements ICommand {
 	public enableHooks = false;
@@ -26,7 +27,7 @@ export class InstallCommand implements ICommand {
 		this.$projectDataService.initialize(this.$projectData.projectDir);
 		for (let platform of this.$platformsData.platformsNames) {
 			let platformData = this.$platformsData.getPlatformData(platform);
-			let frameworkPackageData = this.$projectDataService.getValue(platformData.frameworkPackageName);
+			let frameworkPackageData = this.$projectDataService.getValue(platformData.frameworkPackageName, constants.DEV_DEPENDENCIES);
 			if (frameworkPackageData && frameworkPackageData.version) {
 				try {
 					await this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`]);

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as shelljs from "shelljs";
+import * as constants from "../constants";
 
 export class UpdateCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
@@ -13,7 +14,7 @@ export class UpdateCommand implements ICommand {
 		private $logger: ILogger) { }
 
 	public async execute(args: string[]): Promise<void> {
-		let folders = ["lib", "hooks", "platforms", "node_modules"];
+		let folders = ["hooks", "platforms", "node_modules"];
 		let tmpDir = path.join(this.$projectData.projectDir, ".tmp_backup");
 
 		try {
@@ -63,7 +64,7 @@ export class UpdateCommand implements ICommand {
 		this.$projectDataService.initialize(this.$projectData.projectDir);
 		for (let platform of availablePlatforms) {
 			let platformData = this.$platformsData.getPlatformData(platform);
-			let platformVersion = this.$projectDataService.getValue(platformData.frameworkPackageName);
+			let platformVersion = this.$projectDataService.getValue(platformData.frameworkPackageName, constants.DEV_DEPENDENCIES);
 			if (platformVersion) {
 				packagePlatforms.push(platform);
 				this.$projectDataService.removeProperty(platformData.frameworkPackageName);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,6 +15,11 @@ export const TESTING_FRAMEWORKS = ['jasmine', 'mocha', 'qunit'];
 export const TEST_RUNNER_NAME = "nativescript-unit-test-runner";
 export const LIVESYNC_EXCLUDED_FILE_PATTERNS = ["**/*.js.map", "**/*.ts"];
 export const XML_FILE_EXTENSION = ".xml";
+export const DEV_DEPENDENCIES = "devDependencies";
+export const FRAMEWORK_TO_PACKAGE:IStringDictionary = {
+	"android": TNS_ANDROID_RUNTIME_NAME,
+	"ios": TNS_IOS_RUNTIME_NAME
+};
 
 export class PackageVersion {
 	static NEXT = "next";

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -5,6 +5,7 @@ interface IPluginsService {
 	prepare(pluginData: IDependencyData, platform: string): Promise<void>;
 	getAllInstalledPlugins(): Promise<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(): Promise<void>;
+	getInstalledFrameworkVersion(platform: string): string;
 
 	/**
 	 * Returns all dependencies and devDependencies from pacakge.json file.

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -67,7 +67,7 @@ interface IProjectDataService {
 	 * @param {string} propertyName The name of the property to be checked in `nativescript` key.
 	 * @returns {any} The value of the property.
 	 */
-	getValue(propertyName: string): any;
+	getValue(propertyName: string, key?: string): any;
 
 	/**
 	 * Sets a value in the `nativescript` key in a project's package.json.

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -417,7 +417,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		if (!this._canUseGradle) {
 			if (!frameworkVersion) {
 				this.$projectDataService.initialize(this.$projectData.projectDir);
-				let frameworkInfoInProjectFile = this.$projectDataService.getValue(this.platformData.frameworkPackageName);
+				let frameworkInfoInProjectFile = this.$projectDataService.getValue(this.platformData.frameworkPackageName, constants.DEV_DEPENDENCIES);
 				frameworkVersion = frameworkInfoInProjectFile && frameworkInfoInProjectFile.version;
 			}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -14,7 +14,7 @@ class LiveSyncService implements ILiveSyncService {
 		private $platformsData: IPlatformsData,
 		private $platformService: IPlatformService,
 		private $projectData: IProjectData,
-		private $projectDataService: IProjectDataService,
+		private $pluginsService: IPluginsService,
 		private $prompter: IPrompter,
 		private $injector: IInjector,
 		private $mobileHelper: Mobile.IMobileHelper,
@@ -26,8 +26,7 @@ class LiveSyncService implements ILiveSyncService {
 		private $processService: IProcessService) { }
 
 	private async ensureAndroidFrameworkVersion(platformData: IPlatformData): Promise<void> { // TODO: this can be moved inside command or canExecute function
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let frameworkVersion = this.$projectDataService.getValue(platformData.frameworkPackageName).version;
+		let frameworkVersion = this.$pluginsService.getInstalledFrameworkVersion(platformData.normalizedPlatformName);
 
 		if (platformData.normalizedPlatformName.toLowerCase() === this.$devicePlatformsConstants.Android.toLowerCase()) {
 			if (semver.lt(frameworkVersion, "1.2.1")) {
@@ -46,9 +45,9 @@ class LiveSyncService implements ILiveSyncService {
 	}
 
 	public async liveSync(platform: string, applicationReloadAction?: (deviceAppData: Mobile.IDeviceAppData) => Promise<void>): Promise<void> {
-			if (this.$options.justlaunch) {
-				this.$options.watch = false;
-			}
+		if (this.$options.justlaunch) {
+			this.$options.watch = false;
+		}
 		let liveSyncData: ILiveSyncData[] = [];
 
 		if (platform) {

--- a/lib/services/platform-project-service-base.ts
+++ b/lib/services/platform-project-service-base.ts
@@ -1,3 +1,5 @@
+import * as constants from "../constants";
+
 export class PlatformProjectServiceBase implements IPlatformProjectServiceBase {
 	constructor(protected $fs: IFileSystem,
 		protected $projectData: IProjectData,
@@ -24,7 +26,7 @@ export class PlatformProjectServiceBase implements IPlatformProjectServiceBase {
 
 	protected getFrameworkVersion(runtimePackageName: string): string {
 		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let frameworkVersion = this.$projectDataService.getValue(runtimePackageName).version;
+		let frameworkVersion = this.$projectDataService.getValue(runtimePackageName, constants.DEV_DEPENDENCIES).version;
 		return frameworkVersion;
 	}
 }

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -82,7 +82,7 @@ export class PlatformService implements IPlatformService {
 		let packageToInstall = "";
 		let npmOptions: IStringDictionary = {
 			pathToSave: path.join(this.$projectData.platformsDir, platform),
-			dependencyType: "save"
+			dependencyType: "save-dev"
 		};
 
 		if (!this.$options.frameworkPath) {
@@ -97,8 +97,7 @@ export class PlatformService implements IPlatformService {
 			let frameworkDir = path.join(downloadedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME);
 			frameworkDir = path.resolve(frameworkDir);
 
-			let coreModuleName = await this.addPlatformCore(platformData, frameworkDir);
-			await this.$npm.uninstall(coreModuleName, { save: true }, this.$projectData.projectDir);
+			await this.addPlatformCore(platformData, frameworkDir);
 		} catch (err) {
 			this.$fs.deleteDirectory(platformPath);
 			throw err;
@@ -129,17 +128,15 @@ export class PlatformService implements IPlatformService {
 		if (customTemplateOptions) {
 			frameworkPackageNameData.template = customTemplateOptions.selectedTemplate;
 		}
-		this.$projectDataService.setValue(platformData.frameworkPackageName, frameworkPackageNameData);
 
 		return coreModuleName;
-
 	}
 
 	private async getPathToPlatformTemplate(selectedTemplate: string, frameworkPackageName: string): Promise<any> {
 		if (!selectedTemplate) {
 			// read data from package.json's nativescript key
 			// check the nativescript.tns-<platform>.template value
-			let nativescriptPlatformData = this.$projectDataService.getValue(frameworkPackageName);
+			let nativescriptPlatformData = this.$projectDataService.getValue(frameworkPackageName, constants.DEV_DEPENDENCIES);
 			selectedTemplate = nativescriptPlatformData && nativescriptPlatformData.template;
 		}
 
@@ -577,6 +574,7 @@ export class PlatformService implements IPlatformService {
 			let platformDir = path.join(this.$projectData.platformsDir, platform);
 			this.$fs.deleteDirectory(platformDir);
 			this.$projectDataService.removeProperty(platformData.frameworkPackageName);
+			this.$npm.uninstall(platformData.frameworkPackageName, {"save-dev": true});
 
 			this.$logger.out(`Platform ${platform} successfully removed.`);
 		});
@@ -709,7 +707,7 @@ export class PlatformService implements IPlatformService {
 		let platformData = this.$platformsData.getPlatformData(platform);
 
 		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let data = this.$projectDataService.getValue(platformData.frameworkPackageName);
+		let data = this.$projectDataService.getValue(platformData.frameworkPackageName, constants.DEV_DEPENDENCIES);
 		let currentVersion = data && data.version ? data.version : "0.2.0";
 
 		let newVersion = version === constants.PackageVersion.NEXT ?

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -273,11 +273,10 @@ export class PluginsService implements IPluginsService {
 		};
 	}
 
-	private getInstalledFrameworkVersion(platform: string): string {
-		let platformData = this.$platformsData.getPlatformData(platform);
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let frameworkData = this.$projectDataService.getValue(platformData.frameworkPackageName);
-		return frameworkData.version;
+	public getInstalledFrameworkVersion(platform: string): string {
+		let pathToInstalledFrameworkPackageJson = path.join(this.$projectData.projectDir, constants.NODE_MODULES_FOLDER_NAME, constants.FRAMEWORK_TO_PACKAGE[platform.toLowerCase()], constants.PACKAGE_JSON_FILE_NAME);
+		let jsonContent = this.$fs.readJson(pathToInstalledFrameworkPackageJson);
+		return jsonContent.version;
 	}
 
 	private isPluginDataValidForPlatform(pluginData: IPluginData, platform: string): boolean {

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -18,9 +18,13 @@ export class ProjectDataService implements IProjectDataService {
 		}
 	}
 
-	public getValue(propertyName: string): any {
+	public getValue(propertyName: string, key?: string): any {
 		this.loadProjectFile();
-		return this.projectData ? this.projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE][propertyName] : null;
+		let rootKey: string = this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE;
+		if (key) {
+			rootKey = key;
+		}
+		return this.projectData ? this.projectData[rootKey][propertyName] : null;
 	}
 
 	public setValue(key: string, value: any): void {

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -126,6 +126,14 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		let dependenciesBuilder = this.$injector.resolve(NodeModulesDependenciesBuilder, {});
 		let productionDependencies = dependenciesBuilder.getProductionDependencies(this.$projectData.projectDir);
 
+		let prodDependenciesArr = [];
+		for (let i in productionDependencies) {
+			prodDependenciesArr.push(productionDependencies[i].name);
+		}
+
+		let prodDependenciesFilePath = path.join(this.$projectData.projectDir, "platforms", "android", "productionDependencies.json");
+		this.$fs.writeJson(prodDependenciesFilePath, prodDependenciesArr);
+
 		if (!this.$options.bundle) {
 			const tnsModulesCopy = this.$injector.resolve(TnsModulesCopy, {
 				outputRoot: absoluteOutputPath

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -112,9 +112,9 @@ function createProjectFile(testInjector: IInjector): string {
 		"version": "0.1.0",
 		"nativescript": {
 			"id": "org.nativescript.Test",
-			"tns-android": {
-				"version": "1.4.0"
-			}
+		},
+		"devDependencies": {
+			"tns-android": "1.4.0"
 		}
 	};
 


### PR DESCRIPTION
Previously `tns-android` and `tns-ios` have been installed in nativescript key in the root `package.json`, which is illogical since these platforms are just regular npm packages.
With this PR, both platforms are installed as `devDependencies` and the `package.json` looks like:
```
{
  "nativescript": {
    "id": "org.nativescript.<app_name>"
  },
  "dependencies": {
    ....
  },
  "devDependencies": {
    "tns-android": "^2.5.0"
  }
}
```
This change does not introduce any breaking changes, but it's a first step towards future improvements.