### PR TITLE
Fix creating multiple projects in a single process

### DIFF
--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -23,10 +23,9 @@ export class InstallCommand implements ICommand {
 
 		await this.$pluginsService.ensureAllDependenciesAreInstalled();
 
-		this.$projectDataService.initialize(this.$projectData.projectDir);
 		for (let platform of this.$platformsData.platformsNames) {
 			let platformData = this.$platformsData.getPlatformData(platform);
-			let frameworkPackageData = this.$projectDataService.getValue(platformData.frameworkPackageName);
+			const frameworkPackageData = this.$projectDataService.getNSValue(this.$projectData.projectDir, platformData.frameworkPackageName);
 			if (frameworkPackageData && frameworkPackageData.version) {
 				try {
 					await this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`]);

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -60,13 +60,12 @@ export class UpdateCommand implements ICommand {
 		let availablePlatforms = this.$platformService.getAvailablePlatforms();
 		let packagePlatforms: string[] = [];
 
-		this.$projectDataService.initialize(this.$projectData.projectDir);
 		for (let platform of availablePlatforms) {
 			let platformData = this.$platformsData.getPlatformData(platform);
-			let platformVersion = this.$projectDataService.getValue(platformData.frameworkPackageName);
+			const platformVersion = this.$projectDataService.getNSValue(this.$projectData.projectDir, platformData.frameworkPackageName);
 			if (platformVersion) {
 				packagePlatforms.push(platform);
-				this.$projectDataService.removeProperty(platformData.frameworkPackageName);
+				this.$projectDataService.removeNSProperty(this.$projectData.projectDir, platformData.frameworkPackageName);
 			}
 		}
 

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -60,36 +60,38 @@ interface IProjectData {
 }
 
 interface IProjectDataService {
-	initialize(projectDir: string): void;
-
 	/**
 	 * Returns a value from `nativescript` key in project's package.json.
+	 * @param {string} projectDir The project directory - the place where the root package.json is located.
 	 * @param {string} propertyName The name of the property to be checked in `nativescript` key.
 	 * @returns {any} The value of the property.
 	 */
-	getValue(propertyName: string): any;
+	getNSValue(projectDir: string, propertyName: string): any;
 
 	/**
 	 * Sets a value in the `nativescript` key in a project's package.json.
+	 * @param {string} projectDir The project directory - the place where the root package.json is located.
 	 * @param {string} key Key to be added to `nativescript` key in project's package.json.
 	 * @param {any} value Value of the key to be added to `nativescript` key in project's package.json.
 	 * @returns {void}
 	 */
-	setValue(key: string, value: any): void;
+	setNSValue(projectDir: string, key: string, value: any): void;
 
 	/**
 	 * Removes a property from `nativescript` key in project's package.json.
+	 * @param {string} projectDir The project directory - the place where the root package.json is located.
 	 * @param {string} propertyName The name of the property to be removed from `nativescript` key.
 	 * @returns {void}
 	 */
-	removeProperty(propertyName: string): void;
+	removeNSProperty(projectDir: string, propertyName: string): void;
 
 	/**
 	 * Removes dependency from package.json
+	 * @param {string} projectDir The project directory - the place where the root package.json is located.
 	 * @param {string} dependencyName Name of the dependency that has to be removed.
 	 * @returns {void}
 	 */
-	removeDependency(dependencyName: string): void;
+	removeDependency(projectDir: string, dependencyName: string): void;
 }
 
 /**

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -426,8 +426,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	private canUseGradle(frameworkVersion?: string): boolean {
 		if (!this._canUseGradle) {
 			if (!frameworkVersion) {
-				this.$projectDataService.initialize(this.$projectData.projectDir);
-				let frameworkInfoInProjectFile = this.$projectDataService.getValue(this.platformData.frameworkPackageName);
+				const frameworkInfoInProjectFile = this.$projectDataService.getNSValue(this.$projectData.projectDir, this.platformData.frameworkPackageName);
 				frameworkVersion = frameworkInfoInProjectFile && frameworkInfoInProjectFile.version;
 			}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -26,8 +26,7 @@ class LiveSyncService implements ILiveSyncService {
 		private $processService: IProcessService) { }
 
 	private async ensureAndroidFrameworkVersion(platformData: IPlatformData): Promise<void> { // TODO: this can be moved inside command or canExecute function
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let frameworkVersion = this.$projectDataService.getValue(platformData.frameworkPackageName).version;
+		const frameworkVersion = this.$projectDataService.getNSValue(this.$projectData.projectDir, platformData.frameworkPackageName).version;
 
 		if (platformData.normalizedPlatformName.toLowerCase() === this.$devicePlatformsConstants.Android.toLowerCase()) {
 			if (semver.lt(frameworkVersion, "1.2.1")) {

--- a/lib/services/platform-project-service-base.ts
+++ b/lib/services/platform-project-service-base.ts
@@ -23,8 +23,6 @@ export class PlatformProjectServiceBase implements IPlatformProjectServiceBase {
 	}
 
 	protected getFrameworkVersion(runtimePackageName: string): string {
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let frameworkVersion = this.$projectDataService.getValue(runtimePackageName).version;
-		return frameworkVersion;
+		return this.$projectDataService.getNSValue(this.$projectData.projectDir, runtimePackageName).version;
 	}
 }

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -116,7 +116,6 @@ export class PlatformService implements IPlatformService {
 		let installedVersion = coreModuleData.version;
 		let coreModuleName = coreModuleData.name;
 
-		this.$projectDataService.initialize(this.$projectData.projectDir);
 		let customTemplateOptions = await this.getPathToPlatformTemplate(this.$options.platformTemplate, platformData.frameworkPackageName);
 		let pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
 		await platformData.platformProjectService.createProject(path.resolve(frameworkDir), installedVersion, pathToTemplate);
@@ -130,7 +129,8 @@ export class PlatformService implements IPlatformService {
 		if (customTemplateOptions) {
 			frameworkPackageNameData.template = customTemplateOptions.selectedTemplate;
 		}
-		this.$projectDataService.setValue(platformData.frameworkPackageName, frameworkPackageNameData);
+
+		this.$projectDataService.setNSValue(this.$projectData.projectDir, platformData.frameworkPackageName, frameworkPackageNameData);
 
 		return coreModuleName;
 
@@ -140,7 +140,7 @@ export class PlatformService implements IPlatformService {
 		if (!selectedTemplate) {
 			// read data from package.json's nativescript key
 			// check the nativescript.tns-<platform>.template value
-			let nativescriptPlatformData = this.$projectDataService.getValue(frameworkPackageName);
+			const nativescriptPlatformData = this.$projectDataService.getNSValue(this.$projectData.projectDir, frameworkPackageName);
 			selectedTemplate = nativescriptPlatformData && nativescriptPlatformData.template;
 		}
 
@@ -582,8 +582,6 @@ export class PlatformService implements IPlatformService {
 	}
 
 	public async removePlatforms(platforms: string[]): Promise<void> {
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-
 		for (let platform of platforms) {
 			this.validatePlatformInstalled(platform);
 			let platformData = this.$platformsData.getPlatformData(platform);
@@ -592,7 +590,7 @@ export class PlatformService implements IPlatformService {
 
 			let platformDir = path.join(this.$projectData.platformsDir, platform);
 			this.$fs.deleteDirectory(platformDir);
-			this.$projectDataService.removeProperty(platformData.frameworkPackageName);
+			this.$projectDataService.removeNSProperty(this.$projectData.projectDir, platformData.frameworkPackageName);
 
 			this.$logger.out(`Platform ${platform} successfully removed.`);
 		}
@@ -724,8 +722,7 @@ export class PlatformService implements IPlatformService {
 	private async updatePlatform(platform: string, version: string): Promise<void> {
 		let platformData = this.$platformsData.getPlatformData(platform);
 
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let data = this.$projectDataService.getValue(platformData.frameworkPackageName);
+		let data = this.$projectDataService.getNSValue(this.$projectData.projectDir, platformData.frameworkPackageName);
 		let currentVersion = data && data.version ? data.version : "0.2.0";
 
 		let newVersion = version === constants.PackageVersion.NEXT ?

--- a/lib/services/plugin-variables-service.ts
+++ b/lib/services/plugin-variables-service.ts
@@ -23,14 +23,12 @@ export class PluginVariablesService implements IPluginVariablesService {
 		});
 
 		if (!_.isEmpty(values)) {
-			this.$projectDataService.initialize(this.$projectData.projectDir);
-			this.$projectDataService.setValue(this.getPluginVariablePropertyName(pluginData.name), values);
+			this.$projectDataService.setNSValue(this.$projectData.projectDir, this.getPluginVariablePropertyName(pluginData.name), values);
 		}
 	}
 
 	public removePluginVariablesFromProjectFile(pluginName: string): void {
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-		this.$projectDataService.removeProperty(this.getPluginVariablePropertyName(pluginName));
+		this.$projectDataService.removeNSProperty(this.$projectData.projectDir, this.getPluginVariablePropertyName(pluginName));
 	}
 
 	public async interpolatePluginVariables(pluginData: IPluginData, pluginConfigurationFilePath: string): Promise<void> {
@@ -97,8 +95,7 @@ export class PluginVariablesService implements IPluginVariablesService {
 
 		variableData.name = pluginVariableName;
 
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let pluginVariableValues = this.$projectDataService.getValue(this.getPluginVariablePropertyName(pluginData.name));
+		const pluginVariableValues = this.$projectDataService.getNSValue(this.$projectData.projectDir, this.getPluginVariablePropertyName(pluginData.name));
 		variableData.value = pluginVariableValues ? pluginVariableValues[pluginVariableName] : undefined;
 
 		return variableData;

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -56,8 +56,7 @@ export class PluginsService implements IPluginsService {
 				await this.$pluginVariablesService.savePluginVariablesInProjectFile(pluginData);
 			} catch (err) {
 				// Revert package.json
-				this.$projectDataService.initialize(this.$projectData.projectDir);
-				this.$projectDataService.removeProperty(this.$pluginVariablesService.getPluginVariablePropertyName(pluginData.name));
+				this.$projectDataService.removeNSProperty(this.$projectData.projectDir, this.$pluginVariablesService.getPluginVariablePropertyName(pluginData.name));
 				await this.$npm.uninstall(plugin, PluginsService.NPM_CONFIG, this.$projectData.projectDir);
 
 				throw err;
@@ -275,8 +274,7 @@ export class PluginsService implements IPluginsService {
 
 	private getInstalledFrameworkVersion(platform: string): string {
 		let platformData = this.$platformsData.getPlatformData(platform);
-		this.$projectDataService.initialize(this.$projectData.projectDir);
-		let frameworkData = this.$projectDataService.getValue(platformData.frameworkPackageName);
+		const frameworkData = this.$projectDataService.getNSValue(this.$projectData.projectDir, platformData.frameworkPackageName);
 		return frameworkData.version;
 	}
 

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -1,75 +1,109 @@
 import * as path from "path";
-import * as assert from "assert";
+
+interface IProjectFileData {
+	projectData: any;
+	projectFilePath: string;
+}
 
 export class ProjectDataService implements IProjectDataService {
 	private static DEPENDENCIES_KEY_NAME = "dependencies";
 
-	private projectFilePath: string;
-	private projectData: IDictionary<any>;
-	private projectFileIndent: string;
-
 	constructor(private $fs: IFileSystem,
-		private $staticConfig: IStaticConfig) {
+		private $staticConfig: IStaticConfig,
+		private $logger: ILogger) {
 	}
 
-	public initialize(projectDir: string): void {
-		if (!this.projectFilePath) {
-			this.projectFilePath = path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME);
-		}
+	public getNSValue(projectDir: string, propertyName: string): any {
+		return this.getValue(projectDir, this.getNativeScriptPropertyName(propertyName));
 	}
 
-	public getValue(propertyName: string): any {
-		this.loadProjectFile();
-		return this.projectData ? this.projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE][propertyName] : null;
+	public setNSValue(projectDir: string, key: string, value: any): void {
+		this.setValue(projectDir, this.getNativeScriptPropertyName(key), value);
 	}
 
-	public setValue(key: string, value: any): void {
-		this.loadProjectFile();
-		if (!this.projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE]) {
-			this.projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE] = Object.create(null);
-		}
-		this.projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE][key] = value;
-		this.$fs.writeJson(this.projectFilePath, this.projectData, this.projectFileIndent);
+	public removeNSProperty(projectDir: string, propertyName: string): void {
+		this.removeProperty(projectDir, this.getNativeScriptPropertyName(propertyName));
 	}
 
-	public removeProperty(propertyName: string): void {
-		this.loadProjectFile();
-		delete this.projectData[this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE][propertyName];
-		this.$fs.writeJson(this.projectFilePath, this.projectData, this.projectFileIndent);
+	public removeDependency(projectDir: string, dependencyName: string): void {
+		const projectFileInfo = this.getProjectFileData(projectDir);
+		delete projectFileInfo.projectData[ProjectDataService.DEPENDENCIES_KEY_NAME][dependencyName];
+		this.$fs.writeJson(projectFileInfo.projectFilePath, projectFileInfo.projectData);
 	}
 
-	public removeDependency(dependencyName: string): void {
-		this.loadProjectFile();
-		delete this.projectData[ProjectDataService.DEPENDENCIES_KEY_NAME][dependencyName];
-		this.$fs.writeJson(this.projectFilePath, this.projectData, this.projectFileIndent);
-	}
+	private getValue(projectDir: string, propertyName: string): any {
+		const projectData = this.getProjectFileData(projectDir).projectData;
 
-	private loadProjectFile(): void {
-		assert.ok(this.projectFilePath, "Initialize method of projectDataService is not called.");
-
-		if (!this.$fs.exists(this.projectFilePath)) {
-			this.$fs.writeJson(this.projectFilePath, {
-				"description": "NativeScript Application",
-				"license": "SEE LICENSE IN <your-license-filename>",
-				"readme": "NativeScript Application",
-				"repository": "<fill-your-repository-here>"
-			});
+		if (projectData) {
+			try {
+				return this.getPropertyValueFromJson(projectData, propertyName);
+			} catch (err) {
+				this.$logger.trace(`Error while trying to get property ${propertyName} from ${projectDir}. Error is:`, err);
+			}
 		}
 
-		// Detect indent and use it later to write JSON.
-		let projectFileContent = this.$fs.readText(this.projectFilePath);
-
-		this.projectFileIndent = projectFileContent ? this.detectIndent(projectFileContent) : "\t";
-
-		this.projectData = projectFileContent ? JSON.parse(projectFileContent) : Object.create(null);
+		return null;
 	}
 
-	private detectIndent(content: string): any {
-		const leadingSpace = content.match(/(^[ ]+)\S/m);
-		if (leadingSpace) {
-			return leadingSpace[1].length;
+	private getNativeScriptPropertyName(propertyName: string) {
+		return `${this.$staticConfig.CLIENT_NAME_KEY_IN_PROJECT_FILE}.${propertyName}`;
+	}
+
+	private getPropertyValueFromJson(jsonData: any, dottedPropertyName: string): any {
+		const props = dottedPropertyName.split(".");
+		let result = jsonData[props.shift()];
+
+		for (let prop of props) {
+			result = result[prop];
 		}
-		return "\t";
+
+		return result;
+	}
+
+	private setValue(projectDir: string, key: string, value: any): void {
+		const projectFileInfo = this.getProjectFileData(projectDir);
+
+		const props = key.split(".");
+		let data: any = projectFileInfo.projectData;
+		let currentData = data;
+
+		_.each(props, (prop, index: number) => {
+			if (index === (props.length - 1)) {
+				currentData[prop] = value;
+			} else {
+				currentData[prop] = currentData[prop] || Object.create(null);
+			}
+
+			currentData = currentData[prop];
+		});
+
+		this.$fs.writeJson(projectFileInfo.projectFilePath, data);
+	}
+
+	private removeProperty(projectDir: string, propertyName: string): void {
+		const projectFileInfo = this.getProjectFileData(projectDir);
+		let data: any = projectFileInfo.projectData;
+		let currentData = data;
+		const props = propertyName.split(".");
+		const propertyToDelete = props.splice(props.length - 1, 1)[0];
+
+		_.each(props, (prop) => {
+			currentData = currentData[prop];
+		});
+
+		delete currentData[propertyToDelete];
+		this.$fs.writeJson(projectFileInfo.projectFilePath, data);
+	}
+
+	private getProjectFileData(projectDir: string): IProjectFileData {
+		const projectFilePath = path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME);
+		const projectFileContent = this.$fs.readText(projectFilePath);
+		const projectData = projectFileContent ? JSON.parse(projectFileContent) : Object.create(null);
+
+		return {
+			projectData,
+			projectFilePath
+		};
 	}
 }
 $injector.register("projectDataService", ProjectDataService);

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -12,7 +12,8 @@ export class ProjectService implements IProjectService {
 		private $projectDataService: IProjectDataService,
 		private $projectHelper: IProjectHelper,
 		private $projectNameService: IProjectNameService,
-		private $projectTemplatesService: IProjectTemplatesService) { }
+		private $projectTemplatesService: IProjectTemplatesService,
+		private $staticConfig: IStaticConfig) { }
 
 	@exportedPromise("projectService")
 	public async createProject(projectOptions: IProjectSettings): Promise<void> {
@@ -61,6 +62,7 @@ export class ProjectService implements IProjectService {
 			this.$fs.deleteDirectory(projectDir);
 			throw err;
 		}
+
 		this.$logger.printMarkdown("Project `%s` was successfully created.", projectName);
 	}
 
@@ -72,6 +74,7 @@ export class ProjectService implements IProjectService {
 		} else {
 			this.$logger.trace(`Template ${templatePath} does not have ${constants.PACKAGE_JSON_FILE_NAME} file.`);
 		}
+
 		return null;
 	}
 
@@ -134,8 +137,16 @@ export class ProjectService implements IProjectService {
 	}
 
 	private createPackageJson(projectDir: string, projectId: string): void {
-		this.$projectDataService.initialize(projectDir);
-		this.$projectDataService.setValue("id", projectId);
+		const projectFilePath = path.join(projectDir, this.$staticConfig.PROJECT_FILE_NAME);
+
+		this.$fs.writeJson(projectFilePath, {
+			"description": "NativeScript Application",
+			"license": "SEE LICENSE IN <your-license-filename>",
+			"readme": "NativeScript Application",
+			"repository": "<fill-your-repository-here>"
+		});
+
+		this.$projectDataService.setNSValue(projectDir, "id", projectId);
 	}
 }
 $injector.register("projectService", ProjectService);

--- a/test/services/project-data-service.ts
+++ b/test/services/project-data-service.ts
@@ -1,0 +1,234 @@
+import { Yok } from "../../lib/common/yok";
+import { assert } from "chai";
+import { ProjectDataService } from "../../lib/services/project-data-service";
+import { LoggerStub } from "../stubs";
+
+const CLIENT_NAME_KEY_IN_PROJECT_FILE = "nativescript";
+
+const testData: any = [{
+	"propertyValue": 1,
+	"propertyName": "root",
+	"description": "returns correct result when a single propertyName is passed and the value of it is number"
+},
+{
+	"propertyValue": "expectedData",
+	"propertyName": "root",
+	"description": "returns correct result when a single propertyName is passed and the value of it is string"
+},
+{
+	"propertyValue": "expectedData",
+	"propertyName": "root.prop1",
+	"description": "returns correct result when inner propertyName is passed and the value of it is string"
+},
+{
+	"propertyValue": 1234,
+	"propertyName": "root.prop1",
+	"description": "returns correct result when inner propertyName is passed and the value of it is number"
+},
+{
+	"propertyValue": "expectedData",
+	"propertyName": "root.prop1.prop2.prop3.prop4",
+	"description": "returns correct result when really inner propertyName is passed and the value of it is string"
+}
+];
+
+const createTestInjector = (readTextData?: string): IInjector => {
+	const testInjector = new Yok();
+	testInjector.register("staticConfig", {
+		CLIENT_NAME_KEY_IN_PROJECT_FILE: CLIENT_NAME_KEY_IN_PROJECT_FILE,
+		PROJECT_FILE_NAME: "package.json"
+	});
+
+	testInjector.register("fs", {
+		writeJson: (filename: string, data: any, space?: string, encoding?: string): void => {
+			/** intentionally left blank */
+		},
+
+		readText: (filename: string, encoding?: IReadFileOptions | string): string => {
+			return readTextData;
+		}
+	});
+
+	testInjector.register("logger", LoggerStub);
+
+	testInjector.register("projectDataService", ProjectDataService);
+
+	return testInjector;
+};
+
+describe("projectDataService", () => {
+	const generateJsonDataFromTestData = (currentTestData: any, skipNativeScriptKey?: boolean) => {
+		const props = currentTestData.propertyName.split(".");
+		let data: any = {};
+		let currentData: any = skipNativeScriptKey ? data : (data[CLIENT_NAME_KEY_IN_PROJECT_FILE] = {});
+
+		_.each(props, (prop, index: number) => {
+			if (index === (props.length - 1)) {
+				currentData[prop] = currentTestData.propertyValue;
+			} else {
+				currentData[prop] = {};
+			}
+
+			currentData = currentData[prop];
+		});
+
+		return data;
+	};
+
+	const generateFileContentFromTestData = (currentTestData: any, skipNativeScriptKey?: boolean) => {
+		const data = generateJsonDataFromTestData(currentTestData, skipNativeScriptKey);
+		return JSON.stringify(data);
+	};
+
+	describe("getNSValue", () => {
+
+		_.each(testData, currentTestData => {
+
+			it(currentTestData.description, () => {
+				const testInjector = createTestInjector(generateFileContentFromTestData(currentTestData));
+				const projectDataService: IProjectDataService = testInjector.resolve("projectDataService");
+
+				const actualValue = projectDataService.getNSValue("projectDir", currentTestData.propertyName);
+				assert.deepEqual(actualValue, currentTestData.propertyValue);
+			});
+
+		});
+	});
+
+	describe("setNSValue", () => {
+
+		_.each(testData, currentTestData => {
+
+			it(currentTestData.description, () => {
+				const defaultEmptyData: any = {};
+				defaultEmptyData[CLIENT_NAME_KEY_IN_PROJECT_FILE] = {};
+
+				const testInjector = createTestInjector(JSON.stringify(defaultEmptyData));
+				const fs: IFileSystem = testInjector.resolve("fs");
+
+				let dataPassedToWriteJson: any = null;
+				fs.writeJson = (filename: string, data: any, space?: string, encoding?: string): void => {
+					dataPassedToWriteJson = data;
+				};
+
+				const projectDataService: IProjectDataService = testInjector.resolve("projectDataService");
+				projectDataService.setNSValue("projectDir", currentTestData.propertyName, currentTestData.propertyValue);
+
+				assert.deepEqual(dataPassedToWriteJson, generateJsonDataFromTestData(currentTestData));
+				assert.isTrue(!!dataPassedToWriteJson[CLIENT_NAME_KEY_IN_PROJECT_FILE], "Data passed to write JSON must contain nativescript key.");
+			});
+
+		});
+
+		it("removes only the selected property", () => {
+			const initialData: any = {};
+			initialData[CLIENT_NAME_KEY_IN_PROJECT_FILE] = {
+				"root": {
+					"id": "1",
+					"constantItem": "myValue"
+				}
+			};
+
+			const testInjector = createTestInjector(JSON.stringify(initialData));
+			const fs: IFileSystem = testInjector.resolve("fs");
+
+			let dataPassedToWriteJson: any = null;
+			fs.writeJson = (filename: string, data: any, space?: string, encoding?: string): void => {
+				dataPassedToWriteJson = data;
+			};
+
+			const projectDataService: IProjectDataService = testInjector.resolve("projectDataService");
+			projectDataService.setNSValue("projectDir", "root.id", "2");
+			const expectedData = _.cloneDeep(initialData);
+			expectedData[CLIENT_NAME_KEY_IN_PROJECT_FILE].root.id = "2";
+			assert.isTrue(!!dataPassedToWriteJson[CLIENT_NAME_KEY_IN_PROJECT_FILE], "Data passed to write JSON must contain nativescript key.");
+			assert.deepEqual(dataPassedToWriteJson, expectedData);
+			assert.deepEqual(dataPassedToWriteJson[CLIENT_NAME_KEY_IN_PROJECT_FILE].root.id, "2");
+			assert.deepEqual(dataPassedToWriteJson[CLIENT_NAME_KEY_IN_PROJECT_FILE].root.constantItem, "myValue");
+		});
+
+	});
+
+	describe("removeNSProperty", () => {
+
+		const generateExpectedDataFromTestData = (currentTestData: any) => {
+			const props = currentTestData.propertyName.split(".");
+			props.splice(props.length - 1, 1);
+
+			let data: any = {};
+			let currentData: any = data[CLIENT_NAME_KEY_IN_PROJECT_FILE] = {};
+
+			_.each(props, (prop) => {
+				currentData = currentData[prop] = {};
+			});
+
+			return data;
+		};
+
+		_.each(testData, currentTestData => {
+
+			it(currentTestData.description, () => {
+				generateFileContentFromTestData(currentTestData);
+
+				const testInjector = createTestInjector(generateFileContentFromTestData(currentTestData));
+				const fs: IFileSystem = testInjector.resolve("fs");
+
+				let dataPassedToWriteJson: any = null;
+				fs.writeJson = (filename: string, data: any, space?: string, encoding?: string): void => {
+					dataPassedToWriteJson = data;
+				};
+
+				const projectDataService: IProjectDataService = testInjector.resolve("projectDataService");
+				projectDataService.removeNSProperty("projectDir", currentTestData.propertyName);
+
+				assert.deepEqual(dataPassedToWriteJson, generateExpectedDataFromTestData(currentTestData));
+				assert.isTrue(!!dataPassedToWriteJson[CLIENT_NAME_KEY_IN_PROJECT_FILE], "Data passed to write JSON must contain nativescript key.");
+			});
+
+		});
+
+		it("removes only the selected property", () => {
+			const initialData: any = {};
+			initialData[CLIENT_NAME_KEY_IN_PROJECT_FILE] = {
+				"root": {
+					"id": "1",
+					"constantItem": "myValue"
+				}
+			};
+
+			const testInjector = createTestInjector(JSON.stringify(initialData));
+			const fs: IFileSystem = testInjector.resolve("fs");
+
+			let dataPassedToWriteJson: any = null;
+			fs.writeJson = (filename: string, data: any, space?: string, encoding?: string): void => {
+				dataPassedToWriteJson = data;
+			};
+
+			const projectDataService: IProjectDataService = testInjector.resolve("projectDataService");
+			projectDataService.removeNSProperty("projectDir", "root.id");
+			assert.deepEqual(dataPassedToWriteJson, { nativescript: { root: { constantItem: "myValue" } } });
+		});
+	});
+
+	describe("removeDependency", () => {
+		it("removes specified dependency from project file", () => {
+			let currentTestData = {
+				propertyName: "dependencies.myDeps",
+				propertyValue: "1.0.0"
+			};
+
+			const testInjector = createTestInjector(generateFileContentFromTestData(currentTestData, true));
+			const fs: IFileSystem = testInjector.resolve("fs");
+
+			let dataPassedToWriteJson: any = null;
+			fs.writeJson = (filename: string, data: any, space?: string, encoding?: string): void => {
+				dataPassedToWriteJson = data;
+			};
+
+			const projectDataService: IProjectDataService = testInjector.resolve("projectDataService");
+			projectDataService.removeDependency("projectDir", "myDeps");
+
+			assert.deepEqual(dataPassedToWriteJson, { dependencies: {} });
+		});
+	});
+});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -351,15 +351,13 @@ export class PlatformProjectServiceStub implements IPlatformProjectService {
 }
 
 export class ProjectDataService implements IProjectDataService {
-	initialize(projectDir: string): void { }
-
-	async getValue(propertyName: string): Promise<any> {
-		return Promise.resolve({});
+	getNSValue(propertyName: string): any {
+		return {};
 	}
 
-	setValue(key: string, value: any): void { }
+	setNSValue(key: string, value: any): void { }
 
-	removeProperty(propertyName: string): void { }
+	removeNSProperty(propertyName: string): void { }
 
 	removeDependency(dependencyName: string): void { }
 }


### PR DESCRIPTION
In case the CLI is `required` as a library (used in a long living process, not as a command-line interface), trying to create a project multiple times leads to errors.
The problem is in the `projectDataService` which caches the path to first created project file (package.json) and uses it for all consecutive operations.
In other cases, when CLI had to use the projectDataService, it always had to call `projectDataService.initialize` method.

Instead of relying on a magically called initialize method, modify the service methods to work with any project dir and execute the required operation for it.
This will fix the creation of multiple projects as all operations will work with currently passed project directory.
Also remove the code that creates a `package.json` file during `loadProjectFile` in projectDataService - it's required only when a project is created, so move it there.

Rename the methods getValue, setValue and removeProperty to getNSValue, setNSValue, removeNSProperty as they are intended to modify the nativescript key in package.json.
We can later expose getValue, setValue and removeProperty (they are currently private).