### PR TITLE
Emit liveSyncStopped for every device

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -83,6 +83,10 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 					await liveSyncProcessInfo.actionsChain;
 				}
 
+				_.each(liveSyncProcessInfo.deviceDescriptors, descriptor => {
+					this.emit(LiveSyncEvents.liveSyncStopped, { projectDir, deviceIdentifier: descriptor.identifier });
+				});
+
 				liveSyncProcessInfo.isStopped = true;
 				liveSyncProcessInfo.deviceDescriptors = [];
 
@@ -93,8 +97,6 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 						projectData
 					}
 				});
-
-				this.emit(LiveSyncEvents.liveSyncStopped, { projectDir });
 			}
 		}
 	}


### PR DESCRIPTION
In case one wants to stop livesync for all devices emit events for each device instead of one event for them all.

Ping @rosen-vladimirov 