### PR TITLE
 Separate preparation of JS from native code

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -105,6 +105,7 @@ $injector.require("devicePathProvider", "./device-path-provider");
 $injector.requireCommand("platform|clean", "./commands/platform-clean");
 
 $injector.requirePublicClass("liveSyncService", "./services/livesync/livesync-service");
+$injector.requirePublicClass("liveSyncCommandHelper", "./services/livesync/livesync-command-helper");
 $injector.require("debugLiveSyncService", "./services/livesync/debug-livesync-service");
 $injector.require("androidLiveSyncService", "./services/livesync/android-livesync-service");
 $injector.require("iOSLiveSyncService", "./services/livesync/ios-livesync-service");

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -105,7 +105,7 @@ $injector.require("devicePathProvider", "./device-path-provider");
 $injector.requireCommand("platform|clean", "./commands/platform-clean");
 
 $injector.requirePublicClass("liveSyncService", "./services/livesync/livesync-service");
-$injector.requirePublicClass("liveSyncCommandHelper", "./services/livesync/livesync-command-helper");
+$injector.require("liveSyncCommandHelper", "./services/livesync/livesync-command-helper");
 $injector.require("debugLiveSyncService", "./services/livesync/debug-livesync-service");
 $injector.require("androidLiveSyncService", "./services/livesync/android-livesync-service");
 $injector.require("iOSLiveSyncService", "./services/livesync/ios-livesync-service");

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -2,22 +2,23 @@
 import { isInteractive } from "../common/helpers";
 import { DebugCommandErrors } from "../constants";
 
