### PR TITLE
Remove ignore path for DS_Store. This is captured by hidden files ign…

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -107,7 +107,7 @@ class LiveSyncService implements ILiveSyncService {
 			}
 		}
 
-		let watcher = choki.watch(pattern, { ignoreInitial: true, cwd: syncWorkingDirectory, ignored: '**/*.DS_Store' }).on("all", (event: string, filePath: string) => {
+		let watcher = choki.watch(pattern, { ignoreInitial: true, cwd: syncWorkingDirectory }).on("all", (event: string, filePath: string) => {
 			that.$dispatcher.dispatch(async () => {
 				try {
 					filePath = path.join(syncWorkingDirectory, filePath);


### PR DESCRIPTION
After we have introduced ignore of the hidden files, we don't need to check for .DS_Store anymore as it's a hidden directory and therefore filtered anyway.