### PR TITLE
Ignore .DS_Store file changes on Mac (#2473)

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -134,7 +134,7 @@ class LiveSyncService implements ILiveSyncService {
 			}
 		}
 
-		let watcher = choki.watch(pattern, { ignoreInitial: true, cwd: syncWorkingDirectory }).on("all", (event: string, filePath: string) => {
+		let watcher = choki.watch(pattern, { ignoreInitial: true, cwd: syncWorkingDirectory, ignored: '**/*.DS_Store' }).on("all", (event: string, filePath: string) => {
 			fiberBootstrap.run(() => {
 				that.$dispatcher.dispatch(() => (() => {
 					try {


### PR DESCRIPTION
* Ignore .DS_Store file changes on Mac

https://github.com/paulmillr/chokidar#path-filtering

Resolves:
https://github.com/NativeScript/nativescript-cli/issues/2472

* Updated to ignored: '**/*.DS_Store'