### PR TITLE
Track exceptions in separate Analytics project

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -24,6 +24,7 @@ export class StaticConfig extends StaticConfigBase implements IStaticConfig {
 	public CLIENT_NAME = "tns";
 	public CLIENT_NAME_ALIAS = "NativeScript";
 	public ANALYTICS_API_KEY = "5752dabccfc54c4ab82aea9626b7338e";
+	public ANALYTICS_EXCEPTIONS_API_KEY = "35478fe7de68431399e96212540a3d5d";
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "TrackFeatureUsage";
 	public ERROR_REPORT_SETTING_NAME = "TrackExceptions";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "3.1.1",
+  "version": "3.1.2",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {


### PR DESCRIPTION
Track all exceptions from CLI in a separate analytics project.
Also track the result of `tns error-reporting enable/disable` in the same project where the exceptions are tracked.

Update common-lib where the following changes had been applied:
Allow tracking exceptions in a different Analytics project. In case the specified CLI wants to track exceptions to a separeate project, it can do it by setting the new property in staticConfig - `ANALYTICS_EXCEPTIONS_API_KEY`.
Allow tracking the result of `tns error-reporting enable/disable` to the same project where exceptions tracking is sent.
Speed up check if current Analytics request is sent - we check on 1000ms, while in fact it takes between 150 and 400ms. So make the check on 100ms.