### PR TITLE
Prevent starting a simulator when build --forDevice

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -329,7 +329,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 		// build only for device specific architecture
 		if (!buildConfig.release && !buildConfig.architectures) {
-			await this.$devicesService.initialize({ platform: this.$devicePlatformsConstants.iOS.toLowerCase(), deviceId: buildConfig.device });
+			await this.$devicesService.initialize({ platform: this.$devicePlatformsConstants.iOS.toLowerCase(), deviceId: buildConfig.device,
+				isBuildForDevice: true });
 			let instances = this.$devicesService.getDeviceInstances();
 			let devicesArchitectures = _(instances)
 				.filter(d => this.$mobileHelper.isiOSPlatform(d.deviceInfo.platform) && d.deviceInfo.activeArchitecture)


### PR DESCRIPTION
When we're executing

`tns build {platform} --forDevice`

we don't need to fire up the Simulator. We've changed the common lib to respect a flag named `isBuildForDevice` and in this case not to start the Simulator if no real devices are found attached.

Here we're just passing this `isBuildForDevicе` when running build forDevice