### PR TITLE
Install karma peer dependencies on `test init`

### DIFF
--- a/lib/commands/test-init.ts
+++ b/lib/commands/test-init.ts
@@ -53,7 +53,7 @@ class TestInitCommand implements ICommand {
 						'save-dev': true
 					});
 				} catch (e) {
-					this.$logger.info(e.message);
+					this.$logger.error(e.message);
 				}
 			}
 		}

--- a/lib/commands/test-init.ts
+++ b/lib/commands/test-init.ts
@@ -37,6 +37,18 @@ class TestInitCommand implements ICommand {
 				'save-dev': true,
 				optional: false,
 			});
+
+			let modulePath = path.join(projectDir, "node_modules", mod);
+			let modulePackageJsonPath = path.join(modulePath, "package.json");
+			let modulePackageJsonContent = this.$fs.readJson(modulePackageJsonPath);
+			let modulePeerDependencies = modulePackageJsonContent.peerDependencies || {};
+
+			for (let peerDependency in modulePeerDependencies) {
+				let dependencyVersion = modulePeerDependencies[peerDependency] || "*";
+				await this.$npm.install(`${peerDependency}@${dependencyVersion}`, projectDir, {
+					'save-dev': true
+				});
+			}
 		}
 
 		await this.$pluginsService.add('nativescript-unit-test-runner', this.$projectData);

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -76,10 +76,10 @@ export class NodePackageManager implements INodePackageManager {
 		let diff = dependencyDiff.concat(devDependencyDiff);
 
 		if (diff.length <= 0 && dependenciesBefore.length === dependenciesAfter.length && packageName !== pathToSave) {
-			this.$errors.failWithoutHelp(`The plugin ${packageName} is already installed`);
+			this.$logger.warn(`The plugin ${packageName} is already installed`);
 		}
 		if (diff.length <= 0 && dependenciesBefore.length !== dependenciesAfter.length) {
-			this.$errors.failWithoutHelp(`Couldn't install package correctly`);
+			this.$logger.warn(`Couldn't install package ${packageName} correctly`);
 		}
 
 		return diff;


### PR DESCRIPTION
### Problem:
Often when running `tns test init` it is unclear that there are unmet peer dependencies that are critical to `karma`'s proper execution.

### Proposed Solution:
When executing `test init` in a NativeScript, project karma testing frameworks' (`karma-jasmine/qunit/mocha`) peer dependencies will be implicitly installed. These dependencies are `jasmine-core`, `qunit`, and `mocha` respectively, depending on the framework selected from the interactive console prompt.