### PR TITLE
Increase the timeout of initial ios device detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.0.3",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-device-lib": "~0.3.0",
+    "ios-device-lib": "0.4.0",
     "ios-mobileprovision-finder": "1.0.9",
     "ios-sim-portable": "~2.0.0",
     "lockfile": "1.0.1",


### PR DESCRIPTION
Currently we have logic to find the intially attached (at the moment of starting the CLI) iOS devices. Its executed at the beginning of each device related commands and it checks on 500ms for device found.
However this is a problem as we may find one device and skip the others devices (in case more than one device is attached). So first CLI operations are excuted only for one device. The next operations however are executed over all devices found. For example `tns run ios` we execute several operations - install on all devices, upload files to all devices, etc. However in case the install operation is executed, only the first device is discovered. After that the upload files operations are executed on all devices. Due to the fact that the application is not installed on the other devices, the operation fails.

So increase the initial timeout to 2 seconds. Also increas the overall timeout that we wait for discovering iOS devices from 5 to 6 seconds.

Also update ios-device-lib to latest version, which resolves several issues with GDB server on device.