### PR TITLE
Move skipNativePrepare to deviceDescriptors

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -88,6 +88,11 @@ interface ILiveSyncDeviceInfo {
 	 * In case it is not passed, the default output for local builds will be used.
 	 */
 	outputPath?: string;
+
+	/**
+	 * Whether to skip preparing the native platform.
+	 */
+	skipNativePrepare?: boolean;
 }
 
 /**
@@ -120,11 +125,6 @@ interface ILiveSyncInfo {
 	 * Forces a build before the initial livesync.
 	 */
 	clean?: boolean;
-
-	/**
-	 * Whether to skip preparing the native platform.
-	 */
-	skipNativePrepare?: boolean;
 }
 
 interface ILatestAppPackageInstalledSettings extends IDictionary<IDictionary<boolean>> { /* empty */ }

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -237,7 +237,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 					deviceBuildInfoDescriptor,
 					liveSyncData,
 					settings
-				}, { skipNativePrepare: liveSyncData.skipNativePrepare });
+				}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
 				const liveSyncResultInfo = await this.getLiveSyncService(platform).fullSync({
 					projectData, device,
@@ -339,7 +339,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 										deviceBuildInfoDescriptor,
 										settings: latestAppPackageInstalledSettings,
 										modifiedFiles: allModifiedFiles
-									}, { skipNativePrepare: liveSyncData.skipNativePrepare });
+									}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
 									const service = this.getLiveSyncService(device.deviceInfo.platform);
 									const settings: ILiveSyncWatchInfo = {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -278,7 +278,6 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			this.$errors.failWithoutHelp(`Unable to install dependencies. Make sure your package.json is valid and all dependencies are correct. Error is: ${err.message}`);
 		}
 
-		await this.$pluginsService.validate(platformData, projectData);
 		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, config, nativePrepare);
 
 		const bundle = appFilesUpdaterOptions.bundle;
@@ -341,6 +340,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 
 		if (!changesInfo || changesInfo.modulesChanged || appFilesUpdaterOptions.bundle) {
+			await this.$pluginsService.validate(platformData, projectData);
+
 			let appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 			let lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath) ? this.$fs.getFsStats(appDestinationDirectoryPath).mtime : null;
 


### PR DESCRIPTION
Each device can use different build types - cloud or local. So the `skipNativePrepare` option should be passed per each device, not for the whole livesync operation.