### PR TITLE
added forgoten parameter

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -44,9 +44,9 @@ class LiveSyncService implements ILiveSyncService {
 	}
 
 	public async liveSync(platform: string, projectData: IProjectData, applicationReloadAction?: (deviceAppData: Mobile.IDeviceAppData) => Promise<void>): Promise<void> {
-			if (this.$options.justlaunch) {
-				this.$options.watch = false;
-			}
+		if (this.$options.justlaunch) {
+			this.$options.watch = false;
+		}
 		let liveSyncData: ILiveSyncData[] = [];
 
 		if (platform) {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -225,7 +225,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				}
 			}
 
-			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, platformSpecificData);
+			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo);
 			this.$projectChangesService.savePrepareInfo(platform, projectData);
 		} else {
 			this.$logger.out("Skipping prepare.");


### PR DESCRIPTION
See more info: https://github.com/NativeScript/nativescript-cli/issues/2586

_Problem_
Sometimes on prepare, there were platform specific files like `name.android.js` that weren't processed correctly.