### PR TITLE
Fix ios-device-operations dispose

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -83,9 +83,10 @@ export class DebugIOSCommand extends DebugPlatformCommand {
 		$platformService: IPlatformService,
 		$options: IOptions,
 		$projectData: IProjectData,
-		$platformsData: IPlatformsData) {
-
+		$platformsData: IPlatformsData,
+		$iosDeviceOperations: IIOSDeviceOperations) {
 		super($iOSDebugService, $devicesService, $injector, $logger, $devicePlatformsConstants, $config, $usbLiveSyncService, $platformService, $projectData, $options, $platformsData);
+		$iosDeviceOperations.setShouldDispose(this.$options.justlaunch);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/device-sockets/ios/socket-request-executor.ts
+++ b/lib/device-sockets/ios/socket-request-executor.ts
@@ -4,10 +4,7 @@ export class IOSSocketRequestExecutor implements IiOSSocketRequestExecutor {
 	constructor(private $errors: IErrors,
 		private $iOSNotification: IiOSNotification,
 		private $iOSNotificationService: IiOSNotificationService,
-		private $logger: ILogger,
-		private $iosDeviceOperations: IIOSDeviceOperations) {
-		this.$iosDeviceOperations.setShouldDispose(false);
-	}
+		private $logger: ILogger) { }
 
 	public async executeAttachRequest(device: Mobile.IiOSDevice, timeout: number, projectId: string): Promise<void> {
 		const deviceIdentifier = device.deviceInfo.identifier;

--- a/lib/services/ios-log-filter.ts
+++ b/lib/services/ios-log-filter.ts
@@ -1,22 +1,27 @@
 let sourcemap = require("source-map");
 import * as path from "path";
 import { cache } from "../common/decorators";
+import * as iOSLogFilterBase from "../common/mobile/ios/ios-log-filter";
 
-export class IOSLogFilter implements Mobile.IPlatformLogFilter {
+export class IOSLogFilter extends iOSLogFilterBase.IOSLogFilter implements Mobile.IPlatformLogFilter {
+	protected infoFilterRegex = /^.*?(<Notice>:.*?((CONSOLE LOG|JS ERROR).*?)|(<Warning>:.*?)|(<Error>:.*?))$/im;
 
 	private partialLine: string = null;
 
-	constructor(private $fs: IFileSystem,
-		private $projectData: IProjectData) { }
+	constructor($loggingLevels: Mobile.ILoggingLevels,
+		private $fs: IFileSystem,
+		private $projectData: IProjectData) {
+			super($loggingLevels);
+		}
 
 	public filterData(data: string, logLevel: string, pid?: string): string {
+		data  = super.filterData(data, logLevel, pid);
 		if (pid && data && data.indexOf(`[${pid}]`) === -1) {
 			return null;
 		}
 
-		let skipLastLine = data[data.length - 1] !== "\n";
-
 		if (data) {
+			let skipLastLine = data[data.length - 1] !== "\n";
 			let lines = data.split("\n");
 			let result = "";
 			for (let i = 0; i < lines.length; i++) {
@@ -45,7 +50,7 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 						continue;
 					}
 				}
-				if (skipLastLine && i === lines.length - 1) {
+				if (skipLastLine && i === lines.length - 1 && lines.length > 1) {
 					this.partialLine = line;
 				} else {
 					result += this.getOriginalFileLocation(line) + "\n";


### PR DESCRIPTION
We need to check if the justlaunch flag is passed before we set the should dispose property to false. If we set it to false unconditionally when we pass justlaunch flag the process will never exit.

Fixes https://github.com/NativeScript/nativescript-cli/issues/2654