### PR TITLE
Plamen5kov/use xcodebuild instead of xcrun

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -248,8 +248,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			"-exportPath", exportPath,
 			"-exportOptionsPlist", platformData.configurationFilePath
 		];
-
-		await this.$childProcess.spawnFromEvent("xcodebuild", args, "exit", 
+		await this.$childProcess.spawnFromEvent("xcodebuild", args, "exit",
 			{ stdio: buildConfig.buildOutputStdio || 'inherit', cwd: this.getPlatformData(projectData).projectRoot },
 			{ emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: false });
 
@@ -458,12 +457,12 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 	private async createIpa(projectRoot: string, projectData: IProjectData, buildConfig: IBuildConfig): Promise<string> {
 		let xarchivePath = await this.archive(projectData);
-		let exportFileIpa = await this.exportDevelopmentArchive(projectData, 
+		let exportFileIpa = await this.exportDevelopmentArchive(projectData,
 			buildConfig,
-			{ 
-				archivePath: xarchivePath, 
+			{
+				archivePath: xarchivePath,
 			});
-			
+
 		return exportFileIpa;
 	}
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -231,9 +231,9 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	/**
-	 * Exports .xcarchive for AppStore distribution.
+	 * Exports .xcarchive for a development device.
 	 */
-	public async exportDevelopmentArchive(projectData: IProjectData, buildConfig: IBuildConfig, options: { archivePath: string, exportDir?: string, teamID?: string }): Promise<string> {
+	private async exportDevelopmentArchive(projectData: IProjectData, buildConfig: IBuildConfig, options: { archivePath: string, exportDir?: string, teamID?: string }): Promise<string> {
 		let platformData = this.getPlatformData(projectData);
 		let projectRoot = platformData.projectRoot;
 		let archivePath = options.archivePath;
@@ -250,7 +250,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		];
 		await this.$childProcess.spawnFromEvent("xcodebuild", args, "exit",
 			{ stdio: buildConfig.buildOutputStdio || 'inherit', cwd: this.getPlatformData(projectData).projectRoot },
-			{ emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: false });
+			{ emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: true });
 
 		return exportFile;
 	}


### PR DESCRIPTION
xccrun PackageApplication is now deprecated in XCode 8.3, therefore we're switching to xcodebuild and execute two steps:

- archive the application
- export the `.xarchive` to `.ipa`

related issue: https://github.com/NativeScript/nativescript-cli/issues/2668