### PR TITLE
Conform ios inspector code with npm 5

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -71,3 +71,4 @@ export const TYPESCRIPT_NAME = "typescript";
 export const BUILD_OUTPUT_EVENT_NAME = "buildOutput";
 export const CONNECTION_ERROR_EVENT_NAME = "connectionError";
 export const VERSION_STRING = "version";
+export const INSPECTOR_CACHE_DIRNAME = "ios-inspector";


### PR DESCRIPTION
Cache structure has changed in npm 5.
Do not rely on said structure but instead use the profile-dir for caching the inspector.

Fixes https://github.com/NativeScript/nativescript-cli/issues/2855

Ping @TsvetanMilanov @rosen-vladimirov 