### PR TITLE
Fix EPIPE during livesync on iOS

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,7 @@
   "name": "nativescript",
   "version": "3.2.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/chai": {
       "version": "4.0.1",
@@ -13,19 +14,28 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-0.0.31.tgz",
       "integrity": "sha512-DWT96QeM5AeASIkChnFtEOy6O45WvKmaw27MPhAKLkx06TaFNqrzJuWVurKjCEo3PqVV89YLR2iVON8PhTRaLg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/chai": "4.0.1"
+      }
     },
     "@types/chokidar": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-1.6.0.tgz",
       "integrity": "sha1-2xhDNg1UjyZ+84o1+Tj+IkM8Uoc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.61"
+      }
     },
     "@types/form-data": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
       "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.61"
+      }
     },
     "@types/node": {
       "version": "6.0.61",
@@ -37,13 +47,20 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@types/qr-image/-/qr-image-3.2.0.tgz",
       "integrity": "sha1-09XkVzWSOnIpoHbH/JC6ufDcYgs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.61"
+      }
     },
     "@types/request": {
       "version": "0.0.45",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-0.0.45.tgz",
       "integrity": "sha512-OIIREjT58pnpfJjEY5PeBEuRtRR2ED4DF1Ez3Dj9474kCqEKfE+iNAYyM/P3RxxDjNxBhipo+peNBW0S/7Wrzg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "@types/form-data": "0.0.33",
+        "@types/node": "6.0.61"
+      }
     },
     "@types/semver": {
       "version": "5.3.32",
@@ -74,6 +91,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -86,7 +106,11 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -98,7 +122,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -130,18 +159,28 @@
     "anymatch": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc="
+      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8="
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -158,7 +197,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -221,7 +263,12 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -237,7 +284,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "big-integer": {
       "version": "1.6.23",
@@ -254,12 +304,27 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
       "dev": true,
+      "requires": {
+        "bytes": "2.2.0",
+        "content-type": "1.0.2",
+        "debug": "2.2.0",
+        "depd": "1.1.0",
+        "http-errors": "1.3.1",
+        "iconv-lite": "0.4.13",
+        "on-finished": "2.3.0",
+        "qs": "5.2.0",
+        "raw-body": "2.1.7",
+        "type-is": "1.6.15"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "iconv-lite": {
           "version": "0.4.13",
@@ -284,12 +349,18 @@
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "bplist-creator": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
-      "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU="
+      "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+      "requires": {
+        "stream-buffers": "2.2.0"
+      }
     },
     "bplist-parser": {
       "version": "0.1.0",
@@ -299,12 +370,21 @@
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc="
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -337,7 +417,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -355,6 +438,10 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      },
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
@@ -367,7 +454,11 @@
     "cardinal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk="
+      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
+      "requires": {
+        "ansicolors": "0.2.1",
+        "redeyed": "1.0.1"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -379,24 +470,47 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chai": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
       "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "2.0.2",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.3"
+      }
     },
     "chai-as-promised": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.0.0.tgz",
       "integrity": "sha512-7YYdnXPq2pV9nvRBb36Wi/MXfT8j2iL/H76GtenlOMatXbMoQLb+PonuVHGFsw5wE2M6R/VFciq8AnSSAix0GA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "check-error": "1.0.2",
+        "eslint": "3.19.0"
+      }
     },
     "chalk": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
-      "integrity": "sha1-CbRTzsSXp1Ug5KYK5IIUqHAOCSE="
+      "integrity": "sha1-CbRTzsSXp1Ug5KYK5IIUqHAOCSE=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "check-error": {
       "version": "1.0.2",
@@ -407,7 +521,18 @@
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg="
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.2",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "circular-json": {
       "version": "0.3.1",
@@ -418,17 +543,31 @@
     "cli-color": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
-      "integrity": "sha1-dfpfcowwjMSsWUsF4GzF2A2szYY="
+      "integrity": "sha1-dfpfcowwjMSsWUsF4GzF2A2szYY=",
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.24",
+        "memoizee": "0.3.10",
+        "timers-ext": "0.1.2"
+      }
     },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-table": {
       "version": "https://github.com/telerik/cli-table/tarball/v0.3.1.2",
       "integrity": "sha1-B+E8MRgVTFOJPTvnp+CNmQ6G2Fk=",
