### PR TITLE
Pass mobileProvisionData to prepare

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -228,6 +228,11 @@ interface IPlatformSpecificData {
 	 * Target SDK for Android.
 	 */
 	sdk: string;
+
+	/**
+	 * Data from mobileProvision.
+	 */
+	mobileProvisionData?: any;
 }
 
 /**


### PR DESCRIPTION
On Windows and Linux we are unable to execute macOS specific commands. During project preparation for iOS we need to know the data from specified provison. In this scenario, pass the data from it as a non mandatory parameter.
This way the default behavior will be kept, but we'll have a way to skip the `security` command which fails on Windows.