### PR TITLE
Fix CFBundleURLTypes merging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "osenv": "0.1.3",
     "pbxproj-dom": "1.0.11",
     "plist": "1.1.0",
-    "plist-merge-patch": "0.0.9",
+    "plist-merge-patch": "0.1.0",
     "plistlib": "0.2.1",
     "progress-stream": "1.1.1",
     "properties-parser": "0.2.3",


### PR DESCRIPTION
Remove `updateCFBundleURLSchemes`  method since we fixed session.patch logic for merging  CFBundleURLTypes.

Fix [#2936](https://github.com/NativeScript/nativescript-cli/issues/2936)
* Note merge after new version of plist-merge-patch is released. Until this happened npm install will fail.