+      "requires": {
+        "colors": "1.0.3",
+        "lodash": "3.6.0",
+        "wcwidth": "1.0.1"
+      },
       "dependencies": {
         "colors": {
           "version": "1.0.3",
@@ -450,7 +589,12 @@
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
     },
     "clone": {
       "version": "1.0.2",
@@ -460,7 +604,10 @@
     "clui": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/clui/-/clui-0.3.1.tgz",
-      "integrity": "sha1-AT0ILOht2/BguG05J/iauMM79CM="
+      "integrity": "sha1-AT0ILOht2/BguG05J/iauMM79CM=",
+      "requires": {
+        "cli-color": "0.3.2"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -486,13 +633,19 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -503,7 +656,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "content-type": {
       "version": "1.0.2",
@@ -519,13 +677,22 @@
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "csproj2ts": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/csproj2ts/-/csproj2ts-0.0.8.tgz",
       "integrity": "sha1-nRxxniDELM6MTeKQCO/DVUn9Em8=",
       "dev": true,
+      "requires": {
+        "es6-promise": "4.1.1",
+        "lodash": "4.17.4",
+        "semver": "5.3.0",
+        "xml2js": "0.4.17"
+      },
       "dependencies": {
         "es6-promise": {
           "version": "4.1.1",
@@ -545,17 +712,26 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
     },
     "d": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk="
+      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "requires": {
+        "es5-ext": "0.10.24"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -573,12 +749,19 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -590,6 +773,9 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
       "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
       "dev": true,
+      "requires": {
+        "type-detect": "3.0.0"
+      },
       "dependencies": {
         "type-detect": {
           "version": "3.0.0",
@@ -608,13 +794,25 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730="
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "1.0.2"
+      }
     },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.2.8"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -631,7 +829,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -649,13 +850,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -671,22 +879,37 @@
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.24",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz",
-      "integrity": "sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ="
+      "integrity": "sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=",
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24",
+        "es6-symbol": "3.1.1"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "requires": {
+            "es5-ext": "0.10.24"
+          }
         }
       }
     },
@@ -695,12 +918,23 @@
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.24"
+          }
         }
       }
     },
@@ -715,12 +949,22 @@
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.24"
+          }
         }
       }
     },
@@ -728,11 +972,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "requires": {
+            "es5-ext": "0.10.24"
+          }
         }
       }
     },
@@ -740,16 +991,31 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
       "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.24",
+        "es6-iterator": "0.1.3",
+        "es6-symbol": "2.0.1"
+      },
       "dependencies": {
         "es6-iterator": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-          "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4="
+          "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.24",
+            "es6-symbol": "2.0.1"
+          }
         },
         "es6-symbol": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-          "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M="
+          "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
+          "requires": {
+            "d": "0.1.1",
+            "es5-ext": "0.10.24"
+          }
         }
       }
     },
@@ -763,6 +1029,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -781,7 +1054,10 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -790,18 +1066,33 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.24"
+          }
         },
         "es6-weak-map": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
           "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.24",
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
         }
       }
     },
@@ -810,12 +1101,56 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.9.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.13.1",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.6",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "cli-width": {
           "version": "2.1.0",
@@ -827,13 +1162,33 @@
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.1.0",
+            "figures": "1.7.0",
+            "lodash": "4.13.1",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
         },
         "readline2": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
           "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "mute-stream": "0.0.5"
+          }
         },
         "rx-lite": {
           "version": "3.1.2",
@@ -853,7 +1208,11 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "2.7.0",
@@ -864,13 +1223,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -888,11 +1254,18 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.24"
+      },
       "dependencies": {
         "d": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "requires": {
+            "es5-ext": "0.10.24"
+          }
         }
       }
     },
@@ -917,12 +1290,18 @@
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s="
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc="
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -932,7 +1311,10 @@
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE="
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extsprintf": {
       "version": "1.0.2",
