### PR TITLE
Fix several issues in `@next` version

### DIFF
--- a/lib/commands/add-platform.ts
+++ b/lib/commands/add-platform.ts
@@ -9,7 +9,7 @@ export class AddPlatformCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData);
+		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, this.$options.frameworkPath);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -71,12 +71,12 @@ export class PublishIOS implements ICommand {
 				};
 				this.$logger.info("Building .ipa with the selected mobile provision and/or certificate.");
 				// This is not very correct as if we build multiple targets we will try to sign all of them using the signing identity here.
-				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options.provision);
+				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 				await this.$platformService.buildPlatform(platform, iOSBuildConfig, this.$projectData);
 				ipaFilePath = this.$platformService.lastOutputPath(platform, { isForDevice: iOSBuildConfig.buildForDevice }, this.$projectData);
 			} else {
 				this.$logger.info("No .ipa, mobile provision or certificate set. Perfect! Now we'll build .xcarchive and let Xcode pick the distribution certificate and provisioning profile for you when exporting .ipa for AppStore submission.");
-				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options.provision);
+				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 
 				let platformData = this.$platformsData.getPlatformData(platform, this.$projectData);
 				let iOSProjectService = <IOSProjectService>platformData.platformProjectService;

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -3,13 +3,13 @@ export class BuildCommandBase {
 		protected $projectData: IProjectData,
 		protected $platformsData: IPlatformsData,
 		protected $platformService: IPlatformService) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async executeCore(args: string[]): Promise<void> {
 		let platform = args[0].toLowerCase();
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options.provision);
+		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 		this.$options.clean = true;
 		const buildConfig: IiOSBuildConfig = {
 			buildForDevice: this.$options.forDevice,

--- a/lib/commands/clean-app.ts
+++ b/lib/commands/clean-app.ts
@@ -8,7 +8,7 @@ export class CleanAppCommandBase {
 	public async execute(args: string[]): Promise<void> {
 		let platform = args[0].toLowerCase();
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		return this.$platformService.cleanDestinationApp(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData);
+		return this.$platformService.cleanDestinationApp(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 	}
 }
 

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -31,7 +31,7 @@
 			provision: this.$options.provision,
 			teamId: this.$options.teamId
 		};
-		await this.$platformService.deployPlatform(this.$devicesService.platform, appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options.provision);
+		await this.$platformService.deployPlatform(this.$devicesService.platform, appFilesUpdaterOptions, deployOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 		this.$config.debugLivesync = true;
 		let applicationReloadAction = async (deviceAppData: Mobile.IDeviceAppData): Promise<void> => {
 			let projectData: IProjectData = this.$injector.resolve("projectData");

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -7,8 +7,8 @@ export class DeployOnDeviceCommand implements ICommand {
 		private $projectData: IProjectData,
 		private $errors: IErrors,
 		private $mobileHelper: Mobile.IMobileHelper) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async execute(args: string[]): Promise<void> {
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
@@ -27,7 +27,7 @@ export class DeployOnDeviceCommand implements ICommand {
 			keyStorePassword: this.$options.keyStorePassword,
 			keyStorePath: this.$options.keyStorePath
 		};
-		return this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options.provision);
+		return this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -19,7 +19,11 @@ export class EmulateCommandBase {
 			availableDevices: this.$options.availableDevices,
 			platformTemplate: this.$options.platformTemplate,
 			provision: this.$options.provision,
-			teamId: this.$options.teamId
+			teamId: this.$options.teamId,
+			keyStoreAlias: this.$options.keyStoreAlias,
+			keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
+			keyStorePassword: this.$options.keyStorePassword,
+			keyStorePath: this.$options.keyStorePath
 		};
 		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 	}

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -21,7 +21,7 @@ export class EmulateCommandBase {
 			provision: this.$options.provision,
 			teamId: this.$options.teamId
 		};
-		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, this.$options.provision);
+		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 	}
 }
 

