### PR TITLE
Error handling fixes.

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -104,7 +104,7 @@ export class NodePackageManager implements INodePackageManager {
 		try {
 			viewResult = await this.$childProcess.exec(`npm view ${packageName} ${flags}`);
 		} catch (e) {
-			this.$errors.failWithoutHelp(e);
+			this.$errors.failWithoutHelp(e.message);
 		}
 		return JSON.parse(viewResult);
 	}
@@ -221,7 +221,6 @@ export class NodePackageManager implements INodePackageManager {
 
 			if (childProcess.stderr) {
 				childProcess.stderr.on("data", (data: string) => {
-					console.error(data.toString());
 					capturedErr += data;
 				});
 			}

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -42,7 +42,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		} catch (error) {
 			this.$logger.debug(error);
 
-			throw new Error(error);
+			throw error;
 		}
 	}
 
@@ -91,11 +91,9 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		if (this.$fs.exists(possiblePackageName)) {
 			packageName = possiblePackageName;
 		}
-		if (packageName.indexOf(".tgz") >= 0) {
-			version = null;
-		}
+
 		// check if the packageName is url or local file and if it is, let npm install deal with the version
-		if (this.isURL(packageName) || this.$fs.exists(packageName)) {
+		if (this.isURL(packageName) || this.$fs.exists(packageName) || this.isTgz(packageName)) {
 			version = null;
 		} else {
 			version = version || await this.getLatestCompatibleVersion(packageName);
@@ -108,7 +106,11 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		return pathToInstalledPackage;
 	}
 
-	private isURL(str: string) {
+	private isTgz(packageName: string): boolean {
+		return packageName.indexOf(".tgz") >= 0;
+	}
+
+	private isURL(str: string): boolean {
 		let urlRegex = '^(?!mailto:)(?:(?:http|https|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$';
 		let url = new RegExp(urlRegex, 'i');
 		return str.length < 2083 && url.test(str);


### PR DESCRIPTION
* The parameter of `failWithoutHelp` should be a string, not an Error object.
* Remove console.error().
* Move check for tgz.

If the path to the tgz is wrong we will try to get a latest compatible version, which will exec `npm view dist-tag --json`. However, npm view over tgz file has different behavior with npm 3, 4, and 5.
npm 3 will return a parse error.
npm 4 return 500 internal server error.
npm 5 try to find package.json in the current working directory and return information about this package.