@@ -949,18 +1331,29 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "websocket-driver": "0.6.5"
+      }
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "file-sync-cmp": {
       "version": "0.1.1",
@@ -981,24 +1374,45 @@
     "fill-range": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM="
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8="
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "findup-sync": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
+      "requires": {
+        "glob": "5.0.15"
+      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.2",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
@@ -1006,7 +1420,13 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -1016,7 +1436,10 @@
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4="
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1026,7 +1449,12 @@
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1038,6 +1466,10 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
       "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "optional": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -1047,7 +1479,11 @@
         "ajv": {
           "version": "4.11.8",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -1061,7 +1497,11 @@
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
         },
         "asn1": {
           "version": "0.2.3",
@@ -1095,19 +1535,32 @@
         "bcrypt-pbkdf": {
           "version": "1.0.1",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
         },
         "boom": {
           "version": "2.10.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -1129,7 +1582,10 @@
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -1146,12 +1602,18 @@
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1163,7 +1625,10 @@
         "debug": {
           "version": "2.6.8",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -1182,7 +1647,10 @@
         "ecc-jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "extend": {
           "version": "3.0.1",
@@ -1201,7 +1669,12 @@
         "form-data": {
           "version": "2.1.4",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -1209,22 +1682,46 @@
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
         },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1235,7 +1732,15 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -1249,7 +1754,11 @@
         "har-validator": {
           "version": "4.2.1",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -1259,7 +1768,13 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
         },
         "hoek": {
           "version": "2.16.3",
@@ -1268,11 +1783,20 @@
         "http-signature": {
           "version": "1.1.1",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -1285,7 +1809,10 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -1304,7 +1831,10 @@
         "jodid25519": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "jsbn": {
           "version": "0.1.1",
@@ -1319,7 +1849,10 @@
         "json-stable-stringify": {
           "version": "1.0.1",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -1335,6 +1868,12 @@
           "version": "1.4.0",
           "bundled": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1349,11 +1888,17 @@
         },
         "mime-types": {
           "version": "2.1.15",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -1361,7 +1906,10 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -1371,17 +1919,38 @@
         "node-pre-gyp": {
           "version": "0.6.36",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
         },
         "npmlog": {
           "version": "4.1.0",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -1399,7 +1968,10 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -1414,7 +1986,11 @@
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -1443,6 +2019,12 @@
           "version": "1.2.1",
           "bundled": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -1453,16 +2035,52 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -1486,12 +2104,26 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
           "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1502,11 +2134,19 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
@@ -1515,7 +2155,10 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -1524,22 +2167,43 @@
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
         },
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
         },
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -1563,12 +2227,18 @@
         "verror": {
           "version": "1.3.6",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -1579,7 +2249,10 @@
     "gaze": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.0.tgz",
-      "integrity": "sha1-dNP/sBEO3nFcnxW7pWxum4UdPOA="
+      "integrity": "sha1-dNP/sBEO3nFcnxW7pWxum4UdPOA=",
+      "requires": {
+        "globule": "1.2.0"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -1591,7 +2264,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -1620,6 +2296,9 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1632,23 +2311,41 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      },
       "dependencies": {
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q="
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg="
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -1660,12 +2357,25 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "globule": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.2"
+      },
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -1696,18 +2406,50 @@
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
       "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
       "dev": true,
+      "requires": {
+        "coffee-script": "1.10.0",
+        "dateformat": "1.0.12",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.3.0",
+        "glob": "7.0.6",
+        "grunt-cli": "1.2.0",
+        "grunt-known-options": "1.1.0",
+        "grunt-legacy-log": "1.0.0",
+        "grunt-legacy-util": "1.0.0",
+        "iconv-lite": "0.4.18",
+        "js-yaml": "3.5.5",
+        "minimatch": "3.0.2",
+        "nopt": "3.0.6",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.2.8"
+      },
       "dependencies": {
         "glob": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.2",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "grunt-cli": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "findup-sync": "0.3.0",
+            "grunt-known-options": "1.1.0",
+            "nopt": "3.0.6",
+            "resolve": "1.1.7"
+          }
         },
         "iconv-lite": {
           "version": "0.4.18",
@@ -1719,7 +2461,11 @@
           "version": "3.5.5",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
           "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "2.7.0"
+          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -1734,6 +2480,10 @@
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.0.0.tgz",
       "integrity": "sha1-ay7ZQRfix//jLuBFeMlv5GJam20=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "rimraf": "2.6.1"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -1745,7 +2495,10 @@
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         }
       }
     },
@@ -1754,12 +2507,23 @@
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "file-sync-cmp": "0.1.1"
+      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         }
       }
     },
@@ -1768,6 +2532,12 @@
       "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
       "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "gaze": "1.1.0",
+        "lodash": "3.10.1",
+        "tiny-lr": "0.2.1"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -1794,6 +2564,13 @@
       "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
       "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
       "dev": true,
+      "requires": {
+        "colors": "1.1.2",
+        "grunt-legacy-log-utils": "1.0.0",
+        "hooker": "0.2.3",
+        "lodash": "3.10.1",
+        "underscore.string": "3.2.3"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -1808,12 +2585,23 @@
       "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "lodash": "4.3.0"
+      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "lodash": {
           "version": "4.3.0",
@@ -1828,6 +2616,15 @@
       "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
       "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "exit": "0.1.2",
+        "getobject": "0.1.0",
+        "hooker": "0.2.3",
+        "lodash": "4.3.0",
+        "underscore.string": "3.2.3",
+        "which": "1.2.14"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -1847,13 +2644,31 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.3.0.tgz",
       "integrity": "sha1-3lYGCpNN+OzuZAdLYcYwSQDXEVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.0",
+        "npm-run-path": "1.0.0",
+        "object-assign": "4.1.1"
+      }
     },
     "grunt-ts": {
       "version": "6.0.0-beta.16",
       "resolved": "https://registry.npmjs.org/grunt-ts/-/grunt-ts-6.0.0-beta.16.tgz",
       "integrity": "sha1-wC9P+cgRAE7suTOJBaBds/hpIMM=",
       "dev": true,
+      "requires": {
+        "chokidar": "1.7.0",
+        "csproj2ts": "0.0.8",
+        "detect-indent": "4.0.0",
+        "detect-newline": "2.1.0",
+        "es6-promise": "0.1.2",
+        "jsmin2": "1.2.1",
+        "lodash": "4.17.4",
+        "ncp": "0.5.1",
+        "rimraf": "2.2.6",
+        "semver": "5.3.0",
+        "strip-bom": "2.0.0"
+      },
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -1874,6 +2689,12 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -1885,7 +2706,10 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -1897,12 +2721,19 @@
     "har-validator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -1913,7 +2744,13 @@
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -1935,12 +2772,21 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
       "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "statuses": "1.3.1"
+      }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.11",
@@ -1963,12 +2809,19 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -1979,6 +2832,18 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
       "integrity": "sha1-c2bjijMeYZBJWKzlstpKml9jZ5g=",
+      "requires": {
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.0",
+        "cli-width": "1.1.1",
+        "figures": "1.7.0",
+        "lodash": "3.10.1",
+        "readline2": "0.1.1",
+        "run-async": "0.1.0",
+        "rx-lite": "2.5.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -1998,36 +2863,65 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ios-device-lib": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.7.tgz",
-      "integrity": "sha1-E3G8cfGwnbICdtLcA1BR8OCTsIg=",
-      "dependencies": {
-        "node-uuid": {
-          "version": "1.4.7",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-          "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
-        }
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.8.tgz",
+      "integrity": "sha1-VJJWQk+3HzrCnJHuxTqVYrybxhY=",
+      "requires": {
+        "bufferpack": "0.0.6",
+        "node-uuid": "1.3.3"
       }
     },
     "ios-mobileprovision-finder": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/ios-mobileprovision-finder/-/ios-mobileprovision-finder-1.0.9.tgz",
       "integrity": "sha1-Hc80ywKeP+oMhSkmu79K6GTswKc=",
+      "requires": {
+        "chalk": "1.1.3",
+        "plist": "2.1.0",
+        "yargs": "6.6.0"
+      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "plist": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
-          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU="
+          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+          "requires": {
+            "base64-js": "1.2.0",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.21"
+          }
         },
         "yargs": {
           "version": "6.6.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg="
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
         }
       }
     },
@@ -2035,10 +2929,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.0.0.tgz",
       "integrity": "sha1-VOCVccIb+TNH8sfAFSno9fHEtfI=",
+      "requires": {
+        "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
+        "colors": "0.6.2",
+        "lodash": "3.2.0",
+        "osenv": "0.1.3",
+        "plist": "1.1.0",
+        "shelljs": "0.7.0",
+        "yargs": "4.7.1"
+      },
       "dependencies": {
         "bplist-parser": {
           "version": "https://github.com/telerik/node-bplist-parser/tarball/master",
-          "integrity": "sha1-X7BVlo1KqtkGi+pkMyFRiYKHtFY="
+          "integrity": "sha1-X7BVlo1KqtkGi+pkMyFRiYKHtFY=",
+          "requires": {
+            "big-integer": "1.6.23"
+          }
         },
         "colors": {
           "version": "0.6.2",
@@ -2058,17 +2964,41 @@
         "shelljs": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.0.tgz",
-          "integrity": "sha1-P28uSWXOxWX2X/OGHWRPh5KBpXY="
+          "integrity": "sha1-P28uSWXOxWX2X/OGHWRPh5KBpXY=",
+          "requires": {
+            "glob": "7.1.2",
+            "interpret": "1.0.3",
+            "rechoir": "0.6.2"
+          }
         },
         "yargs": {
           "version": "4.7.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.7.1.tgz",
-          "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8="
+          "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.3",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "1.0.0",
+            "string-width": "1.0.2",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
+          }
         },
         "yargs-parser": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ="
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
         }
       }
     },
