### PR TITLE
Improve get latest compatible version to search for major.minor.*x* versions

### DIFF
--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -20,15 +20,23 @@ export class NpmInstallationManager implements INpmInstallationManager {
 	}
 
 	public async getLatestCompatibleVersion(packageName: string): Promise<string> {
+		const configVersion = this.$staticConfig.version;
+		const isPreReleaseVersion = semver.prerelease(configVersion) !== null;
+		let cliVersionRange = `~${semver.major(configVersion)}.${semver.minor(configVersion)}.0`;
+		if (isPreReleaseVersion) {
+			// if the user has some 0-19 pre-release version, include pre-release versions in the search query.
+			cliVersionRange = `~${configVersion}`;
+		}
 
-		let cliVersionRange = `~${this.$staticConfig.version}`;
-		let latestVersion = await this.getLatestVersion(packageName);
+		const latestVersion = await this.getLatestVersion(packageName);
 		if (semver.satisfies(latestVersion, cliVersionRange)) {
 			return latestVersion;
 		}
-		let data = await this.$npm.view(packageName, { "versions": true });
 
-		return semver.maxSatisfying(data, cliVersionRange) || latestVersion;
+		const data = await this.$npm.view(packageName, { "versions": true });
+
+		const maxSatisfying = semver.maxSatisfying(data, cliVersionRange);
+		return maxSatisfying || latestVersion;
 	}
 
 	public async install(packageName: string, projectDir: string, opts?: INpmInstallOptions): Promise<any> {

--- a/test/npm-installation-manager.ts
+++ b/test/npm-installation-manager.ts
@@ -146,6 +146,12 @@ describe("Npm installation manager tests", () => {
 			packageLatestVersion: "1.4.0",
 			cliVersion: "1.6.0-2016-10-01-182",
 			expectedResult: "1.4.0"
+		},
+		"When CLI Version has patch version larger than an existing package, should return max compliant package from the same major.minor version": {
+			versions: ["1.0.0", "1.0.1", "1.4.0", "2.5.0", "2.5.1", "2.5.2", "3.0.0"],
+			packageLatestVersion: "3.0.0",
+			cliVersion: "2.5.4",
+			expectedResult: "2.5.2"
 		}
 	};
 


### PR DESCRIPTION
This has been fixed in CLI 2.5.5, but it never get into our master or release branch:
Not merged PR: https://github.com/NativeScript/nativescript-cli/pull/2800
Merged PR in 2.5.5: https://github.com/NativeScript/nativescript-cli/pull/2793

I've just cherry-picked the commit from PR 2800.


The problem arises when we have CLI 3.1.3 for example, but a template has versions 3.1.0, 3.1.1, 3.2.0, 3.2.1...
In this case CLI should install template 3.1.1, but instead it uses latest (3.2.1). The problem is that we have been using semver comparison based on CLI's version (~3.1.3), while in fact we should get only major and minor numbers from it (~3.1.0)