### PR TITLE
Fix connect ECONNREFUSED error when trying to debug on iOS Sim

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -288,7 +288,7 @@ interface IAndroidToolsInfoData {
 }
 
 interface ISocketProxyFactory extends NodeJS.EventEmitter {
-	createTCPSocketProxy(factory: () => Promise<any>): any;
+	createTCPSocketProxy(factory: () => Promise<any>): Promise<any>;
 	createWebSocketProxy(factory: () => Promise<any>): Promise<any>;
 }
 

--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -1,7 +1,7 @@
 interface IDebugData {
 	deviceIdentifier: string;
 	applicationIdentifier: string;
-	pathToAppPackage: string;
+	pathToAppPackage?: string;
 	projectName?: string;
 	projectDir?: string;
 }
@@ -17,7 +17,7 @@ interface IDebugOptions {
 }
 
 interface IDebugDataService {
-	createDebugData(debugService: IPlatformDebugService, options: IOptions, buildConfig: IBuildConfig): IDebugData;
+	createDebugData(projectData: IProjectData, options: IOptions): IDebugData;
 }
 
 interface IDebugService extends NodeJS.EventEmitter {

--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -45,13 +45,14 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 				});
 
 				frontendSocket.on("close", () => {
-					console.log("frontend socket closed");
+					this.$logger.info("Frontend socket closed");
 					if (!(<any>backendSocket).destroyed) {
 						backendSocket.destroy();
 					}
 				});
