### PR TITLE
Detach event handlers after action is done

### DIFF
--- a/lib/services/local-build-service.ts
+++ b/lib/services/local-build-service.ts
@@ -1,21 +1,23 @@
 import { EventEmitter } from "events";
 import { BUILD_OUTPUT_EVENT_NAME } from "../constants";
+import { attachAwaitDetach } from "../common/helpers";
 
 export class LocalBuildService extends EventEmitter {
 	constructor(private $projectData: IProjectData,
-	private $platformService: IPlatformService) {
+		private $platformService: IPlatformService) {
 		super();
 	}
 
 	public async build(platform: string, platformBuildOptions: IPlatformBuildData, platformTemplate?: string): Promise<string> {
 		this.$projectData.initializeProjectData(platformBuildOptions.projectDir);
 		await this.$platformService.preparePlatform(platform, platformBuildOptions, platformTemplate, this.$projectData, { provision: platformBuildOptions.provision, sdk: null });
-		this.$platformService.on(BUILD_OUTPUT_EVENT_NAME, (data: any) => {
+		const handler = (data: any) => {
 			data.projectDir = platformBuildOptions.projectDir;
 			this.emit(BUILD_OUTPUT_EVENT_NAME, data);
-		});
+		};
 		platformBuildOptions.buildOutputStdio = "pipe";
-		await this.$platformService.buildPlatform(platform, platformBuildOptions, this.$projectData);
+
+		await attachAwaitDetach(BUILD_OUTPUT_EVENT_NAME, this.$platformService, handler, this.$platformService.buildPlatform(platform, platformBuildOptions, this.$projectData));
 		return this.$platformService.lastOutputPath(platform, platformBuildOptions, this.$projectData);
 	}
 }


### PR DESCRIPTION
In order to not emit `buildOutput` event multiple times during build in a long running process (fusion) we have to detach event handlers after build is done.

Merge after https://github.com/telerik/mobile-cli-lib/pull/940

Ping @rosen-vladimirov @TsvetanMilanov 