### PR TITLE
Pass Android release options for build/deploy/run

### DIFF
--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -18,7 +18,11 @@ export class BuildCommandBase {
 			teamId: this.$options.teamId,
 			device: this.$options.device,
 			provision: this.$options.provision,
-			release: this.$options.release
+			release: this.$options.release,
+			keyStoreAlias: this.$options.keyStoreAlias,
+			keyStorePath: this.$options.keyStorePath,
+			keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
+			keyStorePassword: this.$options.keyStorePassword
 		};
 		await this.$platformService.buildPlatform(platform, buildConfig, this.$projectData);
 		if (this.$options.copyTo) {

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -21,7 +21,11 @@ export class DeployOnDeviceCommand implements ICommand {
 			release: this.$options.release,
 			forceInstall: true,
 			provision: this.$options.provision,
-			teamId: this.$options.teamId
+			teamId: this.$options.teamId,
+			keyStoreAlias: this.$options.keyStoreAlias,
+			keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
+			keyStorePassword: this.$options.keyStorePassword,
+			keyStorePath: this.$options.keyStorePath
 		};
 		return this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options.provision);
 	}

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -16,7 +16,11 @@ export class RunCommandBase {
 			platformTemplate: this.$options.platformTemplate,
 			release: this.$options.release,
 			provision: this.$options.provision,
-			teamId: this.$options.teamId
+			teamId: this.$options.teamId,
+			keyStoreAlias: this.$options.keyStoreAlias,
+			keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
+			keyStorePassword: this.$options.keyStorePassword,
+			keyStorePath: this.$options.keyStorePath
 		};
 		await this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options.provision);
 

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -147,7 +147,7 @@ interface IDeviceEmulator extends IEmulator, IDeviceIdentifier { }
 
 interface IRunPlatformOptions extends IJustLaunch, IDeviceEmulator { }
 
-interface IDeployPlatformOptions extends IPlatformTemplate, IRelease, IClean, IDeviceEmulator, IProvision, ITeamIdentifier {
+interface IDeployPlatformOptions extends IAndroidReleaseOptions, IPlatformTemplate, IRelease, IClean, IDeviceEmulator, IProvision, ITeamIdentifier {
 	projectDir: string;
 	forceInstall?: boolean;
 }

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -437,7 +437,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				release: deployOptions.release,
 				device: deployOptions.device,
 				provision: deployOptions.provision,
-				teamId: deployOptions.teamId
+				teamId: deployOptions.teamId,
+				keyStoreAlias: deployOptions.keyStoreAlias,
+				keyStoreAliasPassword: deployOptions.keyStoreAliasPassword,
+				keyStorePassword: deployOptions.keyStorePassword,
+				keyStorePath: deployOptions.keyStorePath
 			};
 			let shouldBuild = await this.shouldBuild(platform, projectData, buildConfig);
 			if (shouldBuild) {


### PR DESCRIPTION
The commands build, deploy and run should pass Android specific options: `keyStorePath, keyStoreAlias, keyStorePassword, keyStoreAliasPassword` to the services.
This will fix building of projects for Android in release config.