### PR TITLE
Remove App_Resources, when the changes are in the other files.

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -283,12 +283,21 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		if (!changesInfo || changesInfo.appFilesChanged) {
 			await this.copyAppFiles(platform, appFilesUpdaterOptions, projectData);
+
+			// remove the App_Resources folder from the app/assets as here we're applying other files changes.
+			const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+			const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
+			if (this.$fs.exists(appResourcesDirectoryPath)) {
+				this.$fs.deleteDirectory(appResourcesDirectoryPath);
+			}
 		}
+
 		if (!changesInfo || changesInfo.appResourcesChanged) {
 			await this.copyAppFiles(platform, appFilesUpdaterOptions, projectData);
 			this.copyAppResources(platform, projectData);
 			await platformData.platformProjectService.prepareProject(projectData, platformSpecificData);
 		}
+
 		if (!changesInfo || changesInfo.modulesChanged) {
 			await this.copyTnsModules(platform, projectData);
 		}


### PR DESCRIPTION
When we look for "FileChanges" we divide them in categories:

-- FileChanged
-- AppResources Changed

The FileChanged is triggered for all files, excluding the ones in App_Resource directory. The CopyAppFiles method copies all /app files though, therefore including the App_Resource files. The functionality to clean-up the App_Resources folder from the /app is in the prepare which is not executed in this case.

This will be refactored, as soon as I add some tests to cover the functionality and ensure we don't do introduce many regression bugs.