### PR TITLE
Fix rebuilding application every time when a change is applied

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -108,6 +108,8 @@ export class ProjectChangesService implements IProjectChangesService {
 			if (this._prepareInfo.changesRequireBuild) {
 				this._prepareInfo.changesRequireBuildTime = this._prepareInfo.time;
 			}
+
+			this._prepareInfo.projectFileHash = this.getProjectFileStrippedHash(projectData, platform);
 		}
 
 		this._changesInfo.nativePlatformStatus = this._prepareInfo.nativePlatformStatus;


### PR DESCRIPTION
In case you have built your application and you add a new npm package as dependency, the LiveSync will always rebuild the app, no matter of the change applied afterwards. The problem is in our project-changes-service that persists shasum of the package.json. However it is never reset, so we always have the hashed shasum of the package.json when the applcation has been build for the first time. Fix this by setting the correct value for projectFileHash - this way the checks are correct and applying change in .js (.xml, .css) files will not trigger rebuild of app.