### PR TITLE
Fix plugins prompts on postinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 NativeScript CLI Changelog
 ================
+
+3.1.2 (2017, July 06)
+==
+
+### Fixed
+* [Fixed #2950](https://github.com/NativeScript/nativescript-cli/issues/2950): Unable to provide user input on postinstall of plugin
+
 3.1.1 (2017, June 28)
 ==
 


### PR DESCRIPTION
In case some plugins (like `nativescript-plugin-firebase`) try to prompt the user on postinstall, users are unable to answer the question when `tns plugin add <name>` is used.
The reason is that the stdin of current process is not passed to the stdin of the `npm install` process and the user has no way to input the result.
Fix this by using "inherit" of current stdio when the console is interactive.

Fixes #2521 again.
Fixes https://github.com/NativeScript/nativescript-cli/issues/2950