### PR TITLE
Make --provision work with distribution certificates and able to update the project after initial prepare

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -124,6 +124,9 @@ $injector.require("projectChangesService", "./services/project-changes-service")
 
 $injector.require("emulatorPlatformService", "./services/emulator-platform-service");
 
+$injector.require("pbxprojDomXcode", "./node/pbxproj-dom-xcode");
+$injector.require("xcode", "./node/xcode");
+
 $injector.require("staticConfig", "./config");
 
 $injector.require("requireService", "./services/require-service");

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -27,7 +27,7 @@ export class EmulateCommandBase {
 			keyStorePassword: this.$options.keyStorePassword,
 			keyStorePath: this.$options.keyStorePath
 		};
-		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, this.$options.provision);
+		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, this.$options);
 	}
 }
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -281,7 +281,7 @@ interface IClean {
 }
 
 interface IProvision {
-	provision: any;
+	provision: string;
 }
 
 interface ITeamIdentifier {

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -15,8 +15,11 @@ interface IProjectChangesInfo {
 	configChanged: boolean;
 	packageChanged: boolean;
 	nativeChanged: boolean;
-	hasChanges: boolean;
-	changesRequireBuild: boolean;
+	signingChanged: boolean;
+
+	readonly hasChanges: boolean;
+	readonly changesRequireBuild: boolean;
+	readonly changesRequirePrepare: boolean;
 }
 
 interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision {}

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -258,6 +258,12 @@ interface IPlatformProjectService extends NodeJS.EventEmitter {
 	 * @returns {void}
 	 */
 	cleanProject(projectRoot: string, projectData: IProjectData): Promise<void>
+
+	/**
+	 * Check the current state of the project, and validate against the options.
+	 * If there are parts in the project that are inconsistent with the desired options, marks them in the changeset flags.
+	 */
+	checkForChanges(changeset: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): void;
 }
 
 interface IAndroidProjectPropertiesManager {

--- a/lib/node/pbxproj-dom-xcode.ts
+++ b/lib/node/pbxproj-dom-xcode.ts
@@ -1,0 +1,7 @@
+import * as pbxprojDomXcodeModule from "pbxproj-dom/xcode";
+
+declare global {
+	type IPbxprojDomXcode = typeof pbxprojDomXcodeModule;
+}
+
+$injector.register("pbxprojDomXcode", pbxprojDomXcodeModule);

--- a/lib/node/xcode.ts
+++ b/lib/node/xcode.ts
@@ -1,0 +1,11 @@
+import * as xcode from "xcode";
+
+declare global {
+	type IXcode = typeof xcode;
+	export namespace IXcode {
+		export type project = typeof xcode.project;
+		export interface Options extends xcode.Options {} // tslint:disable-line
+	}
+}
+
+$injector.register("xcode", xcode);

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -438,6 +438,10 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		await adb.executeShellCommand(["rm", "-rf", deviceRootPath]);
 	}
 
+	public checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): void {
+		// Nothing android specific to check yet.
+	}
+
 	private _canUseGradle: boolean;
 	private canUseGradle(projectData: IProjectData, frameworkVersion?: string): boolean {
 		if (!this._canUseGradle) {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -2,7 +2,6 @@ import * as path from "path";
 import * as shell from "shelljs";
 import * as os from "os";
 import * as semver from "semver";
-import * as xcode from "xcode";
 import * as constants from "../constants";
 import * as helpers from "../common/helpers";
 import { attachAwaitDetach } from "../common/helpers";
@@ -11,7 +10,6 @@ import { PlistSession } from "plist-merge-patch";
 import { EOL } from "os";
 import * as temp from "temp";
 import * as plist from "plist";
-import { Xcode } from "pbxproj-dom/xcode";
 import { IOSProvisionService } from "./ios-provision-service";
 
 export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServiceBase implements IPlatformProjectService {
@@ -42,7 +40,9 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		private $pluginVariablesService: IPluginVariablesService,
 		private $xcprojService: IXcprojService,
 		private $iOSProvisionService: IOSProvisionService,
-		private $sysInfo: ISysInfo) {
+		private $sysInfo: ISysInfo,
+		private $pbxprojDomXcode: IPbxprojDomXcode,
+		private $xcode: IXcode) {
 		super($fs, $projectDataService);
 	}
 
@@ -379,10 +379,9 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		await this.createIpa(projectRoot, projectData, buildConfig);
 	}
 
-	private async setupSigningFromProvision(projectRoot: string, projectData: IProjectData, provision?: any): Promise<void> {
+	private async setupSigningFromProvision(projectRoot: string, projectData: IProjectData, provision?: string): Promise<void> {
 		if (provision) {
-			const pbxprojPath = path.join(projectRoot, projectData.projectName + ".xcodeproj", "project.pbxproj");
-			const xcode = Xcode.open(pbxprojPath);
+			const xcode = this.$pbxprojDomXcode.Xcode.open(this.getPbxProjPath(projectData));
 			const signing = xcode.getSigning(projectData.projectName);
 
 			let shouldUpdateXcode = false;
@@ -399,8 +398,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			}
 
 			if (shouldUpdateXcode) {
-				// This is slow, it read through 260 mobileprovision files on my machine and does quite some checking whether provisioning profiles and devices will match.
-				// That's why we try to avoid id by checking in the Xcode first.
 				const pickStart = Date.now();
 				const mobileprovision = await this.$iOSProvisionService.pick(provision, projectData.projectId);
 				const pickEnd = Date.now();
@@ -428,11 +425,16 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	private async setupSigningForDevice(projectRoot: string, buildConfig: IiOSBuildConfig, projectData: IProjectData): Promise<void> {
-		const pbxprojPath = path.join(projectRoot, projectData.projectName + ".xcodeproj", "project.pbxproj");
-		const xcode = Xcode.open(pbxprojPath);
+		const xcode = this.$pbxprojDomXcode.Xcode.open(this.getPbxProjPath(projectData));
 		const signing = xcode.getSigning(projectData.projectName);
 
-		if ((this.readXCConfigProvisioningProfile(projectData) || this.readXCConfigProvisioningProfileForIPhoneOs(projectData)) && (!signing || signing.style !== "Manual")) {
+		const hasProvisioningProfileInXCConfig =
+			this.readXCConfigProvisioningProfileSpecifierForIPhoneOs(projectData) ||
+			this.readXCConfigProvisioningProfileSpecifier(projectData) ||
+			this.readXCConfigProvisioningProfileForIPhoneOs(projectData) ||
+			this.readXCConfigProvisioningProfile(projectData);
+
+		if (hasProvisioningProfileInXCConfig && (!signing || signing.style !== "Manual")) {
 			xcode.setManualSigningStyle(projectData.projectName);
 			xcode.save();
 		} else if (!buildConfig.provision && !(signing && signing.style === "Manual" && !buildConfig.teamId)) {
@@ -490,7 +492,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		let frameworkBinaryPath = path.join(frameworkPath, frameworkName);
 		let isDynamic = _.includes((await this.$childProcess.spawnFromEvent("otool", ["-Vh", frameworkBinaryPath], "close")).stdout, " DYLIB ");
 
-		let frameworkAddOptions: xcode.Options = { customFramework: true };
+		let frameworkAddOptions: IXcode.Options = { customFramework: true };
 
 		if (isDynamic) {
 			frameworkAddOptions["embed"] = true;
@@ -623,7 +625,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 
 		if (provision) {
 			let projectRoot = path.join(projectData.platformsDir, "ios");
-			await this.setupSigningFromProvision(projectRoot, provision);
+			await this.setupSigningFromProvision(projectRoot, projectData, provision);
 		}
 
 		let project = this.createPbxProj(projectData);
@@ -787,7 +789,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 	}
 
 	private createPbxProj(projectData: IProjectData): any {
-		let project = new xcode.project(this.getPbxProjPath(projectData));
+		let project = new this.$xcode.project(this.getPbxProjPath(projectData));
 		project.parseSync();
 
 		return project;
@@ -842,6 +844,35 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 
 	public beforePrepareAllPlugins(): Promise<void> {
 		return Promise.resolve();
+	}
+
+	public checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): void {
+		const provision = options.provision;
+		if (provision !== undefined) {
+			// Check if the native project's signing is set to the provided provision...
+			const pbxprojPath = this.getPbxProjPath(projectData);
+
+			if (this.$fs.exists(pbxprojPath)) {
+				const xcode = this.$pbxprojDomXcode.Xcode.open(pbxprojPath);
+				const signing = xcode.getSigning(projectData.projectName);
+				if (signing && signing.style === "Manual") {
+					for (let name in signing.configurations) {
+						let config = signing.configurations[name];
+						if (config.uuid !== provision && config.name !== provision) {
+							changesInfo.signingChanged = true;
+							break;
+						}
+					}
+				} else {
+					// Specifying provisioning profile requires "Manual" signing style.
+					// If the current signing style was not "Manual" it was probably "Automatic" or,
+					// it was not uniform for the debug and release build configurations.
+					changesInfo.signingChanged = true;
+				}
+			} else {
+				changesInfo.signingChanged = true;
+			}
+		}
 	}
 
 	private getAllLibsForPluginWithFileExtension(pluginData: IPluginData, fileExtension: string): string[] {
@@ -1184,6 +1215,14 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 
 	private readXCConfigProvisioningProfileForIPhoneOs(projectData: IProjectData): string {
 		return this.readXCConfig("PROVISIONING_PROFILE[sdk=iphoneos*]", projectData);
+	}
+
+	private readXCConfigProvisioningProfileSpecifier(projectData: IProjectData): string {
+		return this.readXCConfig("PROVISIONING_PROFILE_SPECIFIER", projectData);
+	}
+
+	private readXCConfigProvisioningProfileSpecifierForIPhoneOs(projectData: IProjectData): string {
+		return this.readXCConfig("PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]", projectData);
 	}
 
 	private async getDevelopmentTeam(projectData: IProjectData, teamId?: string): Promise<string> {

--- a/lib/services/ios-provision-service.ts
+++ b/lib/services/ios-provision-service.ts
@@ -29,7 +29,7 @@ export class IOSProvisionService {
 
 		function formatSupportedDeviceCount(prov: mobileprovision.provision.MobileProvision) {
 			if (devices.length > 0 && prov.Type === "Development") {
-				return prov.ProvisionedDevices.reduce((count, device) => count + (devices.indexOf(device) >= 0 ? 1 : 0), 0) + "/" + devices.length + " targets";
+				return prov.ProvisionedDevices.filter(device => devices.indexOf(device) >= 0).length + "/" + devices.length + " targets";
 			} else {
 				return "";
 			}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -290,7 +290,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			}
 		}
 
-		if (!changesInfo || changesInfo.appResourcesChanged) {
+		if (!changesInfo || changesInfo.changesRequirePrepare) {
 			await this.copyAppFiles(platform, appFilesUpdaterOptions, projectData);
 			this.copyAppResources(platform, projectData);
 			await platformData.platformProjectService.prepareProject(projectData, platformSpecificData);

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "mute-stream": "0.0.5",
     "open": "0.0.5",
     "osenv": "0.1.3",
-    "pbxproj-dom": "1.0.9",
+    "pbxproj-dom": "1.0.11",
     "plist": "1.1.0",
     "plist-merge-patch": "0.0.9",
     "plistlib": "0.2.1",
@@ -98,8 +98,8 @@
     "grunt-tslint": "4.0.0",
     "istanbul": "0.4.5",
     "mocha": "3.1.2",
-    "mocha-typescript": "^1.0.4",
     "should": "7.0.2",
+    "source-map-support": "^0.4.14",
     "tslint": "4.3.1",
     "typescript": "2.1.4"
   },

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,6 @@
 --recursive
 --reporter spec
+--require source-map-support/register
 --require test/test-bootstrap.js
 --timeout 150000
 test/

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -159,7 +159,8 @@ async function setupProject(dependencies?: any): Promise<any> {
 				ensureConfigurationFileInAppResources: (): any => null,
 				interpolateConfigurationFile: (): void => undefined,
 				isPlatformPrepared: (projectRoot: string) => false,
-				validatePlugins: (projectData: IProjectData) => Promise.resolve()
+				validatePlugins: (projectData: IProjectData) => Promise.resolve(),
+				checkForChanges: () => { /* */ }
 			}
 		};
 	};

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -418,7 +418,8 @@ describe('Platform Service Tests', () => {
 						ensureConfigurationFileInAppResources: (): any => null,
 						interpolateConfigurationFile: (): void => undefined,
 						isPlatformPrepared: (projectRoot: string) => false,
-						prepareAppResources: (appResourcesDirectoryPath: string, projectData: IProjectData): void => undefined
+						prepareAppResources: (appResourcesDirectoryPath: string, projectData: IProjectData): void => undefined,
+						checkForChanges: () => { /* */ }
 					}
 				};
 			};
@@ -842,7 +843,8 @@ describe('Platform Service Tests', () => {
 						processConfigurationFilesFromAppResources: () => Promise.resolve(),
 						ensureConfigurationFileInAppResources: (): any => null,
 						interpolateConfigurationFile: (): void => undefined,
-						isPlatformPrepared: (projectRoot: string) => false
+						isPlatformPrepared: (projectRoot: string) => false,
+						checkForChanges: () => { /* */ }
 					},
 					frameworkPackageName: "tns-ios"
 				};

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -357,6 +357,9 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	async cleanProject(projectRoot: string, projectData: IProjectData): Promise<void> {
 		return Promise.resolve();
 	}
+	checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): void {
+		// Nothing yet.
+	}
 }
 
 export class ProjectDataService implements IProjectDataService {

--- a/test/tns-appstore-upload.ts
+++ b/test/tns-appstore-upload.ts
@@ -1,10 +1,8 @@
-import { suite, test/*, only*/ } from "mocha-typescript";
 import { PublishIOS } from "../lib/commands/appstore-upload";
 import { PrompterStub, LoggerStub, ProjectDataStub } from "./stubs";
 import * as chai from "chai";
 import * as yok from "../lib/common/yok";
 
-@suite("tns appstore")
 class AppStore {
 	static itunesconnect = {
 		user: "person@private.com",
@@ -142,7 +140,6 @@ class AppStore {
 		};
 	}
 
-	@test("without args, prompts for itunesconnect credentionals, prepares, archives and uploads")
 	async noArgs() {
 		this.expectItunesPrompt();
 		this.expectPreparePlatform();
@@ -155,7 +152,6 @@ class AppStore {
 		this.assert();
 	}
 
-	@test("with command line itunesconnect credentionals, prepares, archives and uploads")
 	async itunesconnectArgs() {
 		this.expectPreparePlatform();
 		this.expectArchive();
@@ -167,7 +163,6 @@ class AppStore {
 		this.assert();
 	}
 
-	@test("passes --team-id to xcodebuild exportArchive")
 	async teamIdOption() {
 		this.expectItunesPrompt();
 		this.expectPreparePlatform();
@@ -182,3 +177,21 @@ class AppStore {
 		this.assert();
 	}
 }
+
+describe("tns appstore", () => {
+	it("without args, prompts for itunesconnect credentionals, prepares, archives and uploads", async () => {
+		const instance = new AppStore();
+		instance.before();
+		await instance.noArgs();
+	});
+	it("with command line itunesconnect credentionals, prepares, archives and uploads", async () => {
+		const instance = new AppStore();
+		instance.before();
+		await instance.itunesconnectArgs();
+	});
+	it("passes --team-id to xcodebuild exportArchive", async () => {
+		const instance = new AppStore();
+		instance.before();
+		await instance.teamIdOption();
+	});
+});


### PR DESCRIPTION
 - Issuing `tns <prepare|build|deploy etc.> ios --provision <provision uuid or name/specifier>` will now update the native Xcode and invalidate the prepare step and native build if necessary (in case it was used with different provision than the last time).

 - In case in the xcconfig was used a PROVISIONING_PROFILE_SPECIFIER the build will set a "Manual" signing style in the Xcode project similar to the behaviour triggered with PROVISIONING_PROFILE. Also when one of these two is provided in the xcconfig, if the --provision was never used, any DEVELOPMENT_TEAM or CODE_SIGN_SPECIFIED will be cleared off the pbxproj so the values from the xcconfig can be respected. There is room for improvement to allow a behaviour that once --provsion was used, if it is not used in subsequent command and the xcconfig has singing flags it would clear the pbxproj and fallback to the xcconfig.

 - The path to the pbxproj is now changes and should respect scenarios when the id of the project does not match the folder name of the project.
