### PR TITLE
Fix watch incorrectly being overrided by justlaunch always

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -62,7 +62,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 
 		let that = (<any>this);
 		// if justlaunch is set, it takes precedence over the --watch flag and the default true value
-		if(that.justlaunch) {
+		if (that.justlaunch) {
 			that.watch = false;
 		}
 	}

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -61,7 +61,10 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 		}
 
 		let that = (<any>this);
-		that.watch = !that.justlaunch;
+		// if justlaunch is set, it takes precedence over the --watch flag and the default true value
+		if(that.justlaunch) {
+			that.watch = false;
+		}
 	}
 }
 $injector.register("options", Options);


### PR DESCRIPTION
The Watch Option was completely overriden by the Justlaunch option, every time. This is a newly introduced issue. Now, the justlaunch will take precedence if it's set to true and the watch will be set to false in this case, no matter what's passed for watch.