### PR TITLE
provided more information to plugin authors

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -42,9 +42,10 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {string} platformTemplate The name of the platform template.
 	 * @param {IProjectData} projectData DTO with information about the project.
 	 * @param {IPlatformSpecificData} platformSpecificData Platform specific data required for project preparation.
+	 * @param {Array} filesToSync Files about to be synced to device.
 	 * @returns {boolean} true indicates that the platform was prepared.
 	 */
-	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<boolean>;
+	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, filesToSync?: Array<String>): Promise<boolean>;
 
 	/**
 	 * Determines whether a build is necessary. A build is necessary when one of the following is true:

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -123,7 +123,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 							let batch = this.batch[platform];
 							await batch.syncFiles(async (filesToSync: string[]) => {
 								const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-								await this.$platformService.preparePlatform(this.liveSyncData.platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+								await this.$platformService.preparePlatform(this.liveSyncData.platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, filesToSync);
 								let canExecute = this.getCanExecuteAction(this.liveSyncData.platform, this.liveSyncData.appIdentifier);
 								let deviceFileAction = (deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => this.transferFiles(deviceAppData, localToDevicePaths, this.liveSyncData.projectFilesPath, !filePath);
 								let action = this.getSyncAction(filesToSync, deviceFileAction, afterFileSyncAction, projectData);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -190,7 +190,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return _.filter(this.$platformsData.platformsNames, p => { return this.isPlatformPrepared(p, projectData); });
 	}
 
-	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<boolean> {
+	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, filesToSync?: Array<String>): Promise<boolean> {
 		this.validatePlatform(platform, projectData);
 
 		await this.trackProjectType(projectData);
@@ -229,7 +229,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				}
 			}
 
-			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo);
+			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo, filesToSync);
 			this.$projectChangesService.savePrepareInfo(platform, projectData);
 		} else {
 			this.$logger.out("Skipping prepare.");
@@ -257,7 +257,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	@helpers.hook('prepare')
-	private async preparePlatformCore(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo): Promise<void> {
+	private async preparePlatformCore(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>): Promise<void> {
 		this.$logger.out("Preparing project...");
 
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -256,6 +256,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
+	/* Hooks are expected to use "filesToSync" parameter, as to give plugin authors additional information about the sync process.*/
 	@helpers.hook('prepare')
 	private async preparePlatformCore(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>): Promise<void> {
 		this.$logger.out("Preparing project...");


### PR DESCRIPTION
_Problem_:
Plugin authors do unnecessary changes, because they lack the information about files about to be synced. This workflow causes too much trouble, which can be easily avoided if cli provides more information to the plugin authors, who will then be able to handle the erroneous behavior.

_Solution_:
Introduced `hookArgs.filesToSync` parameter which contains all changed files as a string array. If no files are marked as changed `filesToSync` is `undefined`.

Plugin authors needed more information on what files have changed during livesync and we now provide this information through `hookArgs.filesToSync`, which is a string array full with all detected changed files. `hookArgs` is a parameter of the `before-(after)-prepare-hook.js` files, that gets resolved by an injector.