### PR TITLE
Fix installation of tns-core-modules during project creation

### DIFF
--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -108,7 +108,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 
 		packageName = packageName + (version ? `@${version}` : "");
 
-		let npmOptions: any = { silent: true };
+		let npmOptions: any = { silent: true, "save-exact": true };
 
 		if (dependencyType) {
 			npmOptions[dependencyType] = true;

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -114,7 +114,7 @@ class ProjectIntegrationTest {
 		this.testInjector.register("fs", FileSystem);
 		this.testInjector.register("projectDataService", ProjectDataServiceLib.ProjectDataService);
 		this.testInjector.register("staticConfig", StaticConfig);
-		this.testInjector.register("analyticsService", { track: async () => undefined });
+		this.testInjector.register("analyticsService", { track: async (): Promise<any> => undefined });
 
 		this.testInjector.register("npmInstallationManager", NpmInstallationManager);
 		this.testInjector.register("npm", NpmLib.NodePackageManager);
@@ -130,6 +130,7 @@ class ProjectIntegrationTest {
 				return dummyString;
 			}
 		});
+		this.testInjector.register("npmInstallationManager", NpmInstallationManager);
 	}
 }
 
@@ -471,6 +472,7 @@ describe("Project Service Tests", () => {
 			testInjector.register("projectTemplatesService", {});
 			testInjector.register("staticConfig", {});
 			testInjector.register("projectHelper", {});
+			testInjector.register("npmInstallationManager", {});
 
 			return testInjector;
 		};


### PR DESCRIPTION
CLI tries to install `tns-core-modules` during project creation. In case the template does not have `tns-core-modules` in it, CLI will install latest version of `tns-core-modules` which may (and most probably is) be incompatible with the runtime and other dependencies of the project.
In such cases ensure the CLI installs version of tns-core-modules that matches its own version, i.e. when CLI is 2.5.2, it should install latest 2.5.x core modules.
Also ensure exact versions are installed and persisted by `npmInstallationManager`.