### PR TITLE
make livesync work with renamed files and folders

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -219,6 +219,10 @@ export class ProjectChangesService implements IProjectChangesService {
 	}
 
 	private containsNewerFiles(dir: string, skipDir: string, projectData: IProjectData, processFunc?: (filePath: string, projectData: IProjectData) => boolean): boolean {
+		if (this.isDirectoryModified(dir)) {
+			return true;
+		}
+
 		let files = this.$fs.readDirectory(dir);
 		for (let file of files) {
 			let filePath = path.join(dir, file);
@@ -244,10 +248,6 @@ export class ProjectChangesService implements IProjectChangesService {
 			}
 
 			if (fileStats.isDirectory()) {
-				if (this.isDirectoryModified(dir)) {
-					return true;
-				}
-
 				if (this.containsNewerFiles(filePath, skipDir, projectData, processFunc)) {
 					return true;
 				}

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -219,7 +219,8 @@ export class ProjectChangesService implements IProjectChangesService {
 	}
 
 	private containsNewerFiles(dir: string, skipDir: string, projectData: IProjectData, processFunc?: (filePath: string, projectData: IProjectData) => boolean): boolean {
-		if (this.isDirectoryModified(dir)) {
+		const dirFileStat = this.$fs.getFsStats(dir);
+		if (this.isFileModified(dirFileStat)) {
 			return true;
 		}
 
@@ -230,10 +231,8 @@ export class ProjectChangesService implements IProjectChangesService {
 				continue;
 			}
 
-			let fileStats = this.$fs.getFsStats(filePath);
-
-			let changed =  fileStats.mtime.getTime() > this._outputProjectMtime ||
-				fileStats.ctime.getTime() >= this._outputProjectCTime;
+			const fileStats = this.$fs.getFsStats(filePath);
+			let changed = this.isFileModified(fileStats);
 
 			if (changed) {
 				if (processFunc) {
@@ -257,10 +256,9 @@ export class ProjectChangesService implements IProjectChangesService {
 		return false;
 	}
 
-	private isDirectoryModified(dirPath: string): boolean {
-		const dirPathStat = this.$fs.getFsStats(dirPath);
-		return  dirPathStat.mtime.getTime() > this._outputProjectMtime ||
-					dirPathStat.ctime.getTime() >= this._outputProjectCTime;
+	private isFileModified(filePathStat: IFsStats): boolean {
+		return  filePathStat.mtime.getTime() >= this._outputProjectMtime ||
+					filePathStat.ctime.getTime() >= this._outputProjectCTime;
 	}
 
 	private fileChangeRequiresBuild(file: string, projectData: IProjectData) {

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -233,6 +233,10 @@ export class ProjectChangesService implements IProjectChangesService {
 
 			const fileStats = this.$fs.getFsStats(filePath);
 			let changed = this.isFileModified(fileStats);
+			if (!changed) {
+				let lFileStats = this.$fs.getLsStats(filePath);
+				changed = this.isFileModified(lFileStats);
+			}
 
 			if (changed) {
 				if (processFunc) {

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -220,7 +220,7 @@ export class ProjectChangesService implements IProjectChangesService {
 
 	private containsNewerFiles(dir: string, skipDir: string, projectData: IProjectData, processFunc?: (filePath: string, projectData: IProjectData) => boolean): boolean {
 		const dirFileStat = this.$fs.getFsStats(dir);
-		if(this.isFileModified(dirFileStat, dir)) {
+		if (this.isFileModified(dirFileStat, dir)) {
 			return true;
 		}
 
@@ -258,12 +258,12 @@ export class ProjectChangesService implements IProjectChangesService {
 
 	private isFileModified(filePathStat: IFsStats, filePath: string): boolean {
 		let changed = filePathStat.mtime.getTime() >= this._outputProjectMtime ||
-					filePathStat.ctime.getTime() >= this._outputProjectCTime;
+			filePathStat.ctime.getTime() >= this._outputProjectCTime;
 
 		if (!changed) {
 			let lFileStats = this.$fs.getLsStats(filePath);
 			changed = lFileStats.mtime.getTime() >= this._outputProjectMtime ||
-					lFileStats.ctime.getTime() >= this._outputProjectCTime;
+				lFileStats.ctime.getTime() >= this._outputProjectCTime;
 		}
 
 		return changed;

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -6,8 +6,6 @@ import { PlatformsData } from "../lib/platforms-data";
 import { ProjectChangesService } from "../lib/services/project-changes-service";
 import * as Constants from "../lib/constants";
 import { FileSystem } from "../lib/common/file-system";
-import * as HostInfoLib from "../lib/common/host-info";
-import * as ErrorsLib from "../lib/common/errors";
 
 // start tracking temporary folders/files
 temp.track();
@@ -28,8 +26,6 @@ class ProjectChangesServiceTest extends BaseServiceTest {
 		this.injector.register("platformsData", PlatformsData);
 		this.injector.register("androidProjectService", {});
 		this.injector.register("iOSProjectService", {});
-		this.injector.register("hostInfo", HostInfoLib.HostInfo);
-		this.injector.register("errors", ErrorsLib.Errors);
 		this.injector.register("fs", FileSystem);
 		this.injector.register("devicePlatformsConstants", {});
 		this.injector.register("devicePlatformsConstants", {});

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -6,6 +6,8 @@ import { PlatformsData } from "../lib/platforms-data";
 import { ProjectChangesService } from "../lib/services/project-changes-service";
 import * as Constants from "../lib/constants";
 import { FileSystem } from "../lib/common/file-system";
+import * as HostInfoLib from "../lib/common/host-info";
+import * as ErrorsLib from "../lib/common/errors";
 
 // start tracking temporary folders/files
 temp.track();
@@ -26,7 +28,8 @@ class ProjectChangesServiceTest extends BaseServiceTest {
 		this.injector.register("platformsData", PlatformsData);
 		this.injector.register("androidProjectService", {});
 		this.injector.register("iOSProjectService", {});
-
+		this.injector.register("hostInfo", HostInfoLib.HostInfo);
+		this.injector.register("errors", ErrorsLib.Errors);
 		this.injector.register("fs", FileSystem);
 		this.injector.register("devicePlatformsConstants", {});
 		this.injector.register("devicePlatformsConstants", {});


### PR DESCRIPTION
_problem_
On Mac, renaming isn't caught as a change by the incremental prepare.

_effect_
When livesync is ran and a file in the `app/` folder is renamed, the change is not properly applied in the application.

_solution_
Add check for access time so renamed files are prepared.

_Edit_: Checking folder access times before traversing files in it can save us a lot of time checking files.