### PR TITLE
Fix getting info for Android tools

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -337,13 +337,14 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		return (() => {
 			if (!this.installedTargetsCache) {
 				try {
+					this.installedTargetsCache = [];
 					const pathToInstalledTargets = path.join(this.androidHome, "platforms");
-					if (!this.$fs.exists(pathToInstalledTargets)) {
+					if (this.$fs.exists(pathToInstalledTargets)) {
 						this.installedTargetsCache = this.$fs.readDirectory(pathToInstalledTargets);
 						this.$logger.trace("Installed Android Targets are: ", this.installedTargetsCache);
-					} else {
-						this.installedTargetsCache = [];
 					}
+
+					this.$logger.trace("Installed Android Targets are: ", this.installedTargetsCache);
 				} catch (err) {
 					this.$logger.trace("Unable to get Android targets. Error is: " + err);
 				}

--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -339,11 +339,11 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 				try {
 					const pathToInstalledTargets = path.join(this.androidHome, "platforms");
 					if (!this.$fs.exists(pathToInstalledTargets)) {
-						throw new Error("No Android Targets installed.");
+						this.installedTargetsCache = this.$fs.readDirectory(pathToInstalledTargets);
+						this.$logger.trace("Installed Android Targets are: ", this.installedTargetsCache);
+					} else {
+						this.installedTargetsCache = [];
 					}
-
-					this.installedTargetsCache = this.$fs.readDirectory(pathToInstalledTargets);
-					this.$logger.trace("Installed Android Targets are: ", this.installedTargetsCache);
 				} catch (err) {
 					this.$logger.trace("Unable to get Android targets. Error is: " + err);
 				}

--- a/lib/declarations.ts
+++ b/lib/declarations.ts
@@ -176,12 +176,11 @@ interface IAndroidToolsInfo {
 	validateJavacVersion(installedJavaVersion: string, options?: { showWarningsAsErrors: boolean }): IFuture<boolean>;
 
 	/**
-	 * Returns the path to `android` executable. It should be `$ANDROID_HOME/tools/android`.
-	 * In case ANDROID_HOME is not defined, check if `android` is part of $PATH.
+	 * Validates if ANDROID_HOME environment variable is set correctly.
 	 * @param {any} options Defines if the warning messages should treated as error.
-	 * @return {string} Path to the `android` executable.
+	 * @returns {boolean} true in case ANDROID_HOME is correctly set, false otherwise.
 	 */
-	getPathToAndroidExecutable(options?: { showWarningsAsErrors: boolean }): IFuture<string>;
+	validateAndroidHomeEnvVariable(options?: { showWarningsAsErrors: boolean }): boolean;
 
 	/**
 	 * Gets the path to `adb` executable from ANDROID_HOME. It should be `$ANDROID_HOME/platform-tools/adb` in case it exists.

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -92,8 +92,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			this.validatePackageName(this.$projectData.projectId);
 			this.validateProjectName(this.$projectData.projectName);
 
-			// this call will fail in case `android` is not set correctly.
-			this.$androidToolsInfo.getPathToAndroidExecutable({ showWarningsAsErrors: true }).wait();
+			this.$androidToolsInfo.validateAndroidHomeEnvVariable({ showWarningsAsErrors: true });
 			let javaCompilerVersion = this.$sysInfo.getJavaCompilerVersion().wait();
 			this.$androidToolsInfo.validateJavacVersion(javaCompilerVersion, { showWarningsAsErrors: true }).wait();
 		}).future<void>()();

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -47,7 +47,7 @@ class DoctorService implements IDoctorService {
 				result = true;
 			}
 
-			if (!sysInfo.androidInstalled) {
+			if (!sysInfo.emulatorInstalled) {
 				this.$logger.warn("WARNING: The Android SDK is not installed or is not configured properly.");
 				this.$logger.out("You will not be able to build your projects for Android and run them in the native emulator." + EOL
 					+ "To be able to build for Android and run apps in the native emulator, verify that you have" + EOL

--- a/lib/services/emulator-platform-service.ts
+++ b/lib/services/emulator-platform-service.ts
@@ -1,213 +1,193 @@
-import * as path from "path";
 import * as fiberBootstrap from "../common/fiber-bootstrap";
 import { createTable } from "../common/helpers";
 import Future = require("fibers/future");
 
 export class EmulatorPlatformService implements IEmulatorPlatformService {
 
-    constructor(
-        private $mobileHelper: Mobile.IMobileHelper,
-        private $childProcess: IChildProcess,
-        private $devicesService: Mobile.IDevicesService,
-        private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-        private $dispatcher: IFutureDispatcher,
-        private $options: IOptions,
-        private $logger: ILogger) {}
+	constructor(
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $childProcess: IChildProcess,
+		private $devicesService: Mobile.IDevicesService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $dispatcher: IFutureDispatcher,
+		private $options: IOptions,
+		private $logger: ILogger,
+		private $androidEmulatorServices: Mobile.IAndroidEmulatorServices) { }
 
-    public startEmulator(info: IEmulatorInfo): IFuture<void> {
-        if (!info.isRunning) {
+	public startEmulator(info: IEmulatorInfo): IFuture<void> {
+		if (!info.isRunning) {
 
-            if (this.$mobileHelper.isAndroidPlatform(info.platform)) {
-                this.$options.avd = this.$options.device;
-                this.$options.device = null;
-                let platformsData: IPlatformsData = $injector.resolve("platformsData");
-                let platformData = platformsData.getPlatformData(info.platform);
-                let emulatorServices = platformData.emulatorServices;
-                emulatorServices.checkAvailability();
-                emulatorServices.checkDependencies().wait();
-                emulatorServices.startEmulator().wait();
-                this.$options.avd = null;
-                return Future.fromResult();
-            }
+			if (this.$mobileHelper.isAndroidPlatform(info.platform)) {
+				this.$options.avd = this.$options.device;
+				this.$options.device = null;
+				let platformsData: IPlatformsData = $injector.resolve("platformsData");
+				let platformData = platformsData.getPlatformData(info.platform);
+				let emulatorServices = platformData.emulatorServices;
+				emulatorServices.checkAvailability();
+				emulatorServices.checkDependencies().wait();
+				emulatorServices.startEmulator().wait();
+				this.$options.avd = null;
+				return Future.fromResult();
+			}
 
-            if (this.$mobileHelper.isiOSPlatform(info.platform)) {
-                this.stopEmulator(info.platform).wait();
-                let future = new Future<void>();
-                this.$childProcess.exec(`open -a Simulator --args -CurrentDeviceUDID ${info.id}`).wait();
-                let timeoutFunc = () => {
-                    fiberBootstrap.run(() => {
-                        info = this.getEmulatorInfo("ios", info.id).wait();
-                        if (info.isRunning) {
-                            this.$devicesService.initialize({ platform: info.platform, deviceId: info.id }).wait();
-                            let device = this.$devicesService.getDeviceByIdentifier(info.id);
-                            device.applicationManager.checkForApplicationUpdates().wait();
-                            future.return();
-                            return;
-                        }
-                        setTimeout(timeoutFunc, 2000);
-                    });
-                };
-                timeoutFunc();
-                return future;
-            }
-        }
+			if (this.$mobileHelper.isiOSPlatform(info.platform)) {
+				this.stopEmulator(info.platform).wait();
+				let future = new Future<void>();
+				this.$childProcess.exec(`open -a Simulator --args -CurrentDeviceUDID ${info.id}`).wait();
+				let timeoutFunc = () => {
+					fiberBootstrap.run(() => {
+						info = this.getEmulatorInfo("ios", info.id).wait();
+						if (info.isRunning) {
+							this.$devicesService.initialize({ platform: info.platform, deviceId: info.id }).wait();
+							let device = this.$devicesService.getDeviceByIdentifier(info.id);
+							device.applicationManager.checkForApplicationUpdates().wait();
+							future.return();
+							return;
+						}
+						setTimeout(timeoutFunc, 2000);
+					});
+				};
+				timeoutFunc();
+				return future;
+			}
+		}
 
-        return Future.fromResult();
-    }
+		return Future.fromResult();
+	}
 
-    private stopEmulator(platform: string): IFuture<void> {
-        if (this.$mobileHelper.isiOSPlatform(platform)) {
-            return this.$childProcess.exec("pkill -9 -f Simulator");
-        }
-        return Future.fromResult();
-    }
+	private stopEmulator(platform: string): IFuture<void> {
+		if (this.$mobileHelper.isiOSPlatform(platform)) {
+			return this.$childProcess.exec("pkill -9 -f Simulator");
+		}
+		return Future.fromResult();
+	}
 
-    public getEmulatorInfo(platform: string, idOrName: string): IFuture<IEmulatorInfo> {
-        return (() => {
-
-            if (this.$mobileHelper.isAndroidPlatform(platform)) {
-                let androidEmulators = this.getAndroidEmulators().wait();
-                let found = androidEmulators.filter((info:IEmulatorInfo) => info.id === idOrName);
-                if (found.length > 0) {
-                    return found[0];
-                }
-                this.$devicesService.initialize({platform: platform, deviceId: null, skipInferPlatform: true}).wait();
-                let info:IEmulatorInfo = null;
-                let action = (device:Mobile.IDevice) => {
-                    return (() => {
-                        if (device.deviceInfo.identifier === idOrName) {
-                            info = {
-                                id: device.deviceInfo.identifier,
-                                name: device.deviceInfo.displayName,
-                                version: device.deviceInfo.version,
-                                platform: "Android",
-                                type: "emulator",
-                                isRunning: true
-                            };
-                        }
-                    }).future<void>()();
-                };
-                this.$devicesService.execute(action, undefined, {allowNoDevices: true}).wait();
-                return info;
-            }
-
-            if (this.$mobileHelper.isiOSPlatform(platform)) {
-                let emulators = this.getiOSEmulators().wait();
-                let sdk: string = null;
-                let versionStart = idOrName.indexOf("(");
-                if (versionStart > 0) {
-                    sdk = idOrName.substring(versionStart+1, idOrName.indexOf(")", versionStart)).trim();
-                    idOrName = idOrName.substring(0, versionStart-1).trim();
-                }
-                let found = emulators.filter((info:IEmulatorInfo) => {
-                let sdkMatch = sdk ? info.version === sdk : true;
-                    return sdkMatch && info.id === idOrName || info.name === idOrName;
-                });
-                return found.length>0 ? found[0] : null;
-            }
-
-            return null;
-
-        }).future<IEmulatorInfo>()();
-    }
-
-    public listAvailableEmulators(platform: string): IFuture<void> {
+	public getEmulatorInfo(platform: string, idOrName: string): IFuture<IEmulatorInfo> {
 		return (() => {
-            let emulators: IEmulatorInfo[] = [];
-            if (!platform || this.$mobileHelper.isiOSPlatform(platform)) {
-                let iosEmulators = this.getiOSEmulators().wait();
-                if (iosEmulators) {
-                    emulators = emulators.concat(iosEmulators);
-                }
+
+			if (this.$mobileHelper.isAndroidPlatform(platform)) {
+				let androidEmulators = this.getAndroidEmulators().wait();
+				let found = androidEmulators.filter((info: IEmulatorInfo) => info.id === idOrName);
+				if (found.length > 0) {
+					return found[0];
+				}
+				this.$devicesService.initialize({ platform: platform, deviceId: null, skipInferPlatform: true }).wait();
+				let info: IEmulatorInfo = null;
+				let action = (device: Mobile.IDevice) => {
+					return (() => {
+						if (device.deviceInfo.identifier === idOrName) {
+							info = {
+								id: device.deviceInfo.identifier,
+								name: device.deviceInfo.displayName,
+								version: device.deviceInfo.version,
+								platform: "Android",
+								type: "emulator",
+								isRunning: true
+							};
+						}
+					}).future<void>()();
+				};
+				this.$devicesService.execute(action, undefined, { allowNoDevices: true }).wait();
+				return info;
 			}
-            if (!platform || this.$mobileHelper.isAndroidPlatform(platform)) {
-                let androidEmulators = this.getAndroidEmulators().wait();
-                if (androidEmulators) {
-                    emulators = emulators.concat(androidEmulators);
-                }
+
+			if (this.$mobileHelper.isiOSPlatform(platform)) {
+				let emulators = this.getiOSEmulators().wait();
+				let sdk: string = null;
+				let versionStart = idOrName.indexOf("(");
+				if (versionStart > 0) {
+					sdk = idOrName.substring(versionStart + 1, idOrName.indexOf(")", versionStart)).trim();
+					idOrName = idOrName.substring(0, versionStart - 1).trim();
+				}
+				let found = emulators.filter((info: IEmulatorInfo) => {
+					let sdkMatch = sdk ? info.version === sdk : true;
+					return sdkMatch && info.id === idOrName || info.name === idOrName;
+				});
+				return found.length > 0 ? found[0] : null;
 			}
-            this.outputEmulators("\nAvailable emulators", emulators);
-            this.$logger.out("\nConnected devices & emulators");
-            $injector.resolveCommand("device").execute(platform ? [platform] : []).wait();
+
+			return null;
+
+		}).future<IEmulatorInfo>()();
+	}
+
+	public listAvailableEmulators(platform: string): IFuture<void> {
+		return (() => {
+			let emulators: IEmulatorInfo[] = [];
+			if (!platform || this.$mobileHelper.isiOSPlatform(platform)) {
+				let iosEmulators = this.getiOSEmulators().wait();
+				if (iosEmulators) {
+					emulators = emulators.concat(iosEmulators);
+				}
+			}
+			if (!platform || this.$mobileHelper.isAndroidPlatform(platform)) {
+				let androidEmulators = this.getAndroidEmulators().wait();
+				if (androidEmulators) {
+					emulators = emulators.concat(androidEmulators);
+				}
+			}
+			this.outputEmulators("\nAvailable emulators", emulators);
+			this.$logger.out("\nConnected devices & emulators");
+			$injector.resolveCommand("device").execute(platform ? [platform] : []).wait();
 		}).future<void>()();
-    }
+	}
 
-    public getiOSEmulators(): IFuture<IEmulatorInfo[]> {
-        return (()=>{
-            let output = this.$childProcess.exec("xcrun simctl list --json").wait();
-            let list = JSON.parse(output);
-            let emulators: IEmulatorInfo[] = [];
-            for (let osName in list["devices"]) {
-                if (osName.indexOf("iOS") === -1) {
-                    continue;
-                }
-                let os = list["devices"][osName];
-                let version = this.parseiOSVersion(osName);
-                for (let device of os) {
-                    if (device["availability"] !== "(available)") {
-                        continue;
-                    }
-                    let emulatorInfo: IEmulatorInfo = {
-                        id: device["udid"],
-                        name: device["name"],
-                        isRunning: device["state"] === "Booted",
-                        type: "simulator",
-                        version: version,
-                        platform: "iOS"
-                    };
-                    emulators.push(emulatorInfo);
-                }
-            }
-            return emulators;
-        }).future<IEmulatorInfo[]>()();
-    }
+	public getiOSEmulators(): IFuture<IEmulatorInfo[]> {
+		return (() => {
+			let output = this.$childProcess.exec("xcrun simctl list --json").wait();
+			let list = JSON.parse(output);
+			let emulators: IEmulatorInfo[] = [];
+			for (let osName in list["devices"]) {
+				if (osName.indexOf("iOS") === -1) {
+					continue;
+				}
+				let os = list["devices"][osName];
+				let version = this.parseiOSVersion(osName);
+				for (let device of os) {
+					if (device["availability"] !== "(available)") {
+						continue;
+					}
+					let emulatorInfo: IEmulatorInfo = {
+						id: device["udid"],
+						name: device["name"],
+						isRunning: device["state"] === "Booted",
+						type: "simulator",
+						version: version,
+						platform: "iOS"
+					};
+					emulators.push(emulatorInfo);
+				}
+			}
+			return emulators;
+		}).future<IEmulatorInfo[]>()();
+	}
 
-    public getAndroidEmulators(): IFuture<IEmulatorInfo[]> {
-        return (() => {
-            let androidPath = path.join(process.env.ANDROID_HOME, "tools", "android");
-            let text:string = this.$childProcess.exec(`"${androidPath}" list avd`).wait();
-            let notLoadedIndex = text.indexOf("The following");
-            if (notLoadedIndex > 0) {
-                text = text.substring(0, notLoadedIndex);
-            }
-            let textBlocks = text.split("---------");
-            let emulators: IEmulatorInfo[] = [];
-            for (let block of textBlocks) {
-                let lines = block.split("\n");
-                let info:IEmulatorInfo = { name: "", version: "", id: "",  platform: "Android", type: "Emulator" };
-                for (let line of lines) {
-                    if (line.indexOf("Target") >= 0) {
-                        info.version = line.substring(line.indexOf(":")+1).replace("Android", "").trim();
-                    }
-                    if (line.indexOf("Name") >= 0) {
-                        info.id = line.substring(line.indexOf(":")+1).trim();
-                    }
-                    if (line.indexOf("Device") >= 0) {
-                        info.name = line.substring(line.indexOf(":")+1).trim();
-                    }
-                    info.isRunning = false;
-                }
-                emulators.push(info);
-            }
-            return emulators;
-        }).future<IEmulatorInfo[]>()();
-    }
+	public getAndroidEmulators(): IFuture<IEmulatorInfo[]> {
+		return (() => {
+			const androidVirtualDevices: Mobile.IAvdInfo[] = this.$androidEmulatorServices.getAvds().map(avd => this.$androidEmulatorServices.getInfoFromAvd(avd));
+			const emulators: IEmulatorInfo[] = _.map(androidVirtualDevices, avd => {
+				return { name: avd.device, version: avd.target, id: avd.name, platform: "Android", type: "Emulator", isRunning: false };
+			});
 
-    private parseiOSVersion(osName: string): string {
-        osName = osName.replace("com.apple.CoreSimulator.SimRuntime.iOS-", "");
-        osName = osName.replace(/-/g, ".");
-        osName = osName.replace("iOS", "");
-        osName = osName.trim();
-        return osName;
-    }
+			return emulators;
+		}).future<IEmulatorInfo[]>()();
+	}
 
-    private outputEmulators(title: string, emulators: IEmulatorInfo[]) {
-        this.$logger.out(title);
-        let table: any = createTable(["Device Name", "Platform", "Version", "Device Identifier"], []);
-        for (let info of emulators) {
-            table.push([info.name, info.platform, info.version, info.id]);
-        }
-        this.$logger.out(table.toString());
-    }
+	private parseiOSVersion(osName: string): string {
+		osName = osName.replace("com.apple.CoreSimulator.SimRuntime.iOS-", "");
+		osName = osName.replace(/-/g, ".");
+		osName = osName.replace("iOS", "");
+		osName = osName.trim();
+		return osName;
+	}
+
+	private outputEmulators(title: string, emulators: IEmulatorInfo[]) {
+		this.$logger.out(title);
+		let table: any = createTable(["Device Name", "Platform", "Version", "Device Identifier"], []);
+		for (let info of emulators) {
+			table.push([info.name, info.platform, info.version, info.id]);
+		}
+		this.$logger.out(table.toString());
+	}
 }
 $injector.register("emulatorPlatformService", EmulatorPlatformService);

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -12,7 +12,7 @@ export class SysInfo extends SysInfoBase {
 		super($childProcess, $hostInfo, $iTunesValidator, $logger, $winreg, $androidEmulatorServices);
 	}
 
-	public getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string, pathToAndroid: string }): IFuture<ISysInfoData> {
+	public getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string }): IFuture<ISysInfoData> {
 		return ((): ISysInfoData => {
 			let defaultAndroidToolsInfo = {
 				pathToAdb: this.$androidToolsInfo.getPathToAdbFromAndroidHome().wait()

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -1,21 +1,21 @@
-import {SysInfoBase} from "./common/sys-info-base";
+import { SysInfoBase } from "./common/sys-info-base";
 import * as path from "path";
 
 export class SysInfo extends SysInfoBase {
 	constructor(protected $childProcess: IChildProcess,
-				protected $hostInfo: IHostInfo,
-				protected $iTunesValidator: Mobile.IiTunesValidator,
-				protected $logger: ILogger,
-				protected $winreg: IWinReg,
-				private $androidToolsInfo: IAndroidToolsInfo) {
-		super($childProcess, $hostInfo, $iTunesValidator, $logger, $winreg);
+		protected $hostInfo: IHostInfo,
+		protected $iTunesValidator: Mobile.IiTunesValidator,
+		protected $logger: ILogger,
+		protected $winreg: IWinReg,
+		protected $androidEmulatorServices: Mobile.IAndroidEmulatorServices,
+		private $androidToolsInfo: IAndroidToolsInfo) {
+		super($childProcess, $hostInfo, $iTunesValidator, $logger, $winreg, $androidEmulatorServices);
 	}
 
-	public getSysInfo(pathToPackageJson: string, androidToolsInfo?: {pathToAdb: string, pathToAndroid: string}): IFuture<ISysInfoData> {
+	public getSysInfo(pathToPackageJson: string, androidToolsInfo?: { pathToAdb: string, pathToAndroid: string }): IFuture<ISysInfoData> {
 		return ((): ISysInfoData => {
 			let defaultAndroidToolsInfo = {
-				pathToAdb: this.$androidToolsInfo.getPathToAdbFromAndroidHome().wait(),
-				pathToAndroid: this.$androidToolsInfo.getPathToAndroidExecutable().wait()
+				pathToAdb: this.$androidToolsInfo.getPathToAdbFromAndroidHome().wait()
 			};
 			return super.getSysInfo(pathToPackageJson || path.join(__dirname, "..", "package.json"), androidToolsInfo || defaultAndroidToolsInfo).wait();
 		}).future<ISysInfoData>()();

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -518,6 +518,10 @@ export class AndroidToolsInfoStub implements IAndroidToolsInfo {
 	getPathToAdbFromAndroidHome(): IFuture<string> {
 		return Future.fromResult("");
 	}
+
+	public validateAndroidHomeEnvVariable(options?: { showWarningsAsErrors: boolean }): boolean {
+		return false;
+	}
 }
 
 export class ChildProcessStub {


### PR DESCRIPTION
Due to changes in Android SDK, we have to update the checks in CLI. While gathering system information, we check the android executable, which is no longer returning correct results.

We use the android executable to find information about installed Android SDKs and to construct correct paths based on ANDROID_HOME. Fix this by listing directories inside ANDROID_HOME and find the information about installed SDKs from there.
Fix messages pointing to `android` executable to point to `sdkmanager` (in case it exists).

In order to fix this, we rely on the emulator executable, which is the real thing we need as it is the one that allows us to work with Android Emulators (this is changed in mobile-cli-lib).
Fix sys-info checks and get correct path to emulator according to latest changes. 
PR In mobile-cli-lib: https://github.com/telerik/mobile-cli-lib/pull/907