### PR TITLE
Track the amount and device type of builds and livesync operations

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -131,7 +131,7 @@ interface IPlatformService {
 	 * @param {{isForDevice: boolean}} settings Defines if the searched artifact should be for simulator.
 	 * @returns {void}
 	 */
-	copyLastOutput(platform: string, targetPath: string, settings: {isForDevice: boolean}): void;
+	copyLastOutput(platform: string, targetPath: string, settings: { isForDevice: boolean }): void;
 
 	lastOutputPath(platform: string, settings: { isForDevice: boolean }): string;
 
@@ -150,6 +150,38 @@ interface IPlatformService {
 	 * @returns {IFuture<void>}
 	 */
 	trackProjectType(): IFuture<void>;
+
+	/**
+	 * Sends information to analytics for specific platform related action, for example Build, LiveSync, etc.
+	 * @param {ITrackPlatformAction} actionData The data describing current action.
+	 * @returns {IFuture<void>}
+	 */
+	trackActionForPlatform(actionData: ITrackPlatformAction): IFuture<void>;
+}
+
+/**
+ * Describes information that will be tracked for specific action related for platforms - build, livesync, etc.
+ */
+interface ITrackPlatformAction {
+	/**
+	 * Name of the action.
+	 */
+	action: string;
+
+	/**
+	 * Platform for which the action will be executed.
+	 */
+	platform: string;
+
+	/**
+	 * Defines if the action is for device or emulator.
+	 */
+	isForDevice: boolean;
+
+	/**
+	 * Defines the OS version of the device for which the action will be executed.
+	 */
+	deviceOsVersion?: string;
 }
 
 interface IPlatformData {

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -12,10 +12,6 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 
 	protected liveSyncData: ILiveSyncData;
 
-	private get $analyticsService(): IAnalyticsService {
-		return this.$injector.resolve("analyticsService");
-	}
-
 	constructor(_liveSyncData: ILiveSyncData,
 		private $devicesService: Mobile.IDevicesService,
 		private $mobileHelper: Mobile.IMobileHelper,
@@ -43,9 +39,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 			let canExecute = this.getCanExecuteAction(platform, appIdentifier);
 			let action = (device: Mobile.IDevice): IFuture<void> => {
 				return (() => {
-					const normalizePlatformName = this.$mobileHelper.normalizePlatformName(platform);
-					const deviceType = device.isEmulator ? "emulator" : "device";
-					this.$analyticsService.track("LiveSync", `${normalizePlatformName}.${deviceType}`).wait();
+					this.$platformService.trackActionForPlatform({ action: "LiveSync", platform, isForDevice: !device.isEmulator, deviceOsVersion: device.deviceInfo.version }).wait();
 
 					let deviceAppData = this.$deviceAppDataFactory.create(appIdentifier, this.$mobileHelper.normalizePlatformName(platform), device);
 					let localToDevicePaths: Mobile.ILocalToDevicePathData[] = null;

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -12,6 +12,10 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 
 	protected liveSyncData: ILiveSyncData;
 
+	private get $analyticsService(): IAnalyticsService {
+		return this.$injector.resolve("analyticsService");
+	}
+
 	constructor(_liveSyncData: ILiveSyncData,
 		private $devicesService: Mobile.IDevicesService,
 		private $mobileHelper: Mobile.IMobileHelper,
@@ -39,6 +43,10 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 			let canExecute = this.getCanExecuteAction(platform, appIdentifier);
 			let action = (device: Mobile.IDevice): IFuture<void> => {
 				return (() => {
+					const normalizePlatformName = this.$mobileHelper.normalizePlatformName(platform);
+					const deviceType = device.isEmulator ? "emulator" : "device";
+					this.$analyticsService.track("LiveSync", `${normalizePlatformName}.${deviceType}`).wait();
+
 					let deviceAppData = this.$deviceAppDataFactory.create(appIdentifier, this.$mobileHelper.normalizePlatformName(platform), device);
 					let localToDevicePaths: Mobile.ILocalToDevicePathData[] = null;
 					if (this.shouldTransferAllFiles(platform, deviceAppData)) {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -392,15 +392,24 @@ export class PlatformService implements IPlatformService {
 		}).future<void>()();
 	}
 
+	public trackActionForPlatform(actionData: ITrackPlatformAction): IFuture<void> {
+		return (() => {
+			const normalizePlatformName = this.$mobileHelper.normalizePlatformName(actionData.platform);
+			const deviceType = actionData.isForDevice ? "device" : "emulator";
+			this.$analyticsService.track(actionData.action, `${normalizePlatformName}.${deviceType}`).wait();
+			if (actionData.deviceOsVersion) {
+				this.$analyticsService.track(`Device OS version`, `${normalizePlatformName}_${actionData.deviceOsVersion}`).wait();
+			}
+		}).future<void>()();
+	}
+
 	public buildPlatform(platform: string, buildConfig?: IBuildConfig): IFuture<void> {
 		return (() => {
 			this.$logger.out("Building project...");
 
 			this.trackProjectType().wait();
-
-			const normalizePlatformName = this.$mobileHelper.normalizePlatformName(platform);
-			const deviceType = buildConfig && buildConfig.buildForDevice ? "device" : "emulator";
-			this.$analyticsService.track("Build", `${normalizePlatformName}.${deviceType}`).wait();
+			const isForDevice = this.$options.forDevice || (buildConfig && buildConfig.buildForDevice);
+			this.trackActionForPlatform({ action: "Build", platform, isForDevice }).wait();
 
 			let platformData = this.$platformsData.getPlatformData(platform);
 			platformData.platformProjectService.buildProject(platformData.projectRoot, buildConfig).wait();
@@ -468,6 +477,8 @@ export class PlatformService implements IPlatformService {
 					} else {
 						this.$logger.out("Skipping install.");
 					}
+
+					this.trackActionForPlatform({ action: "Deploy", platform: device.deviceInfo.platform, isForDevice: !device.isEmulator, deviceOsVersion: device.deviceInfo.version }).wait();
 				}).future<void>()();
 			};
 			this.$devicesService.execute(action, this.getCanExecuteAction(platform)).wait();

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -398,6 +398,10 @@ export class PlatformService implements IPlatformService {
 
 			this.trackProjectType().wait();
 
+			const normalizePlatformName = this.$mobileHelper.normalizePlatformName(platform);
+			const deviceType = buildConfig && buildConfig.buildForDevice ? "device" : "emulator";
+			this.$analyticsService.track("Build", `${normalizePlatformName}.${deviceType}`).wait();
+
 			let platformData = this.$platformsData.getPlatformData(platform);
 			platformData.platformProjectService.buildProject(platformData.projectRoot, buildConfig).wait();
 			let prepareInfo = this.$projectChangesService.getPrepareInfo(platform);

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -679,6 +679,10 @@ export class PlatformServiceStub implements IPlatformService {
 	public trackProjectType(): IFuture<void> {
 		return Future.fromResult();
 	}
+
+	public trackActionForPlatform(actionData: ITrackPlatformAction): IFuture<void> {
+		return Future.fromResult();
+	}
 }
 
 export class EmulatorPlatformService implements IEmulatorPlatformService {


### PR DESCRIPTION
In order to unsderstand the workflow of our users, we need to track how many builds they are executing, how many livesync operations, etc. We also need to know if the operation is for device or emulator (iOSSimulator).
This will allow us to focus the development and provide better features in the future.