### PR TITLE
Fix getting info for Android tools

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -14,7 +14,6 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 	private showWarningsAsErrors: boolean;
 	private toolsInfo: IAndroidToolsInfoData;
 	private selectedCompileSdk: number;
-	private installedTargetsCache: string[] = null;
 	private androidHome = process.env["ANDROID_HOME"];
 
 	constructor(private $childProcess: IChildProcess,
@@ -313,22 +312,16 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return parseInt(androidSdkString.replace(`${AndroidToolsInfo.ANDROID_TARGET_PREFIX}-`, ""));
 	}
 
+	@cache()
 	private getInstalledTargets(): string[] {
-		if (!this.installedTargetsCache) {
-			try {
-				const pathToInstalledTargets = path.join(this.androidHome, "platforms");
-				if (!this.$fs.exists(pathToInstalledTargets)) {
-					throw new Error("No Android Targets installed.");
-				}
-
-				this.installedTargetsCache = this.$fs.readDirectory(pathToInstalledTargets);
-				this.$logger.trace("Installed Android Targets are: ", this.installedTargetsCache);
-			} catch (err) {
-				this.$logger.trace("Unable to get Android targets. Error is: " + err);
-			}
+		let installedTargets: string[] = [];
+		const pathToInstalledTargets = path.join(this.androidHome, "platforms");
+		if (!this.$fs.exists(pathToInstalledTargets)) {
+			installedTargets = this.$fs.readDirectory(pathToInstalledTargets);
+			this.$logger.trace("Installed Android Targets are: ", installedTargets);
 		}
 
-		return this.installedTargetsCache;
+		return installedTargets;
 	}
 
 	private getMaxSupportedVersion(): number {

--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -318,10 +318,11 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 	private getInstalledTargets(): string[] {
 		let installedTargets: string[] = [];
 		const pathToInstalledTargets = path.join(this.androidHome, "platforms");
-		if (!this.$fs.exists(pathToInstalledTargets)) {
+		if (this.$fs.exists(pathToInstalledTargets)) {
 			installedTargets = this.$fs.readDirectory(pathToInstalledTargets);
-			this.$logger.trace("Installed Android Targets are: ", installedTargets);
 		}
+
+		this.$logger.trace("Installed Android Targets are: ", installedTargets);
 
 		return installedTargets;
 	}

--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -14,7 +14,9 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 	private showWarningsAsErrors: boolean;
 	private toolsInfo: IAndroidToolsInfoData;
 	private selectedCompileSdk: number;
-	private androidHome = process.env["ANDROID_HOME"];
+	private get androidHome(): string {
+		return process.env["ANDROID_HOME"];
+	}
 
 	constructor(private $childProcess: IChildProcess,
 		private $errors: IErrors,
@@ -29,7 +31,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		if (!this.toolsInfo) {
 			let infoData: IAndroidToolsInfoData = Object.create(null);
 			infoData.androidHomeEnvVar = this.androidHome;
-			infoData.compileSdkVersion = this.getCompileSdk();
+			infoData.compileSdkVersion = this.getCompileSdkVersion();
 			infoData.buildToolsVersion = this.getBuildToolsVersion();
 			infoData.targetSdkVersion = this.getTargetSdk();
 			infoData.supportRepositoryVersion = this.getAndroidSupportRepositoryVersion();
@@ -163,17 +165,17 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 
 	@cache()
 	private getPathToSdkManagementTool(): string {
-		const sdkmanagerName = "sdkmanager";
-		let sdkManagementToolPath = sdkmanagerName;
+		const sdkManagerName = "sdkmanager";
+		let sdkManagementToolPath = sdkManagerName;
 
 		const isAndroidHomeValid = this.validateAndroidHomeEnvVariable();
 
 		if (isAndroidHomeValid) {
 			// In case ANDROID_HOME is correct, check if sdkmanager exists and if not it means the SDK has not been updated.
 			// In this case user shoud use `android` from the command-line instead of sdkmanager.
-			const pathToSdkmanager = path.join(this.androidHome, "tools", "bin", sdkmanagerName);
+			const pathToSdkManager = path.join(this.androidHome, "tools", "bin", sdkManagerName);
 			const pathToAndroidExecutable = path.join(this.androidHome, "tools", "android");
-			const pathToExecutable = this.$fs.exists(pathToSdkmanager) ? pathToSdkmanager : pathToAndroidExecutable;
+			const pathToExecutable = this.$fs.exists(pathToSdkManager) ? pathToSdkManager : pathToAndroidExecutable;
 
 			this.$logger.trace(`Path to Android SDK Management tool is: ${pathToExecutable}`);
 
@@ -208,7 +210,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		}
 	}
 
-	private getCompileSdk(): number {
+	private getCompileSdkVersion(): number {
 		if (!this.selectedCompileSdk) {
 			let userSpecifiedCompileSdk = this.$options.compileSdk;
 			if (userSpecifiedCompileSdk) {
@@ -235,7 +237,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 	}
 
 	private getTargetSdk(): number {
-		let targetSdk = this.$options.sdk ? parseInt(this.$options.sdk) : this.getCompileSdk();
+		let targetSdk = this.$options.sdk ? parseInt(this.$options.sdk) : this.getCompileSdkVersion();
 		this.$logger.trace(`Selected targetSdk is: ${targetSdk}`);
 		return targetSdk;
 	}
@@ -282,7 +284,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 	}
 
 	private getAppCompatRange(): string {
-		let compileSdkVersion = this.getCompileSdk();
+		let compileSdkVersion = this.getCompileSdkVersion();
 		let requiredAppCompatRange: string;
 		if (compileSdkVersion) {
 			requiredAppCompatRange = `>=${compileSdkVersion} <${compileSdkVersion + 1}`;

--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -25,14 +25,15 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		private $options: IOptions,
 		protected $staticConfig: Config.IStaticConfig) { }
 
-	public async getToolsInfo(): Promise<IAndroidToolsInfoData> {
+	@cache()
+	public getToolsInfo(): IAndroidToolsInfoData {
 		if (!this.toolsInfo) {
 			let infoData: IAndroidToolsInfoData = Object.create(null);
 			infoData.androidHomeEnvVar = this.androidHome;
-			infoData.compileSdkVersion = await this.getCompileSdk();
-			infoData.buildToolsVersion = await this.getBuildToolsVersion();
-			infoData.targetSdkVersion = await this.getTargetSdk();
-			infoData.supportRepositoryVersion = await this.getAndroidSupportRepositoryVersion();
+			infoData.compileSdkVersion = this.getCompileSdk();
+			infoData.buildToolsVersion = this.getBuildToolsVersion();
+			infoData.targetSdkVersion = this.getTargetSdk();
+			infoData.supportRepositoryVersion = this.getAndroidSupportRepositoryVersion();
 			infoData.generateTypings = this.shouldGenerateTypings();
 
 			this.toolsInfo = infoData;
@@ -41,21 +42,10 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return this.toolsInfo;
 	}
 
-	@cache()
-	private getPathToSdkManagementTool(): string {
-		const pathToSdkmanager = path.join(this.androidHome, "tools", "bin", "sdkmanager") + (this.$hostInfo.isWindows ? ".bat" : "");
-		const pathToAndroidExecutable = path.join(this.androidHome, "tools", "android") + (this.$hostInfo.isWindows ? ".bat" : "");
-		const pathToExecutable = this.$fs.exists(pathToSdkmanager) ? pathToSdkmanager : pathToAndroidExecutable;
-
-		this.$logger.trace(`Path to Android SDK Management tool is: ${pathToExecutable}`);
-
-		return pathToExecutable.replace(this.androidHome, this.$hostInfo.isWindows ? "%ANDROID_HOME%" : "$ANDROID_HOME");
-	}
-
-	public async validateInfo(options?: { showWarningsAsErrors: boolean, validateTargetSdk: boolean }): Promise<boolean> {
+	public validateInfo(options?: { showWarningsAsErrors: boolean, validateTargetSdk: boolean }): boolean {
 		let detectedErrors = false;
 		this.showWarningsAsErrors = options && options.showWarningsAsErrors;
-		let toolsInfoData = await this.getToolsInfo();
+		let toolsInfoData = this.getToolsInfo();
 		let isAndroidHomeValid = this.validateAndroidHomeEnvVariable();
 		if (!toolsInfoData.compileSdkVersion) {
 			this.printMessage(`Cannot find a compatible Android SDK for compilation. To be able to build for Android, install Android SDK ${AndroidToolsInfo.MIN_REQUIRED_COMPILE_TARGET} or later.`,
@@ -149,26 +139,49 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return null;
 	}
 
-	private _cachedAndroidHomeValidationResult: boolean = null;
+	@cache()
 	public validateAndroidHomeEnvVariable(options?: { showWarningsAsErrors: boolean }): boolean {
-		if (this._cachedAndroidHomeValidationResult === null) {
-			this.showWarningsAsErrors = options && options.showWarningsAsErrors;
-
-			this._cachedAndroidHomeValidationResult = true;
-			let expectedDirectoriesInAndroidHome = ["build-tools", "tools", "platform-tools", "extras"];
-			if (!this.androidHome || !this.$fs.exists(this.androidHome)) {
-				this.printMessage("The ANDROID_HOME environment variable is not set or it points to a non-existent directory. You will not be able to perform any build-related operations for Android.",
-					"To be able to perform Android build-related operations, set the `ANDROID_HOME` variable to point to the root of your Android SDK installation directory.");
-				this._cachedAndroidHomeValidationResult = false;
-			} else if (!_.some(expectedDirectoriesInAndroidHome.map(dir => this.$fs.exists(path.join(this.androidHome, dir))))) {
-				this.printMessage("The ANDROID_HOME environment variable points to incorrect directory. You will not be able to perform any build-related operations for Android.",
-					"To be able to perform Android build-related operations, set the `ANDROID_HOME` variable to point to the root of your Android SDK installation directory, " +
-					"where you will find `tools` and `platform-tools` directories.");
-				this._cachedAndroidHomeValidationResult = false;
-			}
+		if (options) {
+			this.showWarningsAsErrors = options.showWarningsAsErrors;
 		}
 
-		return this._cachedAndroidHomeValidationResult;
+		const expectedDirectoriesInAndroidHome = ["build-tools", "tools", "platform-tools", "extras"];
+		let androidHomeValidationResult = true;
+
+		if (!this.androidHome || !this.$fs.exists(this.androidHome)) {
+			this.printMessage("The ANDROID_HOME environment variable is not set or it points to a non-existent directory. You will not be able to perform any build-related operations for Android.",
+				"To be able to perform Android build-related operations, set the `ANDROID_HOME` variable to point to the root of your Android SDK installation directory.");
+			androidHomeValidationResult = false;
+		} else if (!_.some(expectedDirectoriesInAndroidHome.map(dir => this.$fs.exists(path.join(this.androidHome, dir))))) {
+			this.printMessage("The ANDROID_HOME environment variable points to incorrect directory. You will not be able to perform any build-related operations for Android.",
+				"To be able to perform Android build-related operations, set the `ANDROID_HOME` variable to point to the root of your Android SDK installation directory, " +
+				"where you will find `tools` and `platform-tools` directories.");
+			androidHomeValidationResult = false;
+		}
+
+		return androidHomeValidationResult;
+	}
+
+	@cache()
+	private getPathToSdkManagementTool(): string {
+		const sdkmanagerName = "sdkmanager";
+		let sdkManagementToolPath = sdkmanagerName;
+
+		const isAndroidHomeValid = this.validateAndroidHomeEnvVariable();
+
+		if (isAndroidHomeValid) {
+			// In case ANDROID_HOME is correct, check if sdkmanager exists and if not it means the SDK has not been updated.
+			// In this case user shoud use `android` from the command-line instead of sdkmanager.
+			const pathToSdkmanager = path.join(this.androidHome, "tools", "bin", sdkmanagerName);
+			const pathToAndroidExecutable = path.join(this.androidHome, "tools", "android");
+			const pathToExecutable = this.$fs.exists(pathToSdkmanager) ? pathToSdkmanager : pathToAndroidExecutable;
+
+			this.$logger.trace(`Path to Android SDK Management tool is: ${pathToExecutable}`);
+
+			sdkManagementToolPath = pathToExecutable.replace(this.androidHome, this.$hostInfo.isWindows ? "%ANDROID_HOME%" : "$ANDROID_HOME");
+		}
+
+		return sdkManagementToolPath;
 	}
 
 	private shouldGenerateTypings(): boolean {
@@ -196,11 +209,11 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		}
 	}
 
-	private async getCompileSdk(): Promise<number> {
+	private getCompileSdk(): number {
 		if (!this.selectedCompileSdk) {
 			let userSpecifiedCompileSdk = this.$options.compileSdk;
 			if (userSpecifiedCompileSdk) {
-				let installedTargets = await this.getInstalledTargets();
+				let installedTargets = this.getInstalledTargets();
 				let androidCompileSdk = `${AndroidToolsInfo.ANDROID_TARGET_PREFIX}-${userSpecifiedCompileSdk}`;
 				if (!_.includes(installedTargets, androidCompileSdk)) {
 					this.$errors.failWithoutHelp(`You have specified '${userSpecifiedCompileSdk}' for compile sdk, but it is not installed on your system.`);
@@ -208,7 +221,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 
 				this.selectedCompileSdk = userSpecifiedCompileSdk;
 			} else {
-				let latestValidAndroidTarget = await this.getLatestValidAndroidTarget();
+				let latestValidAndroidTarget = this.getLatestValidAndroidTarget();
 				if (latestValidAndroidTarget) {
 					let integerVersion = this.parseAndroidSdkString(latestValidAndroidTarget);
 
@@ -222,8 +235,8 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return this.selectedCompileSdk;
 	}
 
-	private async getTargetSdk(): Promise<number> {
-		let targetSdk = this.$options.sdk ? parseInt(this.$options.sdk) : await this.getCompileSdk();
+	private getTargetSdk(): number {
+		let targetSdk = this.$options.sdk ? parseInt(this.$options.sdk) : this.getCompileSdk();
 		this.$logger.trace(`Selected targetSdk is: ${targetSdk}`);
 		return targetSdk;
 	}
@@ -258,7 +271,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return `${AndroidToolsInfo.REQUIRED_BUILD_TOOLS_RANGE_PREFIX} <=${this.getMaxSupportedVersion()}`;
 	}
 
-	private async getBuildToolsVersion(): Promise<string> {
+	private getBuildToolsVersion(): string {
 		let buildToolsVersion: string;
 		if (this.androidHome) {
 			let pathToBuildTools = path.join(this.androidHome, "build-tools");
@@ -269,8 +282,8 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return buildToolsVersion;
 	}
 
-	private async getAppCompatRange(): Promise<string> {
-		let compileSdkVersion = await this.getCompileSdk();
+	private getAppCompatRange(): string {
+		let compileSdkVersion = this.getCompileSdk();
 		let requiredAppCompatRange: string;
 		if (compileSdkVersion) {
 			requiredAppCompatRange = `>=${compileSdkVersion} <${compileSdkVersion + 1}`;
@@ -279,9 +292,9 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return requiredAppCompatRange;
 	}
 
-	private async getAndroidSupportRepositoryVersion(): Promise<string> {
+	private getAndroidSupportRepositoryVersion(): string {
 		let selectedAppCompatVersion: string;
-		let requiredAppCompatRange = await this.getAppCompatRange();
+		let requiredAppCompatRange = this.getAppCompatRange();
 		if (this.androidHome && requiredAppCompatRange) {
 			let pathToAppCompat = path.join(this.androidHome, "extras", "android", "m2repository", "com", "android", "support", "appcompat-v7");
 			selectedAppCompatVersion = this.getMatchingDir(pathToAppCompat, requiredAppCompatRange);
@@ -291,8 +304,8 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return selectedAppCompatVersion;
 	}
 
-	private async getLatestValidAndroidTarget(): Promise<string> {
-		let installedTargets = await this.getInstalledTargets();
+	private getLatestValidAndroidTarget(): string {
+		let installedTargets = this.getInstalledTargets();
 		return _.findLast(AndroidToolsInfo.SUPPORTED_TARGETS.sort(), supportedTarget => _.includes(installedTargets, supportedTarget));
 	}
 
@@ -300,7 +313,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return parseInt(androidSdkString.replace(`${AndroidToolsInfo.ANDROID_TARGET_PREFIX}-`, ""));
 	}
 
-	private async getInstalledTargets(): Promise<string[]> {
+	private getInstalledTargets(): string[] {
 		if (!this.installedTargetsCache) {
 			try {
 				const pathToInstalledTargets = path.join(this.androidHome, "platforms");

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -238,12 +238,11 @@ interface IAndroidToolsInfo {
 	validateJavacVersion(installedJavaVersion: string, options?: { showWarningsAsErrors: boolean }): Promise<boolean>;
 
 	/**
-	 * Returns the path to `android` executable. It should be `$ANDROID_HOME/tools/android`.
-	 * In case ANDROID_HOME is not defined, check if `android` is part of $PATH.
+	 * Validates if ANDROID_HOME environment variable is set correctly.
 	 * @param {any} options Defines if the warning messages should treated as error.
-	 * @return {string} Path to the `android` executable.
+	 * @returns {boolean} true in case ANDROID_HOME is correctly set, false otherwise.
 	 */
-	getPathToAndroidExecutable(options?: { showWarningsAsErrors: boolean }): Promise<string>;
+	validateAndroidHomeEnvVariable(options?: { showWarningsAsErrors: boolean }): boolean;
 
 	/**
 	 * Gets the path to `adb` executable from ANDROID_HOME. It should be `$ANDROID_HOME/platform-tools/adb` in case it exists.

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -220,14 +220,14 @@ interface IAndroidToolsInfo {
 	 * and ANDROID_HOME environement variable.
 	 * @return {IAndroidToolsInfoData} Information about installed Android Tools and SDKs.
 	 */
-	getToolsInfo(): Promise<IAndroidToolsInfoData>;
+	getToolsInfo(): IAndroidToolsInfoData;
 
 	/**
 	 * Validates the information about required Android tools and SDK versions.
 	 * @param {any} options Defines if the warning messages should treated as error and if the targetSdk value should be validated as well.
 	 * @return {boolean} True if there are detected issues, false otherwise.
 	 */
-	validateInfo(options?: { showWarningsAsErrors: boolean, validateTargetSdk: boolean }): Promise<boolean>;
+	validateInfo(options?: { showWarningsAsErrors: boolean, validateTargetSdk: boolean }): boolean;
 
 	/**
 	 * Validates the information about required JAVA version.

--- a/lib/definitions/emulator-platform-service.d.ts
+++ b/lib/definitions/emulator-platform-service.d.ts
@@ -11,6 +11,6 @@ interface IEmulatorPlatformService {
 	listAvailableEmulators(platform: string): Promise<void>;
 	getEmulatorInfo(platform: string, nameOfId: string): Promise<IEmulatorInfo>;
 	getiOSEmulators(): Promise<IEmulatorInfo[]>;
-	getAndroidEmulators(): Promise<IEmulatorInfo[]>;
+	getAndroidEmulators(): IEmulatorInfo[];
 	startEmulator(info: IEmulatorInfo, projectData: IProjectData): Promise<void>;
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -160,7 +160,7 @@ interface IPlatformProjectService extends NodeJS.EventEmitter {
 	validate(projectData: IProjectData): Promise<void>;
 	createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, pathToTemplate?: string): Promise<void>;
 	interpolateData(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
-	interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
+	interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): void;
 
 	/**
 	 * Executes additional actions after native project is created.

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -203,7 +203,6 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		}
 	}
 
-// TODO: Check if we can make this method sync.
 	public interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): void {
 		let manifestPath = this.getPlatformData(projectData).configurationFilePath;
 		shell.sed('-i', /__PACKAGE__/, projectData.projectId, manifestPath);

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -90,8 +90,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		this.validatePackageName(projectData.projectId);
 		this.validateProjectName(projectData.projectName);
 
-		// this call will fail in case `android` is not set correctly.
-		await this.$androidToolsInfo.getPathToAndroidExecutable({ showWarningsAsErrors: true });
+		this.$androidToolsInfo.validateAndroidHomeEnvVariable({ showWarningsAsErrors: true });
 
 		let javaCompilerVersion = await this.$sysInfo.getJavaCompilerVersion();
 

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -103,7 +103,7 @@ class DoctorService implements IDoctorService {
 			this.$logger.out("To be able to work with iOS devices and projects, you need Mac OS X Mavericks or later." + EOL);
 		}
 
-		let androidToolsIssues = await this.$androidToolsInfo.validateInfo();
+		let androidToolsIssues = this.$androidToolsInfo.validateInfo();
 		let javaVersionIssue = await this.$androidToolsInfo.validateJavacVersion(sysInfo.javacVersion);
 		let doctorResult = result || androidToolsIssues || javaVersionIssue;
 

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -46,7 +46,7 @@ class DoctorService implements IDoctorService {
 			result = true;
 		}
 
-		if (!sysInfo.androidInstalled) {
+		if (!sysInfo.emulatorInstalled) {
 			this.$logger.warn("WARNING: The Android SDK is not installed or is not configured properly.");
 			this.$logger.out("You will not be able to build your projects for Android and run them in the native emulator." + EOL
 				+ "To be able to build for Android and run apps in the native emulator, verify that you have" + EOL

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -161,8 +161,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		this.replaceFileContent(pbxprojFilePath, projectData);
 	}
 
-	public interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
-		return Promise.resolve();
+	public interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): void {
+		return undefined;
 	}
 
 	public afterCreateProject(projectRoot: string, projectData: IProjectData): void {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -287,7 +287,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			await platformData.platformProjectService.processConfigurationFilesFromAppResources(appFilesUpdaterOptions.release, projectData);
 		}
 
-		await platformData.platformProjectService.interpolateConfigurationFile(projectData, platformSpecificData);
+		platformData.platformProjectService.interpolateConfigurationFile(projectData, platformSpecificData);
 
 		this.$logger.out("Project successfully prepared (" + platform + ")");
 	}

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -7,14 +7,14 @@ export class SysInfo extends SysInfoBase {
 		protected $iTunesValidator: Mobile.IiTunesValidator,
 		protected $logger: ILogger,
 		protected $winreg: IWinReg,
+		protected $androidEmulatorServices: Mobile.IAndroidEmulatorServices,
 		private $androidToolsInfo: IAndroidToolsInfo) {
-		super($childProcess, $hostInfo, $iTunesValidator, $logger, $winreg);
+		super($childProcess, $hostInfo, $iTunesValidator, $logger, $winreg, $androidEmulatorServices);
 	}
 
-	public async getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string, pathToAndroid: string }): Promise<ISysInfoData> {
+	public async getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string }): Promise<ISysInfoData> {
 		let defaultAndroidToolsInfo = {
-			pathToAdb: await this.$androidToolsInfo.getPathToAdbFromAndroidHome(),
-			pathToAndroid: await this.$androidToolsInfo.getPathToAndroidExecutable()
+			pathToAdb: await this.$androidToolsInfo.getPathToAdbFromAndroidHome()
 		};
 
 		return super.getSysInfo(pathToPackageJson || await path.join(__dirname, "..", "package.json"), androidToolsInfo || defaultAndroidToolsInfo);

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -157,7 +157,7 @@ async function setupProject(dependencies?: any): Promise<any> {
 				getAppResourcesDestinationDirectoryPath: () => path.join(androidFolderPath, "src", "main", "res"),
 				processConfigurationFilesFromAppResources: () => Promise.resolve(),
 				ensureConfigurationFileInAppResources: (): any => null,
-				interpolateConfigurationFile: () => Promise.resolve(),
+				interpolateConfigurationFile: (): void => undefined,
 				isPlatformPrepared: (projectRoot: string) => false
 			}
 		};

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -325,7 +325,7 @@ describe('Platform Service Tests', () => {
 						getAppResourcesDestinationDirectoryPath: () => "",
 						processConfigurationFilesFromAppResources: () => Promise.resolve(),
 						ensureConfigurationFileInAppResources: (): any => null,
-						interpolateConfigurationFile: () => Promise.resolve(),
+						interpolateConfigurationFile: (): void => undefined,
 						isPlatformPrepared: (projectRoot: string) => false
 					}
 				};
@@ -398,7 +398,7 @@ describe('Platform Service Tests', () => {
 						getAppResourcesDestinationDirectoryPath: () => "",
 						processConfigurationFilesFromAppResources: () => Promise.resolve(),
 						ensureConfigurationFileInAppResources: (): any => null,
-						interpolateConfigurationFile: () => Promise.resolve(),
+						interpolateConfigurationFile: (): void => undefined,
 						isPlatformPrepared: (projectRoot: string) => false
 					}
 				};

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -298,8 +298,8 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	async interpolateData(): Promise<void> {
 		return Promise.resolve();
 	}
-	async interpolateConfigurationFile(): Promise<void> {
-		return Promise.resolve();
+	interpolateConfigurationFile(): void {
+		return ;
 	}
 	afterCreateProject(projectRoot: string): void {
 		return null;
@@ -489,7 +489,7 @@ export class LiveSyncServiceStub implements ILiveSyncService {
 }
 
 export class AndroidToolsInfoStub implements IAndroidToolsInfo {
-	public async getToolsInfo(): Promise<IAndroidToolsInfoData> {
+	public getToolsInfo(): IAndroidToolsInfoData {
 		let infoData: IAndroidToolsInfoData = Object.create(null);
 		infoData.androidHomeEnvVar = "";
 		infoData.compileSdkVersion = 23;
@@ -499,7 +499,7 @@ export class AndroidToolsInfoStub implements IAndroidToolsInfo {
 		return infoData;
 	}
 
-	public async validateInfo(options?: { showWarningsAsErrors: boolean, validateTargetSdk: boolean }): Promise<boolean> {
+	public validateInfo(options?: { showWarningsAsErrors: boolean, validateTargetSdk: boolean }): boolean {
 		return true;
 	}
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -690,8 +690,8 @@ export class EmulatorPlatformService implements IEmulatorPlatformService {
 		return Promise.resolve(null);
 	}
 
-	public getAndroidEmulators(): Promise<IEmulatorInfo[]> {
-		return Promise.resolve(null);
+	public getAndroidEmulators(): IEmulatorInfo[] {
+		return null;
 	}
 
 	public startEmulator(info: IEmulatorInfo): Promise<void> {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -511,8 +511,12 @@ export class AndroidToolsInfoStub implements IAndroidToolsInfo {
 		return "";
 	}
 
-	async getPathToAdbFromAndroidHome(): Promise<string> {
+	public async getPathToAdbFromAndroidHome(): Promise<string> {
 		return Promise.resolve("");
+	}
+
+	public validateAndroidHomeEnvVariable(options?: { showWarningsAsErrors: boolean }): boolean {
+		return false;
 	}
 }
 


### PR DESCRIPTION
Due to changes in Android SDK, we have to update the checks in CLI. While gathering system information, we check the android executable, which is no longer returning correct results.

We use the android executable to find information about installed Android SDKs and to construct correct paths based on ANDROID_HOME. Fix this by listing directories inside ANDROID_HOME and find the information about installed SDKs from there.
Fix messages pointing to `android` executable to point to `sdkmanager` (in case it exists).

In order to fix this, we rely on the emulator executable, which is the real thing we need as it is the one that allows us to work with Android Emulators (this is changed in mobile-cli-lib).
Fix sys-info checks and get correct path to emulator according to latest changes.

PR in mobile-cli-lib https://github.com/telerik/mobile-cli-lib/pull/906