### PR TITLE
Respect configuration when preparing project files

### DIFF
--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -1,9 +1,13 @@
+import * as helpers from "../common/helpers";
+
 function RunTestCommandFactory(platform: string) {
 	return function RunTestCommand(
+		$options: IOptions,
 		$testExecutionService: ITestExecutionService,
 		$projectData: IProjectData) {
 		$projectData.initializeProjectData();
-		this.execute = (args: string[]): Promise<void> => $testExecutionService.startTestRunner(platform, $projectData);
+		const projectFilesConfig = helpers.getProjectFilesConfig({ isReleaseBuild: this.$options.release });
+		this.execute = (args: string[]): Promise<void> => $testExecutionService.startTestRunner(platform, $projectData, projectFilesConfig);
 		this.allowedParameters = [];
 	};
 }
@@ -12,9 +16,10 @@ $injector.registerCommand("dev-test|android", RunTestCommandFactory('android'));
 $injector.registerCommand("dev-test|ios", RunTestCommandFactory('iOS'));
 
 function RunKarmaTestCommandFactory(platform: string) {
-	return function RunKarmaTestCommand($testExecutionService: ITestExecutionService, $projectData: IProjectData) {
+	return function RunKarmaTestCommand($options: IOptions, $testExecutionService: ITestExecutionService, $projectData: IProjectData) {
 		$projectData.initializeProjectData();
-		this.execute = (args: string[]): Promise<void> => $testExecutionService.startKarmaServer(platform, $projectData);
+		const projectFilesConfig = helpers.getProjectFilesConfig({ isReleaseBuild: this.$options.release });
+		this.execute = (args: string[]): Promise<void> => $testExecutionService.startKarmaServer(platform, $projectData, projectFilesConfig);
 		this.allowedParameters = [];
 	};
 }

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -287,8 +287,8 @@ interface IPlatformsData {
 }
 
 interface INodeModulesBuilder {
-	prepareNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData): Promise<void>;
-	prepareJSNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData): Promise<void>;
+	prepareNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void>;
+	prepareJSNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void>;
 	cleanNodeModules(absoluteOutputPath: string, platform: string): void;
 }
 

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -1,10 +1,10 @@
 interface IPluginsService {
 	add(plugin: string, projectData: IProjectData): Promise<void>; // adds plugin by name, github url, local path and et.
 	remove(pluginName: string, projectData: IProjectData): Promise<void>; // removes plugin only by name
-	prepare(pluginData: IDependencyData, platform: string, projectData: IProjectData): Promise<void>;
+	prepare(pluginData: IDependencyData, platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void>;
 	getAllInstalledPlugins(projectData: IProjectData): Promise<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(projectData: IProjectData): Promise<void>;
-	preparePluginScripts(pluginData: IPluginData, platform: string, projectData: IProjectData): void
+	preparePluginScripts(pluginData: IPluginData, platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): void
 
 	/**
 	 * Returns all dependencies and devDependencies from pacakge.json file.

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -279,8 +279,8 @@ interface IAndroidProjectPropertiesManager {
 }
 
 interface ITestExecutionService {
-	startTestRunner(platform: string, projectData: IProjectData): Promise<void>;
-	startKarmaServer(platform: string, projectData: IProjectData): Promise<void>;
+	startTestRunner(platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void>;
+	startKarmaServer(platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void>;
 }
 
 /**

--- a/lib/providers/project-files-provider.ts
+++ b/lib/providers/project-files-provider.ts
@@ -12,9 +12,9 @@ export class ProjectFilesProvider extends ProjectFilesProviderBase {
 
 	private static INTERNAL_NONPROJECT_FILES = [ "**/*.ts" ];
 
-	public mapFilePath(filePath: string, platform: string, projectData: IProjectData): string {
+	public mapFilePath(filePath: string, platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): string {
 		let platformData = this.$platformsData.getPlatformData(platform.toLowerCase(), projectData);
-		let parsedFilePath = this.getPreparedFilePath(filePath);
+		let parsedFilePath = this.getPreparedFilePath(filePath, projectFilesConfig);
 		let mappedFilePath = "";
 		if (parsedFilePath.indexOf(constants.NODE_MODULES_FOLDER_NAME) > -1) {
 			let relativePath = path.relative(path.join(projectData.projectDir, constants.NODE_MODULES_FOLDER_NAME), parsedFilePath);

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -107,14 +107,14 @@ export class PluginsService implements IPluginsService {
 		return await platformData.platformProjectService.validatePlugins(projectData);
 	}
 
-	public async prepare(dependencyData: IDependencyData, platform: string, projectData: IProjectData): Promise<void> {
+	public async prepare(dependencyData: IDependencyData, platform: string, projectData: IProjectData,  projectFilesConfig: IProjectFilesConfig): Promise<void> {
 		platform = platform.toLowerCase();
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 		let pluginData = this.convertToPluginData(dependencyData, projectData.projectDir);
 
 		let appFolderExists = this.$fs.exists(path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME));
 		if (appFolderExists) {
-			this.preparePluginScripts(pluginData, platform, projectData);
+			this.preparePluginScripts(pluginData, platform, projectData, projectFilesConfig);
 			await this.preparePluginNativeCode(pluginData, platform, projectData);
 
 			// Show message
@@ -122,7 +122,7 @@ export class PluginsService implements IPluginsService {
 		}
 	}
 
-	public preparePluginScripts(pluginData: IPluginData, platform: string, projectData: IProjectData): void {
+	public preparePluginScripts(pluginData: IPluginData, platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): void {
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 		let pluginScriptsDestinationPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME, "tns_modules");
 		let scriptsDestinationExists = this.$fs.exists(pluginScriptsDestinationPath);
@@ -136,7 +136,7 @@ export class PluginsService implements IPluginsService {
 		}
 
 		//prepare platform speciffic files, .map and .ts files
-		this.$projectFilesManager.processPlatformSpecificFiles(pluginScriptsDestinationPath, platform);
+		this.$projectFilesManager.processPlatformSpecificFiles(pluginScriptsDestinationPath, platform, projectFilesConfig);
 	}
 
 	public async preparePluginNativeCode(pluginData: IPluginData, platform: string, projectData: IProjectData): Promise<void> {

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -33,7 +33,7 @@ class TestExecutionService implements ITestExecutionService {
 
 	public platform: string;
 
-	public async startTestRunner(platform: string, projectData: IProjectData): Promise<void> {
+	public async startTestRunner(platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void> {
 		this.platform = platform;
 		this.$options.justlaunch = true;
 		await new Promise<void>((resolve, reject) => {
@@ -133,7 +133,7 @@ class TestExecutionService implements ITestExecutionService {
 		});
 	}
 
-	public async startKarmaServer(platform: string, projectData: IProjectData): Promise<void> {
+	public async startKarmaServer(platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void> {
 		platform = platform.toLowerCase();
 		this.platform = platform;
 

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -8,16 +8,16 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		private $nodeModulesDependenciesBuilder: INodeModulesDependenciesBuilder
 	) { }
 
-	public async prepareNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData): Promise<void> {
+	public async prepareNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void> {
 		const productionDependencies = this.initialPrepareNodeModules(absoluteOutputPath, platform, lastModifiedTime, projectData);
 		const npmPluginPrepare: NpmPluginPrepare = this.$injector.resolve(NpmPluginPrepare);
-		await npmPluginPrepare.preparePlugins(productionDependencies, platform, projectData);
+		await npmPluginPrepare.preparePlugins(productionDependencies, platform, projectData, projectFilesConfig);
 	}
 
-	public async prepareJSNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData): Promise<void> {
+	public async prepareJSNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void> {
 		const productionDependencies = this.initialPrepareNodeModules(absoluteOutputPath, platform, lastModifiedTime, projectData);
 		const npmPluginPrepare: NpmPluginPrepare = this.$injector.resolve(NpmPluginPrepare);
-		await npmPluginPrepare.prepareJSPlugins(productionDependencies, platform, projectData);
+		await npmPluginPrepare.prepareJSPlugins(productionDependencies, platform, projectData, projectFilesConfig);
 	}
 
 	public cleanNodeModules(absoluteOutputPath: string, platform: string): void {

--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -137,7 +137,7 @@ export class NpmPluginPrepare {
 		return result;
 	}
 
-	public async preparePlugins(dependencies: IDependencyData[], platform: string, projectData: IProjectData): Promise<void> {
+	public async preparePlugins(dependencies: IDependencyData[], platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void> {
 		if (_.isEmpty(dependencies) || this.allPrepared(dependencies, platform, projectData)) {
 			return;
 		}
@@ -155,10 +155,10 @@ export class NpmPluginPrepare {
 		await this.afterPrepare(dependencies, platform, projectData);
 	}
 
-	public async prepareJSPlugins(dependencies: IDependencyData[], platform: string, projectData: IProjectData): Promise<void> {
+	public async prepareJSPlugins(dependencies: IDependencyData[], platform: string, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void> {
 		if (_.isEmpty(dependencies) || this.allPrepared(dependencies, platform, projectData)) {
 			return;
-		}
+}
 
 		for (let dependencyKey in dependencies) {
 			const dependency = dependencies[dependencyKey];
@@ -169,7 +169,7 @@ export class NpmPluginPrepare {
 				let platformData = this.$platformsData.getPlatformData(platform, projectData);
 				let appFolderExists = this.$fs.exists(path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME));
 				if (appFolderExists) {
-					this.$pluginsService.preparePluginScripts(pluginData, platform, projectData);
+					this.$pluginsService.preparePluginScripts(pluginData, platform, projectData, projectFilesConfig);
 					// Show message
 					this.$logger.out(`Successfully prepared plugin ${pluginData.name} for ${platform}.`);
 				}

--- a/test/plugin-prepare.ts
+++ b/test/plugin-prepare.ts
@@ -28,7 +28,7 @@ class TestNpmPluginPrepare extends NpmPluginPrepare {
 describe("Plugin preparation", () => {
 	it("skips prepare if no plugins", async () => {
 		const pluginPrepare = new TestNpmPluginPrepare({});
-		await pluginPrepare.preparePlugins([], "android", null);
+		await pluginPrepare.preparePlugins([], "android", null, {});
 		assert.deepEqual({}, pluginPrepare.preparedDependencies);
 	});
 
@@ -42,7 +42,7 @@ describe("Plugin preparation", () => {
 				nativescript: null,
 			}
 		];
-		await pluginPrepare.preparePlugins(testDependencies, "android", null);
+		await pluginPrepare.preparePlugins(testDependencies, "android", null, {});
 		assert.deepEqual({}, pluginPrepare.preparedDependencies);
 	});
 
@@ -62,7 +62,7 @@ describe("Plugin preparation", () => {
 				nativescript: null,
 			}
 		];
-		await pluginPrepare.preparePlugins(testDependencies, "android", null);
+		await pluginPrepare.preparePlugins(testDependencies, "android", null, {});
 		const prepareData = { "tns-core-modules-widgets": true, "nativescript-calendar": true };
 		assert.deepEqual(prepareData, pluginPrepare.preparedDependencies);
 	});

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -516,7 +516,7 @@ describe("Plugins service", () => {
 				`\n@#[line:1,col:39].` +
 				`\n@#[line:1,col:39].`;
 			mockBeginCommand(testInjector, expectedErrorMessage);
-			await pluginsService.prepare(pluginJsonData, "android", projectData);
+			await pluginsService.prepare(pluginJsonData, "android", projectData, {});
 		});
 	});
 });

--- a/test/project-files-provider.ts
+++ b/test/project-files-provider.ts
@@ -57,37 +57,37 @@ describe("project-files-provider", () => {
 	describe("mapFilePath", () => {
 		it("returns file path from prepared project when path from app dir is passed", () => {
 			let projectData: IProjectData = testInjector.resolve("projectData");
-			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.js"), "android", projectData);
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.js"), "android", projectData, {});
 			assert.deepEqual(mappedFilePath, path.join(appDestinationDirectoryPath, "app", "test.js"));
 		});
 
 		it("returns file path from prepared project when path from app/App_Resources/platform dir is passed", () => {
 			let projectData: IProjectData = testInjector.resolve("projectData");
-			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "android", "test.js"), "android", projectData);
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "android", "test.js"), "android", projectData, {});
 			assert.deepEqual(mappedFilePath, path.join(appResourcesDestinationDirectoryPath, "test.js"));
 		});
 
 		it("returns null when path from app/App_Resources/android dir is passed and iOS platform is specified", () => {
 			let projectData: IProjectData = testInjector.resolve("projectData");
-			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "android", "test.js"), "iOS", projectData);
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "android", "test.js"), "iOS", projectData, {});
 			assert.deepEqual(mappedFilePath, null);
 		});
 
 		it("returns null when path from app/App_Resources/ dir (not platform specific) is passed", () => {
 			let projectData: IProjectData = testInjector.resolve("projectData");
-			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "test.js"), "android", projectData);
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "App_Resources", "test.js"), "android", projectData, {});
 			assert.deepEqual(mappedFilePath, null);
 		});
 
 		it("returns file path from prepared project when path from app dir is passed and it contains platform in its name", () => {
 			let projectData: IProjectData = testInjector.resolve("projectData");
-			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.android.js"), "android", projectData);
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.android.js"), "android", projectData, {});
 			assert.deepEqual(mappedFilePath, path.join(appDestinationDirectoryPath, "app", "test.js"));
 		});
 
 		it("returns file path from prepared project when path from app dir is passed and it contains configuration in its name", () => {
 			let projectData: IProjectData = testInjector.resolve("projectData");
-			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.debug.js"), "android", projectData);
+			let mappedFilePath = projectFilesProvider.mapFilePath(path.join(appSourceDir, "test.debug.js"), "android", projectData, {});
 			assert.deepEqual(mappedFilePath, path.join(appDestinationDirectoryPath, "app", "test.js"));
 		});
 	});


### PR DESCRIPTION
Implement processing configuration specific files on build, run and debug. There was some initial logic to process debug configuration by default, but when configuration is explicitly passed we did not respect it.  For example:
`tns build android --release`

Now if the passed argument is valid configuration we process specific files, taking the parameter into consideration.

https://github.com/NativeScript/nativescript-cli/issues/2934

common lib PR: https://github.com/telerik/mobile-cli-lib/pull/986