### PR TITLE
platform clean should preserve the nativescript version used #2496

### DIFF
--- a/lib/commands/platform-clean.ts
+++ b/lib/commands/platform-clean.ts
@@ -9,8 +9,7 @@ export class CleanCommand implements ICommand {
 		}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.removePlatforms(args, this.$projectData);
-		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		await this.$platformService.cleanPlatforms(args, this.$options.platformTemplate, this.$projectData, {provision: this.$options.provision, sdk: this.$options.sdk });
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -1,4 +1,6 @@
 interface IPlatformService extends NodeJS.EventEmitter {
+	cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, framework?: string): Promise<void>;
+	
 	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, frameworkPath?: string): Promise<void>;
 
 	/**

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -47,8 +47,20 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	public async cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, framworkPath?: string): Promise<void> {
-		await this.removePlatforms(platforms, projectData);
-		await this.addPlatforms(platforms, platformTemplate, projectData, platformSpecificData);
+		for (let platform of platforms) {
+			// TODO: Copy pasted - refactor as a common function
+			let platformData = this.$platformsData.getPlatformData(platform, projectData);
+			let currentPlatformData: any = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
+			let version: string;
+			if (currentPlatformData && currentPlatformData[constants.VERSION_STRING]) {
+				version = currentPlatformData[constants.VERSION_STRING];
+			};
+
+			let platformWithVersion: string = platform + "@" + version;
+
+			await this.removePlatforms([platform], projectData);
+			await this.addPlatforms([platformWithVersion], platformTemplate, projectData, platformSpecificData);
+		}
 	}
 
 	public async addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, frameworkPath?: string): Promise<void> {
@@ -75,7 +87,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 		let currentPlatformData: any = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
-		if (currentPlatformData && currentPlatformData[constants.VERSION_STRING]) {
+		if (version === undefined && currentPlatformData && currentPlatformData[constants.VERSION_STRING]) {
 			version = currentPlatformData[constants.VERSION_STRING];
 		}
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -49,7 +49,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	public async cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, framworkPath?: string): Promise<void> {
 		for (let platform of platforms) {
 			let version: string = this.getCurrentPlatformVersion(platform, projectData);
-			let platformWithVersion: string = platform + "@" + version;
+
+			let platformWithVersion: string = platform;
+			if (version !== undefined) {
+				platformWithVersion += "@" + version;
+			}
 
 			await this.removePlatforms([platform], projectData);
 			await this.addPlatforms([platformWithVersion], platformTemplate, projectData, platformSpecificData);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -46,6 +46,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		super();
 	}
 
+	public async cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, framworkPath?: string): Promise<void> {
+		await this.removePlatforms(platforms, projectData);
+		await this.addPlatforms(platforms, platformTemplate, projectData, platformSpecificData);
+	}
+
 	public async addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, frameworkPath?: string): Promise<void> {
 		let platformsDir = projectData.platformsDir;
 		this.$fs.ensureDirectoryExists(platformsDir);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -48,14 +48,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	public async cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, framworkPath?: string): Promise<void> {
 		for (let platform of platforms) {
-			// TODO: Copy pasted - refactor as a common function
-			let platformData = this.$platformsData.getPlatformData(platform, projectData);
-			let currentPlatformData: any = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
-			let version: string;
-			if (currentPlatformData && currentPlatformData[constants.VERSION_STRING]) {
-				version = currentPlatformData[constants.VERSION_STRING];
-			};
-
+			let version: string = this.getCurrentPlatformVersion(platform, projectData);
 			let platformWithVersion: string = platform + "@" + version;
 
 			await this.removePlatforms([platform], projectData);
@@ -72,6 +65,17 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
+	private getCurrentPlatformVersion(platform: string, projectData: IProjectData) : string {
+		let platformData = this.$platformsData.getPlatformData(platform, projectData);
+		let currentPlatformData: any = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
+		let version: string;
+		if (currentPlatformData && currentPlatformData[constants.VERSION_STRING]) {
+			version = currentPlatformData[constants.VERSION_STRING];
+		};
+
+		return version;
+	}
+
 	private async addPlatform(platformParam: string, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, frameworkPath?: string): Promise<void> {
 		let data = platformParam.split("@"),
 			platform = data[0].toLowerCase(),
@@ -86,9 +90,9 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
-		let currentPlatformData: any = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
-		if (version === undefined && currentPlatformData && currentPlatformData[constants.VERSION_STRING]) {
-			version = currentPlatformData[constants.VERSION_STRING];
+
+		if (version === undefined) {
+			version = this.getCurrentPlatformVersion(platform, projectData);
 		}
 
 		// Copy platform specific files in platforms dir

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -245,6 +245,36 @@ describe('Platform Service Tests', () => {
 		});
 	});
 
+	describe("clean platform unit tests", () => {
+		it("should preserve the specified in the project nativescript version", async () => {
+			const versionString = "2.4.1";
+			let fs = testInjector.resolve("fs");
+			fs.exists = () => false;
+
+			let nsValueObject: any = {};
+			nsValueObject[VERSION_STRING] = versionString;
+			let projectDataService = testInjector.resolve("projectDataService");
+			projectDataService.getNSValue = () => nsValueObject;
+
+			let npmInstallationManager = testInjector.resolve("npmInstallationManager");
+			npmInstallationManager.install = (packageName: string, packageDir: string, options: INpmInstallOptions) => {
+				assert.deepEqual(options.version, versionString);
+				return "";
+			};
+
+			let projectData: IProjectData = testInjector.resolve("projectData");
+			platformService.removePlatforms = (platforms: string[], prjctData: IProjectData): Promise<void> => {
+				nsValueObject[VERSION_STRING] = undefined;
+				return Promise.resolve();
+			};
+
+			await platformService.cleanPlatforms(["android"], "", projectData, null);
+
+			nsValueObject[VERSION_STRING] = versionString;
+			await platformService.cleanPlatforms(["ios"], "", projectData, null);
+		});
+	});
+
 	// TODO: Commented as it doesn't seem correct. Check what's the case and why it's been expected to fail.
 	// describe("list platform unit tests", () => {
 	// 	it("fails when platforms are not added", () => {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -581,6 +581,10 @@ export class PlatformServiceStub extends EventEmitter implements IPlatformServic
 		return Promise.resolve(true);
 	}
 
+	public cleanPlatforms(platforms: string[]): Promise<void> {
+		return Promise.resolve();
+	}
+
 	public addPlatforms(platforms: string[]): Promise<void> {
 		return Promise.resolve();
 	}


### PR DESCRIPTION
Consider the following situation: There is a new version of NativeScript available (3.0) and I have existing projects using older version (2.5). I don't want to upgrade immediately for various reasons (too many effort required on my side, I'm just before releasing the app, etc). The current behaviour of the `tns platform clean` command is that it will first remove the specified platform and then the latest available platform (3.0) will be added. This is inconvenience in the described scenario.

As a developer, I would expect when I run `tns platform clean` the version of the platform added to be the same as before running the command (2.5).

Related to issue: [TNS platform clean android #2496](https://github.com/NativeScript/nativescript-cli/issues/2496)