### PR TITLE
Fix `tns debug <platform> --start` inconsistent behavior

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -29,13 +29,14 @@ export class DebugPlatformCommand implements ICommand {
 
 		await this.$platformService.trackProjectType(this.$projectData);
 
+		const selectedDeviceForDebug = await this.getDeviceForDebug();
+		debugData.deviceIdentifier = selectedDeviceForDebug.deviceInfo.identifier;
+
 		if (this.$options.start) {
 			return this.$debugLiveSyncService.printDebugInformation(await this.debugService.debug(debugData, debugOptions));
 		}
 
 		this.$config.debugLivesync = true;
-
-		const selectedDeviceForDebug = await this.getDeviceForDebug();
 
 		await this.$devicesService.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: this.platform });
 


### PR DESCRIPTION
`tns debug <platform>` will check all available devices and will prompt the user to select device for debugging. In case the terminal is not interactive, it will select the emulator/device with highest API level.
However, adding `--start` causes failure as the described logic is not used. So ensure we have this behavior even when `--start` is used.

https://github.com/NativeScript/nativescript-cli/issues/3021