### PR TITLE
Fix LiveSync calls cosecutive times

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -120,9 +120,10 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 		liveSyncData: ILiveSyncInfo, projectData: IProjectData): Promise<void> {
 		// In case liveSync is called for a second time for the same projectDir.
 		const isAlreadyLiveSyncing = this.liveSyncProcessesInfo[projectData.projectDir] && !this.liveSyncProcessesInfo[projectData.projectDir].isStopped;
-		this.setLiveSyncProcessInfo(liveSyncData.projectDir, deviceDescriptors);
 
+		// Prevent cases where liveSync is called consecutive times with the same device, for example [ A, B, C ] and then [ A, B, D ] - we want to execute initialSync only for D.
 		const deviceDescriptorsForInitialSync = isAlreadyLiveSyncing ? _.differenceBy(deviceDescriptors, this.liveSyncProcessesInfo[projectData.projectDir].deviceDescriptors, deviceDescriptorPrimaryKey) : deviceDescriptors;
+		this.setLiveSyncProcessInfo(liveSyncData.projectDir, deviceDescriptors);
 
 		await this.initialSync(projectData, deviceDescriptorsForInitialSync, liveSyncData);
 
@@ -140,7 +141,6 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 		this.liveSyncProcessesInfo[projectDir].isStopped = false;
 
 		const currentDeviceDescriptors = this.liveSyncProcessesInfo[projectDir].deviceDescriptors || [];
-		// Prevent cases where liveSync is called consecutive times with the same device, for example [ A, B, C ] and then [ A, B, D ] - we want to execute initialSync only for D.
 		this.liveSyncProcessesInfo[projectDir].deviceDescriptors = _.uniqBy(currentDeviceDescriptors.concat(deviceDescriptors), deviceDescriptorPrimaryKey);
 	}
 


### PR DESCRIPTION
When CLI is used as a library, the LiveSync method can be called consecutive times for the same projects, but with different device identifiers. For example we may want to start LiveSync on devices with identifiers [ A, B, C ] and later we would like to add devices with identifiers [ D, E ].
In the second call, CLI should detect that LiveSync is already running and execute initial sync only for newly added devices. However the current check for unique device identifiers is not correct and it always returns empty array as we first add the new devices to the old ones and then compare the new array with the already modified old array of devices.
Check the difference before adding new device identifiers to the old ones.