@@ -2080,7 +3010,10 @@
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg="
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -2090,7 +3023,10 @@
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2100,7 +3036,10 @@
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ="
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -2116,23 +3055,38 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM="
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "xtend": {
           "version": "4.0.1",
@@ -2145,7 +3099,10 @@
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -2157,13 +3114,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -2185,7 +3148,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2211,7 +3177,10 @@
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk="
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2223,6 +3192,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.0",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.9.0",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.2.14",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
@@ -2240,7 +3225,14 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.2",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -2252,7 +3244,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -2267,6 +3262,10 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
       "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
       "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "4.0.0",
@@ -2296,7 +3295,10 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -2324,6 +3326,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2335,7 +3343,10 @@
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -2347,13 +3358,20 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "livereload-js": {
       "version": "2.2.2",
@@ -2364,7 +3382,14 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA="
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
     },
     "lockfile": {
       "version": "1.0.1",
@@ -2385,7 +3410,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -2420,7 +3449,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -2438,7 +3472,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -2448,7 +3487,12 @@
     "log4js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-1.0.1.tgz",
-      "integrity": "sha1-+vZMEFa2NSpfu/CpO2Gpl5qEIsw="
+      "integrity": "sha1-+vZMEFa2NSpfu/CpO2Gpl5qEIsw=",
+      "requires": {
+        "debug": "2.6.8",
+        "semver": "5.3.0",
+        "streamroller": "0.2.2"
+      }
     },
     "longest": {
       "version": "1.0.1",
@@ -2460,12 +3504,19 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM="
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "0.10.24"
+      }
     },
     "map-obj": {
       "version": "1.0.1",
@@ -2482,11 +3533,25 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-2.0.0.tgz",
       "integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
+      "requires": {
+        "cardinal": "1.0.0",
+        "chalk": "1.1.3",
+        "cli-table": "https://github.com/telerik/cli-table/tarball/v0.3.1.2",
+        "lodash.assign": "4.2.0",
+        "node-emoji": "1.7.0"
+      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         }
       }
     },
