### PR TITLE
Fix debug device/web socket closing

### DIFF
--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -131,12 +131,13 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 			deviceSocket.on("close", () => {
 				this.$logger.info("Backend socket closed!");
 				if (!this.$options.watch) {
-					process.exit(0);
+					webSocket.close();
 				}
 			});
 
 			webSocket.on("close", () => {
 				this.$logger.info('Frontend socket closed!');
+				deviceSocket.destroy();
 				if (!this.$options.watch) {
 					process.exit(0);
 				}


### PR DESCRIPTION
When we close the websocket we have to destroy the device socket as well.
We need to wait the close event on the device socket instead of end.