### PR TITLE
Fix multiple mkdir commands for the same directory #2653

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - NATIVESCRIPT_SKIP_POSTINSTALL_TASKS=1
 language: node_js
 node_js:
-- '4'
+- '6'
 git:
   submodules: true
 before_script:


### PR DESCRIPTION
Fix the issue with syncing files when copying a folder recursively in the app multiple times. The problem was that the `mkdir` command was executed multiple times. The fix is in the mobile-cli, where the folder is checked for existence and not created multiple times.