### PR TITLE
doctor doesn't crash on missing xcode tools

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -604,10 +604,9 @@ interface IVersionsService {
 	getRuntimesVersions(): Promise<IVersionInformation[]>;
 
 	/**
-	 * Gets versions information about the nativescript components with new.
-	 * @return {Promise<IVersionInformation[]>} The version information.
+	 * Checks version information about the nativescript components and prints available updates if any.
 	 */
-	getComponentsForUpdate(): Promise<void>;
+	checkComponentsForUpdate(): Promise<void>;
 
 	/**
 	 * Gets versions information about all nativescript components.

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -607,7 +607,7 @@ interface IVersionsService {
 	 * Gets versions information about the nativescript components with new.
 	 * @return {Promise<IVersionInformation[]>} The version information.
 	 */
-	getComponentsForUpdate(): Promise<IVersionInformation[]>;
+	getComponentsForUpdate(): Promise<void>;
 
 	/**
 	 * Gets versions information about all nativescript components.

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -95,7 +95,7 @@ class DoctorService implements IDoctorService {
 				result = true;
 			}
 
-			if (await this.$xcprojService.verifyXcproj(false)) {
+			if (sysInfo.cocoapodVer && sysInfo.cocoapodVer && await this.$xcprojService.verifyXcproj(false)) {
 				result = true;
 			}
 		} else {
@@ -123,26 +123,13 @@ class DoctorService implements IDoctorService {
 			}
 		}
 
-		let versionsInformation: IVersionInformation[] = [];
 		try {
-			versionsInformation = await this.$versionsService.getComponentsForUpdate();
-			this.printVersionsInformation(versionsInformation);
+			await this.$versionsService.getComponentsForUpdate();
 		} catch (err) {
 			this.$logger.error("Cannot get the latest versions information from npm. Please try again later.");
 		}
 
 		return doctorResult;
-	}
-
-	private printVersionsInformation(versionsInformation: IVersionInformation[]) {
-		if (versionsInformation && versionsInformation.length) {
-			let table: any = this.$versionsService.createTableWithVersionsInformation(versionsInformation);
-
-			this.$logger.warn("Updates available");
-			this.$logger.out(table.toString() + EOL);
-		} else {
-			this.$logger.out("Your components are up-to-date." + EOL);
-		}
 	}
 
 	private async promptForDocs(link: string): Promise<void> {

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -95,7 +95,7 @@ class DoctorService implements IDoctorService {
 				result = true;
 			}
 
-			if (sysInfo.cocoapodVer && sysInfo.cocoapodVer && await this.$xcprojService.verifyXcproj(false)) {
+			if (sysInfo.xcodeVer && sysInfo.cocoapodVer && await this.$xcprojService.verifyXcproj(false)) {
 				result = true;
 			}
 		} else {
@@ -124,7 +124,7 @@ class DoctorService implements IDoctorService {
 		}
 
 		try {
-			await this.$versionsService.getComponentsForUpdate();
+			await this.$versionsService.checkComponentsForUpdate();
 		} catch (err) {
 			this.$logger.error("Cannot get the latest versions information from npm. Please try again later.");
 		}

--- a/lib/services/versions-service.ts
+++ b/lib/services/versions-service.ts
@@ -1,3 +1,4 @@
+import { EOL } from "os";
 import * as constants from "../constants";
 import * as semver from "semver";
 import * as path from "path";
@@ -14,7 +15,8 @@ class VersionsService implements IVersionsService {
 		private $npmInstallationManager: INpmInstallationManager,
 		private $injector: IInjector,
 		private $staticConfig: Config.IStaticConfig,
-		private $pluginsService: IPluginsService) {
+		private $pluginsService: IPluginsService,
+		private $logger: ILogger) {
 		this.projectData = this.getProjectData();
 	}
 
@@ -84,7 +86,7 @@ class VersionsService implements IVersionsService {
 		return runtimesVersions;
 	}
 
-	public async getComponentsForUpdate(): Promise<IVersionInformation[]> {
+	public async getComponentsForUpdate() {
 		let allComponents: IVersionInformation[] = await this.getAllComponentsVersions();
 		let componentsForUpdate: IVersionInformation[] = [];
 
@@ -94,7 +96,18 @@ class VersionsService implements IVersionsService {
 			}
 		});
 
-		return componentsForUpdate;
+		this.printVersionsInformation(componentsForUpdate, allComponents);
+	}
+
+	private printVersionsInformation(versionsInformation: IVersionInformation[], allComponents: IVersionInformation[]) {
+		if (versionsInformation && versionsInformation.length) {
+			let table: any = this.createTableWithVersionsInformation(versionsInformation);
+
+			this.$logger.warn("Updates available");
+			this.$logger.out(table.toString() + EOL);
+		} else {
+			this.$logger.out(`Your components are up-to-date: ${EOL}${allComponents.map(component => component.componentName)}${EOL}`);
+		}
 	}
 
 	public async getAllComponentsVersions(): Promise<IVersionInformation[]> {

--- a/lib/services/versions-service.ts
+++ b/lib/services/versions-service.ts
@@ -99,7 +99,7 @@ class VersionsService implements IVersionsService {
 		this.printVersionsInformation(componentsForUpdate, allComponents);
 	}
 
-	private printVersionsInformation(versionsInformation: IVersionInformation[], allComponents: IVersionInformation[]) {
+	private printVersionsInformation(versionsInformation: IVersionInformation[], allComponents: IVersionInformation[]): void {
 		if (versionsInformation && versionsInformation.length) {
 			let table: any = this.createTableWithVersionsInformation(versionsInformation);
 

--- a/lib/services/versions-service.ts
+++ b/lib/services/versions-service.ts
@@ -86,7 +86,7 @@ class VersionsService implements IVersionsService {
 		return runtimesVersions;
 	}
 
-	public async getComponentsForUpdate() {
+	public async checkComponentsForUpdate(): Promise<void> {
 		let allComponents: IVersionInformation[] = await this.getAllComponentsVersions();
 		let componentsForUpdate: IVersionInformation[] = [];
 


### PR DESCRIPTION
Doctor crashes because of invalid environment.
Related issue: NativeScript/nativescript-cli#2810

_problem_
* doctor crashes when `xcodebuild` can't be found (when xCode build tools aren't installed).
* provide a more detailed message for: "Your components are up to date"

_solution_
* don't verify xCode project if xcodeVersion and cocoaPods aren't verified
* list the components that are up to date for the user