--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -31,7 +31,7 @@ export class InstallCommand implements ICommand {
 			const frameworkPackageData = this.$projectDataService.getNSValue(this.$projectData.projectDir, platformData.frameworkPackageName);
 			if (frameworkPackageData && frameworkPackageData.version) {
 				try {
-					await this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`], this.$options.platformTemplate, this.$projectData);
+					await this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`], this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, this.$options.frameworkPath);
 				} catch (err) {
 					error = `${error}${EOL}${err}`;
 				}

--- a/lib/commands/livesync.ts
+++ b/lib/commands/livesync.ts
@@ -28,7 +28,7 @@ export class LivesyncCommand implements ICommand {
 			teamId: this.$options.teamId
 		};
 
-		await this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options.provision);
+		await this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 		return this.$usbLiveSyncService.liveSync(args[0], this.$projectData);
 	}
 

--- a/lib/commands/platform-clean.ts
+++ b/lib/commands/platform-clean.ts
@@ -10,7 +10,7 @@ export class CleanCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		await this.$platformService.removePlatforms(args, this.$projectData);
-		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData);
+		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -10,7 +10,7 @@ export class PrepareCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		await this.$platformService.preparePlatform(args[0], appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options.provision);
+		await this.$platformService.preparePlatform(args[0], appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -22,7 +22,7 @@ export class RunCommandBase {
 			keyStorePassword: this.$options.keyStorePassword,
 			keyStorePath: this.$options.keyStorePath
 		};
-		await this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options.provision);
+		await this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 
 		if (this.$options.bundle) {
 			this.$options.watch = false;

--- a/lib/commands/update-platform.ts
+++ b/lib/commands/update-platform.ts
@@ -9,7 +9,7 @@ export class UpdatePlatformCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.updatePlatforms(args, this.$options.platformTemplate, this.$projectData);
+		await this.$platformService.updatePlatforms(args, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -83,12 +83,12 @@ export class UpdateCommand implements ICommand {
 		platforms = platforms.concat(packagePlatforms);
 		if (args.length === 1) {
 			for (let platform of platforms) {
-				await this.$platformService.addPlatforms([platform + "@" + args[0]], this.$options.platformTemplate, this.$projectData);
+				await this.$platformService.addPlatforms([platform + "@" + args[0]], this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, this.$options.frameworkPath);
 			}
 
 			await this.$pluginsService.add("tns-core-modules@" + args[0], this.$projectData);
 		} else {
-			await this.$platformService.addPlatforms(platforms, this.$options.platformTemplate, this.$projectData);
+			await this.$platformService.addPlatforms(platforms, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, this.$options.frameworkPath);
 			await this.$pluginsService.add("tns-core-modules", this.$projectData);
 		}
 

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -60,10 +60,10 @@ interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase 
 	 * @param  {Mobile.IDeviceAppData} deviceAppData Information about the application and the device.
 	 * @param  {Mobile.ILocalToDevicePathData[]} localToDevicePaths Object containing a mapping of file paths from the system to the device.
 	 * @param  {boolean} forceExecuteFullSync If this is passed a full LiveSync is performed instead of an incremental one.
-	 * @param  {string} projectId Project identifier - for example org.nativescript.livesync.
+	 * @param  {IProjectData} projectData Project data.
 	 * @return {Promise<void>}
 	 */
-	refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], forceExecuteFullSync: boolean, projectId: string): Promise<void>;
+	refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], forceExecuteFullSync: boolean, projectData: IProjectData): Promise<void>;
 	/**
 	 * Removes specified files from a connected device
 	 * @param  {string} appIdentifier Application identifier.
@@ -78,7 +78,7 @@ interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase 
 interface IPlatformLiveSyncService {
 	fullSync(projectData: IProjectData, postAction?: (deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => Promise<void>): Promise<void>;
 	partialSync(event: string, filePath: string, dispatcher: IFutureDispatcher, afterFileSyncAction: (deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => Promise<void>, projectData: IProjectData): Promise<void>;
-	refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], isFullSync: boolean, projectId: string): Promise<void>;
+	refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], isFullSync: boolean, projectData: IProjectData): Promise<void>;
 }
 
 interface IBundle {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -1,5 +1,5 @@
 interface IPlatformService extends NodeJS.EventEmitter {
-	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData): Promise<void>;
+	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, frameworkPath?: string): Promise<void>;
 
 	/**
 	 * Gets list of all installed platforms (the ones for which <project dir>/platforms/<platform> exists).
@@ -30,7 +30,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 */
 	removePlatforms(platforms: string[], projectData: IProjectData): Promise<void>;
 
