### PR TITLE
Fix iOS device log filter

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -124,3 +124,5 @@ $injector.require("iOSLogFilter", "./services/ios-log-filter");
 $injector.require("projectChangesService", "./services/project-changes-service");
 
 $injector.require("emulatorPlatformService", "./services/emulator-platform-service");
+
+$injector.require("staticConfig", "./config");

--- a/lib/nativescript-cli-lib-bootstrap.ts
+++ b/lib/nativescript-cli-lib-bootstrap.ts
@@ -9,3 +9,8 @@ $injector.requirePublic("companionAppsService", "./common/appbuilder/services/li
 $injector.requirePublicClass("deviceEmitter", "./common/appbuilder/device-emitter");
 $injector.requirePublicClass("deviceLogProvider", "./common/appbuilder/device-log-provider");
 $injector.requirePublicClass("localBuildService", "./services/local-build-service");
+$injector.require("iOSLogFilter", "./common/mobile/ios/ios-log-filter");
+
+// We need this because some services check if (!$options.justLaunch) to start the device log after some operation.
+// We don't want this behaviour when the CLI is required as library.
+$injector.resolve("options").justLaunch = true;


### PR DESCRIPTION
We need to pass the project directory only for the ios-log-filter in the NS CLI. That's why we can use the projectData instead of adding it as a parameter.

Common lib reference: https://github.com/telerik/mobile-cli-lib/pull/905