### PR TITLE
[npm 5] Fix copping of local dependencies to the tns_modules folder.

### DIFF
--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -44,9 +44,9 @@ export class TnsModulesCopy {
 
 			if (isScoped) {
 				// copy module into tns_modules/@scope/module instead of tns_modules/module
-				shelljs.cp("-Rf", dependency.directory, path.join(this.outputRoot, dependency.name.substring(0, dependency.name.indexOf("/"))));
+				shelljs.cp("-Rf", this.$fs.realpath(dependency.directory), path.join(this.outputRoot, dependency.name.substring(0, dependency.name.indexOf("/"))));
 			} else {
-				shelljs.cp("-Rf", dependency.directory, this.outputRoot);
+				shelljs.cp("-Rf", this.$fs.realpath(dependency.directory), this.outputRoot);
 			}
 
 			// remove platform-specific files (processed separately by plugin services)


### PR DESCRIPTION
Npm 5 create a symlink of the local dependencies.
In order to copy these dependencies in the tns_modules folder,
we need to get there real path, not the symlink path.