### PR TITLE
Fix tns run ios on case sensitive file system

### DIFF
--- a/lib/services/ios-entitlements-service.ts
+++ b/lib/services/ios-entitlements-service.ts
@@ -22,7 +22,7 @@ export class IOSEntitlementsService {
 	}
 
 	public getPlatformsEntitlementsPath(projectData: IProjectData) : string {
-		return path.join(projectData.platformsDir, this.$devicePlatformsConstants.iOS,
+		return path.join(projectData.platformsDir, this.$devicePlatformsConstants.iOS.toLowerCase(),
 			projectData.projectName, projectData.projectName + ".entitlements");
 	}
 	public getPlatformsEntitlementsRelativePath(projectData: IProjectData): string {

--- a/test/ios-entitlements-service.ts
+++ b/test/ios-entitlements-service.ts
@@ -64,6 +64,12 @@ describe("IOSEntitlements Service Tests", () => {
 			let actual = iOSEntitlementsService.getPlatformsEntitlementsRelativePath(projectData);
 			assert.equal(actual, expected);
 		});
+
+		it("Ensure full path to entitlements in platforms dir is correct", () => {
+			const expected = path.join(projectData.platformsDir, "ios", "testApp", "testApp.entitlements");
+			const actual = iOSEntitlementsService.getPlatformsEntitlementsPath(projectData);
+			assert.equal(actual, expected);
+		});
 	});
 
 	describe("Merge", () => {


### PR DESCRIPTION
In case during `tns run ios` the application is uninstalled manually and after that a change is applied, CLI should install the app and continue with livesync operation. However it fails with EPIPE. The problem was in ios-device-lib - it is fixed in 0.4.8 version.

https://github.com/NativeScript/nativescript-cli/issues/2946