### PR TITLE
livesync deletes files and cleans temp folder afterwards

### DIFF
--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -36,7 +36,7 @@ export class AndroidDeviceLiveSyncService extends DeviceLiveSyncServiceBase impl
 				`${deviceProjectRootDirname}/sync`]
 		);
 
-		this.reloadResources(deviceAppData, localToDevicePaths);
+		await this.reloadResources(deviceAppData, localToDevicePaths);
 
 		const canExecuteFastSync = !liveSyncInfo.isFullSync && !_.some(localToDevicePaths,
 			(localToDevicePath: Mobile.ILocalToDevicePathData) => !this.canExecuteFastSync(localToDevicePath.getLocalPath(), projectData, this.device.deviceInfo.platform));

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -91,7 +91,7 @@ export abstract class PlatformLiveSyncServiceBase {
 			modifiedLocalToDevicePaths.push(...localToDevicePaths);
 
 			const deviceLiveSyncService = this.getDeviceLiveSyncService(device, projectData.projectId);
-			deviceLiveSyncService.removeFiles(deviceAppData, localToDevicePaths);
+			await deviceLiveSyncService.removeFiles(deviceAppData, localToDevicePaths);
 		}
 
 		return {


### PR DESCRIPTION
_problem_
Related issue: https://github.com/NativeScript/nativescript-cli/issues/2657
Possibly related to https://github.com/NativeScript/nativescript-cli/issues/2485
* emulators with API level >= 23 the installed application doesn't have the permissions to write in `/data/local/tmp/<application_name>/` and disrupts livesync in some scenarios
* on devices the problem with permissions is even worse and even on API level 22, the application still doesn't have permissions to write in `/data/local/tmp/<application_name>/`

_solution_
The CLI will take care of notifying the runtime and deleting all files after livesync is done, regardless of whether the application needs to be restarted or not.

Edit: tested on iOS and Android: new/delete/modify work, but renaming only works on android, I'll fix the problem on iOS in a different PR. We don't have tests for renaming a file, so it won't affect the tests.