### PR TITLE
Fix adding specific platform

### DIFF
--- a/lib/platforms-data.ts
+++ b/lib/platforms-data.ts
@@ -15,7 +15,13 @@ export class PlatformsData implements IPlatformsData {
 	}
 
 	public getPlatformData(platform: string, projectData: IProjectData): IPlatformData {
-		return this.platformsData[platform.toLowerCase()] && this.platformsData[platform.toLowerCase()].getPlatformData(projectData);
+		const platformKey = platform && _.first(platform.toLowerCase().split("@"));
+		let platformData: IPlatformData;
+		if (platformKey) {
+			platformData = this.platformsData[platformKey] && this.platformsData[platformKey].getPlatformData(projectData);
+		}
+
+		return platformData;
 	}
 
 	public get availablePlatforms(): any {


### PR DESCRIPTION
When trying to execute `tns platform add <platform>@<version>` we fail with message: `Cannot read property 'platformProjectService' of undefined`
The reason is incorrect check when getting platforms-data where we do not expect the version. Split the incoming string by `@` and use the real platform when trying to get the platforms data.