### PR TITLE
Fix debug android command

### DIFF
--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -165,20 +165,20 @@ class AndroidDebugService extends DebugServiceBase implements IPlatformDebugServ
 	private async waitForDebugger(packageName: String): Promise<void> {
 		let waitText: string = `0 /data/local/tmp/${packageName}-debugger-started`;
 		let maxWait = 12;
-		let debugerStarted: boolean = false;
-		while (maxWait > 0 && !debugerStarted) {
+		let debuggerStarted: boolean = false;
+		while (maxWait > 0 && !debuggerStarted) {
 			let forwardsResult = await this.device.adb.executeShellCommand(["ls", "-s", `/data/local/tmp/${packageName}-debugger-started`]);
 
 			maxWait--;
 
-			debugerStarted = forwardsResult.indexOf(waitText) === -1;
+			debuggerStarted = forwardsResult.indexOf(waitText) === -1;
 
-			if (!debugerStarted) {
+			if (!debuggerStarted) {
 				await sleep(500);
 			}
 		}
 
-		if (debugerStarted) {
+		if (debuggerStarted) {
 			this.$logger.info("# NativeScript Debugger started #");
 		} else {
 			this.$logger.warn("# NativeScript Debugger did not start in time #");

--- a/lib/services/android-debug-service.ts
+++ b/lib/services/android-debug-service.ts
@@ -174,7 +174,7 @@ class AndroidDebugService extends DebugServiceBase implements IPlatformDebugServ
 			debugerStarted = forwardsResult.indexOf(waitText) === -1;
 
 			if (!debugerStarted) {
-				sleep(500);
+				await sleep(500);
 			}
 		}
 

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -1,120 +1,12 @@
-import * as constants from "../../../lib/constants";
-import * as path from "path";
 import * as shelljs from "shelljs";
 import { TnsModulesCopy, NpmPluginPrepare } from "./node-modules-dest-copy";
 import { NodeModulesDependenciesBuilder } from "./node-modules-dependencies-builder";
-import { sleep, deferPromise } from "../../../lib/common/helpers";
-
-let glob = require("glob");
 
 export class NodeModulesBuilder implements INodeModulesBuilder {
 	constructor(private $fs: IFileSystem,
 		private $injector: IInjector,
-		private $lockfile: ILockFile,
 		private $options: IOptions
 	) { }
-
-	public async getChangedNodeModules(absoluteOutputPath: string, platform: string, projectData: IProjectData, lastModifiedTime?: Date): Promise<any> {
-		let projectDir = projectData.projectDir;
-		let isNodeModulesModified = false;
-		let nodeModulesPath = path.join(projectDir, constants.NODE_MODULES_FOLDER_NAME);
-		let nodeModules: any = {};
-
-		if (lastModifiedTime) {
-			let defer = deferPromise();
-
-			let match = new glob.Glob("node_modules/**", {
-				cwd: projectDir,
-				follow: true,
-				stat: true
-			}, (er: Error, files: string[]) => {
-				while (this.$lockfile.check()) {
-					sleep(10);
-				}
-
-				this.$lockfile.lock();
-				if (er) {
-					if (!defer.isResolved()) {
-						defer.reject(er);
-					}
-
-					this.$lockfile.unlock();
-					match.abort();
-					return;
-				}
-				for (let i = 0, l = files.length; i < l; i++) {
-					let file = files[i],
-						resolvedPath = path.join(projectDir, file),
-						relativePath = path.relative(projectDir, resolvedPath);
-					let stat = match.statCache[resolvedPath] || match.statCache[relativePath];
-					if (!stat) {
-						match.statCache[resolvedPath] = stat = this.$fs.getFsStats(resolvedPath);
-					}
-
-					if (stat.mtime <= lastModifiedTime) {
-						continue;
-					}
-					if (file === constants.NODE_MODULES_FOLDER_NAME) {
-						isNodeModulesModified = true;
-						this.$lockfile.unlock();
-						match.abort();
-						if (!defer.isResolved()) {
-							defer.resolve();
-						}
-
-						return;
-					}
-					let rootModuleName = path.normalize(file).split(path.sep)[1];
-					let rootModuleFullPath = path.join(nodeModulesPath, rootModuleName);
-					nodeModules[rootModuleFullPath] = rootModuleFullPath;
-				}
-
-				this.$lockfile.unlock();
-			});
-
-			match.on("end", () => {
-				if (!defer.isResolved()) {
-					let intervalId = setInterval(() => {
-						if (!this.$lockfile.check() || defer.isResolved()) {
-							if (!defer.isResolved()) {
-								defer.resolve();
-							}
-							clearInterval(intervalId);
-						}
-					}, 100);
-				}
-			});
-
-			await defer.promise;
-		}
-
-		if (isNodeModulesModified && this.$fs.exists(absoluteOutputPath)) {
-			let currentPreparedTnsModules = this.$fs.readDirectory(absoluteOutputPath);
-			let tnsModulesPath = path.join(projectDir, constants.NODE_MODULES_FOLDER_NAME, constants.TNS_CORE_MODULES_NAME);
-			let tnsModulesInApp = this.$fs.readDirectory(tnsModulesPath);
-			let modulesToDelete = _.difference(currentPreparedTnsModules, tnsModulesInApp);
-			_.each(modulesToDelete, moduleName => this.$fs.deleteDirectory(path.join(absoluteOutputPath, moduleName)));
-		}
-
-		if (!lastModifiedTime || isNodeModulesModified) {
-			this.expandScopedModules(nodeModulesPath, nodeModules);
-		}
-
-		return nodeModules;
-	}
-
-	private expandScopedModules(nodeModulesPath: string, nodeModules: IStringDictionary): void {
-		let nodeModulesDirectories = this.$fs.exists(nodeModulesPath) ? this.$fs.readDirectory(nodeModulesPath) : [];
-		_.each(nodeModulesDirectories, nodeModuleDirectoryName => {
-			let isNpmScope = /^@/.test(nodeModuleDirectoryName);
-			let nodeModuleFullPath = path.join(nodeModulesPath, nodeModuleDirectoryName);
-			if (isNpmScope) {
-				this.expandScopedModules(nodeModuleFullPath, nodeModules);
-			} else {
-				nodeModules[nodeModuleFullPath] = nodeModuleFullPath;
-			}
-		});
-	}
 
 	public async prepareNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData): Promise<void> {
 		if (!this.$fs.exists(absoluteOutputPath)) {


### PR DESCRIPTION
### Fix Android debugging
When executing `tns debug android` for slow emulators/devices we have logic to wait several seconds until debugger is attached.
However we've missed to `await` the `sleep` method and in fact we are not waiting at all. Add the missing await, which fixes the `tns debug android` command.

### Remove unused code
A while ago, we had a logic to find out which node_modules should be processed. However it is not used anymore (removed in https://github.com/NativeScript/nativescript-cli/pull/2152/ ).
So remove the code - we do not need it anymore.