### PR TITLE
Fix debug when using CLI as library

### DIFF
--- a/lib/services/debug-service.ts
+++ b/lib/services/debug-service.ts
@@ -64,7 +64,7 @@ export class DebugService extends EventEmitter implements IDebugService {
 			result = await debugService.debug(debugData, debugOptions);
 		}
 
-		return _.first(result);
+		return result;
 	}
 
 	public getDebugService(device: Mobile.IDevice): IPlatformDebugService {

--- a/test/services/debug-service.ts
+++ b/test/services/debug-service.ts
@@ -8,8 +8,8 @@ import { CONNECTION_ERROR_EVENT_NAME } from "../../lib/constants";
 
 const fakeChromeDebugUrl = "fakeChromeDebugUrl";
 class PlatformDebugService extends EventEmitter /* implements IPlatformDebugService */ {
-	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string[]> {
-		return [fakeChromeDebugUrl];
+	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
+		return fakeChromeDebugUrl;
 	}
 }
 


### PR DESCRIPTION
When CLI is used as a library, the method for debug returns incorrect result - previously the return type of the method we are calling was `string[]`, we've changed it to `string` but forgot to remove the `_.first(result)`.
So now the debug returns incorrect URL. Remove the `_.first` and return the result directly.