### PR TITLE
Change android debug url

### DIFF
--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -227,7 +227,7 @@ class AndroidDebugService implements IDebugService {
 	}
 
 	private startDebuggerClient(port: Number): void {
-		this.$logger.info(`To start debugging, open the following URL in Chrome:${os.EOL}chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=localhost:${port}${os.EOL}`.cyan);
+		this.$logger.info(`To start debugging, open the following URL in Chrome:${os.EOL}chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:${port}${os.EOL}`.cyan);
 	}
 
 	private stopDebuggerClient(): void {


### PR DESCRIPTION
Remove the `v8only` flag from Chrome DevTools debug url to enable use of more inspector agents ([1.2](https://chromedevtools.github.io/debugger-protocol-viewer/1-2/) vs [v8 - node](https://chromedevtools.github.io/debugger-protocol-viewer/v8/))