### PR TITLE
Yosifov/fix init cmd

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -1,7 +1,7 @@
 interface INodePackageManager {
 	install(packageName: string, pathToSave: string, config?: any): Promise<any>;
 	uninstall(packageName: string, config?: any, path?: string): Promise<any>;
-	view(packageName: string, config: any): Promise<any>;
+	view(packageName: string, config: Object): Promise<any>;
 	search(filter: string[], config: any): Promise<any>;
 }
 

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -97,7 +97,7 @@ export class NodePackageManager implements INodePackageManager {
 
 	public async view(packageName: string, config: Object): Promise<any> {
 		const wrappedConfig = _.extend({}, config, { json: true }); // always require view response as JSON
-		
+
 		let flags = this.getFlagsString(wrappedConfig, false);
 		let viewResult: any;
 		try {

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -95,8 +95,10 @@ export class NodePackageManager implements INodePackageManager {
 		return this.$childProcess.exec(`npm search ${args.join(" ")}`);
 	}
 
-	public async view(packageName: string, config: any): Promise<any> {
-		let flags = this.getFlagsString(config, false);
+	public async view(packageName: string, config: Object): Promise<any> {
+		const wrappedConfig = _.extend({}, config, { json: true }); // always require view response as JSON
+		
+		let flags = this.getFlagsString(wrappedConfig, false);
 		let viewResult: any;
 		try {
 			viewResult = await this.$childProcess.exec(`npm view ${packageName} ${flags}`);

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -26,7 +26,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		if (semver.satisfies(latestVersion, cliVersionRange)) {
 			return latestVersion;
 		}
-		let data = await this.$npm.view(packageName, { json: true, "versions": true });
+		let data = await this.$npm.view(packageName, { "versions": true });
 
 		return semver.maxSatisfying(data, cliVersionRange) || latestVersion;
 	}
@@ -122,7 +122,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 	 * because npm view doens't work with those
 	 */
 	private async getVersion(packageName: string, version: string): Promise<string> {
-		let data: any = await this.$npm.view(packageName, { json: true, "dist-tags": true });
+		let data: any = await this.$npm.view(packageName, { "dist-tags": true });
 		this.$logger.trace("Using version %s. ", data[version]);
 
 		return data[version];

--- a/lib/services/init-service.ts
+++ b/lib/services/init-service.ts
@@ -106,8 +106,8 @@ export class InitService implements IInitService {
 			return this.buildVersionData(latestVersion);
 		}
 
-		let data: any = await this.$npm.view(packageName, "versions");
-		let versions = _.filter(data[latestVersion].versions, (version: string) => semver.gte(version, InitService.MIN_SUPPORTED_FRAMEWORK_VERSIONS[packageName]));
+		let allVersions: any = await this.$npm.view(packageName, { "versions": true });
+		let versions = _.filter(allVersions, (version: string) => semver.gte(version, InitService.MIN_SUPPORTED_FRAMEWORK_VERSIONS[packageName]));
 		if (versions.length === 1) {
 			this.$logger.info(`Only ${versions[0]} version is available for ${packageName}.`);
 			return this.buildVersionData(versions[0]);


### PR DESCRIPTION
The Npm.View method has been modified to always set "json":true flag in order to receive a JSON formatted response from the NPM.

The Response when querying for Versions from NPM is no longer an object, but an array of versions - therefore a small fix was required. Now, all versions are filtered by the criteria of being compatible to the currently installed nativescript version.