### PR TITLE
Emit `liveSyncStarted` when the application is really livesynced

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -213,12 +213,6 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 		// Now fullSync
 		const deviceAction = async (device: Mobile.IDevice): Promise<void> => {
 			try {
-				this.emit(LiveSyncEvents.liveSyncStarted, {
-					projectDir: projectData.projectDir,
-					deviceIdentifier: device.deviceInfo.identifier,
-					applicationIdentifier: projectData.projectId
-				});
-
 				const platform = device.deviceInfo.platform;
 				const deviceBuildInfoDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
 
@@ -240,6 +234,12 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 				});
 				await this.$platformService.trackActionForPlatform({ action: "LiveSync", platform: device.deviceInfo.platform, isForDevice: !device.isEmulator, deviceOsVersion: device.deviceInfo.version });
 				await this.refreshApplication(projectData, liveSyncResultInfo);
+
+				this.emit(LiveSyncEvents.liveSyncStarted, {
+					projectDir: projectData.projectDir,
+					deviceIdentifier: device.deviceInfo.identifier,
+					applicationIdentifier: projectData.projectId
+				});
 			} catch (err) {
 				this.$logger.warn(`Unable to apply changes on device: ${device.deviceInfo.identifier}. Error is: ${err.message}.`);
 


### PR DESCRIPTION
`liveSyncStarted` event is currently raised before starting initial LiveSync operation. However this makes sense if the name was `liveSyncStarting`.
So move the event at the end of the initialSync logic - this way it will be raised for each device when the LiveSync is really started.