-export abstract class DebugPlatformCommand implements ICommand {
+export class DebugPlatformCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 	public platform: string;
 
-	constructor(private debugService: IPlatformDebugService,
-		private $devicesService: Mobile.IDevicesService,
-		private $debugDataService: IDebugDataService,
+	constructor(protected $devicesService: Mobile.IDevicesService,
 		protected $platformService: IPlatformService,
 		protected $projectData: IProjectData,
 		protected $options: IOptions,
 		protected $platformsData: IPlatformsData,
 		protected $logger: ILogger,
 		protected $errors: IErrors,
+		private debugService: IPlatformDebugService,
+		private $debugDataService: IDebugDataService,
 		private $debugLiveSyncService: IDebugLiveSyncService,
 		private $config: IConfiguration,
-		private $prompter: IPrompter) {
+		private $prompter: IPrompter,
+		private $liveSyncCommandHelper: ILiveSyncCommandHelper) {
 		this.$projectData.initializeProjectData();
 	}
 
@@ -36,40 +37,7 @@ export abstract class DebugPlatformCommand implements ICommand {
 
 		const selectedDeviceForDebug = await this.getDeviceForDebug();
 
-		const deviceDescriptors: ILiveSyncDeviceInfo[] = [selectedDeviceForDebug]
-			.map(d => {
-				const info: ILiveSyncDeviceInfo = {
-					identifier: d.deviceInfo.identifier,
-					buildAction: async (): Promise<string> => {
-						const buildConfig: IBuildConfig = {
-							buildForDevice: !d.isEmulator,
-							projectDir: this.$options.path,
-							clean: this.$options.clean,
-							teamId: this.$options.teamId,
-							device: this.$options.device,
-							provision: this.$options.provision,
-							release: this.$options.release,
-							keyStoreAlias: this.$options.keyStoreAlias,
-							keyStorePath: this.$options.keyStorePath,
-							keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
-							keyStorePassword: this.$options.keyStorePassword
-						};
-
-						await this.$platformService.buildPlatform(d.deviceInfo.platform, buildConfig, this.$projectData);
-						const pathToBuildResult = await this.$platformService.lastOutputPath(d.deviceInfo.platform, buildConfig, this.$projectData);
-						return pathToBuildResult;
-					}
-				};
-
-				return info;
-			});
-
-		const liveSyncInfo: ILiveSyncInfo = {
-			projectDir: this.$projectData.projectDir,
-			skipWatcher: !this.$options.watch || this.$options.justlaunch,
-			watchAllFiles: this.$options.syncAllFiles
-		};
-
+		const { deviceDescriptors, liveSyncInfo } = await this.$liveSyncCommandHelper.getDevicesLiveSyncInfo(args, [selectedDeviceForDebug]);
 		await this.$debugLiveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
 	}
 
@@ -149,23 +117,22 @@ export abstract class DebugPlatformCommand implements ICommand {
 	}
 }
 
-export class DebugIOSCommand extends DebugPlatformCommand {
+export class DebugIOSCommand implements ICommand {
+	private get debugPlatformCommand(): DebugPlatformCommand {
+		return this.$injector.resolve<DebugPlatformCommand>(DebugPlatformCommand);
+	}
+
+	public allowedParameters: ICommandParameter[] = [];
+
 	constructor(protected $errors: IErrors,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		$logger: ILogger,
-		$iOSDebugService: IPlatformDebugService,
-		$devicesService: Mobile.IDevicesService,
-		$config: IConfiguration,
-		$debugDataService: IDebugDataService,
-		$platformService: IPlatformService,
-		$options: IOptions,
-		$projectData: IProjectData,
-		$platformsData: IPlatformsData,
-		$iosDeviceOperations: IIOSDeviceOperations,
-		$debugLiveSyncService: IDebugLiveSyncService,
-		$prompter: IPrompter) {
-		super($iOSDebugService, $devicesService, $debugDataService, $platformService, $projectData, $options, $platformsData, $logger,
-			$errors, $debugLiveSyncService, $config, $prompter);
+		private $platformService: IPlatformService,
+		private $options: IOptions,
+		private $injector: IInjector,
+		private $projectData: IProjectData,
+		private $platformsData: IPlatformsData,
+		$iosDeviceOperations: IIOSDeviceOperations) {
+
 		// Do not dispose ios-device-lib, so the process will remain alive and the debug application (NativeScript Inspector or Chrome DevTools) will be able to connect to the socket.
 		// In case we dispose ios-device-lib, the socket will be closed and the code will fail when the debug application tries to read/send data to device socket.
 		// That's why the `$ tns debug ios --justlaunch` command will not release the terminal.
@@ -173,12 +140,16 @@ export class DebugIOSCommand extends DebugPlatformCommand {
 		$iosDeviceOperations.setShouldDispose(false);
 	}
 
+	public execute(args: string[]): Promise<void> {
+		return this.debugPlatformCommand.execute(args);
+	}
+
 	public async canExecute(args: string[]): Promise<boolean> {
 		if (!this.$platformService.isPlatformSupportedForOS(this.$devicePlatformsConstants.iOS, this.$projectData)) {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.iOS} can not be built on this OS`);
 		}
 
-		return await super.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.iOS);
+		return await this.debugPlatformCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.iOS);
 	}
 
 	public platform = this.$devicePlatformsConstants.iOS;
@@ -186,26 +157,26 @@ export class DebugIOSCommand extends DebugPlatformCommand {
 
 $injector.registerCommand("debug|ios", DebugIOSCommand);
 
-export class DebugAndroidCommand extends DebugPlatformCommand {
-	constructor(protected $errors: IErrors,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		$logger: ILogger,
-		$androidDebugService: IPlatformDebugService,
-		$devicesService: Mobile.IDevicesService,
-		$config: IConfiguration,
-		$debugDataService: IDebugDataService,
-		$platformService: IPlatformService,
-		$options: IOptions,
-		$projectData: IProjectData,
-		$platformsData: IPlatformsData,
-		$debugLiveSyncService: IDebugLiveSyncService,
-		$prompter: IPrompter) {
-		super($androidDebugService, $devicesService, $debugDataService, $platformService, $projectData, $options, $platformsData, $logger,
-			$errors, $debugLiveSyncService, $config, $prompter);
+export class DebugAndroidCommand implements ICommand {
+	private get debugPlatformCommand(): DebugPlatformCommand {
+		return this.$injector.resolve<DebugPlatformCommand>(DebugPlatformCommand);
 	}
 
+	public allowedParameters: ICommandParameter[] = [];
+
+	constructor(protected $errors: IErrors,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $platformService: IPlatformService,
+		private $options: IOptions,
+		private $injector: IInjector,
+		private $projectData: IProjectData,
+		private $platformsData: IPlatformsData) { }
+
+	public execute(args: string[]): Promise<void> {
+		return this.debugPlatformCommand.execute(args);
+	}
 	public async canExecute(args: string[]): Promise<boolean> {
-		return await super.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.Android);
+		return await this.debugPlatformCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.Android);
 	}
 
 	public platform = this.$devicePlatformsConstants.Android;

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -37,8 +37,7 @@ export class DebugPlatformCommand implements ICommand {
 
 		const selectedDeviceForDebug = await this.getDeviceForDebug();
 
-		const { deviceDescriptors, liveSyncInfo } = await this.$liveSyncCommandHelper.getDevicesLiveSyncInfo(args, [selectedDeviceForDebug]);
-		await this.$debugLiveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
+		await this.$liveSyncCommandHelper.getDevicesLiveSyncInfo([selectedDeviceForDebug], this.$debugLiveSyncService, this.platform);
 	}
 
 	public async getDeviceForDebug(): Promise<Mobile.IDevice> {

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -4,22 +4,21 @@ import { DebugCommandErrors } from "../constants";
 
 export class DebugPlatformCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
-	public platform: string;
 
-	constructor(protected $devicesService: Mobile.IDevicesService,
+	constructor(private debugService: IPlatformDebugService,
+		private platform: string,
+		protected $devicesService: Mobile.IDevicesService,
 		protected $platformService: IPlatformService,
 		protected $projectData: IProjectData,
 		protected $options: IOptions,
 		protected $platformsData: IPlatformsData,
 		protected $logger: ILogger,
 		protected $errors: IErrors,
-		private debugService: IPlatformDebugService,
 		private $debugDataService: IDebugDataService,
 		private $debugLiveSyncService: IDebugLiveSyncService,
 		private $config: IConfiguration,
 		private $prompter: IPrompter,
 		private $liveSyncCommandHelper: ILiveSyncCommandHelper) {
-		this.$projectData.initializeProjectData();
 	}
 
 	public async execute(args: string[]): Promise<void> {
@@ -119,7 +118,7 @@ export class DebugPlatformCommand implements ICommand {
 
 export class DebugIOSCommand implements ICommand {
 	private get debugPlatformCommand(): DebugPlatformCommand {
-		return this.$injector.resolve<DebugPlatformCommand>(DebugPlatformCommand);
+		return this.$injector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: this.$iOSDebugService, platform: this.platform });
 	}
 
 	public allowedParameters: ICommandParameter[] = [];
@@ -131,8 +130,9 @@ export class DebugIOSCommand implements ICommand {
 		private $injector: IInjector,
 		private $projectData: IProjectData,
 		private $platformsData: IPlatformsData,
+		private $iOSDebugService: IDebugService,
 		$iosDeviceOperations: IIOSDeviceOperations) {
-
+		this.$projectData.initializeProjectData();
 		// Do not dispose ios-device-lib, so the process will remain alive and the debug application (NativeScript Inspector or Chrome DevTools) will be able to connect to the socket.
 		// In case we dispose ios-device-lib, the socket will be closed and the code will fail when the debug application tries to read/send data to device socket.
 		// That's why the `$ tns debug ios --justlaunch` command will not release the terminal.
@@ -159,7 +159,7 @@ $injector.registerCommand("debug|ios", DebugIOSCommand);
 
 export class DebugAndroidCommand implements ICommand {
 	private get debugPlatformCommand(): DebugPlatformCommand {
-		return this.$injector.resolve<DebugPlatformCommand>(DebugPlatformCommand);
+		return this.$injector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: this.$androidDebugService, platform: this.platform });
 	}
 
 	public allowedParameters: ICommandParameter[] = [];
@@ -170,7 +170,10 @@ export class DebugAndroidCommand implements ICommand {
 		private $options: IOptions,
 		private $injector: IInjector,
 		private $projectData: IProjectData,
-		private $platformsData: IPlatformsData) { }
+		private $platformsData: IPlatformsData,
+		private $androidDebugService: IDebugService) {
+		this.$projectData.initializeProjectData();
+	}
 
 	public execute(args: string[]): Promise<void> {
 		return this.debugPlatformCommand.execute(args);

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -1,5 +1,6 @@
 ﻿import { CONNECTED_STATUS } from "../common/constants";
 import { isInteractive } from "../common/helpers";
+import { cache } from "../common/decorators";
 import { DebugCommandErrors } from "../constants";
 
 export class DebugPlatformCommand implements ICommand {
@@ -117,6 +118,8 @@ export class DebugPlatformCommand implements ICommand {
 }
 
 export class DebugIOSCommand implements ICommand {
+
+	@cache()
 	private get debugPlatformCommand(): DebugPlatformCommand {
 		return this.$injector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: this.$iOSDebugService, platform: this.platform });
 	}
@@ -158,6 +161,8 @@ export class DebugIOSCommand implements ICommand {
 $injector.registerCommand("debug|ios", DebugIOSCommand);
 
 export class DebugAndroidCommand implements ICommand {
+
+	@cache()
 	private get debugPlatformCommand(): DebugPlatformCommand {
 		return this.$injector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: this.$androidDebugService, platform: this.platform });
 	}

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -59,7 +59,6 @@ export class RunCommandBase implements ICommand {
 		let devices = this.$devicesService.getDeviceInstances();
 		devices = devices.filter(d => !this.platform || d.deviceInfo.platform.toLowerCase() === this.platform.toLowerCase());
 		const { deviceDescriptors, liveSyncInfo } = await this.$liveSyncCommandHelper.getDevicesLiveSyncInfo(args, devices);
-		liveSyncInfo.skipNativePrepare = true;
 		await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
 	}
 }

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -27,6 +27,8 @@ export class RunCommandBase implements ICommand {
 		}
 
 		this.$projectData.initializeProjectData();
+		this.platform = args[0] || this.platform;
+
 		if (!this.platform && !this.$hostInfo.isDarwin) {
 			this.platform = this.$devicePlatformsConstants.Android;
 		}
@@ -45,8 +47,6 @@ export class RunCommandBase implements ICommand {
 		if (this.$options.bundle) {
 			this.$options.watch = false;
 		}
-
-		this.platform = args[0] || this.platform;
 
 		await this.$devicesService.initialize({
 			deviceId: this.$options.device,

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -1,4 +1,5 @@
 import { ERROR_NO_VALID_SUBCOMMAND_FORMAT } from "../common/constants";
+import { cache } from "../common/decorators";
 
 export class RunCommandBase implements ICommand {
 	protected platform: string;
@@ -66,6 +67,8 @@ export class RunCommandBase implements ICommand {
 $injector.registerCommand("run|*all", RunCommandBase);
 
 export class RunIosCommand implements ICommand {
+
+	@cache()
 	private get runCommand(): RunCommandBase {
 		return this.$injector.resolve<RunCommandBase>(RunCommandBase);
 	}
@@ -100,6 +103,8 @@ export class RunIosCommand implements ICommand {
 $injector.registerCommand("run|ios", RunIosCommand);
 
 export class RunAndroidCommand implements ICommand {
+
+	@cache()
 	private get runCommand(): RunCommandBase {
 		return this.$injector.resolve<RunCommandBase>(RunCommandBase);
 	}

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -7,15 +7,13 @@ export class RunCommandBase implements ICommand {
 		protected $liveSyncService: ILiveSyncService,
 		protected $projectData: IProjectData,
 		protected $options: IOptions,
-		protected $emulatorPlatformService: IEmulatorPlatformService,
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		protected $errors: IErrors,
-		private $devicesService: Mobile.IDevicesService,
+		protected $devicesService: Mobile.IDevicesService,
+		protected $platformsData: IPlatformsData,
 		private $hostInfo: IHostInfo,
-		private $iosDeviceOperations: IIOSDeviceOperations,
-		private $mobileHelper: Mobile.IMobileHelper,
-		protected $platformsData: IPlatformsData) {
-	}
+		private $liveSyncCommandHelper: ILiveSyncCommandHelper
+	) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 	public async execute(args: string[]): Promise<void> {
@@ -47,6 +45,8 @@ export class RunCommandBase implements ICommand {
 			this.$options.watch = false;
 		}
 
+		this.platform = args[0] || this.platform;
+
 		await this.$devicesService.initialize({
 			deviceId: this.$options.device,
 			platform: this.platform,
@@ -56,93 +56,33 @@ export class RunCommandBase implements ICommand {
 		});
 
 		await this.$devicesService.detectCurrentlyAttachedDevices();
-
-		const devices = this.$devicesService.getDeviceInstances();
-		// Now let's take data for each device:
-		const deviceDescriptors: ILiveSyncDeviceInfo[] = devices.filter(d => !this.platform || d.deviceInfo.platform === this.platform)
-			.map(d => {
-				const info: ILiveSyncDeviceInfo = {
-					identifier: d.deviceInfo.identifier,
-					buildAction: async (): Promise<string> => {
-						const buildConfig: IBuildConfig = {
-							buildForDevice: !d.isEmulator,
-							projectDir: this.$options.path,
-							clean: this.$options.clean,
-							teamId: this.$options.teamId,
-							device: this.$options.device,
-							provision: this.$options.provision,
-							release: this.$options.release,
-							keyStoreAlias: this.$options.keyStoreAlias,
-							keyStorePath: this.$options.keyStorePath,
-							keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
-							keyStorePassword: this.$options.keyStorePassword
-						};
-
-						await this.$platformService.buildPlatform(d.deviceInfo.platform, buildConfig, this.$projectData);
-						const pathToBuildResult = await this.$platformService.lastOutputPath(d.deviceInfo.platform, buildConfig, this.$projectData);
-						return pathToBuildResult;
-					}
-				};
-
-				return info;
-			});
-
-		const workingWithiOSDevices = !this.platform || this.$mobileHelper.isiOSPlatform(this.platform);
-		const shouldKeepProcessAlive = this.$options.watch || !this.$options.justlaunch;
-		if (workingWithiOSDevices && shouldKeepProcessAlive) {
-			this.$iosDeviceOperations.setShouldDispose(false);
-		}
-
-		if (this.$options.release || this.$options.bundle) {
-			const runPlatformOptions: IRunPlatformOptions = {
-				device: this.$options.device,
-				emulator: this.$options.emulator,
-				justlaunch: this.$options.justlaunch
-			};
-
-			const deployOptions = _.merge<IDeployPlatformOptions>({
-				projectDir: this.$projectData.projectDir,
-				clean: true,
-			}, this.$options.argv);
-
-			await this.$platformService.deployPlatform(args[0], this.$options, deployOptions, this.$projectData, this.$options);
-			await this.$platformService.startApplication(args[0], runPlatformOptions, this.$projectData.projectId);
-			return this.$platformService.trackProjectType(this.$projectData);
-		}
-
-		const liveSyncInfo: ILiveSyncInfo = {
-			projectDir: this.$projectData.projectDir,
-			skipWatcher: !this.$options.watch,
-			watchAllFiles: this.$options.syncAllFiles,
-			clean: this.$options.clean
-		};
-
+		let devices = this.$devicesService.getDeviceInstances();
+		devices = devices.filter(d => !this.platform || d.deviceInfo.platform.toLowerCase() === this.platform.toLowerCase());
+		const { deviceDescriptors, liveSyncInfo } = await this.$liveSyncCommandHelper.getDevicesLiveSyncInfo(args, devices);
+		liveSyncInfo.skipNativePrepare = true;
 		await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
 	}
 }
 
 $injector.registerCommand("run|*all", RunCommandBase);
 
-export class RunIosCommand extends RunCommandBase implements ICommand {
+export class RunIosCommand implements ICommand {
+	private get runCommand(): RunCommandBase {
+		return this.$injector.resolve<RunCommandBase>(RunCommandBase);
+	}
+
 	public allowedParameters: ICommandParameter[] = [];
 	public get platform(): string {
 		return this.$devicePlatformsConstants.iOS;
 	}
 
-	constructor($platformService: IPlatformService,
-		protected $platformsData: IPlatformsData,
+	constructor(protected $platformsData: IPlatformsData,
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		protected $errors: IErrors,
-		$liveSyncService: ILiveSyncService,
-		$projectData: IProjectData,
-		$options: IOptions,
-		$emulatorPlatformService: IEmulatorPlatformService,
-		$devicesService: Mobile.IDevicesService,
-		$hostInfo: IHostInfo,
-		$iosDeviceOperations: IIOSDeviceOperations,
-		$mobileHelper: Mobile.IMobileHelper) {
-		super($platformService, $liveSyncService, $projectData, $options, $emulatorPlatformService, $devicePlatformsConstants, $errors,
-			$devicesService, $hostInfo, $iosDeviceOperations, $mobileHelper, $platformsData);
+		private $injector: IInjector,
+		private $platformService: IPlatformService,
+		private $projectData: IProjectData,
+		private $options: IOptions) {
 	}
 
 	public async execute(args: string[]): Promise<void> {
@@ -150,44 +90,41 @@ export class RunIosCommand extends RunCommandBase implements ICommand {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.iOS} can not be built on this OS`);
 		}
 
-		return this.executeCore([this.$platformsData.availablePlatforms.iOS]);
+		return this.runCommand.executeCore([this.$platformsData.availablePlatforms.iOS]);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
-		return await super.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.iOS);
+		return await this.runCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.iOS);
 	}
 }
 
 $injector.registerCommand("run|ios", RunIosCommand);
 
