### PR TITLE
Stop copying android plugin code, stop writing configurations dir

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -346,7 +346,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	public async preparePluginNativeCode(pluginData: IPluginData, projectData: IProjectData): Promise<void> {
-		// Add to platforms/android/dependencies.json
+		// Do nothing, the Android Gradle script will configure itself based on the input dependencies.json 
 	}
 
 	public async processConfigurationFilesFromAppResources(): Promise<void> {
@@ -356,7 +356,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	public async removePluginNativeCode(pluginData: IPluginData, projectData: IProjectData): Promise<void> {
 		try {
 			// check whether the dependency that's being removed has native code
-			const pluginConfigDir = path.join(this.getPlatformData(projectData).projectRoot, "configurations", pluginData.name);
+			const pluginConfigDir = path.join(this.getPlatformData(projectData).projectRoot, "build", "configurations", pluginData.name);
+			
 			if (this.$fs.exists(pluginConfigDir)) {
 				await this.cleanProject(this.getPlatformData(projectData).projectRoot, projectData);
 			}
@@ -386,6 +387,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			.filter(AndroidProjectService.isNativeAndroidDependency)
 			.map(({ name, directory }) => ({ name, directory: path.relative(platformDir, directory) }));
 		const jsonContent = JSON.stringify(nativeDependencies, null, 4);
+
 		this.$fs.writeFile(dependenciesJsonPath, jsonContent);
 	}
 

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -375,22 +375,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 	public async beforePrepareAllPlugins(projectData: IProjectData, dependencies?: IDependencyData[]): Promise<void> {
 		if (dependencies) {
-			await this.provideV8Dependants(projectData, dependencies);
 			this.provideDependenciesJson(projectData, dependencies);
-		}
-	}
-
-	private async provideV8Dependants(projectData: IProjectData, dependencies: IDependencyData[]): Promise<void> {
-		const platformDir = path.join(projectData.platformsDir, "android");
-		const buildDir = path.join(platformDir, "build-tools");
-		const checkV8dependants = path.join(buildDir, "check-v8-dependants.js");
-		if (this.$fs.exists(checkV8dependants)) {
-			const stringifiedDependencies = JSON.stringify(dependencies);
-			try {
-				await this.spawn('node', [checkV8dependants, stringifiedDependencies, projectData.platformsDir], { stdio: "inherit" });
-			} catch (e) {
-				this.$logger.info("Checking for dependants on v8 public API failed. This is likely caused because of cyclic production dependencies. Error code: " + e.code + "\nMore information: https://github.com/NativeScript/nativescript-cli/issues/2561");
-			}
 		}
 	}
 

--- a/lib/tools/node-modules/node-modules-dependencies-builder.ts
+++ b/lib/tools/node-modules/node-modules-dependencies-builder.ts
@@ -47,10 +47,10 @@ export class NodeModulesDependenciesBuilder implements INodeModulesDependenciesB
 			}
 		}
 
-		return this.distinctDependencies(resolvedDependencies);
+		return this.filterUniqueDependencies(resolvedDependencies);
 	}
 
