### PR TITLE
Fix unit tests on non-macOS

### DIFF
--- a/test/ios-entitlements-service.ts
+++ b/test/ios-entitlements-service.ts
@@ -60,7 +60,7 @@ describe("IOSEntitlements Service Tests", () => {
 
 	describe("Ensure paths constructed are correct", () => {
 		it("Ensure destination entitlements relative path is calculated correctly.", () => {
-			const expected = "testApp/testApp.entitlements";
+			const expected = path.join("testApp", "testApp.entitlements");
 			let actual = iOSEntitlementsService.getPlatformsEntitlementsRelativePath(projectData);
 			assert.equal(actual, expected);
 		});

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -751,6 +751,10 @@ describe("iOS Project Service Signing", () => {
 });
 
 describe("Merge Project XCConfig files", () => {
+	if (require("os").platform() !== "darwin") {
+		console.log("Skipping 'Merge Project XCConfig files' tests. They can work only on macOS");
+		return;
+	}
 	const assertPropertyValues = (expected: any, xcconfigPath: string, injector: IInjector) => {
 		let service = <XCConfigService>injector.resolve('xCConfigService');
 		_.forOwn(expected, (value, key) => {
@@ -782,7 +786,7 @@ describe("Merge Project XCConfig files", () => {
 
 		appResourcesXcconfigPath = path.join(projectData.projectDir, constants.APP_FOLDER_NAME,
 			constants.APP_RESOURCES_FOLDER_NAME, "iOS", "build.xcconfig");
-		appResourceXCConfigContent = `CODE_SIGN_IDENTITY = iPhone Distribution 
+		appResourceXCConfigContent = `CODE_SIGN_IDENTITY = iPhone Distribution
 			// To build for device with XCode 8 you need to specify your development team. More info: https://developer.apple.com/library/prerelease/content/releasenotes/DeveloperTools/RN-Xcode/Introduction.html
 			// DEVELOPMENT_TEAM = YOUR_TEAM_ID;
 			ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/test/test-bootstrap.ts
+++ b/test/test-bootstrap.ts
@@ -9,13 +9,16 @@ const cliGlobal = <ICliGlobal>global;
 cliGlobal._ = require("lodash");
 cliGlobal.$injector = require("../lib/common/yok").injector;
 
+// Requiring colors will modify the prototype of String
+// We need it as in some places we use <string>.<color>, which is undefined when colors is not required
+// So we sometimes miss warnings in the tests as we receive "undefined".
+require("colors");
+
 use(require("chai-as-promised"));
 
 $injector.register("analyticsService", {
-	trackException: (): { wait(): void } => {
-		return {
-			wait: () => undefined
-		};
+	trackException: async (exception: any, message: string): Promise<void> => {
+		// Intentionally left blank.
 	}
 });
 


### PR DESCRIPTION
Currently unit tests from master branch are failing on Windows and Linux. Fix them by applying the following:
- Fix expected path in entitlements test - use `path.join` instead of hardcoded `/` - on Windows the path separator is `\`
- Ignore tests for merging xcconfig files as they can work only on macOS, where ruby is installed. The tests will be ran only in case you are executing them on macOS.
- Require "colors" module in test-bootstrap. During test execution I've noticed some "undefined" statements printed on the terminal. It turned out these are `logger.warn` statements. However the logic in the logger is to print `<message>.yellow`.
When `colors` is not required, the strings do not have `yellow` property, so instead of seeing the real message, the loggger has been printing "undefined".