### PR TITLE
Fix LiveSync on iOS when app is uninstalled manually

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -635,6 +635,7 @@ tns.liveSyncService.on("liveSyncStarted", data => {
 	 * Full paths to files synced during the operation. In case the `syncedFiles.length` is 0, the operation is "fullSync" (i.e. all project files are synced).
 	 */
 	syncedFiles: string[];
+	isFullSync: boolean;
 }
 ```
 

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -150,6 +150,16 @@ interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions {
 }
 
 /**
+ * Describes the action that has been executed during ensureLatestAppPackageIsInstalledOnDevice execution.
+ */
+interface IAppInstalledOnDeviceResult {
+	/**
+	 * Defines if the app has been installed on device from the ensureLatestAppPackageIsInstalledOnDevice method.
+	 */
+	appInstalled: boolean;
+}
+
+/**
  * Describes LiveSync operations.
  */
 interface ILiveSyncService {
@@ -187,7 +197,7 @@ interface ILiveSyncWatchInfo {
 	projectData: IProjectData;
 	filesToRemove: string[];
 	filesToSync: string[];
-	isRebuilt: boolean;
+	isReinstalled: boolean;
 	syncAllFiles: boolean;
 	useLiveEdit?: boolean;
 }

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -59,7 +59,7 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 	}
 
 	public liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<ILiveSyncResultInfo> {
-		if (liveSyncInfo.isRebuilt) {
+		if (liveSyncInfo.isReinstalled) {
 			// In this case we should execute fullsync because iOS Runtime requires the full content of app dir to be extracted in the root of sync dir.
 			return this.fullSync({ projectData: liveSyncInfo.projectData, device, syncAllFiles: liveSyncInfo.syncAllFiles, watch: true });
 		} else {


### PR DESCRIPTION
Whenever application is reinstalled on iOS device, we have to execute full sync operation due to iOS runtime requirements.
However, in case the application is uninstalled manually during LiveSync, CLI will reinstall it, but the code that checks if a full sync is required will return false. The problem is that the `isRebuilt` property (renamed to `isReinstalled` now) really checks if the application has been rebuild during current check and expectedly this returns false.
In order to fix this, change the return type of `ensureLatestAppPackageIsInstalledOnDevice`, so it will give the required information if a full sync should be executed.

Also improve the information that we emit in liveSyncExecuted event:
* add new property - `isFullSync` - it can be used to indicate the current operation
* ensure the `syncedFiles` property contains the really synced files - for Android devices the full sync is not always a full sync - it checks the shasums of files and uploads only the modified ones. At the moment we've been returning all project files in the array, even when we upload only a few (or event none) of them. In order to fix this respect the return type of the `transferDirectory` method and use it in LiveSync operations.

Merge after https://github.com/telerik/mobile-cli-lib/pull/992

https://github.com/NativeScript/nativescript-cli/issues/3007