### PR TITLE
Fix getting information for installed npm package

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -193,7 +193,7 @@ interface INpmInstallResultInfo {
 	 * The original output that npm CLI produced upon installation.
 	 * @type {INpmInstallCLIResult}
 	 */
-	originalOutput: INpmInstallCLIResult;
+	originalOutput?: INpmInstallCLIResult;
 }
 
 interface INpmInstallOptions {

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -71,7 +71,7 @@ export class PluginsService implements IPluginsService {
 
 			this.$logger.out(`Successfully installed plugin ${realNpmPackageJson.name}.`);
 		} else {
-			this.$npm.uninstall(realNpmPackageJson.name, { save: true }, projectData.projectDir);
+			await this.$npm.uninstall(realNpmPackageJson.name, { save: true }, projectData.projectDir);
 			this.$errors.failWithoutHelp(`${plugin} is not a valid NativeScript plugin. Verify that the plugin package.json file contains a nativescript key and try again.`);
 		}
 	}


### PR DESCRIPTION
Some npm versions (like 3.9.6) do not report result when package is already installed and `--dry-run` is passed.
This breaks the `JSON.parse()` of the result as it is an empty string.
In this case just parse the original output of `npm install` and search for a result like:
```
<project dir>
`-- nativescript-barcodescanner@1.0.0
```

In case this operation also fails to find which is the installed package, try to find the name from the user specified value.
For example:
```
$ tns plugin add nativescript-barcodescanner@1.0.0
```
The name is `nativescript-barcodescanner` and the version is `1.0.0`.

In case a scoped package is passed, the parsing should also work correctly.

In case a package, that is not NativeScript plugin, is installed via `tns plugin add` command, we have logic to revert the installation.
However the promise that should uninstall the app had never been awaited, so the package was still declared and installed.

When `--json` is passed to `npm install` command, it generates `/etc` dir in the project where npm command is executed.
We have logic to delete it after finishing our command, but it's been executed too early. Fix the code, so command to remove `/etc` will be executed no matter if any of the other operations fails.