-	private distinctDependencies(dependencies: IDependencyData[]): IDependencyData[] {
+	private filterUniqueDependencies(dependencies: IDependencyData[]): IDependencyData[] {
 		const depsDictionary = dependencies.reduce((dict, dep) => {
 			const collision = dict[dep.name];
 			if (!collision || collision.depth > dep.depth) {

--- a/lib/tools/node-modules/node-modules-dependencies-builder.ts
+++ b/lib/tools/node-modules/node-modules-dependencies-builder.ts
@@ -47,18 +47,7 @@ export class NodeModulesDependenciesBuilder implements INodeModulesDependenciesB
 			}
 		}
 
-		return this.filterUniqueDependencies(resolvedDependencies);
-	}
-
-	private filterUniqueDependencies(dependencies: IDependencyData[]): IDependencyData[] {
-		const depsDictionary = dependencies.reduce((dict, dep) => {
-			const collision = dict[dep.name];
-			if (!collision || collision.depth > dep.depth) {
-				dict[dep.name] = dep;
-			}
-			return dict;
-		}, <{ [key: string]: IDependencyData}>{});
-		return Object.keys(depsDictionary).map(key => depsDictionary[key]);
+		return resolvedDependencies;
 	}
 
 	private findModule(rootNodeModulesPath: string, parentModulePath: string, name: string, depth: number, resolvedDependencies: IDependencyData[]): IDependencyData {

--- a/lib/tools/node-modules/node-modules-dependencies-builder.ts
+++ b/lib/tools/node-modules/node-modules-dependencies-builder.ts
@@ -47,7 +47,18 @@ export class NodeModulesDependenciesBuilder implements INodeModulesDependenciesB
 			}
 		}
 
-		return resolvedDependencies;
+		return this.distinctDependencies(resolvedDependencies);
+	}
+
+	private distinctDependencies(dependencies: IDependencyData[]): IDependencyData[] {
+		const depsDictionary = dependencies.reduce((dict, dep) => {
+			const collision = dict[dep.name];
+			if (!collision || collision.depth > dep.depth) {
+				dict[dep.name] = dep;
+			}
+			return dict;
+		}, <{ [key: string]: IDependencyData}>{});
+		return Object.keys(depsDictionary).map(key => depsDictionary[key]);
 	}
 
 	private findModule(rootNodeModulesPath: string, parentModulePath: string, name: string, depth: number, resolvedDependencies: IDependencyData[]): IDependencyData {

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -342,8 +342,20 @@ describe("debug command tests", () => {
 		});
 
 		it("Ensures that beforePrepareAllPlugins will call gradle with clean option when *NOT* livesyncing", async () => {
+			const platformData = testInjector.resolve<IPlatformData>("platformsData");
+			platformData.frameworkPackageName = "tns-android";
+
+			// only test that 'clean' is performed on android <=3.2. See https://github.com/NativeScript/nativescript-cli/pull/3032
+			const projectDataService: IProjectDataService = testInjector.resolve("projectDataService");
+			projectDataService.getNSValue = (projectDir: string, propertyName: string) => {
+				return { version: "3.2.0" };
+			};
+
 			const childProcess: stubs.ChildProcessStub = testInjector.resolve("childProcess");
 			const androidProjectService: IPlatformProjectService = testInjector.resolve("androidProjectService");
+			androidProjectService.getPlatformData = (projectData: IProjectData): IPlatformData => {
+				return platformData;
+			};
 			const projectData: IProjectData = testInjector.resolve("projectData");
 			const spawnFromEventCount = childProcess.spawnFromEventCount;
 			await androidProjectService.beforePrepareAllPlugins(projectData);


### PR DESCRIPTION
**Problem**:
The CLI will execute gradle clean when a plugin with a native counterpart is added/removed, that will force removal of all build artifacts, including the infamous `configurations` directory, where the CLI copies all plugin `include.gradle` scripts. The user may call `gradle clean` on their own however, that will remove `configurations` and the CLI will not regenerate it on a consecutive build, because it would not have detected a change in the plugins in order to copy the gradle scripts over. As a result builds that follow will not include any of the android plugins.

**Proposed Solution**:
Hand over the control over android plugins to the Gradle script, it will generate its own configurations and copy files where necessary as it sees fit. NativeScript CLI's only responsibility towards android plugins will now be to include them in a `dependencies.json` file which is written inside the `platforms/android` directory of a NS project.

**Implementation implications**:
- The plugin variables interpolation logic is removed, as the CLI will no longer take care of copying android plugin files inside platforms/android. There are slightly more elegant ways to handle this. For one - plugin variables could be moved inside the `ns-project/app/package.json` directory either by hand or automatically. The `package.json` will be available on the target device and is readable by plugins.
- Versions of the android runtime prior to 3.2 (or whenever we end up releasing this change) will not be compatible with previous versions of the CLI, and vice-versa. An error message in the android build script will notify the user of the version discrepancies should they occur.

Related issues/PRs: 
 - android runtime - https://github.com/NativeScript/android-runtime/issues/790
 - meta QoL improvements issue - https://github.com/NativeScript/NativeScript/issues/4459

---

CC: @PanayotCankov @Plamen5kov 