### PR TITLE
Adding configuration build parameter to the archive functionality

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -176,10 +176,11 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	 * Archive the Xcode project to .xcarchive.
 	 * Returns the path to the .xcarchive.
 	 */
-	public async archive(projectData: IProjectData, options?: { archivePath?: string }): Promise<string> {
+	public async archive(projectData: IProjectData, buildConfig?: IBuildConfig, options?: { archivePath?: string }): Promise<string> {
 		let projectRoot = this.getPlatformData(projectData).projectRoot;
 		let archivePath = options && options.archivePath ? path.resolve(options.archivePath) : path.join(projectRoot, "/build/archive/", projectData.projectName + ".xcarchive");
-		let args = ["archive", "-archivePath", archivePath]
+		let args = ["archive", "-archivePath", archivePath, "-configuration",
+				(!buildConfig || buildConfig.release) ? "Release" : "Debug" ]
 			.concat(this.xcbuildProjectArgs(projectRoot, projectData, "scheme"));
 		await this.$childProcess.spawnFromEvent("xcodebuild", args, "exit", { stdio: 'inherit' });
 		return archivePath;
@@ -456,7 +457,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	private async createIpa(projectRoot: string, projectData: IProjectData, buildConfig: IBuildConfig): Promise<string> {
-		let xarchivePath = await this.archive(projectData);
+		let xarchivePath = await this.archive(projectData, buildConfig);
 		let exportFileIpa = await this.exportDevelopmentArchive(projectData,
 			buildConfig,
 			{

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -159,9 +159,9 @@ describe("iOSProjectService", () => {
 			return {
 				run: async (): Promise<void> => {
 					if (hasCustomArchivePath) {
-						resultArchivePath = await iOSProjectService.archive(projectData, { archivePath: options.archivePath });
+						resultArchivePath = await iOSProjectService.archive(projectData, null, { archivePath: options.archivePath });
 					} else {
-						resultArchivePath = await iOSProjectService.archive(projectData);
+						resultArchivePath = await iOSProjectService.archive(projectData, null);
 					}
 				},
 				assert: () => {


### PR DESCRIPTION
Add configuration build passing to the xcodebuild when producing the IPA, so that we include the TNSLiveSync framework when built in debug mode and actuall the LiveSync works.