### PR TITLE
Respect current version of CLI when searching for runtimes

### DIFF
--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -27,7 +27,13 @@ export class NpmInstallationManager implements INpmInstallationManager {
 	public getLatestCompatibleVersion(packageName: string): IFuture<string> {
 		return (() => {
 			const configVersion = this.$staticConfig.version;
+			const isPreReleaseVersion = (<any>semver).prerelease(configVersion) !== null;
 			let cliVersionRange = `~${semver.major(configVersion)}.${(<any>semver).minor(configVersion)}.0`;
+			if(isPreReleaseVersion) {
+				// if the user has some 0-19 pre-release version, include pre-release versions in the search query.
+				cliVersionRange = `~${configVersion}`;
+			}
+
 			let latestVersion = this.getLatestVersion(packageName).wait();
 			if (semver.satisfies(latestVersion, cliVersionRange)) {
 				return latestVersion;

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -26,15 +26,16 @@ export class NpmInstallationManager implements INpmInstallationManager {
 
 	public getLatestCompatibleVersion(packageName: string): IFuture<string> {
 		return (() => {
-
-			let cliVersionRange = `~${this.$staticConfig.version}`;
+			const configVersion = this.$staticConfig.version;
+			let cliVersionRange = `~${semver.major(configVersion)}.${(<any>semver).minor(configVersion)}.0`;
 			let latestVersion = this.getLatestVersion(packageName).wait();
 			if (semver.satisfies(latestVersion, cliVersionRange)) {
 				return latestVersion;
 			}
 			let data = this.$npm.view(packageName, { json: true, "versions": true }).wait();
 
-			return semver.maxSatisfying(data, cliVersionRange) || latestVersion;
+			let maxSatisfying = semver.maxSatisfying(data, cliVersionRange);
+			return maxSatisfying || latestVersion;
 		}).future<string>()();
 	}
 

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -6,6 +6,7 @@ import * as shelljs from "shelljs";
 export class ProjectService implements IProjectService {
 
 	constructor(private $npm: INodePackageManager,
+		private $npmInstallationManager: INpmInstallationManager,
 		private $errors: IErrors,
 		private $fs: IFileSystem,
 		private $logger: ILogger,
@@ -166,7 +167,8 @@ export class ProjectService implements IProjectService {
 			if (tnsModulesVersion) {
 				packageName = `${packageName}@${tnsModulesVersion}`;
 			}
-			this.$npm.install(packageName, projectDir, { save: true, "save-exact": true }).wait();
+
+			this.$npmInstallationManager.install(packageName, projectDir, { dependencyType: "save" }).wait();
 		}).future<void>()();
 	}
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "properties-parser": "0.2.3",
     "ref": "https://github.com/icenium/ref/tarball/v1.3.2.3",
     "ref-struct": "https://github.com/telerik/ref-struct/tarball/v1.0.2.5",
-    "semver": "5.0.1",
+    "semver": "5.3.0",
     "shelljs": "0.7.6",
     "source-map": "0.5.6",
     "tabtab": "https://github.com/Icenium/node-tabtab/tarball/master",

--- a/test/npm-installation-manager.ts
+++ b/test/npm-installation-manager.ts
@@ -149,6 +149,13 @@ describe("Npm installation manager tests", () => {
 			packageLatestVersion: "1.4.0",
 			cliVersion: "1.6.0-2016-10-01-182",
 			expectedResult: "1.4.0"
+		},
+
+		"When CLI Version has patch version larger than an existing package, should return max compliant package from the same major.minor version": {
+			versions: ["1.0.0", "1.0.1", "1.4.0", "2.5.0", "2.5.1", "2.5.2"],
+			packageLatestVersion: "3.0.0",
+			cliVersion: "2.5.4",
+			expectedResult: "2.5.2"
 		}
 	};
 


### PR DESCRIPTION
When searching for the ios/android runtimes respect the current version of the CLI and don't search only for matching versions - i.e. if I have CLI 2.5.4 don't look for runtimes >= 2.5.4 only, as they can be available only up to 2.5.2 which is still fine and working for us. So I've changed it to look for 2.5.x or major.minor.*any* compatible versions of the packages, when searching for them.

Replaces $npm.install with the $npmInstallationManager.install 

Updated the semver, to add the prerelease function missing in the last version