-	updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData): Promise<void>;
+	updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
 
 	/**
 	 * Ensures that the specified platform and its dependencies are installed.
@@ -41,10 +41,10 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {IAppFilesUpdaterOptions} appFilesUpdaterOptions Options needed to instantiate AppFilesUpdater class.
 	 * @param {string} platformTemplate The name of the platform template.
 	 * @param {IProjectData} projectData DTO with information about the project.
-	 * @param {any} provision UUID of the provisioning profile used in iOS project preparation.
+	 * @param {IPlatformSpecificData} platformSpecificData Platform specific data required for project preparation.
 	 * @returns {boolean} true indicates that the platform was prepared.
 	 */
-	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, provision: any): Promise<boolean>;
+	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<boolean>;
 
 	/**
 	 * Determines whether a build is necessary. A build is necessary when one of the following is true:
@@ -103,10 +103,10 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {IAppFilesUpdaterOptions} appFilesUpdaterOptions Options needed to instantiate AppFilesUpdater class.
 	 * @param {IDeployPlatformOptions} deployOptions Various options that can manage the deploy operation.
 	 * @param {IProjectData} projectData DTO with information about the project.
-	 * @param {any} provision UUID of the provisioning profile used in iOS project preparation.
+	 * @param {any} platformSpecificData Platform specific data required for project preparation.
 	 * @returns {void}
 	 */
-	deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, provision: any): Promise<void>;
+	deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
 
 	/**
 	 * Runs the application on specified platform. Assumes that the application is already build and installed. Fails if this is not true.
@@ -123,12 +123,12 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {IAppFilesUpdaterOptions} appFilesUpdaterOptions Options needed to instantiate AppFilesUpdater class.
 	 * @param {IEmulatePlatformOptions} emulateOptions Various options that can manage the emulate operation.
 	 * @param {IProjectData} projectData DTO with information about the project.
-	 * @param {any} provision UUID of the provisioning profile used in iOS project preparation.
+	 * @param {any} platformSpecificData Platform specific data required for project preparation.
 	 * @returns {void}
 	 */
-	emulatePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, emulateOptions: IEmulatePlatformOptions, projectData: IProjectData, provision: any): Promise<void>;
+	emulatePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, emulateOptions: IEmulatePlatformOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
 
-	cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData): Promise<void>;
+	cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
 	validatePlatformInstalled(platform: string, projectData: IProjectData): void;
 	validatePlatform(platform: string, projectData: IProjectData): void;
 
@@ -175,6 +175,21 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @returns {Promise<void>}
 	 */
 	trackProjectType(projectData: IProjectData): Promise<void>;