@@ -2499,13 +3564,34 @@
     "memoizee": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
-      "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8="
+      "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.24",
+        "es6-weak-map": "0.1.4",
+        "event-emitter": "0.3.5",
+        "lru-queue": "0.1.0",
+        "next-tick": "0.2.2",
+        "timers-ext": "0.1.2"
+      }
     },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -2518,7 +3604,22 @@
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU="
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "mime-db": {
       "version": "1.27.0",
@@ -2528,12 +3629,18 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "minimatch": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-      "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo="
+      "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -2543,25 +3650,52 @@
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.1.2.tgz",
       "integrity": "sha1-Ufk7Qyv34bF1/8Iog8zQvjLbprU=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.0.5",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "glob": {
           "version": "7.0.5",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
           "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.2",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -2573,7 +3707,10 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -2618,7 +3755,11 @@
     "node-emoji": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.7.0.tgz",
-      "integrity": "sha512-dYx345sjhPJUpWaVQKjP0/43y+nTcfBRTZfSciM3ZEbRGaU/9AKaHBPf7AJ9vOKcK0W3v67AgI4m4oo02NLHhQ=="
+      "integrity": "sha512-dYx345sjhPJUpWaVQKjP0/43y+nTcfBRTZfSciM3ZEbRGaU/9AKaHBPf7AJ9vOKcK0W3v67AgI4m4oo02NLHhQ==",
+      "requires": {
+        "lodash.toarray": "4.4.0",
+        "string.prototype.codepointat": "0.2.0"
+      }
     },
     "node-uuid": {
       "version": "1.3.3",
@@ -2634,23 +3775,38 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw=="
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk="
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
       "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-key": "1.0.0"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -2675,18 +3831,28 @@
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo="
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -2704,6 +3870,10 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
@@ -2717,7 +3887,15 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -2727,7 +3905,10 @@
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -2737,17 +3918,30 @@
     "osenv": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-      "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc="
+      "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw="
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "parseurl": {
       "version": "1.3.1",
@@ -2758,7 +3952,10 @@
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s="
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2785,7 +3982,12 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE="
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -2821,17 +4023,32 @@
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pkg-conf": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
-      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls="
+      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+      "requires": {
+        "find-up": "1.1.2",
+        "load-json-file": "1.1.0",
+        "object-assign": "4.1.1",
+        "symbol": "0.2.3"
+      }
     },
     "plist": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-1.1.0.tgz",
       "integrity": "sha1-/2cIWQyXzEOOe8Rd5SUb1yXz+J0=",
+      "requires": {
+        "base64-js": "0.0.6",
+        "util-deprecate": "1.0.0",
+        "xmlbuilder": "2.2.1",
+        "xmldom": "0.1.21"
+      },
       "dependencies": {
         "base64-js": {
           "version": "0.0.6",
@@ -2846,7 +4063,10 @@
         "xmlbuilder": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
-          "integrity": "sha1-kyZDDxMNh0NdTECGZDqikm4QWjI="
+          "integrity": "sha1-kyZDDxMNh0NdTECGZDqikm4QWjI=",
+          "requires": {
+            "lodash-node": "2.4.1"
+          }
         }
       }
     },
@@ -2854,6 +4074,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/plist-merge-patch/-/plist-merge-patch-0.1.0.tgz",
       "integrity": "sha1-eOTAlL6dtLpHWdpktvGkz2rTIJE=",
+      "requires": {
+        "lodash": "4.17.4",
+        "plist": "2.1.0"
+      },
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -2863,7 +4087,12 @@
         "plist": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
-          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU="
+          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+          "requires": {
+            "base64-js": "1.2.0",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.21"
+          }
         }
       }
     },
