### PR TITLE
Fix debug on iOS simulator with watch

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -78,17 +78,28 @@ class IOSDebugService extends DebugServiceBase implements IPlatformDebugService 
 		}
 
 		_.forEach(this._sockets, socket => socket.destroy());
+
 		this._sockets = [];
 
 		if (this._lldbProcess) {
 			this._lldbProcess.stdin.write("process detach\n");
-			this._lldbProcess.kill();
+
+			await this.killProcess(this._lldbProcess);
 			this._lldbProcess = undefined;
 		}
 
 		if (this._childProcess) {
-			this._childProcess.kill();
+			await this.killProcess(this._childProcess);
 			this._childProcess = undefined;
+		}
+	}
+
+	private async killProcess(childProcess: ChildProcess): Promise<void> {
+		if (childProcess) {
+			return new Promise<void>((resolve, reject) => {
+				childProcess.on("close", resolve);
+				childProcess.kill();
+			});
 		}
 	}
 


### PR DESCRIPTION
During `tns debug ios`, in case you make changes, the application must be restarted and the debugger must attached again. However, in many cases we kill the old lldb process and immediately try to start the new one. The childProcess.kill operation finishes, but lldb process does not die immedietely. So in some occasions, the attach of new debugger fails. This leads to multiple errors - you cannot start this application on simulator anymore, you cannot exit CLI's process with `Ctrl + C`, etc.
Fix this by attaching to "close" event of the processes and waiting for them to be really finish their execution.