### PR TITLE
Fix message when unable to find devices for LiveSync

### DIFF
--- a/lib/services/livesync/livesync-command-helper.ts
+++ b/lib/services/livesync/livesync-command-helper.ts
@@ -17,7 +17,11 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 
 	public async executeLiveSyncOperation(devices: Mobile.IDevice[], liveSyncService: ILiveSyncService, platform: string): Promise<void> {
 		if (!devices || !devices.length) {
-			this.$errors.failWithoutHelp("Unable to find applicable devices to execute operation and unable to start emulator when platform is not specified.");
+			if (platform) {
+				this.$errors.failWithoutHelp("Unable to find applicable devices to execute operation. Ensure connected devices are trusted and try again.");
+			} else {
+				this.$errors.failWithoutHelp("Unable to find applicable devices to execute operation and unable to start emulator when platform is not specified.");
+			}
 		}
 
 		const workingWithiOSDevices = !platform || this.$mobileHelper.isiOSPlatform(platform);


### PR DESCRIPTION
In case there are attached, but not trusted devices, `tns run <platform>` command prints error that it is unable to find devices and cannot start emulator when platform is not specified.
But the platform has been specified, so improve the error message in such cases.