### PR TITLE
Fix debug for iOS devices

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -55,7 +55,7 @@ export abstract class DebugPlatformCommand implements ICommand {
 
 			await deviceAppData.device.applicationManager.stopApplication(applicationId);
 
-			const buildConfig: IBuildConfig = _.merge({ buildForDevice: this.$options.forDevice }, deployOptions);
+			const buildConfig: IBuildConfig = _.merge({ buildForDevice: !deviceAppData.device.isEmulator }, deployOptions);
 			debugData.pathToAppPackage = this.$platformService.lastOutputPath(this.debugService.platform, buildConfig, projectData);
 
 			this.printDebugInformation(await this.debugService.debug(debugData, debugOptions));


### PR DESCRIPTION
Currently the `tns debug ios` command tries to find already built result for iOS Simulator. The problem is incorrect value passed to `buildForDevice` property. It should be set based on the current device.