@@ -2871,6 +4100,13 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/plistlib/-/plistlib-0.2.1.tgz",
       "integrity": "sha1-RukssEmKCjrtO+5bXE2IKQVNqGw=",
+      "requires": {
+        "async": "0.2.10",
+        "moment": "2.4.0",
+        "node-xml": "1.0.2",
+        "underscore": "1.5.2",
+        "xml": "0.0.12"
+      },
       "dependencies": {
         "moment": {
           "version": "2.4.0",
@@ -2910,7 +4146,12 @@
     "progress-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.1.1.tgz",
-      "integrity": "sha1-nsvxh5MsSUHVUCGRkNdN7ArEX1Q="
+      "integrity": "sha1-nsvxh5MsSUHVUCGRkNdN7ArEX1Q=",
+      "requires": {
+        "single-line-log": "0.3.1",
+        "speedometer": "0.1.4",
+        "through2": "0.2.3"
+      }
     },
     "properties-parser": {
       "version": "0.2.3",
@@ -2936,23 +4177,36 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ="
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
             }
           }
         },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         }
       }
     },
@@ -2961,6 +4215,11 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
       "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
       "dev": true,
+      "requires": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.13",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "bytes": {
           "version": "2.4.0",
@@ -2979,27 +4238,55 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg="
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI="
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
     },
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg="
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.2",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
+      }
     },
     "readline2": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
       "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
