### PR TITLE
Remove emulator launch from ios-provision-service.

### DIFF
--- a/lib/services/ios-provision-service.ts
+++ b/lib/services/ios-provision-service.ts
@@ -77,7 +77,8 @@ export class IOSProvisionService {
 			devices = [this.$options.device];
 		} else {
 			await this.$devicesService.initialize({
-				platform: "ios"
+				platform: "ios",
+				skipEmulatorStart: true
 			});
 			devices = _(this.$devicesService.getDeviceInstances())
 				.filter(d => this.$mobileHelper.isiOSPlatform(d.deviceInfo.platform))


### PR DESCRIPTION
`tns prepare ios --provision` command which is supposed to list and filter provisions for the connected devices should not start ios simulator.

[#2889](https://github.com/NativeScript/nativescript-cli/issues/2889)