### PR TITLE
Track the amount and device type of builds and livesync operations

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -192,6 +192,13 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @returns {Promise<void>}
 	 */
 	trackProjectType(projectData: IProjectData): Promise<void>;
+
+	/**
+	 * Sends information to analytics for specific platform related action, for example Build, LiveSync, etc.
+	 * @param {ITrackPlatformAction} actionData The data describing current action.
+	 * @returns {Promise<void>}
+	 */
+	trackActionForPlatform(actionData: ITrackPlatformAction): Promise<void>;
 }
 
 /**
@@ -207,6 +214,31 @@ interface IPlatformSpecificData {
 	 * Target SDK for Android.s
 	 */
 	sdk: string;
+}
+
+/**
+ * Describes information that will be tracked for specific action related for platforms - build, livesync, etc.
+ */
+interface ITrackPlatformAction {
+	/**
+	 * Name of the action.
+	 */
+	action: string;
+
+	/**
+	 * Platform for which the action will be executed.
+	 */
+	platform: string;
+
+	/**
+	 * Defines if the action is for device or emulator.
+	 */
+	isForDevice: boolean;
+
+	/**
+	 * Defines the OS version of the device for which the action will be executed.
+	 */
+	deviceOsVersion?: string;
 }
 
 interface IPlatformData {

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -34,6 +34,8 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 		let projectFilesPath = this.liveSyncData.projectFilesPath;
 		let canExecute = this.getCanExecuteAction(platform, appIdentifier);
 		let action = async (device: Mobile.IDevice): Promise<void> => {
+			await this.$platformService.trackActionForPlatform({ action: "LiveSync", platform, isForDevice: !device.isEmulator, deviceOsVersion: device.deviceInfo.version });
+
 			let deviceAppData = this.$deviceAppDataFactory.create(appIdentifier, this.$mobileHelper.normalizePlatformName(platform), device);
 			let localToDevicePaths: Mobile.ILocalToDevicePathData[] = null;
 			if (await this.shouldTransferAllFiles(platform, deviceAppData, projectData)) {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -255,7 +255,7 @@ export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
 			normalizedPlatformName: "",
 			appDestinationDirectoryPath: "",
 			deviceBuildOutputPath: "",
-			getValidPackageNames: (buildOptions: {isForDevice?: boolean, isReleaseBuild?: boolean}) => [],
+			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
 			frameworkFilesExtensions: [],
 			relativeToFrameworkConfigurationFilePath: "",
 			fastLivesyncFileExtensions: []
@@ -276,7 +276,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 			emulatorServices: undefined,
 			projectRoot: "",
 			deviceBuildOutputPath: "",
-			getValidPackageNames: (buildOptions: {isForDevice?: boolean, isReleaseBuild?: boolean}) => [],
+			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
 			frameworkFilesExtensions: [],
 			appDestinationDirectoryPath: "",
 			relativeToFrameworkConfigurationFilePath: "",
@@ -302,7 +302,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 		return Promise.resolve();
 	}
 	interpolateConfigurationFile(): void {
-		return ;
+		return;
 	}
 	afterCreateProject(projectRoot: string): void {
 		return null;
@@ -350,7 +350,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 		return null;
 	}
 	async stopServices(): Promise<ISpawnResult> {
-		return Promise.resolve({stderr: "", stdout: "", exitCode: 0});
+		return Promise.resolve({ stderr: "", stdout: "", exitCode: 0 });
 	}
 	async cleanProject(projectRoot: string, projectData: IProjectData): Promise<void> {
 		return Promise.resolve();
@@ -680,6 +680,10 @@ export class PlatformServiceStub extends EventEmitter implements IPlatformServic
 	}
 
 	public async trackProjectType(): Promise<void> {
+		return null;
+	}
+
+	public async trackActionForPlatform(actionData: ITrackPlatformAction): Promise<void> {
 		return null;
 	}
 }


### PR DESCRIPTION
> NOTE: Cherry-pick from release


* Track the amount and device type of builds and livesync operations

In order to unsderstand the workflow of our users, we need to track how many builds they are executing, how many livesync operations, etc. We also need to know if the operation is for device or emulator (iOSSimulator).
This will allow us to focus the development and provide better features in the future.

* Track information for deploy and for device OS

Track information for deploy operations. Introduce new method in platformService, that tracks the action.
Track the device OS version as well.

* Track Android only for build operations

Track only Android platform for build operation. We do not need to track Android.emulator and Android.device for build operations as they are both the same actions.