### PR TITLE
Improve debugService public API

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -36,7 +36,7 @@ export abstract class DebugPlatformCommand implements ICommand {
 		await this.$platformService.trackProjectType(this.$projectData);
 
 		if (this.$options.start) {
-			return this.printDebugInformation(await this.debugService.debug(debugData, debugOptions));
+			return this.printDebugInformation(await this.debugService.debug<string[]>(debugData, debugOptions));
 		}
 
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
@@ -58,7 +58,7 @@ export abstract class DebugPlatformCommand implements ICommand {
 			const buildConfig: IBuildConfig = _.merge({ buildForDevice: !deviceAppData.device.isEmulator }, deployOptions);
 			debugData.pathToAppPackage = this.$platformService.lastOutputPath(this.debugService.platform, buildConfig, projectData);
 
-			this.printDebugInformation(await this.debugService.debug(debugData, debugOptions));
+			this.printDebugInformation(await this.debugService.debug<string[]>(debugData, debugOptions));
 		};
 
 		return this.$usbLiveSyncService.liveSync(this.$devicesService.platform, this.$projectData, applicationReloadAction);

--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -1,31 +1,124 @@
+/**
+ * Describes information for starting debug process.
+ */
 interface IDebugData {
+	/**
+	 * Id of the device on which the debug process will be started.
+	 */
 	deviceIdentifier: string;
+
+	/**
+	 * Application identifier of the app that it will be debugged.
+	 */
 	applicationIdentifier: string;
+
+	/**
+	 * Path to .app built for iOS Simulator.
+	 */
 	pathToAppPackage?: string;
+
+	/**
+	 * The name of the application, for example `MyProject`.
+	 */
 	projectName?: string;
+
+	/**
+	 * Path to project.
+	 */
 	projectDir?: string;
 }
 
+/**
+ * Describes all options that define the behavior of debug.
+ */
 interface IDebugOptions {
+	/**
+	 * Defines if Chrome-Dev Tools should be used for debugging.
+	 */
 	chrome?: boolean;
+
+	/**
+	 * Defines if thе application is already started on device.
+	 */
 	start?: boolean;
+
+	/**
+	 * Defines if we should stop the currently running debug process.
+	 */
 	stop?: boolean;
+
+	/**
+	 * Defines if debug process is for emulator (not for real device).
+	 */
 	emulator?: boolean;
+
+	/**
+	 * Defines if the debug process should break on the first line.
+	 */
 	debugBrk?: boolean;
+
+	/**
+	 * Defines if the debug process will not have a client attached (i.e. the process will be started, but NativeScript Inspector will not be started and it will not attach to the running debug process).
+	 */
 	client?: boolean;
+
+	/**
+	 * Defines if the process will watch for further changes in the project and transferrs them to device immediately, resulting in restar of the debug process.
+	 */
 	justlaunch?: boolean;
+
+	/**
+	 * Defines if bundled Chrome DevTools should be used or specific commit. Valid for iOS only.
+	 */
+	useBundledDevTools?: boolean;
 }
 
+/**
+ * Describes methods to create debug data object used by other methods.
+ */
 interface IDebugDataService {
+	/**
+	 * Creates the debug data based on specified options.
+	 * @param {IProjectData} projectData The data describing project that will be debugged.
+	 * @param {IOptions} options The options based on which debugData will be created
+	 * @returns {IDebugData} Data describing the required information for starting debug process.
+	 */
 	createDebugData(projectData: IProjectData, options: IOptions): IDebugData;
 }
 
+/**
+ * Describes methods for debug operation.
+ */
 interface IDebugService extends NodeJS.EventEmitter {
-	debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string[]>;
+	/**
+	 * Starts debug operation based on the specified debug data.
+	 * @param {IDebugData} debugData Describes information for device and application that will be debugged.
+	 * @param {IDebugOptions} debugOptions Describe possible options to modify the behaivor of the debug operation, for example stop on the first line.
+	 * @returns {Promise<T>} Array of URLs that can be used for debugging or a string representing a single url that can be used for debugging.
+	 */
+	debug<T>(debugData: IDebugData, debugOptions: IDebugOptions): Promise<T>;
 }
 
+/**
+ * Describes actions required for debugging on specific platform (Android or iOS).
+ */
 interface IPlatformDebugService extends IDebugService {
+	/**
+	 * Starts debug operation.
+	 * @param {IDebugData} debugData Describes information for device and application that will be debugged.
+	 * @param {IDebugOptions} debugOptions Describe possible options to modify the behaivor of the debug operation, for example stop on the first line.
+	 * @returns {Promise<void>}
+	 */
 	debugStart(debugData: IDebugData, debugOptions: IDebugOptions): Promise<void>;
+
+	/**
+	 * Stops debug operation.
+	 * @returns {Promise<void>}
+	 */
 	debugStop(): Promise<void>
+
+	/**
+	 * Mobile platform of the device - Android or iOS.
+	 */
 	platform: string;
 }

--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -33,7 +33,7 @@ interface IDebugData {
  */
 interface IDebugOptions {
 	/**
-	 * Defines if Chrome-Dev Tools should be used for debugging.
+	 * Defines if Chrome DevTools should be used for debugging.
 	 */
 	chrome?: boolean;
 

--- a/lib/services/debug-service.ts
+++ b/lib/services/debug-service.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "events";
 import { CONNECTION_ERROR_EVENT_NAME } from "../constants";
 import { CONNECTED_STATUS } from "../common/constants";
 
-class DebugService extends EventEmitter implements IDebugService {
+export class DebugService extends EventEmitter implements IDebugService {
 	constructor(private $devicesService: Mobile.IDevicesService,
 		private $androidDebugService: IPlatformDebugService,
 		private $iOSDebugService: IPlatformDebugService,
@@ -16,10 +16,9 @@ class DebugService extends EventEmitter implements IDebugService {
 
 	public async debug(debugData: IDebugData, options: IDebugOptions): Promise<string> {
 		const device = this.$devicesService.getDeviceByIdentifier(debugData.deviceIdentifier);
-		const debugService = this.getDebugService(device);
 
 		if (!device) {
-			this.$errors.failWithoutHelp(`Can't find device with identifier ${debugData.deviceIdentifier}`);
+			this.$errors.failWithoutHelp(`Cannot find device with identifier ${debugData.deviceIdentifier}.`);
 		}
 
 		if (device.deviceInfo.status !== CONNECTED_STATUS) {
@@ -38,9 +37,15 @@ class DebugService extends EventEmitter implements IDebugService {
 		// After we find a way to check on iOS we should use it here.
 		const isAppRunning = true;
 		let result: string[];
-		debugOptions.chrome = !debugOptions.client;
+		debugOptions.chrome = true;
+
+		const debugService = this.getDebugService(device);
+		if (!debugService) {
+			this.$errors.failWithoutHelp(`Unsupported device OS: ${device.deviceInfo.platform}. You can debug your applications only on iOS or Android.`);
+		}
+
 		if (this.$mobileHelper.isiOSPlatform(device.deviceInfo.platform)) {
-			if (device.isEmulator && !debugData.pathToAppPackage) {
+			if (device.isEmulator && !debugData.pathToAppPackage && debugOptions.debugBrk) {
 				this.$errors.failWithoutHelp("To debug on iOS simulator you need to provide path to the app package.");
 			}
 

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -196,11 +196,14 @@ class IOSDebugService extends DebugServiceBase implements IPlatformDebugService 
 		if (debugOptions.chrome) {
 			this._socketProxy = await this.$socketProxyFactory.createWebSocketProxy(this.getSocketFactory(device));
 
-			const commitSHA = "02e6bde1bbe34e43b309d4ef774b1168d25fd024"; // corresponds to 55.0.2883 Chrome version
-			let chromeDevToolsPrefix = `chrome-devtools://devtools/remote/serve_file/@${commitSHA}`;
+			let chromeDevToolsPrefix = `chrome-devtools://devtools/`;
 
 			if (debugOptions.useBundledDevTools) {
-				chromeDevToolsPrefix = "chrome-devtools://devtools/bundled";
+				chromeDevToolsPrefix += "bundled";
+			} else {
+				// corresponds to 55.0.2883 Chrome version
+				const commitSHA = "02e6bde1bbe34e43b309d4ef774b1168d25fd024";
+				chromeDevToolsPrefix += `remote/serve_file/@${commitSHA}`;
 			}
 
 			return `${chromeDevToolsPrefix}/inspector.html?experiments=true&ws=localhost:${this._socketProxy.options.port}`;

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -197,7 +197,13 @@ class IOSDebugService extends DebugServiceBase implements IPlatformDebugService 
 			this._socketProxy = await this.$socketProxyFactory.createWebSocketProxy(this.getSocketFactory(device));
 
 			const commitSHA = "02e6bde1bbe34e43b309d4ef774b1168d25fd024"; // corresponds to 55.0.2883 Chrome version
-			return `chrome-devtools://devtools/remote/serve_file/@${commitSHA}/inspector.html?experiments=true&ws=localhost:${this._socketProxy.options.port}`;
+			let chromeDevToolsPrefix = `chrome-devtools://devtools/remote/serve_file/@${commitSHA}`;
+
+			if (debugOptions.useBundledDevTools) {
+				chromeDevToolsPrefix = "chrome-devtools://devtools/bundled";
+			}
+
+			return `${chromeDevToolsPrefix}/inspector.html?experiments=true&ws=localhost:${this._socketProxy.options.port}`;
 		} else {
 			this._socketProxy = await this.$socketProxyFactory.createTCPSocketProxy(this.getSocketFactory(device));
 			await this.openAppInspector(this._socketProxy.address(), debugData, debugOptions);

--- a/test/nativescript-cli-lib.ts
+++ b/test/nativescript-cli-lib.ts
@@ -19,7 +19,8 @@ describe("nativescript-cli-lib", () => {
 		localBuildService: ["build"],
 		deviceLogProvider: null,
 		npm: ["install", "uninstall", "view", "search"],
-		extensibilityService: ["loadExtensions", "getInstalledExtensions", "installExtension", "uninstallExtension"]
+		extensibilityService: ["loadExtensions", "getInstalledExtensions", "installExtension", "uninstallExtension"],
+		debugService: ["debug"]
 	};
 
 	const pathToEntryPoint = path.join(__dirname, "..", "lib", "nativescript-cli-lib.js").replace(/\\/g, "\\\\");

--- a/test/services/debug-service.ts
+++ b/test/services/debug-service.ts
@@ -1,0 +1,292 @@
+import { DebugService } from "../../lib/services/debug-service";
+import { Yok } from "../../lib/common/yok";
+import * as stubs from "../stubs";
+import { assert } from "chai";
+import { EventEmitter } from "events";
+import * as constants from "../../lib/common/constants";
+import { CONNECTION_ERROR_EVENT_NAME } from "../../lib/constants";
+
+const fakeChromeDebugUrl = "fakeChromeDebugUrl";
+class PlatformDebugService extends EventEmitter /* implements IPlatformDebugService */ {
+	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string[]> {
+		return [fakeChromeDebugUrl];
+	}
+};
+
+interface IDebugTestDeviceInfo {
+	deviceInfo: {
+		status: string;
+		platform: string;
+	};
+
+	isEmulator: boolean;
+};
+
+interface IDebugTestData {
+	isDeviceFound: boolean;
+	deviceInformation: IDebugTestDeviceInfo;
+	isApplicationInstalledOnDevice: boolean;
+	hostInfo: {
+		isWindows: boolean;
+		isDarwin: boolean;
+	};
+};
+
+const getDefaultDeviceInformation = (platform?: string): IDebugTestDeviceInfo => ({
+	deviceInfo: {
+		status: constants.CONNECTED_STATUS,
+		platform: platform || "Android"
+	},
+
+	isEmulator: false
+});
+
+const getDefaultTestData = (platform?: string): IDebugTestData => ({
+	isDeviceFound: true,
+	deviceInformation: getDefaultDeviceInformation(platform),
+	isApplicationInstalledOnDevice: true,
+	hostInfo: {
+		isWindows: false,
+		isDarwin: true
+	}
+});
+
+describe("debugService", () => {
+	const getTestInjectorForTestConfiguration = (testData: IDebugTestData): IInjector => {
+		const testInjector = new Yok();
+		testInjector.register("devicesService", {
+			getDeviceByIdentifier: (identifier: string): Mobile.IDevice => {
+				return testData.isDeviceFound ?
+					<Mobile.IDevice> {
+						deviceInfo: testData.deviceInformation.deviceInfo,
+
+						applicationManager: {
+							isApplicationInstalled: async (appIdentifier: string): Promise<boolean> => testData.isApplicationInstalledOnDevice
+						},
+
+						isEmulator: testData.deviceInformation.isEmulator
+					} : null;
+			}
+		});
+
+		testInjector.register("androidDebugService", PlatformDebugService);
+
+		testInjector.register("iOSDebugService", PlatformDebugService);
+
+		testInjector.register("mobileHelper", {
+			isAndroidPlatform: (platform: string) => {
+				return platform.toLowerCase() === "android";
+			},
+			isiOSPlatform: (platform: string) => {
+				return platform.toLowerCase() === "ios";
+			}
+		});
+
+		testInjector.register("errors", stubs.ErrorsStub);
+
+		testInjector.register("hostInfo", testData.hostInfo);
+
+		return testInjector;
+	};
+
+	describe("debug", () => {
+		const getDebugData = (deviceIdentifier?: string): IDebugData => ({
+			applicationIdentifier: "org.nativescript.app1",
+			deviceIdentifier: deviceIdentifier || "Nexus5",
+			projectDir: "/Users/user/app1",
+			projectName: "app1"
+		});
+
+		describe("rejects the result promise when", () => {
+			const assertIsRejected = async (testData: IDebugTestData, expectedError: string, userSpecifiedOptions?: IDebugOptions): Promise<void> => {
+				const testInjector = getTestInjectorForTestConfiguration(testData);
+				const debugService = testInjector.resolve<IDebugService>(DebugService);
+
+				const debugData = getDebugData();
+				await assert.isRejected(debugService.debug(debugData, userSpecifiedOptions), expectedError);
+			};
+
+			it("there's no attached device as the specified identifier", async () => {
+				const testData = getDefaultTestData();
+				testData.isDeviceFound = false;
+
+				await assertIsRejected(testData, "Cannot find device with identifier");
+			});
+
+			it("the device is not trusted", async () => {
+				const testData = getDefaultTestData();
+				testData.deviceInformation.deviceInfo.status = constants.UNREACHABLE_STATUS;
+
+				await assertIsRejected(testData, "is unreachable. Make sure it is Trusted ");
+			});
+
+			it("the application is not installed on device", async () => {
+				const testData = getDefaultTestData();
+				testData.isApplicationInstalledOnDevice = false;
+
+				await assertIsRejected(testData, "is not installed on device with identifier");
+			});
+
+			it("the OS is neither Windows or macOS and device is iOS", async () => {
+				const testData = getDefaultTestData();
+				testData.deviceInformation.deviceInfo.platform = "iOS";
+				testData.hostInfo.isDarwin = testData.hostInfo.isWindows = false;
+
+				await assertIsRejected(testData, "Debugging on iOS devices is not supported for");
+			});
+
+			it("device is neither iOS or Android", async () => {
+				const testData = getDefaultTestData();
+				testData.deviceInformation.deviceInfo.platform = "WP8";
+
+				await assertIsRejected(testData, "Unsupported device OS:");
+			});
+
+			it("when trying to debug on iOS Simulator on macOS, debug-brk is passed, but pathToAppPackage is not", async () => {
+				const testData = getDefaultTestData();
+				testData.deviceInformation.deviceInfo.platform = "iOS";
+				testData.deviceInformation.isEmulator = true;
+
+				await assertIsRejected(testData, "To debug on iOS simulator you need to provide path to the app package.", { debugBrk: true });
+			});
+
+			const assertIsRejectedWhenPlatformDebugServiceFails = async (platform: string): Promise<void> => {
+				const testData = getDefaultTestData();
+				testData.deviceInformation.deviceInfo.platform = platform;
+
+				const testInjector = getTestInjectorForTestConfiguration(testData);
+				const expectedErrorMessage = "Platform specific error";
+				const platformDebugService = testInjector.resolve<IPlatformDebugService>(`${platform}DebugService`);
+				platformDebugService.debug = async (debugData: IDebugData, debugOptions: IDebugOptions): Promise<any> => {
+					throw new Error(expectedErrorMessage);
+				};
+
+				const debugService = testInjector.resolve<IDebugService>(DebugService);
+
+				const debugData = getDebugData();
+				await assert.isRejected(debugService.debug(debugData, null), expectedErrorMessage);
+			};
+
+			it("androidDebugService's debug method fails", async () => {
+				await assertIsRejectedWhenPlatformDebugServiceFails("android");
+			});
+
+			it("iOSDebugService's debug method fails", async () => {
+				await assertIsRejectedWhenPlatformDebugServiceFails("iOS");
+			});
+		});
+
+		describe("passes correct args to", () => {
+			const assertPassedDebugOptions = async (platform: string, userSpecifiedOptions?: IDebugOptions, hostInfo?: { isWindows: boolean, isDarwin: boolean }): Promise<IDebugOptions> => {
+				const testData = getDefaultTestData();
+				testData.deviceInformation.deviceInfo.platform = platform;
+				if (hostInfo) {
+					testData.hostInfo = hostInfo;
+				}
+
+				const testInjector = getTestInjectorForTestConfiguration(testData);
+				const platformDebugService = testInjector.resolve<IPlatformDebugService>(`${platform}DebugService`);
+				let passedDebugOptions: IDebugOptions = null;
+				platformDebugService.debug = async (debugData: IDebugData, debugOptions: IDebugOptions): Promise<any> => {
+					passedDebugOptions = debugOptions;
+					return [];
+				};
+
+				const debugService = testInjector.resolve<IDebugService>(DebugService);
+
+				const debugData = getDebugData();
+				await assert.isFulfilled(debugService.debug(debugData, userSpecifiedOptions));
+				assert.isTrue(passedDebugOptions.chrome);
+				assert.isTrue(passedDebugOptions.start);
+
+				return passedDebugOptions;
+			};
+
+			_.each(["android", "iOS"], platform => {
+				describe(`${platform}DebugService's debug method`, () => {
+					describe("on macOS", () => {
+						it("passes chrome and start as true, when no debugOptions are passed to debugService", async () => {
+							await assertPassedDebugOptions(platform);
+						});
+
+						it("when calling debug service with chrome and start set to false, should disregard them and set both to true", async () => {
+							await assertPassedDebugOptions(platform, { chrome: false, start: false });
+						});
+
+						it("passes other custom options without modification", async () => {
+							const passedDebugOptions = await assertPassedDebugOptions(platform, { emulator: true, useBundledDevTools: true });
+							assert.isTrue(passedDebugOptions.useBundledDevTools);
+							assert.isTrue(passedDebugOptions.emulator);
+						});
+					});
+
+					describe("on Windows", () => {
+						const assertEmulatorOption = (passedDebugOptions: IDebugOptions) => {
+							if (platform === "iOS") {
+								assert.isFalse(passedDebugOptions.emulator);
+							}
+						};
+
+						it("passes chrome and start as true, when no debugOptions are passed to debugService", async () => {
+							const passedDebugOptions = await assertPassedDebugOptions(platform, null, { isWindows: true, isDarwin: false });
+							assertEmulatorOption(passedDebugOptions);
+						});
+
+						it("when calling debug service with chrome and start set to false, should disregard them and set both to true", async () => {
+							const passedDebugOptions = await assertPassedDebugOptions(platform, { chrome: false, start: false }, { isWindows: true, isDarwin: false });
+							assertEmulatorOption(passedDebugOptions);
+						});
+
+						it("passes other custom options without modification", async () => {
+							const passedDebugOptions = await assertPassedDebugOptions(platform, { debugBrk: true, useBundledDevTools: true });
+							assert.isTrue(passedDebugOptions.useBundledDevTools);
+							assert.isTrue(passedDebugOptions.debugBrk);
+						});
+					});
+
+				});
+			});
+		});
+
+		describe(`raises ${CONNECTION_ERROR_EVENT_NAME} event`, () => {
+			_.each(["android", "iOS"], platform => {
+				it(`when ${platform}DebugService raises ${CONNECTION_ERROR_EVENT_NAME} event`, async () => {
+					const testData = getDefaultTestData();
+					testData.deviceInformation.deviceInfo.platform = platform;
+
+					const testInjector = getTestInjectorForTestConfiguration(testData);
+					const debugService = testInjector.resolve<IDebugService>(DebugService);
+					let dataRaisedForConnectionError: any = null;
+					debugService.on(CONNECTION_ERROR_EVENT_NAME, (data: any) => {
+						dataRaisedForConnectionError = data;
+					});
+
+					const debugData = getDebugData();
+					await assert.isFulfilled(debugService.debug(debugData, null));
+
+					const expectedErrorData = { deviceId: "deviceId", message: "my message", code: 2048 };
+					const platformDebugService = testInjector.resolve<IPlatformDebugService>(`${platform}DebugService`);
+					platformDebugService.emit(CONNECTION_ERROR_EVENT_NAME, expectedErrorData);
+					assert.deepEqual(dataRaisedForConnectionError, expectedErrorData);
+				});
+			});
+		});
+
+		describe("returns chrome url returned by platform specific debug service", () => {
+			_.each(["android", "iOS"], platform => {
+				it(`for ${platform} device`, async () => {
+					const testData = getDefaultTestData();
+					testData.deviceInformation.deviceInfo.platform = platform;
+
+					const testInjector = getTestInjectorForTestConfiguration(testData);
+					const debugService = testInjector.resolve<IDebugService>(DebugService);
+
+					const debugData = getDebugData();
+					const url = await debugService.debug(debugData, null);
+
+					assert.deepEqual(url, fakeChromeDebugUrl);
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
When using Chrome DevTools to debug iOS applications, CLI returns a url that points to a specific commit of the dev tools. This way, in case a new version of the dev tools introduces a breaking change, the debugging will still work.
However, in some cases (inside Electron app), we cannot use the remote url, so we must use the bundled one. So introduce a new option (only available when requiring CLI as a library), that defines that the returned url will use the bundled dev tools.
The default behavior (used in CLI), will still return the url that includes remote url.
Also change the definition of `debug` method in the interface, so now the DebugService can safely implement it.
Add a new check in the debug service - in case the device's status is not Connected, we are unable to start debug operation. So fail with correct error message in this case.
Add JSDocs for all debug related interfaces.
Add documentation in PublicAPI.md for the `debugService`.
Add debugService to tests of public API.
Add tests for debugService.
Add verification that in case device's OS is not supported (for example WP8), we'll throw correct error.
