### PR TITLE
Add check for application identifier ios

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -314,6 +314,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				handler,
 				this.buildForSimulator(projectRoot, basicArgs, projectData, buildConfig.buildOutputStdio));
 		}
+
+		this.validateApplicationIdentifier(projectData);
 	}
 
 	public async validatePlugins(projectData: IProjectData): Promise<void> {
@@ -1311,6 +1313,23 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 			}
 		}
 		return teamId;
+	}
+
+	private validateApplicationIdentifier(projectData: IProjectData): void {
+		const projectDir = projectData.projectDir;
+		const infoPlistPath = path.join(projectDir, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME, this.getPlatformData(projectData).normalizedPlatformName, this.getPlatformData(projectData).configurationFileName);
+		const mergedPlistPath =  this.getPlatformData(projectData).configurationFilePath;
+
+		if (!this.$fs.exists(infoPlistPath) || !this.$fs.exists(mergedPlistPath)) {
+			return;
+		}
+
+		const infoPlist = plist.parse(this.$fs.readText(infoPlistPath));
+		const mergedPlist = plist.parse(this.$fs.readText(mergedPlistPath));
+
+		if (infoPlist.CFBundleIdentifier && infoPlist.CFBundleIdentifier !== mergedPlist.CFBundleIdentifier) {
+			this.$logger.warnWithLabel("The CFBundleIdentifier key inside the 'Info.plist' will be overriden by the 'id' inside 'package.json'.");
+		}
 	}
 }
 


### PR DESCRIPTION
### Description
User can change the application identifier inside his Info.plist file by setting CFBundleIdentifier, but our plist merge logic will overwrite the identifier with the one inside package.json.

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[Issue Number]. -->
Fixes https://github.com/NativeScript/nativescript-cli/issues/2825

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->
https://github.com/NativeScript/android-runtime/pull/810

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->
Steps to tests.

1. tns create testApp
2. tns platform add ios
3. Edit CFBundleIdentifier iniside app/AppResources/iOS/Info.plist
4. tns build ios


