### PR TITLE
Fix uploading of .nsprepareinfo on Windows

### DIFF
--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -2,6 +2,7 @@ import syncBatchLib = require("../../common/services/livesync/sync-batch");
 import * as path from "path";
 import * as minimatch from "minimatch";
 import * as util from "util";
+import * as helpers from "../../common/helpers";
 
 const livesyncInfoFileName = ".nslivesyncinfo";
 
@@ -236,7 +237,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 
 	private getLiveSyncInfoFilePath(deviceAppData: Mobile.IDeviceAppData) {
 		let deviceRootPath = path.dirname(deviceAppData.deviceProjectRootPath);
-		let deviceFilePath = path.join(deviceRootPath, livesyncInfoFileName);
+		let deviceFilePath = helpers.fromWindowsRelativePathToUnix(path.join(deviceRootPath, livesyncInfoFileName));
 		return deviceFilePath;
 	}
 


### PR DESCRIPTION
When `.nprepareinfo` file is uploaded on device, we construct the device file path with `path.join` function. On Windows this function returns path similar to `\\data\\local\\tmp`, which is not working for Unix based OSes (Android in this case).
Fix this by converting the path to Unix style.