### PR TITLE
Flatten scoped module when copying into android/src

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -361,8 +361,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		if (this.$fs.exists(pluginPlatformsFolderPath)) {
 			this.$fs.ensureDirectoryExists(pluginConfigurationDirectoryPath);
 
+			let isScoped = pluginData.name.indexOf("@") === 0;
+			let flattenedDependencyName = isScoped ? pluginData.name.replace("/", "_") : pluginData.name;
+
 			// Copy all resources from plugin
-			let resourcesDestinationDirectoryPath = path.join(this.getPlatformData(projectData).projectRoot, "src", pluginData.name);
+			let resourcesDestinationDirectoryPath = path.join(this.getPlatformData(projectData).projectRoot, "src", flattenedDependencyName);
 			this.$fs.ensureDirectoryExists(resourcesDestinationDirectoryPath);
 			shell.cp("-Rf", path.join(pluginPlatformsFolderPath, "*"), resourcesDestinationDirectoryPath);
 

--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -36,18 +36,20 @@ export class TnsModulesCopy {
 
 	private copyDependencyDir(dependency: IDependencyData): void {
 		if (dependency.depth === 0) {
+			const targetPackageDir = path.join(this.outputRoot, dependency.name);
+
+			shelljs.mkdir("-p", targetPackageDir);
+
 			let isScoped = dependency.name.indexOf("@") === 0;
-			let targetDir = this.outputRoot;
 
 			if (isScoped) {
-				targetDir = path.join(this.outputRoot, dependency.name.substring(0, dependency.name.indexOf("/")));
+				// copy module into tns_modules/@scope/module instead of tns_modules/module
+				shelljs.cp("-Rf", dependency.directory, path.join(this.outputRoot, dependency.name.substring(0, dependency.name.indexOf("/"))));
+			} else {
+				shelljs.cp("-Rf", dependency.directory, this.outputRoot);
 			}
 
-			shelljs.mkdir("-p", targetDir);
-			shelljs.cp("-Rf", dependency.directory, targetDir);
-
 			// remove platform-specific files (processed separately by plugin services)
-			const targetPackageDir = path.join(isScoped ? this.outputRoot : targetDir, dependency.name);
 			shelljs.rm("-rf", path.join(targetPackageDir, "platforms"));
 		}
 	}

--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -46,8 +46,8 @@ export class TnsModulesCopy {
 			shelljs.mkdir("-p", targetDir);
 			shelljs.cp("-Rf", dependency.directory, targetDir);
 
-			//remove platform-specific files (processed separately by plugin services)
-			const targetPackageDir = path.join(targetDir, dependency.name);
+			// remove platform-specific files (processed separately by plugin services)
+			const targetPackageDir = path.join(isScoped ? this.outputRoot : targetDir, dependency.name);
 			shelljs.rm("-rf", path.join(targetPackageDir, "platforms"));
 		}
 	}


### PR DESCRIPTION
Flatten scoped npm plugins containing native code when copying into android/src. This is necessary to properly handle plugin flavors (F1, F2, etc.) when building for android.

```
@progress/nativescript-ui-pro -> nativescript-ui-pro
tns-core-modules -> tns-core-modules
```

branches off commit https://github.com/NativeScript/nativescript-cli/pull/2835
Edit: Includes fix:
Preparing a scoped dependency containing platforms wouldn't remove them in the prepared tns_modules location because the path built was wrong.

`assets/app/tns_modules/@scope/nativescript-with-native-dep` used to preserve its `platforms` dir