### PR TITLE
Equalize the non-existent device error message #2446

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -40,7 +40,9 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		private $deviceAppDataFactory: Mobile.IDeviceAppDataFactory,
 		private $projectChangesService: IProjectChangesService,
 		private $emulatorPlatformService: IEmulatorPlatformService,
-		private $analyticsService: IAnalyticsService) {
+		private $analyticsService: IAnalyticsService,
+		private $messages: IMessages,
+		private $staticConfig: Config.IStaticConfig) {
 		super();
 	}
 
@@ -504,7 +506,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				}
 
 				if (found.length === 0) {
-					this.$errors.fail("Cannot find device with name: %s", emulateOptions.device);
+					this.$errors.fail(this.$messages.Devices.NotFoundDeviceByIdentifierErrorMessage, this.$staticConfig.CLIENT_NAME.toLowerCase());
 				}
 			}
 		}

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -26,6 +26,7 @@ import { DevicePlatformsConstants } from "../lib/common/mobile/device-platforms-
 import { XmlValidator } from "../lib/xml-validator";
 import { LockFile } from "../lib/lockfile";
 import ProjectChangesLib = require("../lib/services/project-changes-service");
+import { Messages } from "../lib/common/messages/messages";
 
 import path = require("path");
 import temp = require("temp");
@@ -82,6 +83,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("analyticsService", {
 		track: async () => undefined
 	});
+	testInjector.register("messages", Messages);
 
 	return testInjector;
 }

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -21,6 +21,7 @@ import { XmlValidator } from "../lib/xml-validator";
 import * as ChildProcessLib from "../lib/common/child-process";
 import { CleanCommand } from "../lib/commands/platform-clean";
 import ProjectChangesLib = require("../lib/services/project-changes-service");
+import { Messages } from "../lib/common/messages/messages";
 
 let isCommandExecuted = true;
 
@@ -139,6 +140,7 @@ function createTestInjector() {
 	testInjector.register("analyticsService", {
 		track: async () => undefined
 	});
+	testInjector.register("messages", Messages);
 
 	return testInjector;
 }

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -19,6 +19,7 @@ import { DevicePlatformsConstants } from "../lib/common/mobile/device-platforms-
 import { XmlValidator } from "../lib/xml-validator";
 import * as ChildProcessLib from "../lib/common/child-process";
 import ProjectChangesLib = require("../lib/services/project-changes-service");
+import { Messages } from "../lib/common/messages/messages";
 
 require("should");
 let temp = require("temp");
@@ -80,6 +81,7 @@ function createTestInjector() {
 	testInjector.register("analyticsService", {
 		track: async () => undefined
 	});
+	testInjector.register("messages", Messages);
 
 	return testInjector;
 }


### PR DESCRIPTION
Return the same error when invoking:

tns <command> --device id|name

for both platforms to be:

Cannot resolve the specified connected device by the provided index or identifier. To list currently connected devices and verify that the specified index or identifier exists, run 'tns device'.