### PR TITLE
Change livesync dir permissions on device even if app is not restarted

### DIFF
--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -21,6 +21,14 @@ class AndroidLiveSyncService implements INativeScriptDeviceLiveSyncService {
 	}
 
 	public async refreshApplication(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], forceExecuteFullSync: boolean, projectData: IProjectData): Promise<void> {
+		await this.device.adb.executeShellCommand(
+			["chmod",
+			"777",
+			await deviceAppData.getDeviceProjectRootPath(),
+			`/data/local/tmp/${deviceAppData.appIdentifier}`,
+			`/data/local/tmp/${deviceAppData.appIdentifier}/sync`]
+			);
+
 		let canExecuteFastSync = !forceExecuteFullSync && !_.some(localToDevicePaths, (localToDevicePath: any) => !this.$liveSyncProvider.canExecuteFastSync(localToDevicePath.getLocalPath(), projectData, deviceAppData.platform));
 
 		if (canExecuteFastSync) {
@@ -31,8 +39,6 @@ class AndroidLiveSyncService implements INativeScriptDeviceLiveSyncService {
 	}
 
 	private async restartApplication(deviceAppData: Mobile.IDeviceAppData): Promise<void> {
-		await this.device.adb.executeShellCommand(["chmod", "777", await deviceAppData.getDeviceProjectRootPath(), `/data/local/tmp/${deviceAppData.appIdentifier}`]);
-
 		let devicePathRoot = `/data/data/${deviceAppData.appIdentifier}/files`;
 		let devicePath = this.$mobileHelper.buildDevicePath(devicePathRoot, "code_cache", "secondary_dexes", "proxyThumb");
 		await this.device.adb.executeShellCommand(["rm", "-rf", devicePath]);


### PR DESCRIPTION
Original issue in android-runtime: https://github.com/NativeScript/android-runtime/issues/591

Changing .css and .xml files in a NativeScript project would not change permissions in the temporary sync dir on the device. This could result in showing outdated views on subsequent installs of the application on the same device without using the CLI's livesync service.

The proposed changes will always chmod 777 the sync directory, thus allowing the runtime to remove any previous livesync artifacts.

Relies on changes made in https://github.com/telerik/mobile-cli-lib/pull/943
