### PR TITLE
Fix uploading of .nsbuildinfoon Windows

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -531,7 +531,7 @@ export class PlatformService implements IPlatformService {
 	private getDeviceBuildInfoFilePath(device: Mobile.IDevice): string {
 		let deviceAppData = this.$deviceAppDataFactory.create(this.$projectData.projectId, device.deviceInfo.platform, device);
 		let deviceRootPath = path.dirname(deviceAppData.deviceProjectRootPath);
-		return path.join(deviceRootPath, buildInfoFileName);
+		return helpers.fromWindowsRelativePathToUnix(path.join(deviceRootPath, buildInfoFileName));
 	}
 
 	private getDeviceBuildInfo(device: Mobile.IDevice): IFuture<IBuildInfo> {


### PR DESCRIPTION
When `.nsbuildinfo` file is uploaded on device, we construct the device file path with `path.join` function. On Windows this function returns path similar to `\\data\\local\\tmp`, which is not working for Unix based OSes (Android in this case).
Fix this by converting the path to Unix style.