### PR TITLE
Update ios-device-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.0.3",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-device-lib": "0.4.4",
+    "ios-device-lib": "0.4.5",
     "ios-mobileprovision-finder": "1.0.9",
     "ios-sim-portable": "~3.0.0",
     "lockfile": "1.0.1",


### PR DESCRIPTION
Update ios-device-lib where the following changes are applied:
* uninstall application is changed to use `AMDeviceSecureUninstallApplication` instead of `AMDeviceUninstallApplication`. The `secure` function is guarded against some racing issues that might happen when usign the insecure variant.
* Guard against errors when polling for installed applications - fixes issue when checking for currently installed apps is called during uninstalling of application.