### PR TITLE
Fix ENOENT errors on macOS during livesync

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -33,6 +33,7 @@ export class ProjectChangesService implements IProjectChangesService {
 	private _prepareInfo: IPrepareInfo;
 	private _newFiles: number = 0;
 	private _outputProjectMtime: number;
+	private _outputProjectCTime: number;
 
 	constructor(
 		private $platformsData: IPlatformsData,
@@ -140,6 +141,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			let platformData = this.$platformsData.getPlatformData(platform);
 			let prepareInfoFile = path.join(platformData.projectRoot, prepareInfoFileName);
 			this._outputProjectMtime = this.$fs.getFsStats(prepareInfoFile).mtime.getTime();
+			this._outputProjectCTime = this.$fs.getFsStats(prepareInfoFile).ctime.getTime();
 			return false;
 		}
 		this._prepareInfo = {
@@ -150,6 +152,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			changesRequireBuildTime: null
 		};
 		this._outputProjectMtime = 0;
+		this._outputProjectCTime = 0;
 		this._changesInfo.appFilesChanged = true;
 		this._changesInfo.appResourcesChanged = true;
 		this._changesInfo.modulesChanged = true;
@@ -161,7 +164,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		for (let file of files) {
 			if (this.$fs.exists(file)) {
 				let fileStats = this.$fs.getFsStats(file);
-				if (fileStats.mtime.getTime() > this._outputProjectMtime) {
+				if (fileStats.mtime.getTime() >= this._outputProjectMtime || fileStats.ctime.getTime() >= this._outputProjectCTime) {
 					return true;
 				}
 			}
@@ -179,11 +182,10 @@ export class ProjectChangesService implements IProjectChangesService {
 
 			let fileStats = this.$fs.getFsStats(filePath);
 
-			let changed = fileStats.mtime.getTime() > this._outputProjectMtime || fileStats.ctime.getTime() > this._outputProjectMtime;
-
+			let changed = fileStats.mtime.getTime() >= this._outputProjectMtime || fileStats.ctime.getTime() >= this._outputProjectCTime;
 			if (!changed) {
 				let lFileStats = this.$fs.getLsStats(filePath);
-				changed = lFileStats.mtime.getTime() > this._outputProjectMtime || lFileStats.ctime.getTime() > this._outputProjectMtime;
+				changed = lFileStats.mtime.getTime() >= this._outputProjectMtime || lFileStats.ctime.getTime() >= this._outputProjectCTime;
 			}
 
 			if (changed) {


### PR DESCRIPTION
On macOS sometimes we recive ENOENT errors during livesync operations (`tns run ios`). This is due to the following:
- incorrect detection if a file is modified - we check if the project dir's mTime and cTime values are bigger than the .nsprepareinfo. However in some cases they are equal, which means the dir has been modified in the same moment when the `.nsprepareinfo` is saved. In order to fix this, mark the files/dirs as modified in case the modified time of `.nsprepareinfo` and the respective file are the same.
- In some cases we are not able to sync files to iOS Simulator as chokidar does not raise correct events on macOS when directory is renamed immediately after it's being created.
After adding a file to this directory we throw ENOENT, as such dir does not exist in Simulator's dir. In order to fix this, ensure the directory exist in the simulator.

PR in common-lib: https://github.com/telerik/mobile-cli-lib/pull/892