### PR TITLE
Stop stopping device detection interval

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -37,9 +37,7 @@ class LiveSyncService implements ILiveSyncService {
 			platform = this.$devicesService.getDeviceByIdentifier(this.$options.device).deviceInfo.platform;
 			liveSyncData.push(await this.prepareLiveSyncData(platform, projectData));
 		} else {
-			await this.$devicesService.initialize({ skipInferPlatform: true });
-
-			await this.$devicesService.stopDeviceDetectionInterval();
+			await this.$devicesService.initialize({ skipInferPlatform: true, skipDeviceDetectionInterval: true });
 
 			for (let installedPlatform of this.$platformService.getInstalledPlatforms(projectData)) {
 				if (this.$devicesService.getDevicesForPlatform(installedPlatform).length === 0) {

--- a/lib/services/local-build-service.ts
+++ b/lib/services/local-build-service.ts
@@ -1,4 +1,3 @@
-// import { exportedPromise } from "../common/decorators";
 import { EventEmitter } from "events";
 import { BUILD_OUTPUT_EVENT_NAME } from "../constants";
 

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -1,7 +1,7 @@
 import * as constants from "../constants";
 import * as path from "path";
 import * as shelljs from "shelljs";
-import { exportedPromise, exported } from "../common/decorators";
+import { exported } from "../common/decorators";
 
 export class ProjectService implements IProjectService {
 
@@ -16,7 +16,7 @@ export class ProjectService implements IProjectService {
 		private $projectTemplatesService: IProjectTemplatesService,
 		private $staticConfig: IStaticConfig) { }
 
-	@exportedPromise("projectService")
+	@exported("projectService")
 	public async createProject(projectOptions: IProjectSettings): Promise<void> {
 		let projectName = projectOptions.projectName,
 			selectedTemplate = projectOptions.template;


### PR DESCRIPTION
Delete @exportedPromise decorator as we no longer need it
Stop stopping device detection interval when deploying on iOS devices. These operations no longer conflict as the code is located in an external dependency.

Merge after https://github.com/telerik/mobile-cli-lib/pull/917