### PR TITLE
Update ios-sim-portable to 3.1.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2926,9 +2926,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.0.0.tgz",
-      "integrity": "sha1-VOCVccIb+TNH8sfAFSno9fHEtfI=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.1.0.tgz",
+      "integrity": "sha1-IgAOTTUYgvQz8DtS2TqPICZm/f4=",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.8",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "~3.0.0",
+    "ios-sim-portable": "3.1.0",
     "lockfile": "1.0.1",
     "lodash": "4.13.1",
     "log4js": "1.0.1",


### PR DESCRIPTION
This will fix issue with starting iOS Simulator when a fake device id is passed. Instead we will fail with correct error from now on.

As we are now using shrinkwrap file, the version of ios-sim-portable is always strict, so set it to strict in package.json as well.
Related to: https://github.com/NativeScript/nativescript-cli/issues/2728

Merge after https://github.com/telerik/mobile-cli-lib/pull/1000