### PR TITLE
Handle `node check-v8-dependants.js` throwing an exception

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -396,7 +396,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				let checkV8dependants = path.join(buildDir, "check-v8-dependants.js");
 				if (this.$fs.exists(checkV8dependants)) {
 					let stringifiedDependencies = JSON.stringify(dependencies);
-					await this.spawn('node', [checkV8dependants, stringifiedDependencies, projectData.platformsDir], { stdio: "inherit" });
+					try {
+						await this.spawn('node', [checkV8dependants, stringifiedDependencies, projectData.platformsDir], { stdio: "inherit" });
+					} catch (e) {
+						this.$logger.info("Checking for dependants on v8 public API failed. This is likely caused because of cyclic production dependencies. Error code: " + e.code + "\nMore information: https://github.com/NativeScript/nativescript-cli/issues/2561");
+					}
 				}
 			}
 


### PR DESCRIPTION
Log a message if during before-prepare on android an exception is thrown (most likely caused by previously traversed cyclic dependencies) when spawning a node child process to check for plugins depending on the public V8 being exposed by the runtime.

It is important to note that the likely cause, for the process throwing an exception, can be viewed as a separate issue, as having cyclic production dependencies slows down the prepare step considerably.

More info: https://github.com/NativeScript/nativescript-cli/issues/2561#issuecomment-286057592

Addresses: https://github.com/NativeScript/nativescript-cli/issues/2561