### PR TITLE
Fix prepare scoped dependency with native code

### DIFF
--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -46,8 +46,8 @@ export class TnsModulesCopy {
 			shelljs.mkdir("-p", targetDir);
 			shelljs.cp("-Rf", dependency.directory, targetDir);
 
-			//remove platform-specific files (processed separately by plugin services)
-			const targetPackageDir = path.join(targetDir, dependency.name);
+			// remove platform-specific files (processed separately by plugin services)
+			const targetPackageDir = path.join(isScoped ? this.outputRoot : targetDir, dependency.name);
 			shelljs.rm("-rf", path.join(targetPackageDir, "platforms"));
 		}
 	}


### PR DESCRIPTION
Preparing a scoped dependency containing `platforms` wouldn't remove them in the prepared `tns_modules` location because the path built was wrong.