### PR TITLE
Add error handling for debug sockets

### DIFF
--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -113,6 +113,14 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 				webSocket.send(buffer.toString(encoding));
 			});
 
+			webSocket.on("error", err => {
+				this.$logger.trace("Error on debugger websocket", err);
+			});
+
+			deviceSocket.on("error", err => {
+				this.$logger.trace("Error on debugger deviceSocket", err);
+			});
+
 			webSocket.on("message", (message, flags) => {
 				let length = Buffer.byteLength(message, encoding);
 				let payload = new Buffer(length + 4);
@@ -121,9 +129,11 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 				deviceSocket.write(payload);
 			});
 
-			deviceSocket.on("end", () => {
+			deviceSocket.on("close", () => {
 				this.$logger.info("Backend socket closed!");
-				process.exit(0);
+				if (!this.$options.watch) {
+					process.exit(0);
+				}
 			});
 
 			webSocket.on("close", () => {


### PR DESCRIPTION
On Windows closing a socket on the non-nodejs side leads to errors on the nodejs side.
Add error handling for these types of errors.

In addition, only exit the process whenever `--watch` is not set if the app is killed during debugging.
Ping @rosen-vladimirov @TsvetanMilanov 