### PR TITLE
Fix IPA export

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2872,9 +2872,9 @@
       }
     },
     "ios-mobileprovision-finder": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/ios-mobileprovision-finder/-/ios-mobileprovision-finder-1.0.9.tgz",
-      "integrity": "sha1-Hc80ywKeP+oMhSkmu79K6GTswKc=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ios-mobileprovision-finder/-/ios-mobileprovision-finder-1.0.10.tgz",
+      "integrity": "sha1-UaXn+TzUCwN/fI8+JwXjSI11VgE=",
       "requires": {
         "chalk": "1.1.3",
         "plist": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.8",
-    "ios-mobileprovision-finder": "1.0.9",
+    "ios-mobileprovision-finder": "1.0.10",
     "ios-sim-portable": "~3.0.0",
     "lockfile": "1.0.1",
     "lodash": "4.13.1",


### PR DESCRIPTION
Fixes #3020 and related issues by reading the `embedded.mobileprovision` from the built `.app`, detecting the type of the provision that is used and then sending the correct export method when exporting the `.ipa`