### PR TITLE
Add command for setting proxy

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,8 +1,5 @@
 {
 	"DEBUG": false,
-	"USE_PROXY": false,
-	"PROXY_PORT": 8888,
-	"PROXY_HOSTNAME": "127.0.0.1",
 	"TYPESCRIPT_COMPILER_OPTIONS": {},
 	"CI_LOGGER": false,
 	"ANDROID_DEBUG_UI_MAC": "Google Chrome",

--- a/docs/man_pages/general/autocomplete-disable.md
+++ b/docs/man_pages/general/autocomplete-disable.md
@@ -8,7 +8,7 @@ General | `$ tns autocomplete disable`
 Disables command-line completion for bash and zsh shells. You need to restart the shell to complete the operation.
 
 <% if(isHtml) { %>> <% } %>NOTE: This operation might modify the `.bash_profile`, `.bashrc` and `.zshrc` files.
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
@@ -20,4 +20,7 @@ Command | Description
 [error-reporting](error-reporting.html) | Configures anonymous error reporting for the NativeScript CLI.
 [help](help.html) | Lists the available commands or shows information about the selected command.
 [doctor](doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/general/autocomplete-enable.md
+++ b/docs/man_pages/general/autocomplete-enable.md
@@ -8,7 +8,7 @@ General | `$ tns autocomplete enable`
 Enables command-line completion for bash and zsh shells. You need to restart the shell to complete the operation.
 
 <% if(isHtml) { %>> <% } %>NOTE: This operation might modify the `.bash_profile`, `.bashrc` and `.zshrc` files.
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
@@ -20,4 +20,7 @@ Command | Description
 [error-reporting](error-reporting.html) | Configures anonymous error reporting for the NativeScript CLI.
 [help](help.html) | Lists the available commands or shows information about the selected command.
 [doctor](doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/general/autocomplete-status.md
+++ b/docs/man_pages/general/autocomplete-status.md
@@ -7,7 +7,7 @@ General | `$ tns autocomplete status`
 
 Prints your current command-line completion settings.
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
@@ -19,4 +19,7 @@ Command | Description
 [error-reporting](error-reporting.html) | Configures anonymous error reporting for the NativeScript CLI.
 [help](help.html) | Lists the available commands or shows information about the selected command.
 [doctor](doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/general/autocomplete.md
+++ b/docs/man_pages/general/autocomplete.md
@@ -18,7 +18,7 @@ Prints your current command-line completion settings. If disabled, prompts you t
 * `enable` - Enables command-line completion. You need to restart the shell to complete the operation.
 * `disable` - Disables command-line completion. You need to restart the shell to complete the operation.
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
@@ -29,4 +29,7 @@ Command | Description
 [usage-reporting](usage-reporting.html) | Configures anonymous usage reporting for the NativeScript CLI.
 [error-reporting](error-reporting.html) | Configures anonymous error reporting for the NativeScript CLI.
 [doctor](doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/general/doctor.md
+++ b/docs/man_pages/general/doctor.md
@@ -17,4 +17,7 @@ Command | Description
 [autocomplete](autocomplete.html) | Prints your current command-line completion settings. If disabled, prompts you to enable it.
 [help](help.html) | Lists the available commands or shows information about the selected command.
 [info](info.html) | Displays version information about the NativeScript CLI, core modules, and runtimes.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/general/error-reporting.md
+++ b/docs/man_pages/general/error-reporting.md
@@ -15,7 +15,7 @@ All data gathered is used strictly for improving the product and will never be u
 * `enable` - Enables anonymous error reporting.
 * `disable` - Disables anonymous error reporting.
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
@@ -26,4 +26,7 @@ Command | Description
 [autocomplete-enable](autocomplete-enable.html) | Enables command-line completion for bash and zsh shells.
 [autocomplete-disable](autocomplete-disable.html) | Disables command-line completion for bash and zsh shells.
 [doctor](doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/general/help.md
+++ b/docs/man_pages/general/help.md
@@ -23,4 +23,7 @@ Command | Description
 [autocomplete](autocomplete.html) | Prints your current command-line completion settings. If disabled, prompts you to enable it.
 [doctor](doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
 [info](info.html) | Displays version information about the NativeScript CLI, core modules, and runtimes.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/general/info.md
+++ b/docs/man_pages/general/info.md
@@ -17,4 +17,7 @@ Command | Description
 [autocomplete](autocomplete.html) | Prints your current command-line completion settings. If disabled, prompts you to enable it.
 [help](help.html) | Lists the available commands or shows information about the selected command.
 [doctor](doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/general/proxy-clear.md
+++ b/docs/man_pages/general/proxy-clear.md
@@ -1,0 +1,17 @@
+proxy clear
+==========
+
+Usage | Synopsis
+------|-------
+General | `$ tns proxy clear`
+
+Clears proxy settings.
+
+<% if(isHtml) { %>
+### Related Commands
+
+Command | Description
+----------|----------
+[proxy](proxy.html) | Displays proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
+<% } %>

--- a/docs/man_pages/general/proxy-set.md
+++ b/docs/man_pages/general/proxy-set.md
@@ -1,0 +1,28 @@
+proxy set
+==========
+
+Usage | Synopsis
+------|-------
+General | `$ tns proxy set [<Hostname> [<Port><% if(isWindows) {%> [<Username> [<Password>]]<%}%>]]`
+
+Sets proxy settings.
+
+### Attributes
+* `<Hostname>` the hostname of the proxy. If you do not provide this when running the command, the NativeScript CLI will prompt you to provide it.
+* `<Port>` the port of the proxy. If you do not provide this when running the command, the NativeScript CLI will prompt you to provide it.
+<% if(isWindows) {%>
+* `<Username>` and `<Password>` are your credentials for the proxy. These are not necessary, however if you provide a `<Username>` you need to provide a `<Password>` too.
+<% } %>
+
+<% if(isHtml) { %>
+### Command Limitations
+
+* You can set credentials only on Windows Systems.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+<% } %>

--- a/docs/man_pages/general/proxy.md
+++ b/docs/man_pages/general/proxy.md
@@ -1,0 +1,22 @@
+proxy
+==========
+
+Usage | Synopsis
+------|-------
+General | `$ tns proxy [<Command>]`
+
+Displays proxy settings.
+
+### Attributes
+`<Command>` extends the `proxy` command. You can set the following values for this attribute.
+* `set` - Sets proxy settings
+* `clear` - Clears proxy settings
+
+<% if(isHtml) { %>
+### Related Commands
+
+Command | Description
+----------|----------
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
+<% } %>

--- a/docs/man_pages/general/usage-reporting.md
+++ b/docs/man_pages/general/usage-reporting.md
@@ -15,7 +15,7 @@ All data gathered is used strictly for improving the product and will never be u
 * `enable` - Enables anonymous usage reporting.
 * `disable` - Disables anonymous usage reporting.
 
-<% if(isHtml) { %> 
+<% if(isHtml) { %>
 ### Related Commands
 
 Command | Description
@@ -26,4 +26,7 @@ Command | Description
 [autocomplete-enable](autocomplete-enable.html) | Enables command-line completion for bash and zsh shells.
 [autocomplete-disable](autocomplete-disable.html) | Disables command-line completion for bash and zsh shells.
 [doctor](doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
+[proxy](proxy.html) | Displays proxy settings.
+[proxy clear](proxy-clear.html) | Clears proxy settings.
+[proxy set](proxy-set.html) | Sets proxy settings.
 <% } %>

--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -15,6 +15,7 @@ Command | Description
 [error-reporting](general/error-reporting.html) | Configures anonymous error reporting for the NativeScript CLI.
 [doctor](general/doctor.html) | Checks your system for configuration problems which might prevent the NativeScript CLI from working properly.
 [info](general/info.html) | Displays version information about the NativeScript CLI, core modules, and runtimes.
+[proxy](general/proxy.html) | Displays proxy settings.
 
 ## Project Development Commands
 Command | Description

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -6,7 +6,6 @@ export class Configuration extends ConfigBase implements IConfiguration { // Use
 	CI_LOGGER = false;
 	DEBUG = false;
 	TYPESCRIPT_COMPILER_OPTIONS = {};
-	USE_PROXY = false;
 	ANDROID_DEBUG_UI: string = null;
 	USE_POD_SANDBOX: boolean = false;
 	debugLivesync: boolean = false;


### PR DESCRIPTION
At the moment users can set proxy by manually editing the file `<cli installation dir>/config/config.json`.
However this has two issues:
 - the proxy does not support authentication
 - if you install newer version of CLI, the file is overwritten, so you have to set it again.

Fix both issues by:
 - creating command that sets the proxy.
 - (currently) for Windows introduce support for authenticated proxy - username and password are stored via Windows Credential Manager API functions.

Expected workflow:
`$ tns <command that makes http request>`
Your proxy requires a username and password. You can run
        tns proxy set <hostname> <port> <username> <password>
In order to supply NativeScript with the credentials needed.

`$ tns proxy set 127.0.0.1 8888 user pass`
Sucessfully setup proxy.

`$ tns proxy get`
Hostname: 127.0.0.1
Port: 8888
Proxy is Enabled

`$ tns proxy clear`
Sucessfully cleared proxy.

`$ tns proxy get`
No proxy set