### PR TITLE
Respect runtime version written in package json

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -68,3 +68,4 @@ export const ItunesConnectApplicationTypes = new ItunesConnectApplicationTypesCl
 export const ANGULAR_NAME = "angular";
 export const TYPESCRIPT_NAME = "typescript";
 export const BUILD_OUTPUT_EVENT_NAME = "buildOutput";
+export const VERSION_STRING = "version";

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -67,6 +67,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
+		let currentPlatformData: any = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
+		if (currentPlatformData && currentPlatformData[constants.VERSION_STRING]) {
+			version = currentPlatformData[constants.VERSION_STRING];
+		}
 
 		// Copy platform specific files in platforms dir
 		let platformProjectService = platformData.platformProjectService;


### PR DESCRIPTION
Instead of always installing the latest runtime version, respect the one written in `package.json` `nativescript` key.

Ping @TsvetanMilanov @rosen-vladimirov @Plamen5kov 