### PR TITLE
Yosifov/add test

### DIFF
--- a/test/base-service-test.ts
+++ b/test/base-service-test.ts
@@ -1,12 +1,16 @@
 import * as yok from "../lib/common/yok";
 
 export abstract class BaseServiceTest {
-    protected injector: IInjector;
-    constructor() {
-        this.injector = new yok.Yok();
+	protected injector: IInjector;
+	constructor() {
+		this.injector = new yok.Yok();
 
-        this.initInjector();
-    }
+		this.initInjector();
+	}
 
-    abstract initInjector(): void;
+	abstract initInjector(): void;
+
+	resolve(name: string, ctorArguments?: IDictionary<any>): any {
+		return this.injector.resolve(name);
+	}
 }

--- a/test/base-service-test.ts
+++ b/test/base-service-test.ts
@@ -1,0 +1,12 @@
+import * as yok from "../lib/common/yok";
+
+export abstract class BaseServiceTest {
+    protected injector: IInjector;
+    constructor() {
+        this.injector = new yok.Yok();
+
+        this.initInjector();
+    }
+
+    abstract initInjector(): void;
+}

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -415,7 +415,8 @@ describe('Platform Service Tests', () => {
 
 			// Add platform specific files to app and app1 folders
 			let platformSpecificFiles = [
-				"test1.ios.js", "test1-ios-js", "test2.android.js", "test2-android-js"
+				"test1.ios.js", "test1-ios-js", "test2.android.js", "test2-android-js",
+				"main.js"
 			];
 
 			let destinationDirectories = [testDirData.appFolderPath, testDirData.app1FolderPath];
@@ -608,6 +609,159 @@ describe('Platform Service Tests', () => {
 			assertFilesExistance(appDestFolderPath, true, ["test2.js", "test2-android-js", "test1-ios-js"]);
 			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
 			assertFileContent(appDestFolderPath, expectedFileContent, "src/main/res/icon.png");
+		});
+
+		it("should sync new platform specific files (iOS)", async () => {
+			let createdItems = await testPreparePlatform("iOS");
+
+			// create a new platform-specific file - test3.ios.js
+			const expectedFileContent = "new-content-ios";
+			fs.writeFile(path.join(createdItems.testDirData.appFolderPath, "test3.ios.js"), expectedFileContent);
+
+			await execPreparePlatform("iOS", createdItems.testDirData);
+
+			// assert the updated file have been copied to the destination
+			let appDestFolderPath = createdItems.testDirData.appDestFolderPath;
+			assertAppFileContent(appDestFolderPath, expectedFileContent, "test3.js");
+
+			// assert the platform specific files for Android are not copied.
+			assertFilesExistance(appDestFolderPath, false, ["test1.ios.js", "test2.android.js", "test2.js"]);
+			assertFilesExistance(appDestFolderPath, true, ["test1.js", "test2-android-js", "test1-ios-js"]);
+			assertFileContent(appDestFolderPath, "test-image", "Resources/icon.png");
+			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
+		});
+
+		it("should sync new platform specific files (Android)", async () => {
+			let createdItems = await testPreparePlatform("Android");
+
+			// create a new platform-specific file - test3.ios.js
+			const expectedFileContent = "new-content-android";
+			fs.writeFile(path.join(createdItems.testDirData.appFolderPath, "test3.android.js"), expectedFileContent);
+
+			await execPreparePlatform("Android", createdItems.testDirData);
+
+			// assert the updated file have been copied to the destination
+			let appDestFolderPath = createdItems.testDirData.appDestFolderPath;
+			assertAppFileContent(appDestFolderPath, expectedFileContent, "test3.js");
+
+			// assert the platform specific files for iOS are not copied.
+			assertFilesExistance(appDestFolderPath, false, ["test1.android.js", "test2.ios.js", "test1.js"]);
+			assertFilesExistance(appDestFolderPath, true, ["test2.js", "test2-android-js", "test1-ios-js"]);
+			assertFileContent(appDestFolderPath, "test-image", "src/main/res/icon.png");
+			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
+		});
+
+		it("should sync new common files (iOS)", async () => {
+			let createdItems = await testPreparePlatform("iOS");
+
+			// create a new platform-specific file - test3.ios.js
+			const expectedFileContent = "new-content-ios";
+			fs.writeFile(path.join(createdItems.testDirData.appFolderPath, "test3.js"), expectedFileContent);
+
+			await execPreparePlatform("iOS", createdItems.testDirData);
+
+			// assert the updated file have been copied to the destination
+			let appDestFolderPath = createdItems.testDirData.appDestFolderPath;
+			assertAppFileContent(appDestFolderPath, expectedFileContent, "test3.js");
+
+			// assert the platform specific files for Android are not copied.
+			assertFilesExistance(appDestFolderPath, false, ["test1.ios.js", "test2.android.js", "test2.js"]);
+			assertFilesExistance(appDestFolderPath, true, ["test1.js", "test2-android-js", "test1-ios-js"]);
+			assertFileContent(appDestFolderPath, "test-image", "Resources/icon.png");
+			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
+		});
+
+		it("should sync new common files (Android)", async () => {
+			let createdItems = await testPreparePlatform("Android");
+
+			// create a new platform-specific file - test3.ios.js
+			const expectedFileContent = "new-content-android";
+			fs.writeFile(path.join(createdItems.testDirData.appFolderPath, "test3.js"), expectedFileContent);
+
+			await execPreparePlatform("Android", createdItems.testDirData);
+
+			// assert the updated file have been copied to the destination
+			let appDestFolderPath = createdItems.testDirData.appDestFolderPath;
+			assertAppFileContent(appDestFolderPath, expectedFileContent, "test3.js");
+
+			// assert the platform specific files for iOS are not copied.
+			assertFilesExistance(appDestFolderPath, false, ["test1.android.js", "test2.ios.js", "test1.js"]);
+			assertFilesExistance(appDestFolderPath, true, ["test2.js", "test2-android-js", "test1-ios-js"]);
+			assertFileContent(appDestFolderPath, "test-image", "src/main/res/icon.png");
+			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
+		});
+
+		it("should sync deleted common file (iOS)", async () => {
+			let createdItems = await testPreparePlatform("iOS");
+
+			// delete the common - main.js file
+			fs.deleteFile(path.join(createdItems.testDirData.appFolderPath, "main.js"));
+
+			await execPreparePlatform("iOS", createdItems.testDirData);
+
+			// assert the updated file have been copied to the destination
+			let appDestFolderPath = createdItems.testDirData.appDestFolderPath;
+			assertFileExistance(appDestFolderPath, false, "main.js");
+
+			// assert the platform specific files for Android are not copied.
+			assertFilesExistance(appDestFolderPath, false, ["test1.ios.js", "test2.android.js", "test2.js"]);
+			assertFilesExistance(appDestFolderPath, true, ["test1.js", "test2-android-js", "test1-ios-js"]);
+			assertFileContent(appDestFolderPath, "test-image", "Resources/icon.png");
+			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
+		});
+
+		it("should sync deleted common file (Android)", async () => {
+			let createdItems = await testPreparePlatform("Android");
+
+			// delete the common - main.js file
+			fs.deleteFile(path.join(createdItems.testDirData.appFolderPath, "main.js"));
+			await execPreparePlatform("Android", createdItems.testDirData);
+
+			// assert the updated file have been copied to the destination
+			let appDestFolderPath = createdItems.testDirData.appDestFolderPath;
+			assertFileExistance(appDestFolderPath, false, "main.js");
+
+			// assert the platform specific files for iOS are not copied.
+			assertFilesExistance(appDestFolderPath, false, ["test1.android.js", "test2.ios.js", "test1.js"]);
+			assertFilesExistance(appDestFolderPath, true, ["test2.js", "test2-android-js", "test1-ios-js"]);
+			assertFileContent(appDestFolderPath, "test-image", "src/main/res/icon.png");
+			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
+		});
+
+		it("should sync deleted platform specific file (iOS)", async () => {
+			let createdItems = await testPreparePlatform("iOS");
+
+			// delete the common - main.js file
+			fs.deleteFile(path.join(createdItems.testDirData.appFolderPath, "test1.ios.js"));
+
+			await execPreparePlatform("iOS", createdItems.testDirData);
+
+			// assert the updated file have been copied to the destination
+			let appDestFolderPath = createdItems.testDirData.appDestFolderPath;
+			assertFileExistance(appDestFolderPath, false, "test1.js");
+			// assert the platform specific files for Android are not copied.
+			assertFilesExistance(appDestFolderPath, false, ["test1.ios.js", "test2.android.js", "test2.js"]);
+			assertFilesExistance(appDestFolderPath, true, ["test2-android-js", "test1-ios-js"]);
+			assertFileContent(appDestFolderPath, "test-image", "Resources/icon.png");
+			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
+		});
+
+		it("should sync deleted platform specific file (Android)", async () => {
+			let createdItems = await testPreparePlatform("Android");
+
+			// delete the common - main.js file
+			fs.deleteFile(path.join(createdItems.testDirData.appFolderPath, "test2.android.js"));
+			await execPreparePlatform("Android", createdItems.testDirData);
+
+			// assert the updated file have been copied to the destination
+			let appDestFolderPath = createdItems.testDirData.appDestFolderPath;
+			assertFileExistance(appDestFolderPath, false, "test2.js");
+
+			// assert the platform specific files for iOS are not copied.
+			assertFilesExistance(appDestFolderPath, false, ["test1.android.js", "test2.ios.js", "test1.js"]);
+			assertFilesExistance(appDestFolderPath, true, ["test2-android-js", "test1-ios-js"]);
+			assertFileContent(appDestFolderPath, "test-image", "src/main/res/icon.png");
+			assertAppResourcesAreRemovedFromAppDest(appDestFolderPath);
 		});
 
 		it("invalid xml is caught", async () => {

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -350,7 +350,7 @@ describe('Platform Service Tests', () => {
 		});
 	});
 
-	describe.only("prepare platform unit tests", () => {
+	describe("prepare platform unit tests", () => {
 		let fs: IFileSystem;
 
 		beforeEach(() => {
@@ -757,70 +757,6 @@ describe('Platform Service Tests', () => {
 							content: expectedFileContent
 						}
 					]
-				};
-
-				return modifications;
-			};
-			await testChangesApplied("Android", applyChangesFn);
-		});
-
-		it("should sync deleted common file (iOS)", async () => {
-			let applyChangesFn = (createdTestData: CreatedTestData) => {
-				// apply changes
-				fs.deleteFile(path.join(createdTestData.testDirData.appFolderPath, "main.js"));
-
-				// construct the folder modifications data
-				let modifications: any = {};
-				modifications[path.join(createdTestData.testDirData.appDestFolderPath, "app")] = {
-					missingFiles: [ "main.js" ]
-				};
-
-				return modifications;
-			};
-			await testChangesApplied("iOS", applyChangesFn);
-		});
-
-		it("should sync deleted common file (Android)", async () => {
-			let applyChangesFn = (createdTestData: CreatedTestData) => {
-				// apply changes
-				fs.deleteFile(path.join(createdTestData.testDirData.appFolderPath, "main.js"));
-
-				// construct the folder modifications data
-				let modifications: any = {};
-				modifications[path.join(createdTestData.testDirData.appDestFolderPath, "app")] = {
-					missingFiles: [ "main.js" ]
-				};
-
-				return modifications;
-			};
-			await testChangesApplied("Android", applyChangesFn);
-		});
-
-		it("should sync deleted platform specific file (iOS)", async () => {
-			let applyChangesFn = (createdTestData: CreatedTestData) => {
-				// apply changes
-				fs.deleteFile(path.join(createdTestData.testDirData.appFolderPath, "test1.ios.js"));
-
-				// construct the folder modifications data
-				let modifications: any = {};
-				modifications[path.join(createdTestData.testDirData.appDestFolderPath, "app")] = {
-					missingFiles: [ "test1.js" ]
-				};
-
-				return modifications;
-			};
-			await testChangesApplied("iOS", applyChangesFn);
-		});
-
-		it("should sync deleted platform specific file (Android)", async () => {
-			let applyChangesFn = (createdTestData: CreatedTestData) => {
-				// apply changes
-				fs.deleteFile(path.join(createdTestData.testDirData.appFolderPath, "test2.android.js"));
-
-				// construct the folder modifications data
-				let modifications: any = {};
-				modifications[path.join(createdTestData.testDirData.appDestFolderPath, "app")] = {
-					missingFiles: [ "test2.js" ]
 				};
 
 				return modifications;

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -127,16 +127,16 @@ class DestinationFolderVerifier {
 		_.forOwn(data, (folder, folderRoot) => {
 			_.each(folder.filesWithContent || [], (file) => {
 				const filePath = path.join(folderRoot, file.name);
-				assert.isTrue(fs.exists(filePath));
-				assert.equal(fs.readFile(filePath).toString(), file.content);
+				assert.isTrue(fs.exists(filePath), `Expected file {filePath} to be present.`);
+				assert.equal(fs.readFile(filePath).toString(), file.content, `File content for {filePath} doesn't match.`);
 			});
 
 			_.each(folder.missingFiles || [], (file) => {
-				assert.isFalse(fs.exists(path.join(folderRoot, file)));
+				assert.isFalse(fs.exists(path.join(folderRoot, file)), `Expected file {file} to be missing.`);
 			});
 
 			_.each(folder.presentFiles || [], (file) => {
-				assert.isTrue(fs.exists(path.join(folderRoot, file)));
+				assert.isTrue(fs.exists(path.join(folderRoot, file)), `Expected file {file} to be present.`);
 			});
 		});
 	}

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -432,11 +432,11 @@ describe('Platform Service Tests', () => {
 
 			// Add App_Resources file to app and app1 folders
 			_.each(destinationDirectories, directoryPath => {
-				let iosIconFullPath = path.join(directoryPath, "App_Resources/ios/icon.png");
+				let iosIconFullPath = path.join(directoryPath, "App_Resources/iOS/icon.png");
 				fs.writeFile(iosIconFullPath, "test-image");
 				created.resources.ios.push(iosIconFullPath);
 
-				let androidFullPath = path.join(directoryPath, "App_Resources/android/icon.png");
+				let androidFullPath = path.join(directoryPath, "App_Resources/Android/icon.png");
 				fs.writeFile(androidFullPath, "test-image");
 				created.resources.android.push(androidFullPath);
 			});
@@ -481,14 +481,14 @@ describe('Platform Service Tests', () => {
 		});
 
 		it("should sync only changed files, without special folders", async () => {
-			let createdItems = await testPreparePlatform("ios");
+			let createdItems = await testPreparePlatform("iOS");
 
 			// update one file.
 			const expected = "updated-data-ios";
 			let test1Js = _.find(createdItems.files, (f) => f.indexOf('test1.ios.js') !== -1);
 			fs.writeFile(test1Js, expected);
 
-			await execPreparePlatform("ios", createdItems.testDirData);
+			await execPreparePlatform("iOS", createdItems.testDirData);
 
 			let destinationTest1Js = path.join(createdItems.testDirData.appDestFolderPath, "app", "test1.js");
 			let actual = fs.readFile(destinationTest1Js);

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -464,6 +464,17 @@ describe('Platform Service Tests', () => {
 			return created;
 		}
 
+		function updateFile(files: string[], fileName: string, content: string) {
+			let fileToUpdate = _.find(files, (f) => f.indexOf(fileName) !== -1);
+			fs.writeFile(fileToUpdate, content);
+		}
+
+		function assertFileContent(createdItems: CreatedItems, expectedFileContent: string, fileName: string) {
+			let destinationFilePath = path.join(createdItems.testDirData.appDestFolderPath, "app", fileName);
+			let actual = fs.readFile(destinationFilePath);
+			assert.equal(actual, expectedFileContent);
+		}
+
 		it("should process only files in app folder when preparing for iOS platform", async () => {
 			await testPreparePlatform("iOS");
 		});
@@ -480,19 +491,26 @@ describe('Platform Service Tests', () => {
 			await testPreparePlatform("Android", true);
 		});
 
-		it("should sync only changed files, without special folders", async () => {
+		it("should sync only changed files, without special folders (iOS)", async () => {
 			let createdItems = await testPreparePlatform("iOS");
 
-			// update one file.
-			const expected = "updated-data-ios";
-			let test1Js = _.find(createdItems.files, (f) => f.indexOf('test1.ios.js') !== -1);
-			fs.writeFile(test1Js, expected);
+			const expectedFileContent = "updated-content-ios";
+			updateFile(createdItems.files, "test1.ios.js", expectedFileContent);			
 
 			await execPreparePlatform("iOS", createdItems.testDirData);
 
-			let destinationTest1Js = path.join(createdItems.testDirData.appDestFolderPath, "app", "test1.js");
-			let actual = fs.readFile(destinationTest1Js);
-			assert.equal(actual, expected);
+			assertFileContent(createdItems, expectedFileContent, "test1.js");
+		});
+
+		it("should sync only changed files, without special folders (Android)", async () => {
+			let createdItems = await testPreparePlatform("Android");
+
+			const expectedFileContent = "updated-content-android";
+			updateFile(createdItems.files, "test2.android.js", expectedFileContent);			
+
+			await execPreparePlatform("Android", createdItems.testDirData);
+
+			assertFileContent(createdItems, expectedFileContent, "test2.js");
 		});
 
 		it("invalid xml is caught", async () => {

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -432,11 +432,11 @@ describe('Platform Service Tests', () => {
 
 			// Add App_Resources file to app and app1 folders
 			_.each(destinationDirectories, directoryPath => {
-				let iosIconFullPath = path.join(directoryPath, "App_Resources/iOS/icon.png");
+				let iosIconFullPath = path.join(directoryPath, "App_Resources/ios/icon.png");
 				fs.writeFile(iosIconFullPath, "test-image");
 				created.resources.ios.push(iosIconFullPath);
 
-				let androidFullPath = path.join(directoryPath, "App_Resources/Android/icon.png");
+				let androidFullPath = path.join(directoryPath, "App_Resources/android/icon.png");
 				fs.writeFile(androidFullPath, "test-image");
 				created.resources.android.push(androidFullPath);
 			});

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -495,7 +495,7 @@ describe('Platform Service Tests', () => {
 			let createdItems = await testPreparePlatform("iOS");
 
 			const expectedFileContent = "updated-content-ios";
-			updateFile(createdItems.files, "test1.ios.js", expectedFileContent);			
+			updateFile(createdItems.files, "test1.ios.js", expectedFileContent);
 
 			await execPreparePlatform("iOS", createdItems.testDirData);
 
@@ -506,7 +506,7 @@ describe('Platform Service Tests', () => {
 			let createdItems = await testPreparePlatform("Android");
 
 			const expectedFileContent = "updated-content-android";
-			updateFile(createdItems.files, "test2.android.js", expectedFileContent);			
+			updateFile(createdItems.files, "test2.android.js", expectedFileContent);
 
 			await execPreparePlatform("Android", createdItems.testDirData);
 

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -142,7 +142,7 @@ class DestinationFolderVerifier {
 	}
 }
 
-describe.only('Platform Service Tests', () => {
+describe('Platform Service Tests', () => {
 	let platformService: IPlatformService, testInjector: IInjector;
 	beforeEach(() => {
 		testInjector = createTestInjector();

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -127,16 +127,16 @@ class DestinationFolderVerifier {
 		_.forOwn(data, (folder, folderRoot) => {
 			_.each(folder.filesWithContent || [], (file) => {
 				const filePath = path.join(folderRoot, file.name);
-				assert.isTrue(fs.exists(filePath), `Expected file {filePath} to be present.`);
-				assert.equal(fs.readFile(filePath).toString(), file.content, `File content for {filePath} doesn't match.`);
+				assert.isTrue(fs.exists(filePath), `Expected file ${filePath} to be present.`);
+				assert.equal(fs.readFile(filePath).toString(), file.content, `File content for ${filePath} doesn't match.`);
 			});
 
 			_.each(folder.missingFiles || [], (file) => {
-				assert.isFalse(fs.exists(path.join(folderRoot, file)), `Expected file {file} to be missing.`);
+				assert.isFalse(fs.exists(path.join(folderRoot, file)), `Expected file ${file} to be missing.`);
 			});
 
 			_.each(folder.presentFiles || [], (file) => {
-				assert.isTrue(fs.exists(path.join(folderRoot, file)), `Expected file {file} to be present.`);
+				assert.isTrue(fs.exists(path.join(folderRoot, file)), `Expected file ${file} to be present.`);
 			});
 		});
 	}

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -142,7 +142,7 @@ class DestinationFolderVerifier {
 	}
 }
 
-describe('Platform Service Tests', () => {
+describe.only('Platform Service Tests', () => {
 	let platformService: IPlatformService, testInjector: IInjector;
 	beforeEach(() => {
 		testInjector = createTestInjector();
@@ -630,7 +630,7 @@ describe('Platform Service Tests', () => {
 			await testChangesApplied("Android", applyChangesFn);
 		});
 
-		it("Ensure, App_Resources get reloaded, after change in the app folder (iOS) #2560", async () => {
+		it("Ensure App_Resources get reloaded after change in the app folder (iOS) #2560", async () => {
 			let applyChangesFn = (createdTestData: CreatedTestData) => {
 				// apply changes
 				const expectedFileContent = "updated-icon-content";
@@ -653,7 +653,7 @@ describe('Platform Service Tests', () => {
 			await testChangesApplied("iOS", applyChangesFn);
 		});
 
-		it("Ensure, App_Resources get reloaded, after change in the app folder (Android) #2560", async () => {
+		it("Ensure App_Resources get reloaded after change in the app folder (Android) #2560", async () => {
 			let applyChangesFn = (createdTestData: CreatedTestData) => {
 				// apply changes
 				const expectedFileContent = "updated-icon-content";
@@ -666,6 +666,52 @@ describe('Platform Service Tests', () => {
 					filesWithContent: [
 						{
 							name: "src/main/res/icon.png",
+							content: expectedFileContent
+						}
+					]
+				};
+
+				return modifications;
+			};
+			await testChangesApplied("Android", applyChangesFn);
+		});
+
+		it("Ensure App_Resources get reloaded after a new file appears in the app folder (iOS) #2560", async () => {
+			let applyChangesFn = (createdTestData: CreatedTestData) => {
+				// apply changes
+				const expectedFileContent = "new-file-content";
+				let iconPngPath = path.join(createdTestData.testDirData.appFolderPath, "App_Resources/iOS/new-file.png");
+				fs.writeFile(iconPngPath, expectedFileContent);
+
+				// construct the folder modifications data
+				let modifications: any = {};
+				modifications[createdTestData.testDirData.appDestFolderPath] = {
+					filesWithContent: [
+						{
+							name: "Resources/new-file.png",
+							content: expectedFileContent
+						}
+					]
+				};
+
+				return modifications;
+			};
+			await testChangesApplied("iOS", applyChangesFn);
+		});
+
+		it("Ensure App_Resources get reloaded after a new file appears in the app folder (Android) #2560", async () => {
+			let applyChangesFn = (createdTestData: CreatedTestData) => {
+				// apply changes
+				const expectedFileContent = "new-file-content";
+				let iconPngPath = path.join(createdTestData.testDirData.appFolderPath, "App_Resources/Android/new-file.png");
+				fs.writeFile(iconPngPath, expectedFileContent);
+
+				// construct the folder modifications data
+				let modifications: any = {};
+				modifications[createdTestData.testDirData.appDestFolderPath] = {
+					filesWithContent: [
+						{
+							name: "src/main/res/new-file.png",
 							content: expectedFileContent
 						}
 					]

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -47,7 +47,7 @@ class ProjectChangesServiceTest extends BaseServiceTest {
 	}
 }
 
-describe.only("Project Changes Service Tests", () => {
+describe("Project Changes Service Tests", () => {
 	let serviceTest: ProjectChangesServiceTest;
 	beforeEach(() => {
 		serviceTest = new ProjectChangesServiceTest();

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -1,0 +1,83 @@
+import * as path from "path";
+import { BaseServiceTest } from "./base-service-test";
+import temp = require("temp");
+import { assert } from "chai";
+import { PlatformsData } from "../lib/platforms-data";
+import { ProjectChangesService } from "../lib/services/project-changes-service";
+import * as Constants from "../lib/constants";
+
+// start tracking temporary folders/files
+temp.track();
+
+class ProjectChangesServiceTest extends BaseServiceTest {
+    public projectDir: string;
+
+    constructor() {
+        super();
+    }
+
+    initInjector(): void {
+        this.projectDir = temp.mkdirSync("projectDir");
+        this.injector.register("projectData", {
+            projectDir: this.projectDir
+        });
+
+        this.injector.register("platformsData", PlatformsData);
+        this.injector.register("androidProjectService", {});
+        this.injector.register("iOSProjectService", {});
+        
+		this.injector.register("fs", {});
+        this.injector.register("devicePlatformsConstants", {});
+        this.injector.register("devicePlatformsConstants", {});
+        this.injector.register("projectChangesService", ProjectChangesService);
+
+    }
+
+    get projectChangesService(): IProjectChangesService {
+        return this.injector.resolve("projectChangesService");
+    }
+
+    get projectData(): IProjectData {
+        return this.injector.resolve("projectData");
+    }
+
+    get platformsData(): any {
+        return this.injector.resolve("platformsData");
+    }
+}
+
+describe.only("Project Changes Service Tests", () => {
+    let serviceTest: ProjectChangesServiceTest;
+    beforeEach(() => {
+        serviceTest = new ProjectChangesServiceTest();
+    });
+
+    describe("Get Prepare Info File Path", () => {
+        beforeEach(() => {
+            const platformsDir = path.join(
+                serviceTest.projectDir,
+                Constants.PLATFORMS_DIR_NAME
+            );
+
+            serviceTest.platformsData.getPlatformData = 
+                (platform: string) => {
+                    return { 
+                        projectRoot: path.join(platformsDir, platform)
+                    };
+                };
+        });
+
+        it("Gets the correct Prepare Info path for ios/android", () => {;
+            for(let os of ["ios", "android"]) {
+                let actualPrepareInfoPath = serviceTest.projectChangesService
+                    .getPrepareInfoFilePath(os, this.projectData);
+
+                const expectedPrepareInfoPath = path.join(serviceTest.projectDir,
+                    Constants.PLATFORMS_DIR_NAME,
+                    os,
+                    ".nsprepareinfo");
+                assert.equal(actualPrepareInfoPath, expectedPrepareInfoPath);                
+            }        
+        });
+    });
+});


### PR DESCRIPTION
Adding tests for:

- Project Service tests - tests regarding the preparePlatform and the changes functionality. We now have tests which verify that we 
   - Do not leave the app/App_Resources folder in the destination folder and therefore in the .apk [#2697](https://github.com/NativeScript/nativescript-cli/issues/2697)
   - Update accordingly common/platform-specific files
   - Sync new common/platform-specific files
   - Sync the changes in the App_Resources folder to the App correctly
- Project Changes Service - initial tests, covering minor functionalities