-export class RunAndroidCommand extends RunCommandBase implements ICommand {
+export class RunAndroidCommand implements ICommand {
+	private get runCommand(): RunCommandBase {
+		return this.$injector.resolve<RunCommandBase>(RunCommandBase);
+	}
+
 	public allowedParameters: ICommandParameter[] = [];
 	public get platform(): string {
 		return this.$devicePlatformsConstants.Android;
 	}
 
-	constructor($platformService: IPlatformService,
-		protected $platformsData: IPlatformsData,
+	constructor(protected $platformsData: IPlatformsData,
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		protected $errors: IErrors,
-		$liveSyncService: ILiveSyncService,
-		$projectData: IProjectData,
-		$options: IOptions,
-		$emulatorPlatformService: IEmulatorPlatformService,
-		$devicesService: Mobile.IDevicesService,
-		$hostInfo: IHostInfo,
-		$iosDeviceOperations: IIOSDeviceOperations,
-		$mobileHelper: Mobile.IMobileHelper) {
-		super($platformService, $liveSyncService, $projectData, $options, $emulatorPlatformService, $devicePlatformsConstants, $errors,
-			$devicesService, $hostInfo, $iosDeviceOperations, $mobileHelper, $platformsData);
+		private $injector: IInjector,
+		private $platformService: IPlatformService,
+		private $projectData: IProjectData,
+		private $options: IOptions) {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		return this.executeCore([this.$platformsData.availablePlatforms.Android]);
+		return this.runCommand.executeCore([this.$platformsData.availablePlatforms.Android]);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
-		await super.canExecute(args);
+		await this.runCommand.canExecute(args);
 		if (!this.$platformService.isPlatformSupportedForOS(this.$devicePlatformsConstants.Android, this.$projectData)) {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.Android} can not be built on this OS`);
 		}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -92,3 +92,9 @@ export class DebugCommandErrors {
 	public static UNABLE_TO_USE_FOR_DEVICE_AND_EMULATOR = "The options --for-device and --emulator cannot be used simultaneously. Please use only one of them.";
 	public static NO_DEVICES_EMULATORS_FOUND_FOR_OPTIONS = "Unable to find device or emulator for specified options.";
 }
+
+export const enum NativePlatformStatus {
+	requiresPlatformAdd = "1",
+	requiresPrepare = "2",
+	alreadyPrepared = "3"
+}

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -256,10 +256,5 @@ interface IDevicePathProvider {
 }
 
 interface ILiveSyncCommandHelper {
-	getDevicesLiveSyncInfo(args: string[], devices: Mobile.IDevice[]): Promise<IDevicesDescriptorsLiveSyncInfo>;
-}
-
-interface IDevicesDescriptorsLiveSyncInfo {
-	deviceDescriptors: ILiveSyncDeviceInfo[]
-	liveSyncInfo: ILiveSyncInfo
+	getDevicesLiveSyncInfo(devices: Mobile.IDevice[], liveSyncService: ILiveSyncService, platform: string): Promise<void>;
 }

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -120,6 +120,11 @@ interface ILiveSyncInfo {
 	 * Forces a build before the initial livesync.
 	 */
 	clean?: boolean;
+
+	/**
+	 * Whether to skip preparing the native platform.
+	 */
+	skipNativePrepare?: boolean;
 }
 
 interface ILatestAppPackageInstalledSettings extends IDictionary<IDictionary<boolean>> { /* empty */ }
@@ -248,4 +253,13 @@ interface IDeviceProjectRootOptions {
 interface IDevicePathProvider {
 	getDeviceProjectRootPath(device: Mobile.IDevice, options: IDeviceProjectRootOptions): Promise<string>;
 	getDeviceSyncZipPath(device: Mobile.IDevice): string;
+}
+
+interface ILiveSyncCommandHelper {
+	getDevicesLiveSyncInfo(args: string[], devices: Mobile.IDevice[]): Promise<IDevicesDescriptorsLiveSyncInfo>;
+}
+
+interface IDevicesDescriptorsLiveSyncInfo {
+	deviceDescriptors: ILiveSyncDeviceInfo[]
+	liveSyncInfo: ILiveSyncInfo
 }

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -47,7 +47,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {Array} filesToSync Files about to be synced to device.
 	 * @returns {boolean} true indicates that the platform was prepared.
 	 */
-	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>): Promise<boolean>;
+	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<boolean>;
 
 	/**
 	 * Determines whether a build is necessary. A build is necessary when one of the following is true:
@@ -288,6 +288,7 @@ interface IPlatformsData {
 
 interface INodeModulesBuilder {
 	prepareNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData): Promise<void>;
+	prepareJSNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData): Promise<void>;
 	cleanNodeModules(absoluteOutputPath: string, platform: string): void;
 }
 

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -4,6 +4,7 @@ interface IPluginsService {
 	prepare(pluginData: IDependencyData, platform: string, projectData: IProjectData): Promise<void>;
 	getAllInstalledPlugins(projectData: IProjectData): Promise<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(projectData: IProjectData): Promise<void>;
+	preparePluginScripts(pluginData: IPluginData, platform: string, projectData: IProjectData): void
 
 	/**
 	 * Returns all dependencies and devDependencies from pacakge.json file.

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -31,7 +31,7 @@ interface IProjectChangesService {
 	getPrepareInfo(platform: string, projectData: IProjectData): IPrepareInfo;
 	savePrepareInfo(platform: string, projectData: IProjectData): void;
 	getPrepareInfoFilePath(platform: string, projectData: IProjectData): string;
-	ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean;
+	setNativePlatformStatus(platform: string, projectData: IProjectData, nativePlatformStatus: IAddedNativePlatform): void;
 	currentChanges: IProjectChangesInfo;
 }
 

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -35,6 +35,9 @@ interface IProjectChangesService {
 	currentChanges: IProjectChangesInfo;
 }
 
+/**
+ * NativePlatformStatus.requiresPlatformAdd | NativePlatformStatus.requiresPrepare | NativePlatformStatus.alreadyPrepared
+ */
 interface IAddedNativePlatform {
 	nativePlatformStatus: "1" | "2" | "3";
 }

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -1,14 +1,14 @@
-interface IPrepareInfo {
+interface IPrepareInfo extends IAddedNativePlatform {
 	time: string;
 	bundle: boolean;
 	release: boolean;
+	projectFileHash: string;
 	changesRequireBuild: boolean;
 	changesRequireBuildTime: string;
-
 	iOSProvisioningProfileUUID?: string;
 }
 
-interface IProjectChangesInfo {
+interface IProjectChangesInfo extends IAddedNativePlatform {
 	appFilesChanged: boolean;
 	appResourcesChanged: boolean;
 	modulesChanged: boolean;
@@ -22,12 +22,19 @@ interface IProjectChangesInfo {
 	readonly changesRequirePrepare: boolean;
 }
 
-interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision {}
+interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision {
+	nativePlatformStatus?: "1" | "2" | "3";
+}
 
 interface IProjectChangesService {
 	checkForChanges(platform: string, projectData: IProjectData, buildOptions: IProjectChangesOptions): IProjectChangesInfo;
 	getPrepareInfo(platform: string, projectData: IProjectData): IPrepareInfo;
 	savePrepareInfo(platform: string, projectData: IProjectData): void;
 	getPrepareInfoFilePath(platform: string, projectData: IProjectData): string;
+	ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean;
 	currentChanges: IProjectChangesInfo;
+}
+
+interface IAddedNativePlatform {
+	nativePlatformStatus: "1" | "2" | "3";
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -132,6 +132,10 @@ interface IBuildForDevice {
 	buildForDevice: boolean;
 }
 
+interface INativePrepare {
+	skip: boolean;
+}
+
 interface IBuildConfig extends IAndroidBuildOptionsSettings, IiOSBuildConfig {
 	projectDir: string;
 	clean?: boolean;

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -133,7 +133,7 @@ interface IBuildForDevice {
 }
 
 interface INativePrepare {
-	skip: boolean;
+	skipNativePrepare: boolean;
 }
 
 interface IBuildConfig extends IAndroidBuildOptionsSettings, IiOSBuildConfig {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -221,7 +221,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		let manifestPath = this.getPlatformData(projectData).configurationFilePath;
 		shell.sed('-i', /__PACKAGE__/, projectData.projectId, manifestPath);
 		if (this.$androidToolsInfo.getToolsInfo().androidHomeEnvVar) {
-			const sdk = (platformSpecificData && platformSpecificData.sdk) || (this.$androidToolsInfo.getToolsInfo().compileSdkVersion).toString();
+			const sdk = (platformSpecificData && platformSpecificData.sdk) || (this.$androidToolsInfo.getToolsInfo().compileSdkVersion || "").toString();
 			shell.sed('-i', /__APILEVEL__/, sdk, manifestPath);
 		}
 	}

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -876,7 +876,6 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 
 			if (!this.$fs.exists(xcuserDataPath) && !this.$fs.exists(sharedDataPath)) {
 				this.$logger.info("Creating project scheme...");
-
 				await this.checkIfXcodeprojIsRequired();
 
 				let createSchemeRubyScript = `ruby -e "require 'xcodeproj'; xcproj = Xcodeproj::Project.open('${projectData.projectName}.xcodeproj'); xcproj.recreate_user_schemes; xcproj.save"`;
@@ -1123,13 +1122,11 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 			this.$fs.writeFile(projectFile, "");
 		}
 
-		if (this.$hostInfo.isDarwin) {
-			await this.checkIfXcodeprojIsRequired();
-			let escapedProjectFile = projectFile.replace(/'/g, "\\'"),
-				escapedPluginFile = pluginFile.replace(/'/g, "\\'"),
-				mergeScript = `require 'xcodeproj'; Xcodeproj::Config.new('${escapedProjectFile}').merge(Xcodeproj::Config.new('${escapedPluginFile}')).save_as(Pathname.new('${escapedProjectFile}'))`;
-			await this.$childProcess.exec(`ruby -e "${mergeScript}"`);
-		}
+		await this.checkIfXcodeprojIsRequired();
+		let escapedProjectFile = projectFile.replace(/'/g, "\\'"),
+			escapedPluginFile = pluginFile.replace(/'/g, "\\'"),
+			mergeScript = `require 'xcodeproj'; Xcodeproj::Config.new('${escapedProjectFile}').merge(Xcodeproj::Config.new('${escapedPluginFile}')).save_as(Pathname.new('${escapedProjectFile}'))`;
+		await this.$childProcess.exec(`ruby -e "${mergeScript}"`);
 	}
 
 	private async mergeProjectXcconfigFiles(release: boolean, projectData: IProjectData): Promise<void> {

--- a/lib/services/livesync/livesync-command-helper.ts
+++ b/lib/services/livesync/livesync-command-helper.ts
@@ -1,16 +1,28 @@
 export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
-	protected platform: string;
 
 	constructor(protected $platformService: IPlatformService,
 		protected $projectData: IProjectData,
 		protected $options: IOptions,
 		protected $devicesService: Mobile.IDevicesService,
 		private $iosDeviceOperations: IIOSDeviceOperations,
-		private $mobileHelper: Mobile.IMobileHelper) {
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $platformsData: IPlatformsData) {
 	}
 
-	public async getDevicesLiveSyncInfo(args: string[], devices: Mobile.IDevice[]): Promise<IDevicesDescriptorsLiveSyncInfo> {
+	public async getDevicesLiveSyncInfo(devices: Mobile.IDevice[], liveSyncService: ILiveSyncService, platform: string): Promise<void> {
 		await this.$devicesService.detectCurrentlyAttachedDevices();
+
+		const workingWithiOSDevices = !platform || this.$mobileHelper.isiOSPlatform(platform);
+		const shouldKeepProcessAlive = this.$options.watch || !this.$options.justlaunch;
+		if (workingWithiOSDevices && shouldKeepProcessAlive) {
+			this.$iosDeviceOperations.setShouldDispose(false);
+		}
+
+		if (this.$options.release || this.$options.bundle) {
+			await this.runInReleaseMode(platform);
+			return;
+		}
+
 		// Now let's take data for each device:
 		const deviceDescriptors: ILiveSyncDeviceInfo[] = devices
 			.map(d => {
@@ -40,30 +52,6 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 				return info;
 			});
 
-		const workingWithiOSDevices = !this.platform || this.$mobileHelper.isiOSPlatform(this.platform);
-		const shouldKeepProcessAlive = this.$options.watch || !this.$options.justlaunch;
-		if (workingWithiOSDevices && shouldKeepProcessAlive) {
-			this.$iosDeviceOperations.setShouldDispose(false);
-		}
-
-		// TODO: test it, might have isuues with `tns run` (no args)
-		if (this.$options.release || this.$options.bundle) {
-			const runPlatformOptions: IRunPlatformOptions = {
-				device: this.$options.device,
-				emulator: this.$options.emulator,
-				justlaunch: this.$options.justlaunch
-			};
-
-			const deployOptions = _.merge<IDeployPlatformOptions>({
-				projectDir: this.$projectData.projectDir,
-				clean: true,
-			}, this.$options.argv);
-
-			await this.$platformService.deployPlatform(args[0], this.$options, deployOptions, this.$projectData, this.$options);
-			await this.$platformService.startApplication(args[0], runPlatformOptions, this.$projectData.projectId);
-			this.$platformService.trackProjectType(this.$projectData);
-		}
-
 		const liveSyncInfo: ILiveSyncInfo = {
 			projectDir: this.$projectData.projectDir,
 			skipWatcher: !this.$options.watch,
@@ -71,10 +59,28 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			clean: this.$options.clean
 		};
 
-		return {
-			deviceDescriptors,
-			liveSyncInfo
+		await liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
+
+	}
+
+	private async runInReleaseMode(platform: string): Promise<void> {
+		const runPlatformOptions: IRunPlatformOptions = {
+			device: this.$options.device,
+			emulator: this.$options.emulator,
+			justlaunch: this.$options.justlaunch
 		};
+
+		const deployOptions = _.merge<IDeployPlatformOptions>({
+			projectDir: this.$projectData.projectDir,
+			clean: true,
+		}, this.$options.argv);
+
+		const availablePlatforms = platform ? [platform] : _.values<string>(this.$platformsData.availablePlatforms);
+		for (const currentPlatform of availablePlatforms) {
+			await this.$platformService.deployPlatform(currentPlatform, this.$options, deployOptions, this.$projectData, this.$options);
+			await this.$platformService.startApplication(currentPlatform, runPlatformOptions, this.$projectData.projectId);
+			this.$platformService.trackProjectType(this.$projectData);
+		}
 	}
 }
 

--- a/lib/services/livesync/livesync-command-helper.ts
+++ b/lib/services/livesync/livesync-command-helper.ts
@@ -1,0 +1,81 @@
+export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
+	protected platform: string;
+
+	constructor(protected $platformService: IPlatformService,
+		protected $projectData: IProjectData,
+		protected $options: IOptions,
+		protected $devicesService: Mobile.IDevicesService,
+		private $iosDeviceOperations: IIOSDeviceOperations,
+		private $mobileHelper: Mobile.IMobileHelper) {
+	}
+
+	public async getDevicesLiveSyncInfo(args: string[], devices: Mobile.IDevice[]): Promise<IDevicesDescriptorsLiveSyncInfo> {
+		await this.$devicesService.detectCurrentlyAttachedDevices();
+		// Now let's take data for each device:
+		const deviceDescriptors: ILiveSyncDeviceInfo[] = devices
+			.map(d => {
+				const info: ILiveSyncDeviceInfo = {
+					identifier: d.deviceInfo.identifier,
+					buildAction: async (): Promise<string> => {
+						const buildConfig: IBuildConfig = {
+							buildForDevice: !d.isEmulator,
+							projectDir: this.$options.path,
+							clean: this.$options.clean,
+							teamId: this.$options.teamId,
+							device: this.$options.device,
+							provision: this.$options.provision,
+							release: this.$options.release,
+							keyStoreAlias: this.$options.keyStoreAlias,
+							keyStorePath: this.$options.keyStorePath,
+							keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
+							keyStorePassword: this.$options.keyStorePassword
+						};
+
+						await this.$platformService.buildPlatform(d.deviceInfo.platform, buildConfig, this.$projectData);
+						const result = await this.$platformService.lastOutputPath(d.deviceInfo.platform, buildConfig, this.$projectData);
+						return result;
+					}
+				};
+
+				return info;
+			});
+
+		const workingWithiOSDevices = !this.platform || this.$mobileHelper.isiOSPlatform(this.platform);
+		const shouldKeepProcessAlive = this.$options.watch || !this.$options.justlaunch;
+		if (workingWithiOSDevices && shouldKeepProcessAlive) {
+			this.$iosDeviceOperations.setShouldDispose(false);
+		}
+
+		// TODO: test it, might have isuues with `tns run` (no args)
+		if (this.$options.release || this.$options.bundle) {
+			const runPlatformOptions: IRunPlatformOptions = {
+				device: this.$options.device,
+				emulator: this.$options.emulator,
+				justlaunch: this.$options.justlaunch
+			};
+
+			const deployOptions = _.merge<IDeployPlatformOptions>({
+				projectDir: this.$projectData.projectDir,
+				clean: true,
+			}, this.$options.argv);
+
+			await this.$platformService.deployPlatform(args[0], this.$options, deployOptions, this.$projectData, this.$options);
+			await this.$platformService.startApplication(args[0], runPlatformOptions, this.$projectData.projectId);
+			this.$platformService.trackProjectType(this.$projectData);
+		}
+
+		const liveSyncInfo: ILiveSyncInfo = {
+			projectDir: this.$projectData.projectDir,
+			skipWatcher: !this.$options.watch,
+			watchAllFiles: this.$options.syncAllFiles,
+			clean: this.$options.clean
+		};
+
+		return {
+			deviceDescriptors,
+			liveSyncInfo
+		};
+	}
+}
+
+$injector.register("liveSyncCommandHelper", LiveSyncCommandHelper);

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -237,7 +237,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 					deviceBuildInfoDescriptor,
 					liveSyncData,
 					settings
-				}, { skip: liveSyncData.skipNativePrepare });
+				}, { skipNativePrepare: liveSyncData.skipNativePrepare });
 
 				const liveSyncResultInfo = await this.getLiveSyncService(platform).fullSync({
 					projectData, device,
@@ -339,7 +339,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 										deviceBuildInfoDescriptor,
 										settings: latestAppPackageInstalledSettings,
 										modifiedFiles: allModifiedFiles
-									}, { skip: liveSyncData.skipNativePrepare });
+									}, { skipNativePrepare: liveSyncData.skipNativePrepare });
 
 									const service = this.getLiveSyncService(device.deviceInfo.platform);
 									const settings: ILiveSyncWatchInfo = {

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -154,7 +154,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 		throw new Error(`Invalid platform ${platform}. Supported platforms are: ${this.$mobileHelper.platformNames.join(", ")}`);
 	}
 
-	private async ensureLatestAppPackageIsInstalledOnDevice(options: IEnsureLatestAppPackageIsInstalledOnDeviceOptions): Promise<void> {
+	private async ensureLatestAppPackageIsInstalledOnDevice(options: IEnsureLatestAppPackageIsInstalledOnDeviceOptions, nativePrepare?: INativePrepare): Promise<void> {
 		const platform = options.device.deviceInfo.platform;
 		if (options.preparedPlatforms.indexOf(platform) === -1) {
 			options.preparedPlatforms.push(platform);
@@ -162,15 +162,11 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 			await this.$platformService.preparePlatform(platform, {
 				bundle: false,
 				release: false,
-			}, null, options.projectData, <any>{}, options.modifiedFiles);
+			}, null, options.projectData, <any>{}, options.modifiedFiles, nativePrepare);
 		}
 
-		const rebuildInfo = _.find(options.rebuiltInformation, info => info.isEmulator === options.device.isEmulator && info.platform === platform);
-
-		if (rebuildInfo) {
-			// Case where we have three devices attached, a change that requires build is found,
-			// we'll rebuild the app only for the first device, but we should install new package on all three devices.
-			await this.$platformService.installApplication(options.device, { release: false }, options.projectData, rebuildInfo.pathToBuildItem, options.deviceBuildInfoDescriptor.outputPath);
+		const buildResult = await this.installedCachedAppPackage(platform, options);
+		if (buildResult) {
 			return;
 		}
 
@@ -185,6 +181,15 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 			action = LiveSyncTrackActionNames.LIVESYNC_OPERATION_BUILD;
 		}
 
+		await this.trackAction(action, platform, options);
+
+		const shouldInstall = await this.$platformService.shouldInstall(options.device, options.projectData, options.deviceBuildInfoDescriptor.outputPath);
+		if (shouldInstall) {
+			await this.$platformService.installApplication(options.device, { release: false }, options.projectData, pathToBuildItem, options.deviceBuildInfoDescriptor.outputPath);
+		}
+	}
+
+	private async trackAction(action: string, platform: string, options: IEnsureLatestAppPackageIsInstalledOnDeviceOptions): Promise<void> {
 		if (!options.settings[platform][options.device.deviceInfo.type]) {
 			let isForDevice = !options.device.isEmulator;
 			options.settings[platform][options.device.deviceInfo.type] = true;
@@ -198,11 +203,19 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 		}
 
 		await this.$platformService.trackActionForPlatform({ action: LiveSyncTrackActionNames.DEVICE_INFO, platform, isForDevice: !options.device.isEmulator, deviceOsVersion: options.device.deviceInfo.version });
+	}
 
-		const shouldInstall = await this.$platformService.shouldInstall(options.device, options.projectData, options.deviceBuildInfoDescriptor.outputPath);
-		if (shouldInstall) {
-			await this.$platformService.installApplication(options.device, { release: false }, options.projectData, pathToBuildItem, options.deviceBuildInfoDescriptor.outputPath);
+	private async installedCachedAppPackage(platform: string, options: IEnsureLatestAppPackageIsInstalledOnDeviceOptions): Promise<any> {
+		const rebuildInfo = _.find(options.rebuiltInformation, info => info.isEmulator === options.device.isEmulator && info.platform === platform);
+
+		if (rebuildInfo) {
+			// Case where we have three devices attached, a change that requires build is found,
+			// we'll rebuild the app only for the first device, but we should install new package on all three devices.
+			await this.$platformService.installApplication(options.device, { release: false }, options.projectData, rebuildInfo.pathToBuildItem, options.deviceBuildInfoDescriptor.outputPath);
+			return rebuildInfo.pathToBuildItem;
 		}
+
+		return null;
 	}
 
 	private async initialSync(projectData: IProjectData, deviceDescriptors: ILiveSyncDeviceInfo[], liveSyncData: ILiveSyncInfo): Promise<void> {
@@ -224,7 +237,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 					deviceBuildInfoDescriptor,
 					liveSyncData,
 					settings
-				});
+				}, { skip: liveSyncData.skipNativePrepare });
 
 				const liveSyncResultInfo = await this.getLiveSyncService(platform).fullSync({
 					projectData, device,
@@ -326,7 +339,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 										deviceBuildInfoDescriptor,
 										settings: latestAppPackageInstalledSettings,
 										modifiedFiles: allModifiedFiles
-									});
+									}, { skip: liveSyncData.skipNativePrepare });
 
 									const service = this.getLiveSyncService(device.deviceInfo.platform);
 									const settings: ILiveSyncWatchInfo = {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -143,7 +143,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		const customTemplateOptions = await this.getPathToPlatformTemplate(platformTemplate, platformData.frameworkPackageName, projectData.projectDir);
 		config.pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
 
-		if (!nativePrepare || !nativePrepare.skip) {
+		if (!nativePrepare || !nativePrepare.skipNativePrepare) {
 			await this.addPlatformCoreNative(platformData, frameworkDir, installedVersion, projectData, config);
 		}
 
@@ -216,7 +216,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<boolean> {
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const changesInfo = await this.initialPrepare(platform, platformData, appFilesUpdaterOptions, platformTemplate, projectData, config, nativePrepare);
-		const requiresNativePrepare = (!nativePrepare || !nativePrepare.skip) && changesInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPrepare;
+		const requiresNativePrepare = (!nativePrepare || !nativePrepare.skipNativePrepare) && changesInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPrepare;
 
 		if (changesInfo.hasChanges || appFilesUpdaterOptions.bundle || requiresNativePrepare) {
 			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, config, changesInfo, filesToSync, nativePrepare);
@@ -282,7 +282,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, config, nativePrepare);
 
 		const bundle = appFilesUpdaterOptions.bundle;
-		const nativePlatformStatus = (nativePrepare && nativePrepare.skip) ? constants.NativePlatformStatus.requiresPlatformAdd : constants.NativePlatformStatus.requiresPrepare;
+		const nativePlatformStatus = (nativePrepare && nativePrepare.skipNativePrepare) ? constants.NativePlatformStatus.requiresPlatformAdd : constants.NativePlatformStatus.requiresPrepare;
 		const changesInfo = this.$projectChangesService.checkForChanges(platform, projectData, { bundle, release: appFilesUpdaterOptions.release, provision: config.provision, nativePlatformStatus });
 
 		this.$logger.trace("Changes info in prepare platform:", changesInfo);
@@ -297,7 +297,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 		await this.preparePlatformCoreJS(platform, platformData, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo);
 
-		if (!nativePrepare || !nativePrepare.skip) {
+		if (!nativePrepare || !nativePrepare.skipNativePrepare) {
 			await this.preparePlatformCoreNative(platform, platformData, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo);
 		}
 
@@ -740,7 +740,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		if (!this.isPlatformInstalled(platform, projectData)) {
 			await this.addPlatform(platform, platformTemplate, projectData, config, "", nativePrepare);
 		} else {
-			const shouldAddNativePlatform = !nativePrepare || !nativePrepare.skip;
+			const shouldAddNativePlatform = !nativePrepare || !nativePrepare.skipNativePrepare;
 			const prepareInfo = this.$projectChangesService.getPrepareInfo(platform, projectData);
 			// In case there's no prepare info, it means only platform add had been executed. So we've come from CLI and we do not need to prepare natively.
 			requiresNativePlatformAdd = prepareInfo && prepareInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPlatformAdd;

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -39,8 +39,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		private $npm: INodePackageManager,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $projectChangesService: IProjectChangesService,
-		private $analyticsService: IAnalyticsService,
-		private $nodeModulesDependenciesBuilder: INodeModulesDependenciesBuilder) {
+		private $analyticsService: IAnalyticsService) {
 		super();
 	}
 
@@ -59,10 +58,17 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	public async addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string): Promise<void> {
-		let platformsDir = projectData.platformsDir;
+		const platformsDir = projectData.platformsDir;
 		this.$fs.ensureDirectoryExists(platformsDir);
 
 		for (let platform of platforms) {
+			this.validatePlatform(platform, projectData);
+			const platformPath = path.join(projectData.platformsDir, platform);
+
+			if (this.$fs.exists(platformPath)) {
+				this.$errors.failWithoutHelp(`Platform ${platform} already added`);
+			}
+
 			await this.addPlatform(platform.toLowerCase(), platformTemplate, projectData, config, frameworkPath);
 		}
 	}
@@ -78,18 +84,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return version;
 	}
 
-	private async addPlatform(platformParam: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string): Promise<void> {
+	private async addPlatform(platformParam: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string, nativePrepare?: INativePrepare): Promise<void> {
 		let data = platformParam.split("@"),
 			platform = data[0].toLowerCase(),
 			version = data[1];
-
-		this.validatePlatform(platform, projectData);
-
-		let platformPath = path.join(projectData.platformsDir, platform);
-
-		if (this.$fs.exists(platformPath)) {
-			this.$errors.failWithoutHelp("Platform %s already added", platform);
-		}
 
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 
@@ -116,15 +114,17 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			npmOptions["version"] = version;
 		}
 
-		let spinner = new clui.Spinner("Installing " + packageToInstall);
-		let projectDir = projectData.projectDir;
+		const spinner = new clui.Spinner("Installing " + packageToInstall);
+		const projectDir = projectData.projectDir;
+		const platformPath = path.join(projectData.platformsDir, platform);
+
 		try {
 			spinner.start();
 			let downloadedPackagePath = await this.$npmInstallationManager.install(packageToInstall, projectDir, npmOptions);
 			let frameworkDir = path.join(downloadedPackagePath, constants.PROJECT_FRAMEWORK_FOLDER_NAME);
 			frameworkDir = path.resolve(frameworkDir);
 
-			let coreModuleName = await this.addPlatformCore(platformData, frameworkDir, platformTemplate, projectData, config);
+			const coreModuleName = await this.addPlatformCore(platformData, frameworkDir, platformTemplate, projectData, config, nativePrepare);
 			await this.$npm.uninstall(coreModuleName, { save: true }, projectData.projectDir);
 		} catch (err) {
 			this.$fs.deleteDirectory(platformPath);
@@ -137,17 +137,15 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	}
 
-	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<string> {
-		let coreModuleData = this.$fs.readJson(path.join(frameworkDir, "..", "package.json"));
-		let installedVersion = coreModuleData.version;
-		let coreModuleName = coreModuleData.name;
-
-		let customTemplateOptions = await this.getPathToPlatformTemplate(platformTemplate, platformData.frameworkPackageName, projectData.projectDir);
+	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, nativePrepare?: INativePrepare): Promise<string> {
+		const coreModuleData = this.$fs.readJson(path.join(frameworkDir, "..", "package.json"));
+		const installedVersion = coreModuleData.version;
+		const customTemplateOptions = await this.getPathToPlatformTemplate(platformTemplate, platformData.frameworkPackageName, projectData.projectDir);
 		config.pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
-		await platformData.platformProjectService.createProject(path.resolve(frameworkDir), installedVersion, projectData, config);
-		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
-		await platformData.platformProjectService.interpolateData(projectData, config);
-		platformData.platformProjectService.afterCreateProject(platformData.projectRoot, projectData);
+
+		if (!nativePrepare || !nativePrepare.skip) {
+			await this.addPlatformCoreNative(platformData, frameworkDir, installedVersion, projectData, config);
+		}
 
 		let frameworkPackageNameData: any = { version: installedVersion };
 		if (customTemplateOptions) {
@@ -156,8 +154,16 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		this.$projectDataService.setNSValue(projectData.projectDir, platformData.frameworkPackageName, frameworkPackageNameData);
 
+		const coreModuleName = coreModuleData.name;
 		return coreModuleName;
 
+	}
+
+	private async addPlatformCoreNative(platformData: IPlatformData, frameworkDir: string, installedVersion: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+		await platformData.platformProjectService.createProject(path.resolve(frameworkDir), installedVersion, projectData, config);
+		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
+		await platformData.platformProjectService.interpolateData(projectData, config);
+		platformData.platformProjectService.afterCreateProject(platformData.projectRoot, projectData);
 	}
 
 	private async getPathToPlatformTemplate(selectedTemplate: string, frameworkPackageName: string, projectDir: string): Promise<{ selectedTemplate: string, pathToTemplate: string }> {
@@ -207,35 +213,13 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	public getPreparedPlatforms(projectData: IProjectData): string[] {
 		return _.filter(this.$platformsData.platformsNames, p => { return this.isPlatformPrepared(p, projectData); });
 	}
+	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<boolean> {
+		const platformData = this.$platformsData.getPlatformData(platform, projectData);
+		const changesInfo = await this.initialPrepare(platform, platformData, appFilesUpdaterOptions, platformTemplate, projectData, config, nativePrepare);
+		const requiresNativePrepare = (!nativePrepare || !nativePrepare.skip) && changesInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPrepare;
 
-	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>): Promise<boolean> {
-		this.validatePlatform(platform, projectData);
-
-		await this.trackProjectType(projectData);
-
-		//We need dev-dependencies here, so before-prepare hooks will be executed correctly.
-		try {
-			await this.$pluginsService.ensureAllDependenciesAreInstalled(projectData);
-		} catch (err) {
-			this.$logger.trace(err);
-			this.$errors.failWithoutHelp(`Unable to install dependencies. Make sure your package.json is valid and all dependencies are correct. Error is: ${err.message}`);
-		}
-
-		let platformData = this.$platformsData.getPlatformData(platform, projectData);
-		await this.$pluginsService.validate(platformData, projectData);
-
-		const bundle = appFilesUpdaterOptions.bundle;
-
-		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, config);
-		let changesInfo = this.$projectChangesService.checkForChanges(platform, projectData, { bundle, release: appFilesUpdaterOptions.release, provision: config.provision });
-
-		this.$logger.trace("Changes info in prepare platform:", changesInfo);
-
-		if (changesInfo.hasChanges) {
-			await this.cleanProject(platform, appFilesUpdaterOptions, platformData, projectData);
-		}
-		if (changesInfo.hasChanges || bundle) {
-			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, config, changesInfo, filesToSync);
+		if (changesInfo.hasChanges || appFilesUpdaterOptions.bundle || requiresNativePrepare) {
+			await this.preparePlatformCore(platform, appFilesUpdaterOptions, projectData, config, changesInfo, filesToSync, nativePrepare);
 			this.$projectChangesService.savePrepareInfo(platform, projectData);
 		} else {
 			this.$logger.out("Skipping prepare.");
@@ -281,42 +265,40 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
+	private async initialPrepare(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, nativePrepare?: INativePrepare): Promise<IProjectChangesInfo> {
+		this.validatePlatform(platform, projectData);
+
+		await this.trackProjectType(projectData);
+
+		//We need dev-dependencies here, so before-prepare hooks will be executed correctly.
+		try {
+			await this.$pluginsService.ensureAllDependenciesAreInstalled(projectData);
+		} catch (err) {
+			this.$logger.trace(err);
+			this.$errors.failWithoutHelp(`Unable to install dependencies. Make sure your package.json is valid and all dependencies are correct. Error is: ${err.message}`);
+		}
+
+		await this.$pluginsService.validate(platformData, projectData);
+		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, config, nativePrepare);
+
+		const bundle = appFilesUpdaterOptions.bundle;
+		const nativePlatformStatus = (nativePrepare && nativePrepare.skip) ? constants.NativePlatformStatus.requiresPlatformAdd : constants.NativePlatformStatus.requiresPrepare;
+		const changesInfo = this.$projectChangesService.checkForChanges(platform, projectData, { bundle, release: appFilesUpdaterOptions.release, provision: config.provision, nativePlatformStatus });
+
+		this.$logger.trace("Changes info in prepare platform:", changesInfo);
+		return changesInfo;
+	}
+
 	/* Hooks are expected to use "filesToSync" parameter, as to give plugin authors additional information about the sync process.*/
 	@helpers.hook('prepare')
-	private async preparePlatformCore(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>): Promise<void> {
+	private async preparePlatformCore(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<void> {
 		this.$logger.out("Preparing project...");
 
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
+		await this.preparePlatformCoreJS(platform, platformData, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo);
 
-		if (!changesInfo || changesInfo.appFilesChanged) {
-			await this.copyAppFiles(platform, appFilesUpdaterOptions, projectData);
-
-			// remove the App_Resources folder from the app/assets as here we're applying other files changes.
-			const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-			const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
-			if (this.$fs.exists(appResourcesDirectoryPath)) {
-				this.$fs.deleteDirectory(appResourcesDirectoryPath);
-			}
-		}
-
-		if (!changesInfo || changesInfo.changesRequirePrepare) {
-			await this.copyAppFiles(platform, appFilesUpdaterOptions, projectData);
-			this.copyAppResources(platform, projectData);
-			await platformData.platformProjectService.prepareProject(projectData, platformSpecificData);
-		}
-
-		if (!changesInfo || changesInfo.modulesChanged) {
-			await this.copyTnsModules(platform, projectData);
-		} else if (appFilesUpdaterOptions.bundle) {
-			let dependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir);
-			for (let dependencyKey in dependencies) {
-				const dependency = dependencies[dependencyKey];
-				let isPlugin = !!dependency.nativescript;
-				if (isPlugin) {
-					let pluginData = this.$pluginsService.convertToPluginData(dependency, projectData.projectDir);
-					await this.$pluginsService.preparePluginNativeCode(pluginData, platform, projectData);
-				}
-			}
+		if (!nativePrepare || !nativePrepare.skip) {
+			await this.preparePlatformCoreNative(platform, platformData, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo);
 		}
 
 		let directoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
@@ -327,17 +309,56 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		this.$projectFilesManager.processPlatformSpecificFiles(directoryPath, platform, excludedDirs);
 
+		this.$logger.out(`Project successfully prepared (${platform})`);
+	}
+
+	private async preparePlatformCoreJS(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>, ): Promise<void> {
+		if (!changesInfo || changesInfo.appFilesChanged) {
+			await this.copyAppFiles(platformData, appFilesUpdaterOptions, projectData);
+
+			// remove the App_Resources folder from the app/assets as here we're applying other files changes.
+			const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+			const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
+			if (this.$fs.exists(appResourcesDirectoryPath)) {
+				this.$fs.deleteDirectory(appResourcesDirectoryPath);
+			}
+		}
+
+		if (!changesInfo || changesInfo.modulesChanged) {
+			await this.copyTnsModules(platform, platformData, projectData);
+		}
+	}
+
+	public async preparePlatformCoreNative(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo): Promise<void> {
+		if (changesInfo.hasChanges) {
+			await this.cleanProject(platform, appFilesUpdaterOptions, platformData, projectData);
+		}
+
+		if (!changesInfo || changesInfo.changesRequirePrepare) {
+			await this.copyAppFiles(platformData, appFilesUpdaterOptions, projectData);
+			this.copyAppResources(platformData, projectData);
+			await platformData.platformProjectService.prepareProject(projectData, platformSpecificData);
+		}
+
+		if (changesInfo && !changesInfo.modulesChanged && appFilesUpdaterOptions.bundle) {
+			let appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+			let lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath) ? this.$fs.getFsStats(appDestinationDirectoryPath).mtime : null;
+
+			let tnsModulesDestinationPath = path.join(appDestinationDirectoryPath, constants.TNS_MODULES_FOLDER_NAME);
+			// Process node_modules folder
+			await this.$nodeModulesBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime, projectData);
+		}
+
 		if (!changesInfo || changesInfo.configChanged || changesInfo.modulesChanged) {
 			await platformData.platformProjectService.processConfigurationFilesFromAppResources(appFilesUpdaterOptions.release, projectData);
 		}
 
 		platformData.platformProjectService.interpolateConfigurationFile(projectData, platformSpecificData);
-
-		this.$logger.out("Project successfully prepared (" + platform + ")");
+		this.$projectChangesService.ensurePrepareInfo(platform, projectData,
+			{ nativePlatformStatus: constants.NativePlatformStatus.alreadyPrepared, release: appFilesUpdaterOptions.release, bundle: appFilesUpdaterOptions.bundle, provision: platformSpecificData.provision });
 	}
 
-	private async copyAppFiles(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData): Promise<void> {
-		let platformData = this.$platformsData.getPlatformData(platform, projectData);
+	private async copyAppFiles(platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData): Promise<void> {
 		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
 		let appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 
@@ -351,8 +372,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		});
 	}
 
-	private copyAppResources(platform: string, projectData: IProjectData): void {
-		let platformData = this.$platformsData.getPlatformData(platform, projectData);
+	private copyAppResources(platformData: IPlatformData, projectData: IProjectData): void {
 		let appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 		let appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
 		if (this.$fs.exists(appResourcesDirectoryPath)) {
@@ -364,15 +384,14 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	private async copyTnsModules(platform: string, projectData: IProjectData): Promise<void> {
-		let platformData = this.$platformsData.getPlatformData(platform, projectData);
+	private async copyTnsModules(platform: string, platformData: IPlatformData, projectData: IProjectData): Promise<void> {
 		let appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 		let lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath) ? this.$fs.getFsStats(appDestinationDirectoryPath).mtime : null;
 
 		try {
 			let tnsModulesDestinationPath = path.join(appDestinationDirectoryPath, constants.TNS_MODULES_FOLDER_NAME);
 			// Process node_modules folder
-			await this.$nodeModulesBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime, projectData);
+			await this.$nodeModulesBuilder.prepareJSNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime, projectData);
 		} catch (error) {
 			this.$logger.debug(error);
 			shell.rm("-rf", appDestinationDirectoryPath);
@@ -715,9 +734,18 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	public async ensurePlatformInstalled(platform: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+	public async ensurePlatformInstalled(platform: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, nativePrepare?: INativePrepare): Promise<void> {
+		let requiresNativePlatformAdd = false;
+
 		if (!this.isPlatformInstalled(platform, projectData)) {
-			await this.addPlatform(platform, platformTemplate, projectData, config);
+			await this.addPlatform(platform, platformTemplate, projectData, config, "", nativePrepare);
+		} else {
+			const shouldAddNativePlatform = !nativePrepare || !nativePrepare.skip;
+			const prepareInfo = this.$projectChangesService.getPrepareInfo(platform, projectData);
+			requiresNativePlatformAdd = !prepareInfo || prepareInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPlatformAdd;
+			if (requiresNativePlatformAdd && shouldAddNativePlatform) {
+				await this.addPlatform(platform, platformTemplate, projectData, config, "", nativePrepare);
+			}
 		}
 	}
 

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -122,7 +122,7 @@ export class PluginsService implements IPluginsService {
 		}
 	}
 
-	private preparePluginScripts(pluginData: IPluginData, platform: string, projectData: IProjectData): void {
+	public preparePluginScripts(pluginData: IPluginData, platform: string, projectData: IProjectData): void {
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 		let pluginScriptsDestinationPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME, "tns_modules");
 		let scriptsDestinationExists = this.$fs.exists(pluginScriptsDestinationPath);

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
-import { NODE_MODULES_FOLDER_NAME } from "../constants";
+import { NODE_MODULES_FOLDER_NAME, NativePlatformStatus, PACKAGE_JSON_FILE_NAME } from "../constants";
+import { getHash } from "../common/helpers";
 
 const prepareInfoFileName = ".nsprepareinfo";
 
@@ -12,6 +13,7 @@ class ProjectChangesInfo implements IProjectChangesInfo {
 	public packageChanged: boolean;
 	public nativeChanged: boolean;
 	public signingChanged: boolean;
+	public nativePlatformStatus: NativePlatformStatus;
 
 	public get hasChanges(): boolean {
 		return this.packageChanged ||
@@ -58,7 +60,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		if (!this.ensurePrepareInfo(platform, projectData, projectChangesOptions)) {
 			this._newFiles = 0;
 			this._changesInfo.appFilesChanged = this.containsNewerFiles(projectData.appDirectoryPath, projectData.appResourcesDirectoryPath, projectData);
-			this._changesInfo.packageChanged = this.filesChanged([path.join(projectData.projectDir, "package.json")]);
+			this._changesInfo.packageChanged = this.isProjectFileChanged(projectData, platform);
 			this._changesInfo.appResourcesChanged = this.containsNewerFiles(projectData.appResourcesDirectoryPath, null, projectData);
 			/*done because currently all node_modules are traversed, a possible improvement could be traversing only the production dependencies*/
 			this._changesInfo.nativeChanged = this.containsNewerFiles(
@@ -72,8 +74,8 @@ export class ProjectChangesService implements IProjectChangesService {
 			let platformResourcesDir = path.join(projectData.appResourcesDirectoryPath, platformData.normalizedPlatformName);
 			if (platform === this.$devicePlatformsConstants.iOS.toLowerCase()) {
 				this._changesInfo.configChanged = this.filesChanged([path.join(platformResourcesDir, platformData.configurationFileName),
-					path.join(platformResourcesDir, "LaunchScreen.storyboard"),
-					path.join(platformResourcesDir, "build.xcconfig")
+				path.join(platformResourcesDir, "LaunchScreen.storyboard"),
+				path.join(platformResourcesDir, "build.xcconfig")
 				]);
 			} else {
 				this._changesInfo.configChanged = this.filesChanged([
@@ -107,6 +109,9 @@ export class ProjectChangesService implements IProjectChangesService {
 				this._prepareInfo.changesRequireBuildTime = this._prepareInfo.time;
 			}
 		}
+
+		this._changesInfo.nativePlatformStatus = this._prepareInfo.nativePlatformStatus;
+
 		return this._changesInfo;
 	}
 
@@ -134,29 +139,62 @@ export class ProjectChangesService implements IProjectChangesService {
 		this.$fs.writeJson(prepareInfoFilePath, this._prepareInfo);
 	}
 
-	private ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean {
+	public ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean {
 		this._prepareInfo = this.getPrepareInfo(platform, projectData);
 		if (this._prepareInfo) {
+			this._prepareInfo.nativePlatformStatus = this._prepareInfo.nativePlatformStatus && this._prepareInfo.nativePlatformStatus < projectChangesOptions.nativePlatformStatus ?
+				projectChangesOptions.nativePlatformStatus :
+				this._prepareInfo.nativePlatformStatus || projectChangesOptions.nativePlatformStatus;
+
 			let platformData = this.$platformsData.getPlatformData(platform, projectData);
 			let prepareInfoFile = path.join(platformData.projectRoot, prepareInfoFileName);
 			this._outputProjectMtime = this.$fs.getFsStats(prepareInfoFile).mtime.getTime();
 			this._outputProjectCTime = this.$fs.getFsStats(prepareInfoFile).ctime.getTime();
+			this.savePrepareInfo(platform, projectData);
 			return false;
 		}
+
 		this._prepareInfo = {
 			time: "",
+			nativePlatformStatus: projectChangesOptions.nativePlatformStatus,
 			bundle: projectChangesOptions.bundle,
 			release: projectChangesOptions.release,
 			changesRequireBuild: true,
+			projectFileHash: this.getProjectFileStrippedHash(projectData, platform),
 			changesRequireBuildTime: null
 		};
+
 		this._outputProjectMtime = 0;
 		this._outputProjectCTime = 0;
+		this._changesInfo = this._changesInfo || new ProjectChangesInfo();
 		this._changesInfo.appFilesChanged = true;
 		this._changesInfo.appResourcesChanged = true;
 		this._changesInfo.modulesChanged = true;
 		this._changesInfo.configChanged = true;
+
+		this.savePrepareInfo(platform, projectData);
 		return true;
+	}
+
+	private getProjectFileStrippedHash(projectData: IProjectData, platform: string): string {
+		platform = platform.toLowerCase();
+		const projectFilePath = path.join(projectData.projectDir, PACKAGE_JSON_FILE_NAME);
+		const projectFileContents = this.$fs.readJson(projectFilePath);
+		_(this.$devicePlatformsConstants)
+			.keys()
+			.map(k => k.toLowerCase())
+			.difference([platform])
+			.each(otherPlatform => {
+				delete projectFileContents.nativescript[`tns-${otherPlatform}`];
+			});
+
+		return getHash(JSON.stringify(projectFileContents));
+	}
+
+	private isProjectFileChanged(projectData: IProjectData, platform: string): boolean {
+		const projectFileStrippedContentsHash = this.getProjectFileStrippedHash(projectData, platform);
+		const prepareInfo = this.getPrepareInfo(platform, projectData);
+		return projectFileStrippedContentsHash !== prepareInfo.projectFileHash;
 	}
 
 	private filesChanged(files: string[]): boolean {
@@ -168,6 +206,7 @@ export class ProjectChangesService implements IProjectChangesService {
 				}
 			}
 		}
+
 		return false;
 	}
 

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -147,7 +147,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		}
 	}
 
-	public ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean {
+	private ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean {
 		this._prepareInfo = this.getPrepareInfo(platform, projectData);
 		if (this._prepareInfo) {
 			this._prepareInfo.nativePlatformStatus = this._prepareInfo.nativePlatformStatus && this._prepareInfo.nativePlatformStatus < projectChangesOptions.nativePlatformStatus ?

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -139,6 +139,14 @@ export class ProjectChangesService implements IProjectChangesService {
 		this.$fs.writeJson(prepareInfoFilePath, this._prepareInfo);
 	}
 
+	public setNativePlatformStatus(platform: string, projectData: IProjectData, addedPlatform: IAddedNativePlatform): void {
+		this._prepareInfo = this._prepareInfo || this.getPrepareInfo(platform, projectData);
+		if (this._prepareInfo) {
+			this._prepareInfo.nativePlatformStatus = addedPlatform.nativePlatformStatus;
+			this.savePrepareInfo(platform, projectData);
+		}
+	}
+
 	public ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean {
 		this._prepareInfo = this.getPrepareInfo(platform, projectData);
 		if (this._prepareInfo) {
@@ -150,7 +158,6 @@ export class ProjectChangesService implements IProjectChangesService {
 			let prepareInfoFile = path.join(platformData.projectRoot, prepareInfoFileName);
 			this._outputProjectMtime = this.$fs.getFsStats(prepareInfoFile).mtime.getTime();
 			this._outputProjectCTime = this.$fs.getFsStats(prepareInfoFile).ctime.getTime();
-			this.savePrepareInfo(platform, projectData);
 			return false;
 		}
 
@@ -171,8 +178,6 @@ export class ProjectChangesService implements IProjectChangesService {
 		this._changesInfo.appResourcesChanged = true;
 		this._changesInfo.modulesChanged = true;
 		this._changesInfo.configChanged = true;
-
-		this.savePrepareInfo(platform, projectData);
 		return true;
 	}
 

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -1,6 +1,6 @@
 import * as stubs from "./stubs";
 import * as yok from "../lib/common/yok";
-import { DebugAndroidCommand } from "../lib/commands/debug";
+import { DebugAndroidCommand, DebugPlatformCommand } from "../lib/commands/debug";
 import { assert } from "chai";
 import { Configuration, StaticConfig } from "../lib/config";
 import { Options } from "../lib/options";
@@ -78,7 +78,7 @@ describe("debug command tests", () => {
 			const testInjector = createTestInjector();
 			const options = testInjector.resolve<IOptions>("options");
 			options.forDevice = options.emulator = true;
-			const debugCommand = <DebugAndroidCommand>testInjector.resolveCommand("debug|android");
+			const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
 			await assert.isRejected(debugCommand.getDeviceForDebug(), DebugCommandErrors.UNABLE_TO_USE_FOR_DEVICE_AND_EMULATOR);
 		});
 
@@ -95,7 +95,7 @@ describe("debug command tests", () => {
 
 			const options = testInjector.resolve<IOptions>("options");
 			options.device = specifiedDeviceOption;
-			const debugCommand = <DebugAndroidCommand>testInjector.resolveCommand("debug|android");
+			const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
 			const selectedDeviceInstance = await debugCommand.getDeviceForDebug();
 			assert.deepEqual(selectedDeviceInstance, deviceInstance);
 		});
@@ -111,7 +111,7 @@ describe("debug command tests", () => {
 			const devicesService = testInjector.resolve<Mobile.IDevicesService>("devicesService");
 			devicesService.getDeviceInstances = (): Mobile.IDevice[] => getDeviceInstancesResult;
 
-			const debugCommand = <DebugAndroidCommand>testInjector.resolveCommand("debug|android");
+			const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
 			await assert.isRejected(debugCommand.getDeviceForDebug(), DebugCommandErrors.NO_DEVICES_EMULATORS_FOUND_FOR_OPTIONS);
 		};
 
@@ -184,7 +184,7 @@ describe("debug command tests", () => {
 			const devicesService = testInjector.resolve<Mobile.IDevicesService>("devicesService");
 			devicesService.getDeviceInstances = (): Mobile.IDevice[] => [deviceInstance];
 
-			const debugCommand = <DebugAndroidCommand>testInjector.resolveCommand("debug|android");
+			const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
 			const actualDeviceInstance = await debugCommand.getDeviceForDebug();
 			assert.deepEqual(actualDeviceInstance, deviceInstance);
 		});
@@ -243,7 +243,7 @@ describe("debug command tests", () => {
 						return choices[1];
 					};
 
-					const debugCommand = <DebugAndroidCommand>testInjector.resolveCommand("debug|android");
+					const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
 					const actualDeviceInstance = await debugCommand.getDeviceForDebug();
 					const expectedChoicesPassedToPrompter = [deviceInstance1, deviceInstance2].map(d => `${d.deviceInfo.identifier} - ${d.deviceInfo.displayName}`);
 					assert.deepEqual(choicesPassedToPrompter, expectedChoicesPassedToPrompter);
@@ -304,7 +304,7 @@ describe("debug command tests", () => {
 
 					devicesService.getDeviceInstances = (): Mobile.IDevice[] => deviceInstances;
 
-					const debugCommand = <DebugAndroidCommand>testInjector.resolveCommand("debug|android");
+					const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
 					const actualDeviceInstance = await debugCommand.getDeviceForDebug();
 
 					assert.deepEqual(actualDeviceInstance, deviceInstance2);

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -69,8 +69,8 @@ function createTestInjector(): IInjector {
 	testInjector.register("prompter", {});
 	testInjector.registerCommand("debug|android", DebugAndroidCommand);
 	testInjector.register("liveSyncCommandHelper", {
-		getDevicesLiveSyncInfo: async (): Promise<IDevicesDescriptorsLiveSyncInfo> => {
-			return { deviceDescriptors: [], liveSyncInfo: null };
+		getDevicesLiveSyncInfo: async (): Promise<void> => {
+			return null;
 		}
 	});
 

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -68,6 +68,11 @@ function createTestInjector(): IInjector {
 
 	testInjector.register("prompter", {});
 	testInjector.registerCommand("debug|android", DebugAndroidCommand);
+	testInjector.register("liveSyncCommandHelper", {
+		getDevicesLiveSyncInfo: async (): Promise<IDevicesDescriptorsLiveSyncInfo> => {
+			return { deviceDescriptors: [], liveSyncInfo: null };
+		}
+	});
 
 	return testInjector;
 }
@@ -78,7 +83,7 @@ describe("debug command tests", () => {
 			const testInjector = createTestInjector();
 			const options = testInjector.resolve<IOptions>("options");
 			options.forDevice = options.emulator = true;
-			const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
+			const debugCommand = testInjector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: {}, platform: "android" });
 			await assert.isRejected(debugCommand.getDeviceForDebug(), DebugCommandErrors.UNABLE_TO_USE_FOR_DEVICE_AND_EMULATOR);
 		});
 
@@ -95,7 +100,7 @@ describe("debug command tests", () => {
 
 			const options = testInjector.resolve<IOptions>("options");
 			options.device = specifiedDeviceOption;
-			const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
+			const debugCommand = testInjector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: {}, platform: "android" });
 			const selectedDeviceInstance = await debugCommand.getDeviceForDebug();
 			assert.deepEqual(selectedDeviceInstance, deviceInstance);
 		});
@@ -111,7 +116,7 @@ describe("debug command tests", () => {
 			const devicesService = testInjector.resolve<Mobile.IDevicesService>("devicesService");
 			devicesService.getDeviceInstances = (): Mobile.IDevice[] => getDeviceInstancesResult;
 
-			const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
+			const debugCommand = testInjector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: {}, platform: "android" });
 			await assert.isRejected(debugCommand.getDeviceForDebug(), DebugCommandErrors.NO_DEVICES_EMULATORS_FOUND_FOR_OPTIONS);
 		};
 
@@ -184,7 +189,7 @@ describe("debug command tests", () => {
 			const devicesService = testInjector.resolve<Mobile.IDevicesService>("devicesService");
 			devicesService.getDeviceInstances = (): Mobile.IDevice[] => [deviceInstance];
 
-			const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
+			const debugCommand = testInjector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: {}, platform: "android" });
 			const actualDeviceInstance = await debugCommand.getDeviceForDebug();
 			assert.deepEqual(actualDeviceInstance, deviceInstance);
 		});
@@ -243,7 +248,7 @@ describe("debug command tests", () => {
 						return choices[1];
 					};
 
-					const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
+					const debugCommand = testInjector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: {}, platform: "android" });
 					const actualDeviceInstance = await debugCommand.getDeviceForDebug();
 					const expectedChoicesPassedToPrompter = [deviceInstance1, deviceInstance2].map(d => `${d.deviceInfo.identifier} - ${d.deviceInfo.displayName}`);
 					assert.deepEqual(choicesPassedToPrompter, expectedChoicesPassedToPrompter);
@@ -304,7 +309,7 @@ describe("debug command tests", () => {
 
 					devicesService.getDeviceInstances = (): Mobile.IDevice[] => deviceInstances;
 
-					const debugCommand = <DebugPlatformCommand>testInjector.resolve(DebugPlatformCommand);
+					const debugCommand = testInjector.resolve<DebugPlatformCommand>(DebugPlatformCommand, { debugService: {}, platform: "android" });
 					const actualDeviceInstance = await debugCommand.getDeviceForDebug();
 
 					assert.deepEqual(actualDeviceInstance, deviceInstance2);

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -49,6 +49,9 @@ function createTestInjector() {
 	testInjector.register("nodeModulesBuilder", {
 		prepareNodeModules: () => {
 			return Promise.resolve();
+		},
+		prepareJSNodeModules: () => {
+			return Promise.resolve();
 		}
 	});
 	testInjector.register("pluginsService", {
@@ -382,6 +385,12 @@ describe('Platform Service Tests', () => {
 
 			let appDestFolderPath = path.join(tempFolder, "appDest");
 			let appResourcesFolderPath = path.join(appDestFolderPath, "App_Resources");
+			fs.writeJson(path.join(tempFolder, "package.json"), {
+				name: "testname",
+				nativescript: {
+					id: "org.nativescript.testname"
+				}
+			});
 
 			return { tempFolder, appFolderPath, app1FolderPath, appDestFolderPath, appResourcesFolderPath };
 		}

--- a/test/plugin-prepare.ts
+++ b/test/plugin-prepare.ts
@@ -7,7 +7,7 @@ class TestNpmPluginPrepare extends NpmPluginPrepare {
 	public preparedDependencies: IDictionary<boolean> = {};
 
 	constructor(private previouslyPrepared: IDictionary<boolean>) {
-		super(null, null, null);
+		super(null, null, null, null);
 	}
 
 	protected getPreviouslyPreparedDependencies(platform: string): IDictionary<boolean> {

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -32,6 +32,13 @@ class ProjectChangesServiceTest extends BaseServiceTest {
 		this.injector.register("devicePlatformsConstants", {});
 		this.injector.register("projectChangesService", ProjectChangesService);
 
+		const fs = this.injector.resolve<IFileSystem>("fs");
+		fs.writeJson(path.join(this.projectDir, Constants.PACKAGE_JSON_FILE_NAME), {
+			nativescript: {
+				id: "org.nativescript.test"
+			}
+		});
+
 	}
 
 	get projectChangesService(): IProjectChangesService {

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -113,13 +113,15 @@ describe("Project Changes Service Tests", () => {
 				// arrange
 				const prepareInfoPath = path.join(serviceTest.projectDir, Constants.PLATFORMS_DIR_NAME,
 					platform, ".nsprepareinfo");
-				const expectedPrepareInfo = {
+				const expectedPrepareInfo: IPrepareInfo = {
 					time: new Date().toString(),
 					bundle: true,
 					release: false,
 					changesRequireBuild: true,
 					changesRequireBuildTime: new Date().toString(),
-					iOSProvisioningProfileUUID: "provisioning_profile_test"
+					iOSProvisioningProfileUUID: "provisioning_profile_test",
+					projectFileHash: "",
+					nativePlatformStatus: Constants.NativePlatformStatus.requiresPlatformAdd
 				};
 				fs.writeJson(prepareInfoPath, expectedPrepareInfo);
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -206,7 +206,7 @@ export class ErrorsStub implements IErrors {
 }
 
 export class NpmInstallationManagerStub implements INpmInstallationManager {
-	async install(packageName: string, pathToSave?: string, options?: INpmInstallOptions ): Promise<string> {
+	async install(packageName: string, pathToSave?: string, options?: INpmInstallOptions): Promise<string> {
 		return Promise.resolve("");
 	}
 
@@ -573,6 +573,10 @@ export class ProjectChangesService implements IProjectChangesService {
 
 	public get currentChanges(): IProjectChangesInfo {
 		return <IProjectChangesInfo>{};
+	}
+
+	public ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean {
+		return true;
 	}
 }
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -575,7 +575,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		return <IProjectChangesInfo>{};
 	}
 
-	public ensurePrepareInfo(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): boolean {
+	public setNativePlatformStatus(platform: string, projectData: IProjectData, nativePlatformStatus: IAddedNativePlatform): boolean {
 		return true;
 	}
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -575,8 +575,8 @@ export class ProjectChangesService implements IProjectChangesService {
 		return <IProjectChangesInfo>{};
 	}
 
-	public setNativePlatformStatus(platform: string, projectData: IProjectData, nativePlatformStatus: IAddedNativePlatform): boolean {
-		return true;
+	public setNativePlatformStatus(platform: string, projectData: IProjectData, nativePlatformStatus: IAddedNativePlatform): void {
+		return;
 	}
 }
 


### PR DESCRIPTION
* Introduce new parameter prepareNative to indicate that native code preparation is explicitly required. 
* Cache additional data in .nsprepareinfo file:   
* nativePlatformStatus - indicates whether native platform should be added, prepared or there's no need to do so;   
* projectFileHash - saves package.json file's contents hash for the current platform. We use this for better heuristics for checking whether package.json is changed. 
* Re-factoring i.e. extract common code to methods

Fixes https://github.com/NativeScript/nativescript-cli/issues/2986
