### PR TITLE
Fix unmet peer dependency break adding of platform.

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -147,7 +147,13 @@ export class NodePackageManager implements INodePackageManager {
 			const originalOutput: INpmInstallCLIResult | INpm5InstallCliResult = JSON.parse(npmDryRunInstallOutput);
 			const npm5Output = <INpm5InstallCliResult> originalOutput;
 			const npmOutput = <INpmInstallCLIResult> originalOutput;
-			const name = _.head(_.keys(npmOutput.dependencies));
+			let name: string;
+			_.forOwn(npmOutput.dependencies, (peerDependency: INpmPeerDependencyInfo, key: string) => {
+				if (!peerDependency.required && !peerDependency.peerMissing) {
+					name = key;
+					return false;
+				}
+			});
 
 			// Npm 5 return different object after performing `npm install --dry-run`.
 			// Considering that the dependency is already installed we should


### PR DESCRIPTION
If there are not satisfied peer dependencies the result of the `npm install --json --dry-run` will contain information about this peer dependency. 
We take the first property from the object and assuming that this is the newly installed dependency, but in this case, it is not.

Fix [#2965](https://github.com/NativeScript/nativescript-cli/issues/2965)