### PR TITLE
Expose npm operations

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -219,6 +219,126 @@ interface ISettingsService {
 tns.settingsService.setSettings({ userAgentName: "myUserAgent" });
 ```
 
+## npm
+`npm` module provides a way to interact with npm specifically the use of install, uninstall, search and view commands.
+
+### install
+Installs specified package. Note that you can use the third argument in order to pass different options to the installation like `ignore-scripts`, `save` or `save-exact` which work exactly like they would if you would execute npm from the command line and pass them as `--` flags.
+* Auxiliary interfaces:
+```TypeScript
+/**
+ * Describes information about installed package.
+ */
+interface INpmInstallResultInfo {
+	/**
+	 * Installed package's name.
+	 * @type {string}
+	 */
+	name: string;
+	/**
+	 * Installed package's version.
+	 * @type {string}
+	 */
+	version: string;
+	/**
+	 * The original output that npm CLI produced upon installation.
+	 * @type {INpmInstallCLIResult}
+	 */
+	originalOutput: INpmInstallCLIResult;
+}
+```
+
+* Definition:
+```TypeScript
+/**
+ * Installs dependency
+ * @param  {string}                            packageName The name of the dependency - can be a path, a url or a string.
+ * @param  {string}                            pathToSave  The destination of the installation.
+ * @param  {IDictionary<string | boolean>} config      Additional options that can be passed to manipulate installation.
+ * @return {Promise<INpmInstallResultInfo>}                Information about installed package.
+*/
+install(packageName: string, pathToSave: string, config: IDictionary<string | boolean>): Promise<INpmInstallResultInfo>;
+```
+
+* Usage:
+```JavaScript
+tns.npm.install("lodash", "/tmp/myProject", { save: true }).then(result => {
+	console.log(`${result.name} installed successfully`);
+}, err => {
+	console.log("An error occurred during installation", err);
+});
+```
+
+### uninstall
+Uninstalls a specified package.
+
+* Definition:
+```TypeScript
+/**
+ * Uninstalls a dependency
+ * @param  {string}                            packageName The name of the dependency.
+ * @param  {IDictionary<string | boolean>} config      Additional options that can be passed to manipulate  uninstallation.
+ * @param  {string}                            path  The destination of the uninstallation.
+ * @return {Promise<any>}                The output of the uninstallation.
+*/
+uninstall(packageName: string, config?: IDictionary<string | boolean>, path?: string): Promise<string>;
+```
+
+* Usage:
+```JavaScript
+tns.npm.uninstall("lodash", "/tmp/myProject", { save: true }).then(output => {
+	console.log(`Uninstalled successfully, output: ${output}`);
+}, err => {
+	console.log("An error occurred during uninstallation", err);
+});
+```
+
+### search
+Searches for a package using keywords.
+
+* Definition:
+```TypeScript
+/**
+ * Searches for a package.
+ * @param  {string[]}                            filter Keywords with which to perform the search.
+ * @param  {IDictionary<string | boolean>} config      Additional options that can be passed to manipulate search.
+ * @return {Promise<string>}                The output of the uninstallation.
+ */
+search(filter: string[], config: IDictionary<string | boolean>): Promise<string>;
+```
+
+* Usage:
+```JavaScript
+tns.npm.search(["nativescript", "cloud"], { silent: true }).then(output => {
+	console.log(`Found: ${output}`);
+}, err => {
+	console.log("An error occurred during searching", err);
+});
+```
+
+### view
+Provides information about a given package.
+
+* Definition
+```TypeScript
+/**
+ * Provides information about a given package.
+ * @param  {string}                            packageName The name of the package.
+ * @param  {IDictionary<string | boolean>} config      Additional options that can be passed to manipulate view.
+ * @return {Promise<any>}                Object, containing information about the package.
+ */
+view(packageName: string, config: Object): Promise<any>;
+```
+
+* Usage:
+```JavaScript
+tns.npm.view(["nativescript"], {}).then(result => {
+	console.log(`${result.name}'s latest version is ${result["dist-tags"].latest}`);
+}, err => {
+	console.log("An error occurred during viewing", err);
+});
+```
+
 ## How to add a new method to Public API
 CLI is designed as command line tool and when it is used as a library, it does not give you access to all of the methods. This is mainly implementation detail. Most of the CLI's code is created to work in command line, not as a library, so before adding method to public API, most probably it will require some modification.
 For example the `$options` injected module contains information about all `--` options passed on the terminal. When the CLI is used as a library, the options are not populated. Before adding method to public API, make sure its implementation does not rely on `$options`.

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -65,7 +65,7 @@ $injector.requireCommand("appstore|upload", "./commands/appstore-upload");
 $injector.requireCommand("publish|ios", "./commands/appstore-upload");
 $injector.require("itmsTransporterService", "./services/itmstransporter-service");
 
-$injector.require("npm", "./node-package-manager");
+$injector.requirePublic("npm", "./node-package-manager");
 $injector.require("npmInstallationManager", "./npm-installation-manager");
 $injector.require("lockfile", "./lockfile");
 $injector.require("dynamicHelpProvider", "./dynamic-help-provider");

--- a/lib/commands/add-platform.ts
+++ b/lib/commands/add-platform.ts
@@ -9,7 +9,7 @@ export class AddPlatformCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, this.$options.frameworkPath);
+		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData, this.$options.provision, this.$options.frameworkPath);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/add-platform.ts
+++ b/lib/commands/add-platform.ts
@@ -9,7 +9,7 @@ export class AddPlatformCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData, this.$options.provision, this.$options.frameworkPath);
+		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -15,8 +15,8 @@ export class PublishIOS implements ICommand {
 		private $options: IOptions,
 		private $prompter: IPrompter,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	private get $platformsData(): IPlatformsData {
 		return this.$injector.resolve("platformsData");
@@ -71,12 +71,12 @@ export class PublishIOS implements ICommand {
 				};
 				this.$logger.info("Building .ipa with the selected mobile provision and/or certificate.");
 				// This is not very correct as if we build multiple targets we will try to sign all of them using the signing identity here.
-				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
 				await this.$platformService.buildPlatform(platform, iOSBuildConfig, this.$projectData);
 				ipaFilePath = this.$platformService.lastOutputPath(platform, iOSBuildConfig, this.$projectData);
 			} else {
 				this.$logger.info("No .ipa, mobile provision or certificate set. Perfect! Now we'll build .xcarchive and let Xcode pick the distribution certificate and provisioning profile for you when exporting .ipa for AppStore submission.");
-				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
 
 				let platformData = this.$platformsData.getPlatformData(platform, this.$projectData);
 				let iOSProjectService = <IOSProjectService>platformData.platformProjectService;

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -9,7 +9,7 @@ export class BuildCommandBase {
 	public async executeCore(args: string[]): Promise<void> {
 		let platform = args[0].toLowerCase();
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
 		this.$options.clean = true;
 		const buildConfig: IBuildConfig = {
 			buildForDevice: this.$options.forDevice,

--- a/lib/commands/clean-app.ts
+++ b/lib/commands/clean-app.ts
@@ -2,13 +2,13 @@ export class CleanAppCommandBase {
 	constructor(protected $options: IOptions,
 		protected $projectData: IProjectData,
 		private $platformService: IPlatformService) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async execute(args: string[]): Promise<void> {
 		let platform = args[0].toLowerCase();
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		return this.$platformService.cleanDestinationApp(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		return this.$platformService.cleanDestinationApp(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
 	}
 }
 

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -41,7 +41,7 @@ export abstract class DebugPlatformCommand implements ICommand {
 
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
 
-		await this.$platformService.deployPlatform(this.$devicesService.platform, appFilesUpdaterOptions, deployOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		await this.$platformService.deployPlatform(this.$devicesService.platform, appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options);
 		this.$config.debugLivesync = true;
 		let applicationReloadAction = async (deviceAppData: Mobile.IDeviceAppData): Promise<void> => {
 			let projectData: IProjectData = this.$injector.resolve("projectData");

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -27,7 +27,7 @@ export class DeployOnDeviceCommand implements ICommand {
 			keyStorePassword: this.$options.keyStorePassword,
 			keyStorePath: this.$options.keyStorePath
 		};
-		return this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		return this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -3,8 +3,8 @@ export class EmulateCommandBase {
 		private $projectData: IProjectData,
 		private $logger: ILogger,
 		private $platformService: IPlatformService) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async executeCore(args: string[]): Promise<void> {
 		this.$logger.warn(`Emulate command is deprecated and will soon be removed. Please use "tns run <platform>" instead. All options available for "tns emulate" are present in "tns run" command. To run on all available emulators, use "tns run <platform> --emulator".`);
@@ -27,7 +27,7 @@ export class EmulateCommandBase {
 			keyStorePassword: this.$options.keyStorePassword,
 			keyStorePath: this.$options.keyStorePath
 		};
-		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, this.$options.provision);
 	}
 }
 

--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -14,8 +14,8 @@ export class InstallCommand implements ICommand {
 		private $fs: IFileSystem,
 		private $stringParameter: ICommandParameter,
 		private $npm: INodePackageManager) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async execute(args: string[]): Promise<void> {
 		return args[0] ? this.installModule(args[0]) : this.installProjectDependencies();
@@ -51,7 +51,13 @@ export class InstallCommand implements ICommand {
 			moduleName = devPrefix + moduleName;
 		}
 
-		await this.$npm.install(moduleName, projectDir, { 'save-dev': true });
+		await this.$npm.install(moduleName, projectDir, {
+			'save-dev': true,
+			disableNpmInstall: this.$options.disableNpmInstall,
+			frameworkPath: this.$options.frameworkPath,
+			ignoreScripts: this.$options.ignoreScripts,
+			path: this.$options.path
+		});
 	}
 }
 

--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -31,7 +31,7 @@ export class InstallCommand implements ICommand {
 			const frameworkPackageData = this.$projectDataService.getNSValue(this.$projectData.projectDir, platformData.frameworkPackageName);
 			if (frameworkPackageData && frameworkPackageData.version) {
 				try {
-					await this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`], this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, this.$options.frameworkPath);
+					await this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`], this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
 				} catch (err) {
 					error = `${error}${EOL}${err}`;
 				}

--- a/lib/commands/platform-clean.ts
+++ b/lib/commands/platform-clean.ts
@@ -5,11 +5,11 @@ export class CleanCommand implements ICommand {
 		private $projectData: IProjectData,
 		private $platformService: IPlatformService,
 		private $errors: IErrors) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.cleanPlatforms(args, this.$options.platformTemplate, this.$projectData, {provision: this.$options.provision, sdk: this.$options.sdk });
+		await this.$platformService.cleanPlatforms(args, this.$options.platformTemplate, this.$projectData, this.$options);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -5,12 +5,12 @@ export class PrepareCommand implements ICommand {
 		private $platformService: IPlatformService,
 		private $projectData: IProjectData,
 		private $platformCommandParameter: ICommandParameter) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async execute(args: string[]): Promise<void> {
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		await this.$platformService.preparePlatform(args[0], appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		await this.$platformService.preparePlatform(args[0], appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -4,8 +4,8 @@ export class RunCommandBase {
 		protected $projectData: IProjectData,
 		protected $options: IOptions,
 		protected $emulatorPlatformService: IEmulatorPlatformService) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async executeCore(args: string[]): Promise<void> {
 
@@ -25,7 +25,7 @@ export class RunCommandBase {
 			keyStorePath: this.$options.keyStorePath
 		};
 
-		await this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		await this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options);
 
 		if (this.$options.bundle) {
 			this.$options.watch = false;

--- a/lib/commands/test-init.ts
+++ b/lib/commands/test-init.ts
@@ -54,7 +54,11 @@ class TestInitCommand implements ICommand {
 				// e.g karma is installed; karma-jasmine depends on karma and will try to install it again
 				try {
 					await this.$npm.install(`${peerDependency}@${dependencyVersion}`, projectDir, {
-						'save-dev': true
+						'save-dev': true,
+						disableNpmInstall: false,
+						frameworkPath: this.$options.frameworkPath,
+						ignoreScripts: this.$options.ignoreScripts,
+						path: this.$options.path
 					});
 				} catch (e) {
 					this.$logger.error(e.message);

--- a/lib/commands/test-init.ts
+++ b/lib/commands/test-init.ts
@@ -17,8 +17,8 @@ class TestInitCommand implements ICommand {
 		private $resources: IResourceLoader,
 		private $pluginsService: IPluginsService,
 		private $logger: ILogger) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async execute(args: string[]): Promise<void> {
 		let projectDir = this.$projectData.projectDir;
@@ -36,6 +36,10 @@ class TestInitCommand implements ICommand {
 			await this.$npm.install(mod, projectDir, {
 				'save-dev': true,
 				optional: false,
+				disableNpmInstall: this.$options.disableNpmInstall,
+				frameworkPath: this.$options.frameworkPath,
+				ignoreScripts: this.$options.ignoreScripts,
+				path: this.$options.path
 			});
 
 			const modulePath = path.join(projectDir, "node_modules", mod);

--- a/lib/commands/update-platform.ts
+++ b/lib/commands/update-platform.ts
@@ -9,7 +9,7 @@ export class UpdatePlatformCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.updatePlatforms(args, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+		await this.$platformService.updatePlatforms(args, this.$options.platformTemplate, this.$projectData, this.$options);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -12,8 +12,8 @@ export class UpdateCommand implements ICommand {
 		private $projectDataService: IProjectDataService,
 		private $fs: IFileSystem,
 		private $logger: ILogger) {
-			this.$projectData.initializeProjectData();
-		}
+		this.$projectData.initializeProjectData();
+	}
 
 	public async execute(args: string[]): Promise<void> {
 		let folders = ["lib", "hooks", "platforms", "node_modules"];
@@ -83,12 +83,12 @@ export class UpdateCommand implements ICommand {
 		platforms = platforms.concat(packagePlatforms);
 		if (args.length === 1) {
 			for (let platform of platforms) {
-				await this.$platformService.addPlatforms([platform + "@" + args[0]], this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, this.$options.frameworkPath);
+				await this.$platformService.addPlatforms([platform + "@" + args[0]], this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
 			}
 
 			await this.$pluginsService.add("tns-core-modules@" + args[0], this.$projectData);
 		} else {
-			await this.$platformService.addPlatforms(platforms, this.$options.platformTemplate, this.$projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, this.$options.frameworkPath);
+			await this.$platformService.addPlatforms(platforms, this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
 			await this.$pluginsService.add("tns-core-modules", this.$projectData);
 		}
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -7,9 +7,31 @@ interface INodePackageManager {
 	 * @return {Promise<INpmInstallResultInfo>}                Information about installed package.
 	 */
 	install(packageName: string, pathToSave: string, config: INodePackageManagerInstallOptions): Promise<INpmInstallResultInfo>;
-	uninstall(packageName: string, config?: any, path?: string): Promise<any>;
+
+	/**
+	 * Uninstalls a dependency
+	 * @param  {string}                            packageName The name of the dependency.
+	 * @param  {IDictionary<string | boolean>} config      Additional options that can be passed to manipulate uninstallation.
+	 * @param  {string}                            path  The destination of the uninstallation.
+	 * @return {Promise<string>}                The output of the uninstallation.
+	 */
+	uninstall(packageName: string, config?: IDictionary<string | boolean>, path?: string): Promise<string>;
+
+	/**
+	 * Provides information about a given package.
+	 * @param  {string}                            packageName The name of the package.
+	 * @param  {IDictionary<string | boolean>} config      Additional options that can be passed to manipulate view.
+	 * @return {Promise<any>}                Object, containing information about the package.
+	 */
 	view(packageName: string, config: Object): Promise<any>;
-	search(filter: string[], config: any): Promise<any>;
+
+	/**
+	 * Searches for a package.
+	 * @param  {string[]}                            filter Keywords with which to perform the search.
+	 * @param  {IDictionary<string | boolean>} config      Additional options that can be passed to manipulate search.
+	 * @return {Promise<string>}                The output of the uninstallation.
+	 */
+	search(filter: string[], config: IDictionary<string | boolean>): Promise<string>;
 }
 
 interface INpmInstallationManager {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -295,10 +295,17 @@ interface IAndroidReleaseOptions {
 	keyStorePath?: string;
 }
 
-interface INpmInstallConfigurationOptions {
+interface INpmInstallConfigurationOptionsBase {
 	frameworkPath: string;
-	disableNpmInstall: boolean;
 	ignoreScripts: boolean; //npm flag
+}
+
+interface INpmInstallConfigurationOptions extends INpmInstallConfigurationOptionsBase {
+	disableNpmInstall: boolean;
+}
+
+interface ICreateProjectOptions extends INpmInstallConfigurationOptionsBase {
+	pathToTemplate?: string;
 }
 
 interface IOptions extends ICommonOptions, IBundle, IPlatformTemplate, IEmulator, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, INpmInstallConfigurationOptions {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -1,7 +1,7 @@
 interface IPlatformService extends NodeJS.EventEmitter {
-	cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, framework?: string): Promise<void>;
+	cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, framework?: string): Promise<void>;
 
-	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, frameworkPath?: string): Promise<void>;
+	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string): Promise<void>;
 
 	/**
 	 * Gets list of all installed platforms (the ones for which <project dir>/platforms/<platform> exists).
@@ -32,7 +32,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 */
 	removePlatforms(platforms: string[], projectData: IProjectData): Promise<void>;
 
-	updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
+	updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void>;
 
 	/**
 	 * Ensures that the specified platform and its dependencies are installed.
@@ -43,11 +43,11 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {IAppFilesUpdaterOptions} appFilesUpdaterOptions Options needed to instantiate AppFilesUpdater class.
 	 * @param {string} platformTemplate The name of the platform template.
 	 * @param {IProjectData} projectData DTO with information about the project.
-	 * @param {IPlatformSpecificData} platformSpecificData Platform specific data required for project preparation.
+	 * @param {IAddPlatformCoreOptions} config Options required for project preparation/creation.
 	 * @param {Array} filesToSync Files about to be synced to device.
 	 * @returns {boolean} true indicates that the platform was prepared.
 	 */
-	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, filesToSync?: Array<String>): Promise<boolean>;
+	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>): Promise<boolean>;
 
 	/**
 	 * Determines whether a build is necessary. A build is necessary when one of the following is true:
@@ -106,10 +106,10 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {IAppFilesUpdaterOptions} appFilesUpdaterOptions Options needed to instantiate AppFilesUpdater class.
 	 * @param {IDeployPlatformOptions} deployOptions Various options that can manage the deploy operation.
 	 * @param {IProjectData} projectData DTO with information about the project.
-	 * @param {any} platformSpecificData Platform specific data required for project preparation.
+	 * @param {IAddPlatformCoreOptions} config Options required for project preparation/creation.
 	 * @returns {void}
 	 */
-	deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
+	deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void>;
 
 	/**
 	 * Runs the application on specified platform. Assumes that the application is already build and installed. Fails if this is not true.
@@ -126,12 +126,12 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {IAppFilesUpdaterOptions} appFilesUpdaterOptions Options needed to instantiate AppFilesUpdater class.
 	 * @param {IEmulatePlatformOptions} emulateOptions Various options that can manage the emulate operation.
 	 * @param {IProjectData} projectData DTO with information about the project.
-	 * @param {any} platformSpecificData Platform specific data required for project preparation.
+	 * @param {IAddPlatformCoreOptions} config Options required for project preparation/creation.
 	 * @returns {void}
 	 */
-	emulatePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, emulateOptions: IEmulatePlatformOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
+	emulatePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, emulateOptions: IEmulatePlatformOptions, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void>;
 
-	cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
+	cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void>;
 	validatePlatformInstalled(platform: string, projectData: IProjectData): void;
 
 	/**
@@ -200,6 +200,8 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 */
 	trackActionForPlatform(actionData: ITrackPlatformAction): Promise<void>;
 }
+
+interface IAddPlatformCoreOptions extends IPlatformSpecificData, ICreateProjectOptions { }
 
 /**
  * Platform specific data required for project preparation.

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -1,7 +1,6 @@
 interface IPluginsService {
 	add(plugin: string, projectData: IProjectData): Promise<void>; // adds plugin by name, github url, local path and et.
 	remove(pluginName: string, projectData: IProjectData): Promise<void>; // removes plugin only by name
-	getAvailable(filter: string[]): Promise<IDictionary<any>>; // gets all available plugins
 	prepare(pluginData: IDependencyData, platform: string, projectData: IProjectData): Promise<void>;
 	getAllInstalledPlugins(projectData: IProjectData): Promise<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(projectData: IProjectData): Promise<void>;

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -69,7 +69,7 @@ interface IProjectData {
 	 * @param {string} projectDir Project root directory.
 	 * @returns {void}
 	 */
-	initializeProjectData(projectDir? :string): void;
+	initializeProjectData(projectDir?: string): void;
 }
 
 interface IProjectDataService {
@@ -158,7 +158,7 @@ interface IiOSBuildConfig extends IBuildForDevice, IDeviceIdentifier, IProvision
 interface IPlatformProjectService extends NodeJS.EventEmitter {
 	getPlatformData(projectData: IProjectData): IPlatformData;
 	validate(projectData: IProjectData): Promise<void>;
-	createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, pathToTemplate?: string): Promise<void>;
+	createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, config: ICreateProjectOptions): Promise<void>;
 	interpolateData(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void>;
 	interpolateConfigurationFile(projectData: IProjectData, platformSpecificData: IPlatformSpecificData): void;
 

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -80,15 +80,15 @@ export class NodePackageManager implements INodePackageManager {
 		}
 
 	@exported("npm")
-	public async uninstall(packageName: string, config?: any, path?: string): Promise<any> {
-		let flags = this.getFlagsString(config, false);
+	public async uninstall(packageName: string, config?: any, path?: string): Promise<string> {
+		const flags = this.getFlagsString(config, false);
 		return this.$childProcess.exec(`npm uninstall ${packageName} ${flags}`, { cwd: path });
 	}
 
 	@exported("npm")
-	public async search(filter: string[], config: any): Promise<any> {
-		let args = (<any[]>([filter] || [])).concat(config.silent);
-		return this.$childProcess.exec(`npm search ${args.join(" ")}`);
+	public async search(filter: string[], config: any): Promise<string> {
+		const flags = this.getFlagsString(config, false);
+		return this.$childProcess.exec(`npm search ${filter.join(" ")} ${flags}`);
 	}
 
 	@exported("npm")

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -91,7 +91,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		}
 
 		let installedModuleNames = await this.npmInstall(packageName, pathToSave, version, dependencyType);
-		let installedPackageName = installedModuleNames[0];
+		let installedPackageName = installedModuleNames.name;
 
 		let pathToInstalledPackage = path.join(pathToSave, "node_modules", installedPackageName);
 		return pathToInstalledPackage;
@@ -103,7 +103,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		return str.length < 2083 && url.test(str);
 	}
 
-	private async npmInstall(packageName: string, pathToSave: string, version: string, dependencyType: string): Promise<any> {
+	private async npmInstall(packageName: string, pathToSave: string, version: string, dependencyType: string): Promise<INpmInstallResultInfo> {
 		this.$logger.out("Installing ", packageName);
 
 		packageName = packageName + (version ? `@${version}` : "");

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -90,8 +90,8 @@ export class NpmInstallationManager implements INpmInstallationManager {
 			version = version || await this.getLatestCompatibleVersion(packageName);
 		}
 
-		let installedModuleNames = await this.npmInstall(packageName, pathToSave, version, dependencyType);
-		let installedPackageName = installedModuleNames.name;
+		let installResultInfo = await this.npmInstall(packageName, pathToSave, version, dependencyType);
+		let installedPackageName = installResultInfo.name;
 
 		let pathToInstalledPackage = path.join(pathToSave, "node_modules", installedPackageName);
 		return pathToInstalledPackage;

--- a/lib/providers/livesync-provider.ts
+++ b/lib/providers/livesync-provider.ts
@@ -53,7 +53,7 @@ export class LiveSyncProvider implements ILiveSyncProvider {
 
 	public async preparePlatformForSync(platform: string, provision: any, projectData: IProjectData): Promise<void> {
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: provision, sdk: this.$options.sdk });
+		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options);
 	}
 
 	public canExecuteFastSync(filePath: string, projectData: IProjectData, platform: string): boolean {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -138,11 +138,14 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 		this.cleanResValues(targetSdkVersion, projectData, frameworkVersion);
 
-		let npmConfig = {
+		let npmConfig: INodePackageManagerInstallOptions = {
 			"save": true,
 			"save-dev": true,
 			"save-exact": true,
-			"silent": true
+			"silent": true,
+			disableNpmInstall: false,
+			frameworkPath: null,
+			ignoreScripts: false
 		};
 
 		let projectPackageJson: any = this.$fs.readJson(projectData.projectFilePath);

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -106,7 +106,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		Promise.resolve();
 	}
 
-	public async createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, pathToTemplate?: string): Promise<void> {
+	public async createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, config: ICreateProjectOptions): Promise<void> {
 		if (semver.lt(frameworkVersion, AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE)) {
 			this.$errors.failWithoutHelp(`The NativeScript CLI requires Android runtime ${AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE} or later to work properly.`);
 		}
@@ -118,10 +118,10 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		this.$logger.trace(`Using Android SDK '${targetSdkVersion}'.`);
 		this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "libs", "-R");
 
-		if (pathToTemplate) {
+		if (config.pathToTemplate) {
 			let mainPath = path.join(this.getPlatformData(projectData).projectRoot, "src", "main");
 			this.$fs.createDirectory(mainPath);
-			shell.cp("-R", path.join(path.resolve(pathToTemplate), "*"), mainPath);
+			shell.cp("-R", path.join(path.resolve(config.pathToTemplate), "*"), mainPath);
 		} else {
 			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "src", "-R");
 		}
@@ -139,13 +139,13 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		this.cleanResValues(targetSdkVersion, projectData, frameworkVersion);
 
 		let npmConfig: INodePackageManagerInstallOptions = {
-			"save": true,
+			save: true,
 			"save-dev": true,
 			"save-exact": true,
-			"silent": true,
+			silent: true,
 			disableNpmInstall: false,
-			frameworkPath: null,
-			ignoreScripts: false
+			frameworkPath: config.frameworkPath,
+			ignoreScripts: config.ignoreScripts
 		};
 
 		let projectPackageJson: any = this.$fs.readJson(projectData.projectFilePath);

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -182,7 +182,14 @@ class DoctorService implements IDoctorService {
 		let spinner = new clui.Spinner("Installing iOS runtime.");
 		try {
 			spinner.start();
-			await this.$npm.install("tns-ios", projDir, { global: false, "ignore-scripts": true, production: true, save: true });
+			await this.$npm.install("tns-ios", projDir, {
+				global: false,
+				production: true,
+				save: true,
+				disableNpmInstall: false,
+				frameworkPath: null,
+				ignoreScripts: true
+			});
 			spinner.stop();
 			let iosDir = path.join(projDir, "node_modules", "tns-ios", "framework");
 			this.$fs.writeFile(

--- a/lib/services/extensibility-service.ts
+++ b/lib/services/extensibility-service.ts
@@ -32,13 +32,10 @@ export class ExtensibilityService implements IExtensibilityService {
 		const localPath = path.resolve(extensionName);
 		const packageName = this.$fs.exists(localPath) ? localPath : extensionName;
 
-		const realName = (await this.$npm.install(packageName, this.pathToExtensions, npmOpts))[0];
+		const installResultInfo = await this.$npm.install(packageName, this.pathToExtensions, npmOpts);
 		this.$logger.trace(`Finished installation of extension '${extensionName}'. Trying to load it now.`);
 
-		// In case the extension is already installed, the $npm.install method will not return the name of the package.
-		// Fallback to the original value.
-		// NOTE: This will not be required once $npm.install starts working correctly.
-		return await this.loadExtension(realName || extensionName);
+		return await this.loadExtension(installResultInfo.name);
 	}
 
 	@exported("extensibilityService")

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -120,14 +120,14 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	// TODO: Remove Promise, reason: readDirectory - unable until androidProjectService has async operations.
-	public async createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, pathToTemplate?: string): Promise<void> {
+	public async createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, config: ICreateProjectOptions): Promise<void> {
 		this.$fs.ensureDirectoryExists(path.join(this.getPlatformData(projectData).projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER));
-		if (pathToTemplate) {
+		if (config.pathToTemplate) {
 			// Copy everything except the template from the runtime
 			this.$fs.readDirectory(frameworkDir)
 				.filter(dirName => dirName.indexOf(IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER) === -1)
 				.forEach(dirName => shell.cp("-R", path.join(frameworkDir, dirName), this.getPlatformData(projectData).projectRoot));
-			shell.cp("-rf", path.join(pathToTemplate, "*"), this.getPlatformData(projectData).projectRoot);
+			shell.cp("-rf", path.join(config.pathToTemplate, "*"), this.getPlatformData(projectData).projectRoot);
 		} else {
 			shell.cp("-R", path.join(frameworkDir, "*"), this.getPlatformData(projectData).projectRoot);
 		}

--- a/lib/services/livesync/platform-livesync-service.ts
+++ b/lib/services/livesync/platform-livesync-service.ts
@@ -135,7 +135,7 @@ export abstract class PlatformLiveSyncServiceBase implements IPlatformLiveSyncSe
 							let batch = this.batch[platform];
 							await batch.syncFiles(async (filesToSync: string[]) => {
 								const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-								await this.$platformService.preparePlatform(this.liveSyncData.platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: this.$options.provision, sdk: this.$options.sdk }, filesToSync);
+								await this.$platformService.preparePlatform(this.liveSyncData.platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options, filesToSync);
 								let canExecute = this.getCanExecuteAction(this.liveSyncData.platform, this.liveSyncData.appIdentifier);
 								let deviceFileAction = (deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]) => this.transferFiles(deviceAppData, localToDevicePaths, this.liveSyncData.projectFilesPath, !filePath);
 								let action = this.getSyncAction(filesToSync, deviceFileAction, afterFileSyncAction, projectData);

--- a/lib/services/local-build-service.ts
+++ b/lib/services/local-build-service.ts
@@ -10,7 +10,12 @@ export class LocalBuildService extends EventEmitter {
 
 	public async build(platform: string, platformBuildOptions: IPlatformBuildData, platformTemplate?: string): Promise<string> {
 		this.$projectData.initializeProjectData(platformBuildOptions.projectDir);
-		await this.$platformService.preparePlatform(platform, platformBuildOptions, platformTemplate, this.$projectData, { provision: platformBuildOptions.provision, sdk: null });
+		await this.$platformService.preparePlatform(platform, platformBuildOptions, platformTemplate, this.$projectData, {
+			provision: platformBuildOptions.provision,
+			sdk: null,
+			frameworkPath: null,
+			ignoreScripts: false
+		});
 		const handler = (data: any) => {
 			data.projectDir = platformBuildOptions.projectDir;
 			this.emit(BUILD_OUTPUT_EVENT_NAME, data);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -176,17 +176,14 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		if (selectedTemplate) {
 			let tempDir = temp.mkdirSync("platform-template");
+			this.$fs.writeJson(path.join(tempDir, constants.PACKAGE_JSON_FILE_NAME), {});
 			try {
-				/*
-				 * Output of npm.install is array of arrays. For example:
-				 * [ [ 'test-android-platform-template@0.0.1',
-				 *	'C:\\Users\\<USER>~1\\AppData\\Local\\Temp\\1\\platform-template11627-15560-rm3ngx\\node_modules\\test-android-platform-template',
-				 *	undefined,
-				 *	undefined,
-				 *	'..\\..\\..\\android-platform-template' ] ]
-				 * Project successfully created.
-				 */
-				let pathToTemplate = (await this.$npm.install(selectedTemplate, tempDir))[0];
+				const npmInstallResult = await this.$npm.install(selectedTemplate, tempDir, {
+					disableNpmInstall: false,
+					frameworkPath: null,
+					ignoreScripts: false
+				});
+				let pathToTemplate = path.join(tempDir, constants.NODE_MODULES_FOLDER_NAME, npmInstallResult.name);
 				return { selectedTemplate, pathToTemplate };
 			} catch (err) {
 				this.$logger.trace("Error while trying to install specified template: ", err);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -46,7 +46,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		super();
 	}
 
-	public async cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, framworkPath?: string): Promise<void> {
+	public async cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, framworkPath?: string): Promise<void> {
 		for (let platform of platforms) {
 			let version: string = this.getCurrentPlatformVersion(platform, projectData);
 
@@ -56,16 +56,16 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			}
 
 			await this.removePlatforms([platform], projectData);
-			await this.addPlatforms([platformWithVersion], platformTemplate, projectData, platformSpecificData);
+			await this.addPlatforms([platformWithVersion], platformTemplate, projectData, config);
 		}
 	}
 
-	public async addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, frameworkPath?: string): Promise<void> {
+	public async addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string): Promise<void> {
 		let platformsDir = projectData.platformsDir;
 		this.$fs.ensureDirectoryExists(platformsDir);
 
 		for (let platform of platforms) {
-			await this.addPlatform(platform.toLowerCase(), platformTemplate, projectData, platformSpecificData, frameworkPath);
+			await this.addPlatform(platform.toLowerCase(), platformTemplate, projectData, config, frameworkPath);
 		}
 	}
 
@@ -80,7 +80,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return version;
 	}
 
-	private async addPlatform(platformParam: string, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, frameworkPath?: string): Promise<void> {
+	private async addPlatform(platformParam: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string): Promise<void> {
 		let data = platformParam.split("@"),
 			platform = data[0].toLowerCase(),
 			version = data[1];
@@ -130,7 +130,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			let frameworkDir = path.join(downloadedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME);
 			frameworkDir = path.resolve(frameworkDir);
 
-			let coreModuleName = await this.addPlatformCore(platformData, frameworkDir, platformTemplate, projectData, platformSpecificData);
+			let coreModuleName = await this.addPlatformCore(platformData, frameworkDir, platformTemplate, projectData, config);
 			await this.$npm.uninstall(coreModuleName, { save: true }, projectData.projectDir);
 		} catch (err) {
 			this.$fs.deleteDirectory(platformPath);
@@ -143,16 +143,16 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	}
 
-	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<string> {
-		let coreModuleData = this.$fs.readJson(path.join(frameworkDir, "../", "package.json"));
+	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<string> {
+		let coreModuleData = this.$fs.readJson(path.join(frameworkDir, "..", "package.json"));
 		let installedVersion = coreModuleData.version;
 		let coreModuleName = coreModuleData.name;
 
 		let customTemplateOptions = await this.getPathToPlatformTemplate(platformTemplate, platformData.frameworkPackageName, projectData.projectDir);
-		let pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
-		await platformData.platformProjectService.createProject(path.resolve(frameworkDir), installedVersion, projectData, pathToTemplate);
+		config.pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
+		await platformData.platformProjectService.createProject(path.resolve(frameworkDir), installedVersion, projectData, config);
 		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
-		await platformData.platformProjectService.interpolateData(projectData, platformSpecificData);
+		await platformData.platformProjectService.interpolateData(projectData, config);
 		platformData.platformProjectService.afterCreateProject(platformData.projectRoot, projectData);
 
 		let frameworkPackageNameData: any = { version: installedVersion };
@@ -214,7 +214,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return _.filter(this.$platformsData.platformsNames, p => { return this.isPlatformPrepared(p, projectData); });
 	}
 
-	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, filesToSync?: Array<String>): Promise<boolean> {
+	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>): Promise<boolean> {
 		this.validatePlatform(platform, projectData);
 
 		await this.trackProjectType(projectData);
@@ -230,8 +230,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 		await this.$pluginsService.validate(platformData, projectData);
 
-		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, platformSpecificData);
-		let changesInfo = this.$projectChangesService.checkForChanges(platform, projectData, { bundle: appFilesUpdaterOptions.bundle, release: appFilesUpdaterOptions.release, provision: platformSpecificData.provision });
+		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, config);
+		let changesInfo = this.$projectChangesService.checkForChanges(platform, projectData, { bundle: appFilesUpdaterOptions.bundle, release: appFilesUpdaterOptions.release, provision: config.provision });
 
 		this.$logger.trace("Changes info in prepare platform:", changesInfo);
 
@@ -245,7 +245,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				}
 			}
 
-			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo, filesToSync);
+			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, config, changesInfo, filesToSync);
 			this.$projectChangesService.savePrepareInfo(platform, projectData);
 		} else {
 			this.$logger.out("Skipping prepare.");
@@ -477,8 +477,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		this.$logger.out(`Successfully installed on device with identifier '${device.deviceInfo.identifier}'.`);
 	}
 
-	public async deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
-		await this.preparePlatform(platform, appFilesUpdaterOptions, deployOptions.platformTemplate, projectData, platformSpecificData);
+	public async deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+		await this.preparePlatform(platform, appFilesUpdaterOptions, deployOptions.platformTemplate, projectData, config);
 		let options: Mobile.IDevicesServicesInitializationOptions = {
 			platform: platform, deviceId: deployOptions.device, emulator: deployOptions.emulator
 		};
@@ -528,7 +528,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		await this.$devicesService.execute(action, this.getCanExecuteAction(platform, runOptions));
 	}
 
-	public async emulatePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, emulateOptions: IEmulatePlatformOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
+	public async emulatePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, emulateOptions: IEmulatePlatformOptions, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
 		if (emulateOptions.avd) {
 			this.$logger.warn(`Option --avd is no longer supported. Please use --device instead!`);
 			return Promise.resolve();
@@ -559,7 +559,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			}
 		}
 
-		await this.deployPlatform(platform, appFilesUpdaterOptions, emulateOptions, projectData, platformSpecificData);
+		await this.deployPlatform(platform, appFilesUpdaterOptions, emulateOptions, projectData, config);
 		return this.startApplication(platform, emulateOptions, projectData.projectId);
 	}
 
@@ -601,8 +601,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return null;
 	}
 
-	public async cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
-		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, platformSpecificData);
+	public async cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, config);
 
 		const appSourceDirectoryPath = path.join(projectData.projectDir, constants.APP_FOLDER_NAME);
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
@@ -657,16 +657,16 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	public async updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
+	public async updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
 		for (let platformParam of platforms) {
 			let data = platformParam.split("@"),
 				platform = data[0],
 				version = data[1];
 
 			if (this.isPlatformInstalled(platform, projectData)) {
-				await this.updatePlatform(platform, version, platformTemplate, projectData, platformSpecificData);
+				await this.updatePlatform(platform, version, platformTemplate, projectData, config);
 			} else {
-				await this.addPlatform(platformParam, platformTemplate, projectData, platformSpecificData);
+				await this.addPlatform(platformParam, platformTemplate, projectData, config);
 			}
 		};
 	}
@@ -718,9 +718,9 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	public async ensurePlatformInstalled(platform: string, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
+	public async ensurePlatformInstalled(platform: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
 		if (!this.isPlatformInstalled(platform, projectData)) {
-			await this.addPlatform(platform, platformTemplate, projectData, platformSpecificData);
+			await this.addPlatform(platform, platformTemplate, projectData, config);
 		}
 	}
 
@@ -780,7 +780,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return this.getLatestApplicationPackage(platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath, platformData.getValidPackageNames({ isForDevice: false, isReleaseBuild: buildConfig.release }));
 	}
 
-	private async updatePlatform(platform: string, version: string, platformTemplate: string, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
+	private async updatePlatform(platform: string, version: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 
 		let data = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
@@ -801,7 +801,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			}
 
 			if (!semver.gt(currentVersion, newVersion)) {
-				await this.updatePlatformCore(platformData, { currentVersion, newVersion, canUpdate, platformTemplate }, projectData, platformSpecificData);
+				await this.updatePlatformCore(platformData, { currentVersion, newVersion, canUpdate, platformTemplate }, projectData, config);
 			} else if (semver.eq(currentVersion, newVersion)) {
 				this.$errors.fail("Current and new version are the same.");
 			} else {
@@ -813,11 +813,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	}
 
-	private async updatePlatformCore(platformData: IPlatformData, updateOptions: IUpdatePlatformOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData): Promise<void> {
+	private async updatePlatformCore(platformData: IPlatformData, updateOptions: IUpdatePlatformOptions, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
 		let packageName = platformData.normalizedPlatformName.toLowerCase();
 		await this.removePlatforms([packageName], projectData);
 		packageName = updateOptions.newVersion ? `${packageName}@${updateOptions.newVersion}` : packageName;
-		await this.addPlatform(packageName, updateOptions.platformTemplate, projectData, platformSpecificData);
+		await this.addPlatform(packageName, updateOptions.platformTemplate, projectData, config);
 		this.$logger.out("Successfully updated to version ", updateOptions.newVersion);
 	}
 

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -103,11 +103,6 @@ export class PluginsService implements IPluginsService {
 		}
 	}
 
-	public getAvailable(filter: string[]): Promise<IDictionary<any>> {
-		let silent: boolean = true;
-		return this.$npm.search(filter, { "silent": silent });
-	}
-
 	public async validate(platformData: IPlatformData, projectData: IProjectData): Promise<void> {
 		return await platformData.platformProjectService.validatePlugins(projectData);
 	}

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -51,13 +51,23 @@ export class ProjectService implements IProjectService {
 			await this.ensureAppResourcesExist(projectDir);
 
 			let packageName = constants.TNS_CORE_MODULES_NAME;
-			await this.$npm.install(packageName, projectDir, { save: true, "save-exact": true });
+			await this.$npm.install(packageName, projectDir, {
+				save: true,
+				"save-exact": true,
+				disableNpmInstall: false,
+				frameworkPath: null,
+				ignoreScripts: projectOptions.ignoreScripts
+			});
 
 			let templatePackageJsonData = this.getDataFromJson(templatePath);
 			this.mergeProjectAndTemplateProperties(projectDir, templatePackageJsonData); //merging dependencies from template (dev && prod)
 			this.removeMergedDependencies(projectDir, templatePackageJsonData);
 
-			await this.$npm.install(projectDir, projectDir, { "ignore-scripts": projectOptions.ignoreScripts });
+			await this.$npm.install(projectDir, projectDir, {
+				disableNpmInstall: false,
+				frameworkPath: null,
+				ignoreScripts: projectOptions.ignoreScripts
+			});
 
 			let templatePackageJson = this.$fs.readJson(path.join(templatePath, "package.json"));
 			await this.$npm.uninstall(templatePackageJson.name, { save: true }, projectDir);
@@ -112,7 +122,13 @@ export class ProjectService implements IProjectService {
 
 			// the template installed doesn't have App_Resources -> get from a default template
 			let defaultTemplateName = constants.RESERVED_TEMPLATE_NAMES["default"];
-			await this.$npm.install(defaultTemplateName, projectDir, { save: true, });
+			await this.$npm.install(defaultTemplateName, projectDir, {
+				save: true,
+				disableNpmInstall: false,
+				frameworkPath: null,
+				ignoreScripts: false
+			});
+
 			let defaultTemplateAppResourcesPath = path.join(projectDir, constants.NODE_MODULES_FOLDER_NAME,
 				defaultTemplateName, constants.APP_RESOURCES_FOLDER_NAME);
 

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -55,7 +55,7 @@ class TestExecutionService implements ITestExecutionService {
 					this.$fs.writeFile(path.join(projectDir, TestExecutionService.SOCKETIO_JS_FILE_NAME), socketIoJs);
 
 					const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-					if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: this.$options.provision, sdk: this.$options.sdk })) {
+					if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options)) {
 						this.$errors.failWithoutHelp("Verify that listed files are well-formed and try again the operation.");
 					}
 					this.detourEntryPoint(projectFilesPath);
@@ -70,7 +70,7 @@ class TestExecutionService implements ITestExecutionService {
 						provision: this.$options.provision,
 						teamId: this.$options.teamId
 					};
-					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, this.$options);
 					await this.$usbLiveSyncService.liveSync(platform, projectData);
 
 					if (this.$options.debugBrk) {
@@ -125,7 +125,7 @@ class TestExecutionService implements ITestExecutionService {
 				const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
 				// Prepare the project AFTER the TestExecutionService.CONFIG_FILE_NAME file is created in node_modules
 				// so it will be sent to device.
-				if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, { provision: this.$options.provision, sdk: this.$options.sdk })) {
+				if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options)) {
 					this.$errors.failWithoutHelp("Verify that listed files are well-formed and try again the operation.");
 				}
 
@@ -145,7 +145,7 @@ class TestExecutionService implements ITestExecutionService {
 					const debugData = this.getDebugData(platform, projectData, deployOptions);
 					await debugService.debug(debugData, this.$options);
 				} else {
-					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, { provision: this.$options.provision, sdk: this.$options.sdk });
+					await this.$platformService.deployPlatform(platform, appFilesUpdaterOptions, deployOptions, projectData, this.$options);
 					await this.$usbLiveSyncService.liveSync(platform, projectData);
 				}
 			};

--- a/test/nativescript-cli-lib.ts
+++ b/test/nativescript-cli-lib.ts
@@ -18,6 +18,7 @@ describe("nativescript-cli-lib", () => {
 		projectService: ["createProject", "isValidNativeScriptProject"],
 		localBuildService: ["build"],
 		deviceLogProvider: null,
+		npm: ["install", "uninstall", "view", "search"],
 		extensibilityService: ["loadExtensions", "getInstalledExtensions", "installExtension", "uninstallExtension"]
 	};
 

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -192,7 +192,7 @@ async function preparePlatform(testInjector: IInjector): Promise<void> {
 	projectData.initializeProjectData();
 	const options: IOptions = testInjector.resolve("options");
 
-	await platformService.preparePlatform("android", { bundle: options.bundle, release: options.release }, "", projectData, { provision: options.provision, sdk: options.sdk });
+	await platformService.preparePlatform("android", { bundle: options.bundle, release: options.release }, "", projectData, options);
 }
 
 describe("Npm support tests", () => {

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -144,6 +144,13 @@ class DestinationFolderVerifier {
 
 describe('Platform Service Tests', () => {
 	let platformService: IPlatformService, testInjector: IInjector;
+	const config: IAddPlatformCoreOptions = {
+		ignoreScripts: false,
+		provision: null,
+		sdk: null,
+		frameworkPath: null
+	};
+
 	beforeEach(() => {
 		testInjector = createTestInjector();
 		testInjector.register("fs", stubs.FileSystemStub);
@@ -156,22 +163,21 @@ describe('Platform Service Tests', () => {
 				let fs = testInjector.resolve("fs");
 				fs.exists = () => false;
 				let projectData: IProjectData = testInjector.resolve("projectData");
+				await platformService.addPlatforms(["Android"], "", projectData, config);
+				await platformService.addPlatforms(["ANDROID"], "", projectData, config);
+				await platformService.addPlatforms(["AnDrOiD"], "", projectData, config);
+				await platformService.addPlatforms(["androiD"], "", projectData, config);
 
-				await platformService.addPlatforms(["Android"], "", projectData, null);
-				await platformService.addPlatforms(["ANDROID"], "", projectData, null);
-				await platformService.addPlatforms(["AnDrOiD"], "", projectData, null);
-				await platformService.addPlatforms(["androiD"], "", projectData, null);
-
-				await platformService.addPlatforms(["iOS"], "", projectData, null);
-				await platformService.addPlatforms(["IOS"], "", projectData, null);
-				await platformService.addPlatforms(["IoS"], "", projectData, null);
-				await platformService.addPlatforms(["iOs"], "", projectData, null);
+				await platformService.addPlatforms(["iOS"], "", projectData, config);
+				await platformService.addPlatforms(["IOS"], "", projectData, config);
+				await platformService.addPlatforms(["IoS"], "", projectData, config);
+				await platformService.addPlatforms(["iOs"], "", projectData, config);
 			});
 			it("should fail if platform is already installed", async () => {
 				let projectData: IProjectData = testInjector.resolve("projectData");
 				// By default fs.exists returns true, so the platforms directory should exists
-				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, null));
-				await assert.isRejected(platformService.addPlatforms(["ios"], "", projectData, null));
+				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, config));
+				await assert.isRejected(platformService.addPlatforms(["ios"], "", projectData, config));
 			});
 			it("should fail if npm is unavalible", async () => {
 				let fs = testInjector.resolve("fs");
@@ -183,7 +189,7 @@ describe('Platform Service Tests', () => {
 				let projectData: IProjectData = testInjector.resolve("projectData");
 
 				try {
-					await platformService.addPlatforms(["android"], "", projectData, null);
+					await platformService.addPlatforms(["android"], "", projectData, config);
 				} catch (err) {
 					assert.equal(errorMessage, err.message);
 				}
@@ -206,8 +212,8 @@ describe('Platform Service Tests', () => {
 
 				let projectData: IProjectData = testInjector.resolve("projectData");
 
-				await platformService.addPlatforms(["android"], "", projectData, null);
-				await platformService.addPlatforms(["ios"], "", projectData, null);
+				await platformService.addPlatforms(["android"], "", projectData, config);
+				await platformService.addPlatforms(["ios"], "", projectData, config);
 			});
 			it("should install latest platform if no information found in package.json's nativescript key", async () => {
 				let fs = testInjector.resolve("fs");
@@ -224,8 +230,8 @@ describe('Platform Service Tests', () => {
 
 				let projectData: IProjectData = testInjector.resolve("projectData");
 
-				await platformService.addPlatforms(["android"], "", projectData, null);
-				await platformService.addPlatforms(["ios"], "", projectData, null);
+				await platformService.addPlatforms(["android"], "", projectData, config);
+				await platformService.addPlatforms(["ios"], "", projectData, config);
 			});
 		});
 		describe("#add platform(ios)", () => {
@@ -242,7 +248,7 @@ describe('Platform Service Tests', () => {
 				};
 
 				try {
-					await platformService.addPlatforms(["ios"], "", projectData, null);
+					await platformService.addPlatforms(["ios"], "", projectData, config);
 				} catch (err) {
 					assert.equal(errorMessage, err.message);
 				}
@@ -262,7 +268,7 @@ describe('Platform Service Tests', () => {
 				let projectData: IProjectData = testInjector.resolve("projectData");
 
 				try {
-					await platformService.addPlatforms(["android"], "", projectData, null);
+					await platformService.addPlatforms(["android"], "", projectData, config);
 				} catch (err) {
 					assert.equal(errorMessage, err.message);
 				}
@@ -294,7 +300,7 @@ describe('Platform Service Tests', () => {
 		it("shouldn't fail when platforms are added", async () => {
 			let projectData: IProjectData = testInjector.resolve("projectData");
 			testInjector.resolve("fs").exists = () => false;
-			await platformService.addPlatforms(["android"], "", projectData, null);
+			await platformService.addPlatforms(["android"], "", projectData, config);
 
 			testInjector.resolve("fs").exists = () => true;
 			await platformService.removePlatforms(["android"], projectData);
@@ -324,10 +330,10 @@ describe('Platform Service Tests', () => {
 				return Promise.resolve();
 			};
 
-			await platformService.cleanPlatforms(["android"], "", projectData, null);
+			await platformService.cleanPlatforms(["android"], "", projectData, config);
 
 			nsValueObject[VERSION_STRING] = versionString;
-			await platformService.cleanPlatforms(["ios"], "", projectData, null);
+			await platformService.cleanPlatforms(["ios"], "", projectData, config);
 		});
 	});
 
@@ -425,7 +431,7 @@ describe('Platform Service Tests', () => {
 
 			platformService = testInjector.resolve("platformService");
 			const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: false, release: release };
-			await platformService.preparePlatform(platformToTest, appFilesUpdaterOptions, "", projectData, { provision: null, sdk: null });
+			await platformService.preparePlatform(platformToTest, appFilesUpdaterOptions, "", projectData, { provision: null, sdk: null, frameworkPath: null, ignoreScripts: false });
 		}
 
 		async function testPreparePlatform(platformToTest: string, release?: boolean): Promise<CreatedTestData> {
@@ -851,7 +857,7 @@ describe('Platform Service Tests', () => {
 			try {
 				testInjector.resolve("$logger").warn = (text: string) => warnings += text;
 				const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: false, release: false };
-				await platformService.preparePlatform("android", appFilesUpdaterOptions, "", projectData, { provision: null, sdk: null });
+				await platformService.preparePlatform("android", appFilesUpdaterOptions, "", projectData, { provision: null, sdk: null, frameworkPath: null, ignoreScripts: false });
 			} finally {
 				testInjector.resolve("$logger").warn = oldLoggerWarner;
 			}

--- a/test/services/extensibility-service.ts
+++ b/test/services/extensibility-service.ts
@@ -77,7 +77,7 @@ describe("extensibilityService", () => {
 					argsPassedToNpmInstall.packageName = packageName;
 					argsPassedToNpmInstall.pathToSave = pathToSave;
 					argsPassedToNpmInstall.config = config;
-					return [userSpecifiedValue];
+					return { name: userSpecifiedValue };
 				};
 
 				const extensibilityService: IExtensibilityService = testInjector.resolve(ExtensibilityService);
@@ -130,7 +130,7 @@ describe("extensibilityService", () => {
 			fs.readDirectory = (dir: string): string[] => [extensionName];
 
 			const npm: INodePackageManager = testInjector.resolve("npm");
-			npm.install = async (packageName: string, pathToSave: string, config?: any): Promise<any> => [extensionName];
+			npm.install = async (packageName: string, pathToSave: string, config?: any): Promise<any> => ({ name: extensionName });
 
 			const extensibilityService: IExtensibilityService = testInjector.resolve(ExtensibilityService);
 			const actualResult = await extensibilityService.installExtension(extensionName);
@@ -148,7 +148,7 @@ describe("extensibilityService", () => {
 			fs.readDirectory = (dir: string): string[] => [extensionName];
 
 			const npm: INodePackageManager = testInjector.resolve("npm");
-			npm.install = async (packageName: string, pathToSave: string, config?: any): Promise<any> => [extensionName];
+			npm.install = async (packageName: string, pathToSave: string, config?: any): Promise<any> => ({ name: extensionName });
 
 			const requireService: IRequireService = testInjector.resolve("requireService");
 			requireService.require = (pathToRequire: string) => {
@@ -230,7 +230,7 @@ describe("extensibilityService", () => {
 				npm.install = async (packageName: string, pathToSave: string, config?: any): Promise<any> => {
 					assert.deepEqual(packageName, extensionNames[0]);
 					isNpmInstallCalled = true;
-					return [packageName];
+					return { name: packageName };
 				};
 
 				const expectedResults: IExtensionData[] = _.map(extensionNames, extensionName => ({ extensionName }));


### PR DESCRIPTION
Expose node-package-manager functonality to be usable when CLI is `require`-d.
* Remove occurrences of `this.$options` in node-package-manager
* Start using `--dry-run` and `--json` for parsing output

Ping @yyosifov @rosen-vladimirov 