### PR TITLE
Fix remove of non-production dependencies.

### DIFF
--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -67,8 +67,16 @@ export class TnsModulesCopy {
 
 		const dependenciesFolder = path.join(targetPackageDir, constants.NODE_MODULES_FOLDER_NAME);
 		if (this.$fs.exists(dependenciesFolder)) {
-			const dependencies = this.$fs.readDirectory(dependenciesFolder);
-			dependencies.filter(dir => !!productionDependencies || !productionDependencies.hasOwnProperty(dir))
+			const dependencies = _.flatten(this.$fs.readDirectory(dependenciesFolder)
+				.map(dir => {
+					if (_.startsWith(dir, "@")) {
+						return this.$fs.readDirectory(path.join(dependenciesFolder, dir));
+					}
+
+					return dir;
+				}));
+
+			dependencies.filter(dir => !productionDependencies || !productionDependencies.hasOwnProperty(dir))
 				.forEach(dir => shelljs.rm("-rf", path.join(dependenciesFolder, dir)));
 		}
 	}


### PR DESCRIPTION
If the scope dependency is not at the root of `node_modules` it will be deleted. We need to traverse the scope dependency directory and append all subdirectory to its name. Then we will get the real name of the dependency like is written in the `package.json` and we can use `productionDependencies.hasOwnProperty(dir)`