+}
+
+/**
+ * Platform specific data required for project preparation.
+ */
+interface IPlatformSpecificData {
+	/**
+	 * UUID of the provisioning profile used in iOS project preparation.
+	 */
+	provision: any;
+
+	/**
+	 * Target SDK for Android.s
+	 */
+	sdk: string;
 }
 
 interface IPlatformData {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -152,8 +152,8 @@ interface IPlatformProjectService extends NodeJS.EventEmitter {
 	getPlatformData(projectData: IProjectData): IPlatformData;
 	validate(projectData: IProjectData): Promise<void>;
 	createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, pathToTemplate?: string): Promise<void>;
-	interpolateData(projectData: IProjectData): Promise<void>;
-	interpolateConfigurationFile(projectData: IProjectData, sdk?: string): Promise<void>;
+	interpolateData(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
+	interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
 
 	/**
 	 * Executes additional actions after native project is created.
@@ -176,10 +176,10 @@ interface IPlatformProjectService extends NodeJS.EventEmitter {
 	/**
 	 * Prepares images in Native project (for iOS).
 	 * @param {IProjectData} projectData DTO with information about the project.
-	 * @param {any} provision UUID of the provisioning profile used in iOS project preparation.
+	 * @param {any} platformSpecificData Platform specific data required for project preparation.
 	 * @returns {void}
 	 */
-	prepareProject(projectData: IProjectData, provision: any): Promise<void>;
+	prepareProject(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
 
 	/**
 	 * Prepares App_Resources in the native project by clearing data from other platform and applying platform specific rules.

--- a/lib/platforms-data.ts
+++ b/lib/platforms-data.ts
@@ -15,7 +15,7 @@ export class PlatformsData implements IPlatformsData {
 	}
 
 	public getPlatformData(platform: string, projectData: IProjectData): IPlatformData {
-		return this.platformsData[platform.toLowerCase()].getPlatformData(projectData);
+		return this.platformsData[platform.toLowerCase()] && this.platformsData[platform.toLowerCase()].getPlatformData(projectData);
 	}
 
 	public get availablePlatforms(): any {

--- a/lib/providers/livesync-provider.ts
+++ b/lib/providers/livesync-provider.ts
@@ -53,7 +53,7 @@ export class LiveSyncProvider implements ILiveSyncProvider {
 
 	public async preparePlatformForSync(platform: string, provision: any, projectData: IProjectData): Promise<void> {
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, provision);
+		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: provision, sdk: this.$options.sdk });
 	}
 
 	public canExecuteFastSync(filePath: string, projectData: IProjectData, platform: string): boolean {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -183,9 +183,9 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		_.map(directoriesToClean, dir => this.$fs.deleteDirectory(dir));
 	}
 
-	public async interpolateData(projectData: IProjectData): Promise<void> {
+	public async interpolateData(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
 		// Interpolate the apilevel and package
-		await this.interpolateConfigurationFile(projectData);
+		await this.interpolateConfigurationFile(projectData, platformSpecificData);
 
 		let stringsFilePath = path.join(this.getAppResourcesDestinationDirectoryPath(projectData), 'values', 'strings.xml');
 		shell.sed('-i', /__NAME__/, projectData.projectName, stringsFilePath);
@@ -204,10 +204,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		}
 	}
 
-	public async interpolateConfigurationFile(projectData: IProjectData, sdk?: string): Promise<void> {
+	public async interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
 		let manifestPath = this.getPlatformData(projectData).configurationFilePath;
 		shell.sed('-i', /__PACKAGE__/, projectData.projectId, manifestPath);
-		shell.sed('-i', /__APILEVEL__/, sdk || (await this.$androidToolsInfo.getToolsInfo()).compileSdkVersion.toString(), manifestPath);
+		const sdk = (platformSpecificData && platformSpecificData.sdk) || (await this.$androidToolsInfo.getToolsInfo()).compileSdkVersion.toString();
+		shell.sed('-i', /__APILEVEL__/, sdk, manifestPath);
 	}
 
 	private getProjectNameFromId(projectData: IProjectData): string {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -132,7 +132,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	//TODO: plamen5kov: revisit this method, might have unnecessary/obsolete logic
-	public async interpolateData(projectData: IProjectData): Promise<void> {
+	public async interpolateData(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
 		let projectRootFilePath = path.join(this.getPlatformData(projectData).projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER);
 		// Starting with NativeScript for iOS 1.6.0, the project Info.plist file resides not in the platform project,
 		// but in the hello-world app template as a platform specific resource.
@@ -161,7 +161,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		this.replaceFileContent(pbxprojFilePath, projectData);
 	}
 
-	public interpolateConfigurationFile(projectData: IProjectData, configurationFilePath?: string): Promise<void> {
+	public interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
 		return Promise.resolve();
 	}
 
@@ -578,7 +578,9 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 		}
 	}
 
-	public async prepareProject(projectData: IProjectData, provision?: any): Promise<void> {
+	public async prepareProject(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
+		let provision = platformSpecificData && platformSpecificData.provision;
+
 		if (provision) {
 			let projectRoot = path.join(projectData.platformsDir, "ios");
 			await this.setupSigningFromProvision(projectRoot, provision);

--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -20,8 +20,8 @@ class AndroidLiveSyncService implements INativeScriptDeviceLiveSyncService {
 		return this.$androidDebugService;
 	}
 
-	public async refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], forceExecuteFullSync: boolean): Promise<void> {
-		let canExecuteFastSync = !forceExecuteFullSync && !_.some(localToDevicePaths, (localToDevicePath: any) => !this.$liveSyncProvider.canExecuteFastSync(localToDevicePath.getLocalPath(), deviceAppData.platform));
+	public async refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], forceExecuteFullSync: boolean, projectData: IProjectData): Promise<void> {
+		let canExecuteFastSync = !forceExecuteFullSync && !_.some(localToDevicePaths, (localToDevicePath: any) => !this.$liveSyncProvider.canExecuteFastSync(localToDevicePath.getLocalPath(), projectData, deviceAppData.platform));
 
 		if (canExecuteFastSync) {
 			return this.reloadPage(deviceAppData, localToDevicePaths);

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -31,7 +31,7 @@ class LiveSyncService implements ILiveSyncService {
 			if (semver.lt(frameworkVersion, "1.2.1")) {
 				let shouldUpdate = await this.$prompter.confirm("You need Android Runtime 1.2.1 or later for LiveSync to work properly. Do you want to update your runtime now?");
 				if (shouldUpdate) {
-					await this.$platformService.updatePlatforms([this.$devicePlatformsConstants.Android.toLowerCase()], this.$options.platformTemplate, projectData);
+					await this.$platformService.updatePlatforms([this.$devicePlatformsConstants.Android.toLowerCase()], this.$options.platformTemplate, projectData, null);
 				} else {
 					return;
 				}

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -123,7 +123,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 							let batch = this.batch[platform];
 							await batch.syncFiles(async (filesToSync: string[]) => {
 								const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-								await this.$platformService.preparePlatform(this.liveSyncData.platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options.provision);
+								await this.$platformService.preparePlatform(this.liveSyncData.platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 								let canExecute = this.getCanExecuteAction(this.liveSyncData.platform, this.liveSyncData.appIdentifier);
 								let deviceFileAction = (deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => this.transferFiles(deviceAppData, localToDevicePaths, this.liveSyncData.projectFilesPath, !filePath);
 								let action = this.getSyncAction(filesToSync, deviceFileAction, afterFileSyncAction, projectData);

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -48,7 +48,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 				return;
 			}
 
-			await this.refreshApplication(deviceAppData, localToDevicePaths, true, projectData.projectId);
+			await this.refreshApplication(deviceAppData, localToDevicePaths, true, projectData);
 			await this.finishLivesync(deviceAppData);
 		};
 		await this.$devicesService.execute(action, canExecute);
@@ -75,10 +75,10 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 		return isTheSamePlatformAction;
 	}
 
-	public async refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], isFullSync: boolean, projectId: string): Promise<void> {
+	public async refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], isFullSync: boolean, projectData: IProjectData): Promise<void> {
 		let deviceLiveSyncService = this.resolveDeviceSpecificLiveSyncService(deviceAppData.device.deviceInfo.platform, deviceAppData.device);
 		this.$logger.info("Refreshing application...");
-		await deviceLiveSyncService.refreshApplication(deviceAppData, localToDevicePaths, isFullSync, projectId);
+		await deviceLiveSyncService.refreshApplication(deviceAppData, localToDevicePaths, isFullSync, projectData);
 	}
 
 	protected async finishLivesync(deviceAppData: Mobile.IDeviceAppData): Promise<void> {
@@ -183,7 +183,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 				isFullSync = true;
 			} else {
 				deviceAppData = this.$deviceAppDataFactory.create(this.liveSyncData.appIdentifier, this.$mobileHelper.normalizePlatformName(this.liveSyncData.platform), device);
-				const mappedFiles = filesToSync.map((file: string) => this.$projectFilesProvider.mapFilePath(file, device.deviceInfo.platform));
+				const mappedFiles = filesToSync.map((file: string) => this.$projectFilesProvider.mapFilePath(file, device.deviceInfo.platform, projectData));
 
 				// Some plugins modify platforms dir on afterPrepare (check nativescript-dev-sass) - we want to sync only existing file.
 				const existingFiles = mappedFiles.filter(m => this.$fs.exists(m));
@@ -202,7 +202,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 			}
 
 			if (!afterFileSyncAction) {
-				await this.refreshApplication(deviceAppData, localToDevicePaths, isFullSync, projectData.projectId);
+				await this.refreshApplication(deviceAppData, localToDevicePaths, isFullSync, projectData);
 			}
 
 			await device.fileSystem.putFile(this.$projectChangesService.getPrepareInfoFilePath(device.deviceInfo.platform, projectData), await this.getLiveSyncInfoFilePath(deviceAppData), this.liveSyncData.appIdentifier);

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -54,7 +54,7 @@ class TestExecutionService implements ITestExecutionService {
 					this.$fs.writeFile(path.join(projectDir, TestExecutionService.SOCKETIO_JS_FILE_NAME), socketIoJs);
 
 					const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-					if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options.provision)) {
+					if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: this.$options.provision, sdk: this.$options.sdk })) {
 						this.$errors.failWithoutHelp("Verify that listed files are well-formed and try again the operation.");
 					}
 					this.detourEntryPoint(projectFilesPath);
@@ -69,7 +69,7 @@ class TestExecutionService implements ITestExecutionService {
 						provision: this.$options.provision,
 						teamId: this.$options.teamId
 					};
-					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, this.$options.provision);
+					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 					await this.$usbLiveSyncService.liveSync(platform, projectData);
 
 					if (this.$options.debugBrk) {
@@ -123,7 +123,7 @@ class TestExecutionService implements ITestExecutionService {
 				const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
 				// Prepare the project AFTER the TestExecutionService.CONFIG_FILE_NAME file is created in node_modules
 				// so it will be sent to device.
-				if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options.provision)) {
+				if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: this.$options.provision, sdk: this.$options.sdk })) {
 					this.$errors.failWithoutHelp("Verify that listed files are well-formed and try again the operation.");
 				}
 
@@ -141,7 +141,7 @@ class TestExecutionService implements ITestExecutionService {
 						teamId: this.$options.teamId
 					};
 
-					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, this.$options.provision);
+					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
 					await this.$usbLiveSyncService.liveSync(platform, projectData);
 				}
 			};

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -98,21 +98,21 @@ describe('Platform Service Tests', () => {
 				fs.exists = () => false;
 				let projectData: IProjectData = testInjector.resolve("projectData");
 
-				await platformService.addPlatforms(["Android"], "", projectData);
-				await platformService.addPlatforms(["ANDROID"], "", projectData);
-				await platformService.addPlatforms(["AnDrOiD"], "", projectData);
-				await platformService.addPlatforms(["androiD"], "", projectData);
+				await platformService.addPlatforms(["Android"], "", projectData, null);
+				await platformService.addPlatforms(["ANDROID"], "", projectData, null);
+				await platformService.addPlatforms(["AnDrOiD"], "", projectData, null);
+				await platformService.addPlatforms(["androiD"], "", projectData, null);
 
-				await platformService.addPlatforms(["iOS"], "", projectData);
-				await platformService.addPlatforms(["IOS"], "", projectData);
-				await platformService.addPlatforms(["IoS"], "", projectData);
-				await platformService.addPlatforms(["iOs"], "", projectData);
+				await platformService.addPlatforms(["iOS"], "", projectData, null);
+				await platformService.addPlatforms(["IOS"], "", projectData, null);
+				await platformService.addPlatforms(["IoS"], "", projectData, null);
+				await platformService.addPlatforms(["iOs"], "", projectData, null);
 			});
 			it("should fail if platform is already installed", async () => {
 				let projectData: IProjectData = testInjector.resolve("projectData");
 				// By default fs.exists returns true, so the platforms directory should exists
-				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData));
-				await assert.isRejected(platformService.addPlatforms(["ios"], "", projectData));
+				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, null));
+				await assert.isRejected(platformService.addPlatforms(["ios"], "", projectData, null));
 			});
 			it("should fail if npm is unavalible", async () => {
 				let fs = testInjector.resolve("fs");
@@ -124,7 +124,7 @@ describe('Platform Service Tests', () => {
 				let projectData: IProjectData = testInjector.resolve("projectData");
 
 				try {
-					await platformService.addPlatforms(["android"], "", projectData);
+					await platformService.addPlatforms(["android"], "", projectData, null);
 				} catch (err) {
 					assert.equal(errorMessage, err.message);
 				}
@@ -144,7 +144,7 @@ describe('Platform Service Tests', () => {
 				};
 
 				try {
-					await platformService.addPlatforms(["ios"], "", projectData);
+					await platformService.addPlatforms(["ios"], "", projectData, null);
 				} catch (err) {
 					assert.equal(errorMessage, err.message);
 				}
@@ -164,7 +164,7 @@ describe('Platform Service Tests', () => {
 				let projectData: IProjectData = testInjector.resolve("projectData");
 
 				try {
-					await platformService.addPlatforms(["android"], "", projectData);
+					await platformService.addPlatforms(["android"], "", projectData, null);
 				} catch (err) {
 					assert.equal(errorMessage, err.message);
 				}
@@ -196,7 +196,7 @@ describe('Platform Service Tests', () => {
 		it("shouldn't fail when platforms are added", async () => {
 			let projectData: IProjectData = testInjector.resolve("projectData");
 			testInjector.resolve("fs").exists = () => false;
-			await platformService.addPlatforms(["android"], "", projectData);
+			await platformService.addPlatforms(["android"], "", projectData, null);
 
 			testInjector.resolve("fs").exists = () => true;
 			await platformService.removePlatforms(["android"], projectData);
@@ -217,7 +217,7 @@ describe('Platform Service Tests', () => {
 				npmInstallationManager.getLatestVersion = async () => "0.2.0";
 				let projectData: IProjectData = testInjector.resolve("projectData");
 
-				await assert.isRejected(platformService.updatePlatforms(["android"], "", projectData));
+				await assert.isRejected(platformService.updatePlatforms(["android"], "", projectData, null));
 			});
 		});
 	});


### PR DESCRIPTION
Each commit fixes different issue, so each commit can be checked on its own.

### Fix adding of invalid platform
When user tries to add invalid platform, CLI should prints user-friendly
message. Instead it fails that cannot read `getPlatformData` of
`undefined`. The reason is a change in platforms-data `getPlatformsData`
method. Fix it to return undefined when there's no platform specific
data. This way the code will detect the invalid platform and will fail
with user-friendly message.
Fixes https://github.com/NativeScript/nativescript-cli/issues/2587

### Fix specifiying --sdk on platform add
During adding of Android platform, users can specify targetSdk via
`--sdk` command line option. This has been broken in previous commit.
As our services should not rely on `$options`, sdk must be passed as
parameter whenever it could be used. It turns out some common methods
(addPlatform, preparePlatform) rely on platform specific data - sdk,
provision, etc. In order to handle this without adding new arguments,
introudce IPlatformSpecificData interface and use it in al methods
where we have to pass some of the platform specific data required for
preparing of the project.
Fixes: https://github.com/NativeScript/nativescript-cli/issues/2588

### 	Pass android specific options for emulate command
In case you want to use `tns emulate android --release`, several android
specific options should be passed and used by the service. Even when
they are passed on the command line, we did not pass them to the
service. Pass required options, so the release build will be
successfully signed.
Fixes: https://github.com/NativeScript/nativescript-cli/issues/2589

### 	Fix livesync watch operations
LiveSync provider that detects how to process the files, needs the
projectData. However we had not passed it and the code fails. Pass the
data wherever its needed. This fixes livesync operations.
Fixes: https://github.com/NativeScript/nativescript-cli/issues/2590
