### PR TITLE
Emit liveSyncStopped properly when stopping on all devices

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -72,6 +72,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 					await liveSyncProcessInfo.actionsChain;
 				}
 
+				removedDeviceIdentifiers = _.map(liveSyncProcessInfo.deviceDescriptors, d => d.identifier);
 				liveSyncProcessInfo.deviceDescriptors = [];
 
 				// Kill typescript watcher


### PR DESCRIPTION
Whenever stopping on all devices we should emit `liveSyncStopped` for each device.

Ping @rosen-vladimirov @TsvetanMilanov 