### PR TITLE
skip the hidden files when livesyncing

### DIFF
--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -110,7 +110,17 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 			}
 		});
 
+		// skip hidden files, to prevent reload of the app for hidden files
+		// created temporarily by the IDEs
+		if (this.isUnixHiddenPath(filePath)) {
+			isFileExcluded = true;
+		}
+
 		return isFileExcluded;
+	}
+
+	private isUnixHiddenPath(filePath: string): boolean {
+		return (/(^|\/)\.[^\/\.]/g).test(filePath);
 	}
 
 	private batchSync(filePath: string, dispatcher: IFutureDispatcher, afterFileSyncAction: (deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => Promise<void>, projectData: IProjectData): void {


### PR DESCRIPTION
Add filter for files which are hidden in linux/Mac to be skipped when livesync-ing the app. Some IDEs create them to backup the currently edited file and this causes a re-deploy/re-run of the Application although it's not necessary.