### PR TITLE
Replace grunt-tslint with direct calling to tslint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,9 @@
-var now = new Date().toISOString();
+const childProcess = require("child_process");
+const now = new Date().toISOString();
 
 function shallowCopy(obj) {
 	var result = {};
-	Object.keys(obj).forEach(function(key) {
+	Object.keys(obj).forEach(function (key) {
 		result[key] = obj[key];
 	});
 	return result;
@@ -11,10 +12,10 @@ function shallowCopy(obj) {
 var travis = process.env["TRAVIS"];
 var buildNumber = process.env["PACKAGE_VERSION"] || process.env["BUILD_NUMBER"] || "non-ci";
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 	var path = require("path");
 	var commonLibNodeModules = path.join("lib", "common", "node_modules");
-	if(require("fs").existsSync(commonLibNodeModules)) {
+	if (require("fs").existsSync(commonLibNodeModules)) {
 		grunt.file.delete(commonLibNodeModules);
 	}
 	grunt.file.write(path.join("lib", "common", ".d.ts"), "");
@@ -48,17 +49,6 @@ module.exports = function(grunt) {
 					removeComments: true
 				}
 			},
-		},
-
-		tslint: {
-			build: {
-				files: {
-					src: ["lib/**/*.ts", "test/**/*.ts", "!lib/common/node_modules/**/*.ts", "!lib/common/messages/**/*.ts", "lib/common/test/unit-tests/**/*.ts", "definitions/**/*.ts", "!lib/**/*.d.ts" , "!test/**/*.d.ts"]
-				},
-				options: {
-					configuration: grunt.file.readJSON("./tslint.json")
-				}
-			}
 		},
 
 		watch: {
@@ -96,7 +86,7 @@ module.exports = function(grunt) {
 				command: "npm pack",
 				options: {
 					execOptions: {
-						env: (function() {
+						env: (function () {
 							var env = shallowCopy(process.env);
 							env["NATIVESCRIPT_SKIP_POSTINSTALL_TASKS"] = "1";
 							return env;
@@ -145,7 +135,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks("grunt-ts");
 	grunt.loadNpmTasks("grunt-tslint");
 
-	grunt.registerTask("set_package_version", function(version) {
+	grunt.registerTask("set_package_version", function (version) {
 		var buildVersion = version !== undefined ? version : buildNumber;
 		if (process.env["BUILD_CAUSE_GHPRBCAUSE"]) {
 			buildVersion = "PR" + buildVersion;
@@ -154,8 +144,8 @@ module.exports = function(grunt) {
 		var packageJson = grunt.file.readJSON("package.json");
 		var versionParts = packageJson.version.split("-");
 		if (process.env["RELEASE_BUILD"]) {
-// HACK - excluded until 1.0.0 release or we refactor our project infrastructure (whichever comes first)
-//			packageJson.version = versionParts[0];
+			// HACK - excluded until 1.0.0 release or we refactor our project infrastructure (whichever comes first)
+			//			packageJson.version = versionParts[0];
 		} else {
 			versionParts[1] = buildVersion;
 			packageJson.version = versionParts.join("-");
@@ -163,7 +153,11 @@ module.exports = function(grunt) {
 		grunt.file.write("package.json", JSON.stringify(packageJson, null, "  "));
 	});
 
-	grunt.registerTask("enableScripts", function(enable) {
+	grunt.registerTask("tslint:build", function (version) {
+		childProcess.execSync("npm run tslint", { stdio: "inherit" });
+	});
+
+	grunt.registerTask("enableScripts", function (enable) {
 		var enableTester = /false/i;
 		var newScriptsAttr = !enableTester.test(enable) ? "scripts" : "skippedScripts";
 		var packageJson = grunt.file.readJSON("package.json");

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preuninstall": "node preuninstall.js",
     "mocha": "node test-scripts/mocha.js",
     "tsc": "tsc",
+    "tslint": "tslint -p tsconfig.json --type-check",
     "test-watch": "node ./dev/tsc-to-mocha-watch.js"
   },
   "repository": {
@@ -97,7 +98,6 @@
     "grunt-contrib-watch": "1.0.0",
     "grunt-shell": "1.3.0",
     "grunt-ts": "6.0.0-beta.16",
-    "grunt-tslint": "5.0.1",
     "istanbul": "0.4.5",
     "mocha": "3.1.2",
     "should": "7.0.2",

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -245,30 +245,6 @@ export class ProjectDataStub implements IProjectData {
 	}
 }
 
-export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
-	public platformsNames: string[];
-
-	public getPlatformData(platform: string, projectData: IProjectData): IPlatformData {
-		return {
-			frameworkPackageName: "",
-			platformProjectService: new PlatformProjectServiceStub(),
-			emulatorServices: undefined,
-			projectRoot: "",
-			normalizedPlatformName: "",
-			appDestinationDirectoryPath: "",
-			deviceBuildOutputPath: "",
-			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
-			frameworkFilesExtensions: [],
-			relativeToFrameworkConfigurationFilePath: "",
-			fastLivesyncFileExtensions: []
-		};
-	}
-
-	public get availablePlatforms(): any {
-		return undefined;
-	}
-}
-
 export class PlatformProjectServiceStub extends EventEmitter implements IPlatformProjectService {
 	getPlatformData(projectData: IProjectData): IPlatformData {
 		return {
@@ -359,6 +335,30 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	}
 	checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): void {
 		// Nothing yet.
+	}
+}
+
+export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
+	public platformsNames: string[];
+
+	public getPlatformData(platform: string, projectData: IProjectData): IPlatformData {
+		return {
+			frameworkPackageName: "",
+			platformProjectService: new PlatformProjectServiceStub(),
+			emulatorServices: undefined,
+			projectRoot: "",
+			normalizedPlatformName: "",
+			appDestinationDirectoryPath: "",
+			deviceBuildOutputPath: "",
+			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
+			frameworkFilesExtensions: [],
+			relativeToFrameworkConfigurationFilePath: "",
+			fastLivesyncFileExtensions: []
+		};
+	}
+
+	public get availablePlatforms(): any {
+		return undefined;
 	}
 }
 


### PR DESCRIPTION
Some rules in our tslint.json require passing `--type-check` flag to `tslint` executable.
However grunt-tslint does not support it. So remove the `grunt-tslint` and spawn the `tslint` via npm script.
Add the new `tslint` script, so now the project can be linted by calling:
* grunt lint
* grunt tslint:build /for backwards compatibility/
* npm run tslint

Fix the errors that are received after passing `--type-check` flag.
Disable all linter errors for all automatically generated files (for messages).

PR in mobile-cli-lib: https://github.com/telerik/mobile-cli-lib/pull/984