### PR TITLE
Emit liveSyncStopped event when LiveSync operation is really stopped

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -65,6 +65,7 @@ interface ILiveSyncProcessInfo {
 	actionsChain: Promise<any>;
 	isStopped: boolean;
 	deviceDescriptors: ILiveSyncDeviceInfo[];
+	currentSyncAction: Promise<any>;
 }
 
 /**


### PR DESCRIPTION
In case `stopLiveSync` is called during livesync, we should await the current action and emit `liveSyncStopped` event. At the moment, we have the following behavior:
1. In case stopLiveSync is called with deviceIdentifiers, we emit `liveSyncStopped` immediately for all of them. However there may be pending actions, for example build + deploy for current device. We cannot stop the actions, so you receive `liveSyncStopped` and application is installed/updated on device after that.
Fix this by persisting the current action and await it before emitting `liveSyncStopped` event.
2. In case we are currently rebuilding the application and some changes are applied during build, we'll update the `actionsChain`. At this point we'll have several actions in the chain. In case stopLiveSync method is called (without deviceIdentifiers), we will await all pending actions, which will result in awaiting the build, deploy and all other actions and we'll emit the `liveSyncStopped` after that. However we should not execute all pending actions - we should just execute the current one and skip the rest.
In order to fix this, just set isStopped to true before awaiting the actions. This way only the current action will be executed.