### PR TITLE
Fix working with 32 bit Node on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.0.3",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-device-lib": "0.4.0",
+    "ios-device-lib": "0.4.1",
     "ios-mobileprovision-finder": "1.0.9",
     "ios-sim-portable": "~2.0.0",
     "lockfile": "1.0.1",


### PR DESCRIPTION
During detecting devices, CLI will try to check if there are iOS devices. However the ios-device-lib has an issue in version 0.4.0 and it fails that the binary cannot be found in case 32-bits Node is used.
So use latest version of the lib, where the issue is fixed.