### PR TITLE
Fix missing await for liveEdit

### DIFF
--- a/lib/services/livesync/ios-device-livesync-service.ts
+++ b/lib/services/livesync/ios-device-livesync-service.ts
@@ -79,7 +79,7 @@ class IOSLiveSyncService implements INativeScriptDeviceLiveSyncService {
 		}
 
 		if (await this.setupSocketIfNeeded(projectData.projectId)) {
-			this.liveEdit(scriptFiles);
+			await this.liveEdit(scriptFiles);
 			await this.reloadPage(deviceAppData, otherFiles);
 		} else {
 			await this.restartApplication(deviceAppData, projectData.projectName);


### PR DESCRIPTION
The liveEdit method returns Promise, but we do not await it, which could lead to incorrect behavior.