### PR TITLE
Fix App_Resources issue - they weren't copied from the /app to /platf…

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -285,6 +285,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			await this.copyAppFiles(platform, appFilesUpdaterOptions, projectData);
 		}
 		if (!changesInfo || changesInfo.appResourcesChanged) {
+			await this.copyAppFiles(platform, appFilesUpdaterOptions, projectData);
 			this.copyAppResources(platform, projectData);
 			await platformData.platformProjectService.prepareProject(projectData, platformSpecificData);
 		}


### PR DESCRIPTION
Fix the App_Resources livesync issue. The changes in the App_Resources were watched properly, but after that the CLI copies the from platforms/{platform_name}/app/App_Resources to platforms/{platform_name}/resources, but it didn't copy them from app/App_Resources to platforms/{platform_name}/app/App_Resources in first place. Therefore this was working only at the first time and you had to add/remove platform in order to refresh the App_Resources contents.