### PR TITLE
release option triggers build every time

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -86,7 +86,7 @@ export class ProjectChangesService implements IProjectChangesService {
 				this._prepareInfo.iOSProvisioningProfileUUID = nextCommandProvisionUUID;
 			}
 		}
-		if (this.$options.bundle !== this._prepareInfo.bundle || this.$options.release !== this._prepareInfo.release) {
+		if (this.$options.bundle !== this._prepareInfo.bundle || this.$options.release) {
 			this._changesInfo.appFilesChanged = true;
 			this._changesInfo.appResourcesChanged = true;
 			this._changesInfo.modulesChanged = true;


### PR DESCRIPTION
_Problem_:
When running release builds twice with changes to a file between them, these changes are not respected.

_Solution_
Build every time in release. With gradle 3.0 that'll happen fast so it won't be slowing down development.