### PR TITLE
Expose debugLiveSyncService

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -702,6 +702,12 @@ tns.liveSyncService.on("notify", data => {
 });
 ```
 
+### Module debugLiveSyncService
+> Stability: 1 - Could be changed due to some new requirments.
+
+This module utilizes the same functionality as the [liveSyncService](#livesyncservice) module with the sole exception that this module's purpose is to support LiveSync along with debugging.
+
+
 ## How to add a new method to Public API
 CLI is designed as command line tool and when it is used as a library, it does not give you access to all of the methods. This is mainly implementation detail. Most of the CLI's code is created to work in command line, not as a library, so before adding method to public API, most probably it will require some modification.
 For example the `$options` injected module contains information about all `--` options passed on the terminal. When the CLI is used as a library, the options are not populated. Before adding method to public API, make sure its implementation does not rely on `$options`.

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -106,7 +106,7 @@ $injector.requireCommand("platform|clean", "./commands/platform-clean");
 
 $injector.requirePublicClass("liveSyncService", "./services/livesync/livesync-service");
 $injector.require("liveSyncCommandHelper", "./services/livesync/livesync-command-helper");
-$injector.require("debugLiveSyncService", "./services/livesync/debug-livesync-service");
+$injector.requirePublicClass("debugLiveSyncService", "./services/livesync/debug-livesync-service");
 $injector.require("androidLiveSyncService", "./services/livesync/android-livesync-service");
 $injector.require("iOSLiveSyncService", "./services/livesync/ios-livesync-service");
 $injector.require("usbLiveSyncService", "./services/livesync/livesync-service"); // The name is used in https://github.com/NativeScript/nativescript-dev-typescript

--- a/lib/services/livesync/debug-livesync-service.ts
+++ b/lib/services/livesync/debug-livesync-service.ts
@@ -33,7 +33,7 @@ export class DebugLiveSyncService extends LiveSyncService implements IDebugLiveS
 			$injector);
 	}
 
-	protected async refreshApplication(projectData: IProjectData, liveSyncResultInfo: ILiveSyncResultInfo): Promise<void> {
+	protected async refreshApplication(projectData: IProjectData, liveSyncResultInfo: ILiveSyncResultInfo, outputPath?: string): Promise<void> {
 		const debugOptions = this.$options;
 		const deployOptions: IDeployPlatformOptions = {
 			clean: this.$options.clean,
@@ -64,7 +64,7 @@ export class DebugLiveSyncService extends LiveSyncService implements IDebugLiveS
 		await deviceAppData.device.applicationManager.stopApplication(applicationId, projectData.projectName);
 
 		const buildConfig: IBuildConfig = _.merge({ buildForDevice: !deviceAppData.device.isEmulator }, deployOptions);
-		debugData.pathToAppPackage = this.$platformService.lastOutputPath(debugService.platform, buildConfig, projectData);
+		debugData.pathToAppPackage = this.$platformService.lastOutputPath(debugService.platform, buildConfig, projectData, outputPath);
 
 		this.printDebugInformation(await debugService.debug(debugData, debugOptions));
 	}

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -92,7 +92,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 		}
 	}
 
-	protected async refreshApplication(projectData: IProjectData, liveSyncResultInfo: ILiveSyncResultInfo): Promise<void> {
+	protected async refreshApplication(projectData: IProjectData, liveSyncResultInfo: ILiveSyncResultInfo, outputPath?: string): Promise<void> {
 		const platformLiveSyncService = this.getLiveSyncService(liveSyncResultInfo.deviceAppData.platform);
 		try {
 			await platformLiveSyncService.refreshApplication(projectData, liveSyncResultInfo);
@@ -255,7 +255,7 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 					watch: !liveSyncData.skipWatcher
 				});
 				await this.$platformService.trackActionForPlatform({ action: "LiveSync", platform: device.deviceInfo.platform, isForDevice: !device.isEmulator, deviceOsVersion: device.deviceInfo.version });
-				await this.refreshApplication(projectData, liveSyncResultInfo);
+				await this.refreshApplication(projectData, liveSyncResultInfo, deviceBuildInfoDescriptor.outputPath);
 
 				this.emit(LiveSyncEvents.liveSyncStarted, {
 					projectDir: projectData.projectDir,

--- a/test/nativescript-cli-lib.ts
+++ b/test/nativescript-cli-lib.ts
@@ -21,6 +21,7 @@ describe("nativescript-cli-lib", () => {
 		npm: ["install", "uninstall", "view", "search"],
 		extensibilityService: ["loadExtensions", "loadExtension", "getInstalledExtensions", "installExtension", "uninstallExtension"],
 		liveSyncService: ["liveSync", "stopLiveSync"],
+		debugLiveSyncService: ["liveSync", "stopLiveSync"],
 		analyticsService: ["startEqatecMonitor"],
 		debugService: ["debug"]
 	};


### PR DESCRIPTION
* Expose debugLiveSyncService so it can be used when CLI is `require`-d as a library
* Respect `outputPath` if passed in `refreshApplication`

Ping @TsvetanMilanov @rosen-vladimirov 