+      "requires": {
+        "mute-stream": "0.0.4",
+        "strip-ansi": "2.0.1"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "1.1.1",
@@ -3014,25 +4301,38 @@
         "strip-ansi": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4="
+          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+          "requires": {
+            "ansi-regex": "1.1.1"
+          }
         }
       }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q="
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
     },
     "redeyed": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
+      "requires": {
+        "esprima": "3.0.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "3.0.0",
@@ -3044,7 +4344,11 @@
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU="
+      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
@@ -3065,12 +4369,39 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.0.1"
+      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -3086,12 +4417,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU="
+      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -3103,14 +4441,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.2.8",
@@ -3120,7 +4465,10 @@
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k="
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "2.5.2",
@@ -3156,25 +4504,41 @@
     "shelljs": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-      "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0="
+      "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "should": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/should/-/should-7.0.2.tgz",
       "integrity": "sha1-HfJOAqlxzx1ZWu0mfi2D8kw3CYM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "should-equal": "0.5.0",
+        "should-format": "0.3.0",
+        "should-type": "0.2.0"
+      }
     },
     "should-equal": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
       "integrity": "sha1-x5fxNfMGf+tp6+zbMGscP+IbPm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
     },
     "should-format": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.3.0.tgz",
       "integrity": "sha1-QgB+wKochupEkUzJER8bnyfTzqw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "should-type": "0.2.0"
+      }
     },
     "should-type": {
       "version": "0.2.0",
@@ -3192,6 +4556,11 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
       "integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
+      "requires": {
+        "bplist-creator": "0.0.7",
+        "bplist-parser": "0.1.1",
+        "plist": "2.0.1"
+      },
       "dependencies": {
         "base64-js": {
           "version": "1.1.2",
@@ -3201,12 +4570,20 @@
         "bplist-parser": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-          "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY="
+          "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+          "requires": {
+            "big-integer": "1.6.23"
+          }
         },
         "plist": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
-          "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os="
+          "integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
+          "requires": {
+            "base64-js": "1.1.2",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.21"
+          }
         }
       }
     },
