### PR TITLE
We passed incorrectly provision in-place of projectId

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -176,7 +176,7 @@ interface IPlatformProjectService extends NodeJS.EventEmitter {
 	 * @param {any} provision UUID of the provisioning profile used in iOS option validation.
 	 * @returns {void}
 	 */
-	validateOptions(projectId?: string, provision?: any): Promise<boolean>;
+	validateOptions(projectId?: string, provision?: true | string): Promise<boolean>;
 
 	validatePlugins(projectData: IProjectData): Promise<void>;
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -85,7 +85,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		return this._platformData;
 	}
 
-	public async validateOptions(projectId: string, provision: any): Promise<boolean> {
+	public async validateOptions(projectId: string, provision: true | string): Promise<boolean> {
 		if (provision === true) {
 			await this.$iOSProvisionService.list(projectId);
 			this.$errors.failWithoutHelp("Please provide provisioning profile uuid or name with the --provision option.");

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -256,18 +256,18 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return true;
 	}
 
-	public async validateOptions(provision: any, projectData: IProjectData, platform?: string): Promise<boolean> {
+	public async validateOptions(provision: true | string, projectData: IProjectData, platform?: string): Promise<boolean> {
 		if (platform) {
 			platform = this.$mobileHelper.normalizePlatformName(platform);
 			this.$logger.trace("Validate options for platform: " + platform);
 			let platformData = this.$platformsData.getPlatformData(platform, projectData);
-			return await platformData.platformProjectService.validateOptions(provision);
+			return await platformData.platformProjectService.validateOptions(projectData.projectId, provision);
 		} else {
 			let valid = true;
 			for (let availablePlatform in this.$platformsData.availablePlatforms) {
 				this.$logger.trace("Validate options for platform: " + availablePlatform);
 				let platformData = this.$platformsData.getPlatformData(availablePlatform, projectData);
-				valid = valid && await platformData.platformProjectService.validateOptions(provision);
+				valid = valid && await platformData.platformProjectService.validateOptions(projectData.projectId, provision);
 			}
 
 			return valid;


### PR DESCRIPTION
We pass provision in-place of projectId downstream since any is assignable from everything and everything is assignable to any.