+
 				backendSocket.on("close", () => {
-					console.log("backend socket closed");
+					this.$logger.info("Backend socket closed");
 					if (!(<any>frontendSocket).destroyed) {
 						frontendSocket.destroy();
 					}

--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -3,6 +3,7 @@ import { CONNECTION_ERROR_EVENT_NAME } from "../../constants";
 import { PacketStream } from "./packet-stream";
 import * as net from "net";
 import * as ws from "ws";
+import * as helpers from "../../common/helpers";
 import temp = require("temp");
 
 export class SocketProxyFactory extends EventEmitter implements ISocketProxyFactory {
@@ -14,7 +15,9 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 		super();
 	}
 
-	public createTCPSocketProxy(factory: () => Promise<net.Socket>): net.Server {
+	public async createTCPSocketProxy(factory: () => Promise<net.Socket>): Promise<net.Server> {
+		const socketFactory = async (callback: (_socket: net.Socket) => void) => helpers.connectEventually(factory, callback);
+
 		this.$logger.info("\nSetting up proxy...\nPress Ctrl + C to terminate, or disconnect.\n");
 
 		let server = net.createServer({
@@ -31,32 +34,33 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 				}
 			});
 
-			const backendSocket = await factory();
-			this.$logger.info("Backend socket created.");
+			await socketFactory((backendSocket: net.Socket) => {
+				this.$logger.info("Backend socket created.");
 
-			backendSocket.on("end", () => {
-				this.$logger.info("Backend socket closed!");
-				if (!(this.$config.debugLivesync && this.$options.watch)) {
-					process.exit(0);
-				}
-			});
+				backendSocket.on("end", () => {
+					this.$logger.info("Backend socket closed!");
+					if (!(this.$config.debugLivesync && this.$options.watch)) {
+						process.exit(0);
+					}
+				});
 
-			frontendSocket.on("close", () => {
-				console.log("frontend socket closed");
-				if (!(<any>backendSocket).destroyed) {
-					backendSocket.destroy();
-				}
-			});
-			backendSocket.on("close", () => {
-				console.log("backend socket closed");
-				if (!(<any>frontendSocket).destroyed) {
-					frontendSocket.destroy();
-				}
-			});
+				frontendSocket.on("close", () => {
+					console.log("frontend socket closed");
+					if (!(<any>backendSocket).destroyed) {
+						backendSocket.destroy();
+					}
+				});
+				backendSocket.on("close", () => {
+					console.log("backend socket closed");
+					if (!(<any>frontendSocket).destroyed) {
+						frontendSocket.destroy();
+					}
+				});
 
-			backendSocket.pipe(frontendSocket);
-			frontendSocket.pipe(backendSocket);
-			frontendSocket.resume();
+				backendSocket.pipe(frontendSocket);
+				frontendSocket.pipe(backendSocket);
+				frontendSocket.resume();
+			});
 		});
 
 		let socketFileLocation = temp.path({ suffix: ".sock" });

--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -128,10 +128,8 @@ class AndroidDebugService extends DebugServiceBase implements IPlatformDebugServ
 		let startDebuggerCommand = ["am", "broadcast", "-a", `\"${packageName}-debug\"`, "--ez", "enable", "true"];
 		await this.device.adb.executeShellCommand(startDebuggerCommand);
 
-		if (debugOptions.chrome) {
-			let port = await this.getForwardedLocalDebugPortForPackageName(deviceId, packageName);
-			return `chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:${port}`;
-		}
+		let port = await this.getForwardedLocalDebugPortForPackageName(deviceId, packageName);
+		return `chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:${port}`;
 	}
 
 	private detachDebugger(packageName: string): Promise<void> {

--- a/lib/services/debug-data-service.ts
+++ b/lib/services/debug-data-service.ts
@@ -1,40 +1,11 @@
 export class DebugDataService implements IDebugDataService {
-	constructor(private $projectData: IProjectData,
-		private $platformService: IPlatformService,
-		private $platformsData: IPlatformsData,
-		private $mobileHelper: Mobile.IMobileHelper) { }
-
-	public createDebugData(debugService: IPlatformDebugService, options: IOptions, buildConfig: IBuildConfig): IDebugData {
-		this.$projectData.initializeProjectData(options.path);
+	public createDebugData(projectData: IProjectData, options: IOptions): IDebugData {
 		return {
-			applicationIdentifier: this.$projectData.projectId,
-			projectDir: this.$projectData.projectDir,
+			applicationIdentifier: projectData.projectId,
+			projectDir: projectData.projectDir,
 			deviceIdentifier: options.device,
-			pathToAppPackage: this.getPathToAppPackage(debugService, options, buildConfig),
-			projectName: this.$projectData.projectName
+			projectName: projectData.projectName
 		};
-	}
-
-	private getPathToAppPackage(debugService: IPlatformDebugService, options: IOptions, buildConfig: IBuildConfig): string {
-		if (this.$mobileHelper.isAndroidPlatform(debugService.platform)) {
-			if (!options.start && !options.emulator) {
-				const platformData = this.getPlatformData(debugService);
-
-				return this.$platformService.getLatestApplicationPackageForDevice(platformData, buildConfig).packageName;
-			}
-		} else if (this.$mobileHelper.isiOSPlatform(debugService.platform)) {
-			if (options.emulator) {
-				const platformData = this.getPlatformData(debugService);
-
-				return this.$platformService.getLatestApplicationPackageForEmulator(platformData, buildConfig).packageName;
-			}
-		}
-
-		return null;
-	}
-
-	private getPlatformData(debugService: IPlatformDebugService): IPlatformData {
-		return this.$platformsData.getPlatformData(debugService.platform, this.$projectData);
 	}
 }
 

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -112,6 +112,7 @@ class IOSDebugService extends DebugServiceBase implements IPlatformDebugService 
 
 				if (!pidMatch) {
 					this.$logger.trace(`Line ${lineText} does not contain the searched pattern: ${pidRegExp}.`);
+					return;
 				}
 
 				const pid = pidMatch[1];

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -103,11 +103,18 @@ class IOSDebugService extends DebugServiceBase implements IPlatformDebugService 
 
 		let lineStream = byline(child_process.stdout);
 		this._childProcess = child_process;
+		const pidRegExp = new RegExp(`${debugData.applicationIdentifier}:\\s?(\\d+)`);
 
 		lineStream.on('data', (line: NodeBuffer) => {
 			let lineText = line.toString();
 			if (lineText && _.startsWith(lineText, debugData.applicationIdentifier)) {
-				let pid = _.trimStart(lineText, debugData.applicationIdentifier + ": ");
+				const pidMatch = lineText.match(pidRegExp);
+
+				if (!pidMatch) {
+					this.$logger.trace(`Line ${lineText} does not contain the searched pattern: ${pidRegExp}.`);
+				}
+
+				const pid = pidMatch[1];
 				this._lldbProcess = this.$childProcess.spawn("lldb", ["-p", pid]);
 				if (log4js.levels.TRACE.isGreaterThanOrEqualTo(this.$logger.getLevel())) {
 					this._lldbProcess.stdout.pipe(process.stdout);
@@ -182,7 +189,7 @@ class IOSDebugService extends DebugServiceBase implements IPlatformDebugService 
 			const commitSHA = "02e6bde1bbe34e43b309d4ef774b1168d25fd024"; // corresponds to 55.0.2883 Chrome version
 			return `chrome-devtools://devtools/remote/serve_file/@${commitSHA}/inspector.html?experiments=true&ws=localhost:${this._socketProxy.options.port}`;
 		} else {
-			this._socketProxy = this.$socketProxyFactory.createTCPSocketProxy(this.getSocketFactory(device));
+			this._socketProxy = await this.$socketProxyFactory.createTCPSocketProxy(this.getSocketFactory(device));
 			await this.openAppInspector(this._socketProxy.address(), debugData, debugOptions);
 			return null;
 		}

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -74,10 +74,9 @@ class TestExecutionService implements ITestExecutionService {
 					await this.$usbLiveSyncService.liveSync(platform, projectData);
 
 					if (this.$options.debugBrk) {
-						const buildConfig: IBuildConfig = _.merge({ buildForDevice: this.$options.forDevice }, deployOptions);
 						this.$logger.info('Starting debugger...');
 						let debugService: IPlatformDebugService = this.$injector.resolve(`${platform}DebugService`);
-						const debugData: IDebugData = this.$debugDataService.createDebugData(debugService, this.$options, buildConfig);
+						const debugData = this.getDebugData(platform, projectData, deployOptions);
 						await debugService.debugStart(debugData, this.$options);
 					}
 					resolve();
@@ -143,8 +142,7 @@ class TestExecutionService implements ITestExecutionService {
 
 				if (this.$options.debugBrk) {
 					const debugService = this.getDebugService(platform);
-					const buildConfig: IBuildConfig = _.merge({ buildForDevice: this.$options.forDevice }, deployOptions);
-					const debugData = this.$debugDataService.createDebugData(debugService, this.$options, buildConfig);
+					const debugData = this.getDebugData(platform, projectData, deployOptions);
 					await debugService.debug(debugData, this.$options);
 				} else {
 					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
@@ -246,6 +244,14 @@ class TestExecutionService implements ITestExecutionService {
 		this.$logger.debug(JSON.stringify(karmaConfig, null, 4));
 
 		return karmaConfig;
+	}
+
+	private getDebugData(platform: string, projectData: IProjectData, deployOptions: IDeployPlatformOptions): IDebugData {
+		const buildConfig: IBuildConfig = _.merge({ buildForDevice: this.$options.forDevice }, deployOptions);
+		let debugData = this.$debugDataService.createDebugData(projectData, this.$options);
+		debugData.pathToAppPackage = this.$platformService.lastOutputPath(platform, buildConfig, projectData);
+
+		return debugData;
 	}
 }
 $injector.register('testExecutionService', TestExecutionService);


### PR DESCRIPTION
When trying to debug on iOS Simulator (via NativeScript Inspector), we often receive `Error: connect ECONNREFUSED 127.0.0.1:18181` error.
There are two different problems. First one is incorrect identifying of the application's PID - we are using `_.trimStart` method totally incorrectly and in case your application identifier has numbers in it, they'll also be replaced in the search PID string. For example in case your app id is `org.nativescript.app10`, and the real PID of the running application is 18129, the current usage of `trimStart` method will give you the PID 8129.
Fix this by applying regular expression and find the correct PID.

The second problem is that there's some delay between opening the NativeScript Inspector and the debugged application on the device. In many cases the first time when we try to connect, we receive the error ECONNREFUSED. However in the previous implementation, we were trying to connect multiple times. Get back the old code and adjust it to work with Promises instead of the old sync execution.


### Second commit:

Fix debug command:  
- `tns debug ios` prints message that you have to open `null` url in Chrome - when you do not pass `--chrome` to this command, it will use NativeScript inspector, so hide the incorrect message.
- debugData is constructed too early in the command - in case the application has not been built before calling `tns debug ...`, construction of debugData will fail as CLI will not be able to find the latest built package. In order to fix this make the `pathToAppPackage` not mandatory (we do not need it for debug commands when `--start` is passed) and populate it after successful deploy of the application. This way it will have correct value. Delete most of the DebugDataService as most of the methods are not needed with these changes.
- remove the check if `--chrome` is passed in order to print the url when `tns debug android` is used. The check was incorrect (it should check the value of `options.client`), but in fact we do not need it - the idea of the check was to suppress starting of Node Inspector, however we do not start it anymore no matter of the passed flags. So remove the incorrect check.