@@ -3224,7 +4601,10 @@
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "source-map": {
       "version": "0.5.6",
@@ -3235,12 +4615,18 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -3267,6 +4653,16 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3290,6 +4686,11 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.2.2.tgz",
       "integrity": "sha1-oTQg4EFp5XPbBo9ZIO4j2IGr/jM=",
+      "requires": {
+        "date-format": "0.0.0",
+        "debug": "0.7.4",
+        "readable-stream": "1.1.14"
+      },
       "dependencies": {
         "debug": {
           "version": "0.7.4",
@@ -3304,7 +4705,13 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -3316,12 +4723,20 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "string.prototype.codepointat": {
       "version": "0.2.0",
@@ -3336,18 +4751,27 @@
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4="
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -3370,6 +4794,14 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.13.1",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.0"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -3381,7 +4813,14 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -3394,12 +4833,19 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
           "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
           "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
             }
           }
         }
@@ -3412,7 +4858,11 @@
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k="
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
+      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -3429,6 +4879,10 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xtend": "2.1.2"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -3438,7 +4892,13 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk="
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -3451,6 +4911,10 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
+      "requires": {
+        "es5-ext": "0.10.24",
+        "next-tick": "1.0.0"
+      },
       "dependencies": {
         "next-tick": {
           "version": "1.0.0",
@@ -3464,12 +4928,23 @@
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
+      "requires": {
+        "body-parser": "1.14.2",
+        "debug": "2.2.0",
+        "faye-websocket": "0.10.0",
+        "livereload-js": "2.2.2",
+        "parseurl": "1.3.1",
+        "qs": "5.1.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -3488,7 +4963,10 @@
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -3513,6 +4991,18 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.3.tgz",
       "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "colors": "1.1.2",
+        "commander": "2.9.0",
+        "diff": "3.3.0",
+        "glob": "7.1.2",
+        "minimatch": "3.0.4",
+        "resolve": "1.3.3",
+        "semver": "5.3.0",
+        "tslib": "1.7.1",
+        "tsutils": "2.6.1"
+      },
       "dependencies": {
         "diff": {
           "version": "3.3.0",
@@ -3524,7 +5014,10 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -3532,12 +5025,18 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.6.1.tgz",
       "integrity": "sha1-mOzwCVlPTkr4hAV75M9BpFC8djc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tslib": "1.7.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -3549,7 +5048,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-detect": {
       "version": "4.0.3",
@@ -3561,7 +5063,11 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.15"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -3581,6 +5087,11 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -3594,7 +5105,12 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
         },
         "window-size": {
           "version": "0.1.0",
@@ -3615,7 +5131,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
         }
       }
     },
@@ -3652,7 +5174,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3667,23 +5192,36 @@
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g="
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "1.0.3"
+      }
     },
     "websocket-driver": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "websocket-extensions": "0.1.1"
+      }
     },
     "websocket-extensions": {
       "version": "0.1.1",
@@ -3695,7 +5233,10 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "which-module": {
       "version": "1.0.0",
@@ -3721,7 +5262,11 @@
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -3732,16 +5277,26 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "ws": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-2.2.0.tgz",
-      "integrity": "sha1-MhinsevRWgnFa7EqPpQ6lg63veU="
+      "integrity": "sha1-MhinsevRWgnFa7EqPpQ6lg63veU=",
+      "requires": {
+        "ultron": "1.1.0"
+      }
     },
     "xcode": {
       "version": "https://github.com/NativeScript/node-xcode/archive/1.4.0.tar.gz",
-      "integrity": "sha1-pws+vYIXCzhk70x9hYy3eXmOHjg="
+      "integrity": "sha1-pws+vYIXCzhk70x9hYy3eXmOHjg=",
+      "requires": {
+        "node-uuid": "1.3.3",
+        "pegjs": "0.6.2"
+      }
     },
     "xml": {
       "version": "0.0.12",
@@ -3753,12 +5308,19 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "dev": true,
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "4.2.1"
+      },
       "dependencies": {
         "xmlbuilder": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
           "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "4.13.1"
+          }
         }
       }
     },
@@ -3779,7 +5341,10 @@
     "xtend": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os="
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "requires": {
+        "object-keys": "0.4.0"
+      }
     },
     "y18n": {
       "version": "3.2.1",
@@ -3789,12 +5354,30 @@
     "yargs": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.0.0.tgz",
-      "integrity": "sha1-kAR5306L9qsOhyFvXtKydguWg0U="
+      "integrity": "sha1-kAR5306L9qsOhyFvXtKydguWg0U=",
+      "requires": {
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
+      }
     },
     "yargs-parser": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw="
+      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+      "requires": {
+        "camelcase": "3.0.0"
+      }
     },
     "zipstream": {
       "version": "https://github.com/Icenium/node-zipstream/tarball/master",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "glob": "^7.0.3",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-device-lib": "0.4.7",
+    "ios-device-lib": "0.4.8",
     "ios-mobileprovision-finder": "1.0.9",
     "ios-sim-portable": "~3.0.0",
     "lockfile": "1.0.1",


### PR DESCRIPTION
In case during `tns run ios` the application is uninstalled manually and after that a change is applied, CLI should install the app and continue with livesync operation. However it fails with EPIPE. The problem was in ios-device-lib - it is fixed in 0.4.8 version.

https://github.com/NativeScript/nativescript-cli/issues/2988