### PR TITLE
Remove .html from the files included in the fast-livesync to force fu…

### DIFF
--- a/lib/providers/livesync-provider.ts
+++ b/lib/providers/livesync-provider.ts
@@ -10,7 +10,7 @@ export class LiveSyncProvider implements ILiveSyncProvider {
 		private $childProcess: IChildProcess,
 		private $options: IOptions) { }
 
-	private static FAST_SYNC_FILE_EXTENSIONS = [".css", ".xml", ".html"];
+	private static FAST_SYNC_FILE_EXTENSIONS = [".css", ".xml"];
 
 	private deviceSpecificLiveSyncServicesCache: IDictionary<any> = {};
 	public get deviceSpecificLiveSyncServices(): IDictionary<any> {


### PR DESCRIPTION
When syncing changes from .html files do a full app-restart. It was included for fast-sync, non-app-restart behavior which caused issues in Angular apps.