### PR TITLE
Fix emulate command

### DIFF
--- a/lib/commands/emulate.ts
+++ b/lib/commands/emulate.ts
@@ -27,7 +27,7 @@ export class EmulateCommandBase {
 			keyStorePassword: this.$options.keyStorePassword,
 			keyStorePath: this.$options.keyStorePath
 		};
-		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, this.$options.provision);
+		return this.$platformService.emulatePlatform(args[0], appFilesUpdaterOptions, emulateOptions, this.$projectData, this.$options);
 	}
 }
 


### PR DESCRIPTION
During refactoring we've decided to pass the whole `$options` object from commands to services. However we've forgotten to change the emulate command.
Pass correct argument which will fix the issue.