### PR TITLE
Fix `tns debug ios --justlaunch`

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -103,7 +103,11 @@ export class DebugIOSCommand extends DebugPlatformCommand {
 		$platformsData: IPlatformsData,
 		$iosDeviceOperations: IIOSDeviceOperations) {
 		super($iOSDebugService, $devicesService, $injector, $devicePlatformsConstants, $config, $usbLiveSyncService, $debugDataService, $platformService, $projectData, $options, $platformsData, $logger);
-		$iosDeviceOperations.setShouldDispose(this.$options.justlaunch);
+		// Do not dispose ios-device-lib, so the process will remain alive and the debug application (NativeScript Inspector or Chrome DevTools) will be able to connect to the socket.
+		// In case we dispose ios-device-lib, the socket will be closed and the code will fail when the debug application tries to read/send data to device socket.
+		// That's why the `$ tns debug ios --justlaunch` command will not release the terminal.
+		// In case we do not set it to false, the dispose will be called once the command finishes its execution, which will prevent the debugging.
+		$iosDeviceOperations.setShouldDispose(false);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {


### PR DESCRIPTION
When `--justlaunch` flag is passed, CLI automatically disposes the `ios-device-lib` after execution of the command. However this closes all opened device sockets and breaks the debug command.
So whenever you try `tns debug ios --justlaunch [--chrome]`, the debug application (NativeScript Inspector) or Chrome DevTools is unable to connect to device socket and fails with error.
Fix this by keeping the `ios-device-lib` alive whenever we try debug for ios. This way the debug application will be able to connect to the device.
NOTE: `tns debug ios --justlaunch [--chrome]` cannot release the terminal as it has to keep the ios-device-lib alive.