### PR TITLE
Ensure platforms directory exists prior to preparing

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -133,8 +133,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			spinner.stop();
 		}
 
+		this.$fs.ensureDirectoryExists(platformPath);
 		this.$logger.out("Project successfully created.");
-
 	}
 
 	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, nativePrepare?: INativePrepare): Promise<string> {


### PR DESCRIPTION
Some plugins require `platforms/<platform>` to exist on their `before-prepare` hooks. Make sure the directory actually exists and let the plugins handle the rest.

Merge after https://github.com/telerik/mobile-cli-lib/pull/994

Ping @rosen-vladimirov @nadyaA @TsvetanMilanov