### PR TITLE
Throw error in case build for simulator fails

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -453,7 +453,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 		await this.$childProcess.spawnFromEvent("xcodebuild", args, "exit",
 			{ stdio: buildOutputStdio || "inherit", cwd: this.getPlatformData(projectData).projectRoot },
-			{ emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: false });
+			{ emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: true });
 	}
 
 	private async createIpa(projectRoot: string, projectData: IProjectData, buildConfig: IBuildConfig): Promise<string> {


### PR DESCRIPTION
When build for iOS Simulator fails, we do not break the process and hide the error. In any case when build operation fails, we should break the process.