### PR TITLE
Improve platform-clean command check for Platform

### DIFF
--- a/lib/commands/platform-clean.ts
+++ b/lib/commands/platform-clean.ts
@@ -18,7 +18,7 @@ export class CleanCommand implements ICommand {
 			this.$errors.fail("No platform specified. Please specify a platform to clean");
 		}
 
-		_.each(args, arg => this.$platformService.validatePlatform(arg, this.$projectData));
+		_.each(args, arg => this.$platformService.validatePlatformInstalled(arg, this.$projectData));
 
 		return true;
 	}

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -130,6 +130,11 @@ interface IPlatformService extends NodeJS.EventEmitter {
 
 	cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
 	validatePlatformInstalled(platform: string, projectData: IProjectData): void;
+
+	/**
+	 * Ensures the passed platform is a valid one (from the supported ones)
+	 * and that it can be built on the current OS
+	 */
 	validatePlatform(platform: string, projectData: IProjectData): void;
 
 	/**


### PR DESCRIPTION
Fixed the platform-clean to execute only when the Platform is Valid and Installed. Add the "platform|clean" module to the test injector - now after platform|clean the code is actually executed.
