### PR TITLE
Fix passing provision to `tns run ios` and passsing `--teamId`

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -94,6 +94,11 @@ interface ILiveSyncDeviceInfo {
 	 * Whether to skip preparing the native platform.
 	 */
 	skipNativePrepare?: boolean;
+
+	/**
+	 * Describes options specific for each platform, like provision for iOS, target sdk for Android, etc.
+	 */
+	platformSpecificOptions?: IPlatformOptions;
 }
 
 /**

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -1,7 +1,7 @@
 interface IPlatformService extends NodeJS.EventEmitter {
-	cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, framework?: string): Promise<void>;
+	cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, framework?: string): Promise<void>;
 
-	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string): Promise<void>;
+	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, frameworkPath?: string): Promise<void>;
 
 	/**
 	 * Gets list of all installed platforms (the ones for which <project dir>/platforms/<platform> exists).
@@ -32,7 +32,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 */
 	removePlatforms(platforms: string[], projectData: IProjectData): Promise<void>;
 
-	updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void>;
+	updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void>;
 
 	/**
 	 * Ensures that the specified platform and its dependencies are installed.
@@ -47,7 +47,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {Array} filesToSync Files about to be synced to device.
 	 * @returns {boolean} true indicates that the platform was prepared.
 	 */
-	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<boolean>;
+	preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<boolean>;
 
 	/**
 	 * Determines whether a build is necessary. A build is necessary when one of the following is true:
@@ -113,7 +113,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @param {IAddPlatformCoreOptions} config Options required for project preparation/creation.
 	 * @returns {void}
 	 */
-	deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void>;
+	deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, config: IPlatformOptions): Promise<void>;
 
 	/**
 	 * Runs the application on specified platform. Assumes that the application is already build and installed. Fails if this is not true.
@@ -124,7 +124,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 */
 	startApplication(platform: string, runOptions: IRunPlatformOptions, projectId: string): Promise<void>;
 
-	cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void>;
+	cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void>;
 	validatePlatformInstalled(platform: string, projectData: IProjectData): void;
 
 	/**
@@ -213,17 +213,12 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	saveBuildInfoFile(platform: string, projectDir: string, buildInfoFileDirname: string): void
 }
 
-interface IAddPlatformCoreOptions extends IPlatformSpecificData, ICreateProjectOptions { }
+interface IPlatformOptions extends IPlatformSpecificData, ICreateProjectOptions { }
 
 /**
  * Platform specific data required for project preparation.
  */
-interface IPlatformSpecificData {
-	/**
-	 * UUID of the provisioning profile used in iOS project preparation.
-	 */
-	provision: any;
-
+interface IPlatformSpecificData extends IProvision {
 	/**
 	 * Target SDK for Android.
 	 */

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -155,10 +155,6 @@ interface IiOSBuildConfig extends IBuildForDevice, IDeviceIdentifier, IProvision
 	 * Code sign identity used for build. If not set iPhone Developer is used as a default when building for device.
 	 */
 	codeSignIdentity?: string;
-	/**
-	 * Team identifier.
-	 */
-	teamIdentifier?: string;
 }
 
 interface IPlatformProjectService extends NodeJS.EventEmitter {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -396,8 +396,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			args.push(`PROVISIONING_PROFILE=${buildConfig.mobileProvisionIdentifier}`);
 		}
 
-		if (buildConfig && buildConfig.teamIdentifier) {
-			args.push(`DEVELOPMENT_TEAM=${buildConfig.teamIdentifier}`);
+		if (buildConfig && buildConfig.teamId) {
+			args.push(`DEVELOPMENT_TEAM=${buildConfig.teamId}`);
 		}
 
 		// this.$logger.out("xcodebuild...");
@@ -470,11 +470,13 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			xcode.setManualSigningStyle(projectData.projectName);
 			xcode.save();
 		} else if (!buildConfig.provision && !(signing && signing.style === "Manual" && !buildConfig.teamId)) {
-			if (buildConfig) {
-				delete buildConfig.teamIdentifier;
-			}
-
 			const teamId = await this.getDevelopmentTeam(projectData, buildConfig.teamId);
+
+			// Remove teamId from build config as we'll set the signing in Xcode project directly.
+			// In case we do not remove it, we'll pass DEVELOPMENT_TEAM=<team id> to xcodebuild, which is unnecessary.
+			if (buildConfig.teamId) {
+				delete buildConfig.teamId;
+			}
 
 			xcode.setAutomaticSigningStyle(projectData.projectName, teamId);
 			xcode.save();
@@ -1328,6 +1330,9 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 				}
 			}
 		}
+
+		this.$logger.trace(`Selected teamId is '${teamId}'.`);
+
 		return teamId;
 	}
 

--- a/lib/services/livesync/livesync-command-helper.ts
+++ b/lib/services/livesync/livesync-command-helper.ts
@@ -40,6 +40,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			.map(d => {
 				const info: ILiveSyncDeviceInfo = {
 					identifier: d.deviceInfo.identifier,
+					platformSpecificOptions: this.$options,
+
 					buildAction: async (): Promise<string> => {
 						const buildConfig: IBuildConfig = {
 							buildForDevice: !d.isEmulator,

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -165,11 +165,12 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 		const appInstalledOnDeviceResult: IAppInstalledOnDeviceResult = { appInstalled: false };
 		if (options.preparedPlatforms.indexOf(platform) === -1) {
 			options.preparedPlatforms.push(platform);
-			// TODO: Pass provision and sdk as a fifth argument here
+
+			const platformSpecificOptions = options.deviceBuildInfoDescriptor.platformSpecificOptions || <IPlatformOptions>{};
 			await this.$platformService.preparePlatform(platform, {
 				bundle: false,
 				release: false,
-			}, null, options.projectData, <any>{}, options.modifiedFiles, nativePrepare);
+			}, null, options.projectData, platformSpecificOptions, options.modifiedFiles, nativePrepare);
 		}
 
 		const buildResult = await this.installedCachedAppPackage(platform, options);
@@ -178,8 +179,10 @@ export class LiveSyncService extends EventEmitter implements ILiveSyncService {
 			return appInstalledOnDeviceResult;
 		}
 
-		// TODO: Pass provision and sdk as a fifth argument here
-		const shouldBuild = await this.$platformService.shouldBuild(platform, options.projectData, <any>{ buildForDevice: !options.device.isEmulator, clean: options.liveSyncData && options.liveSyncData.clean }, options.deviceBuildInfoDescriptor.outputPath);
+		const shouldBuild = await this.$platformService.shouldBuild(platform,
+			options.projectData,
+			<any>{ buildForDevice: !options.device.isEmulator, clean: options.liveSyncData && options.liveSyncData.clean },
+			options.deviceBuildInfoDescriptor.outputPath);
 		let pathToBuildItem = null;
 		let action = LiveSyncTrackActionNames.LIVESYNC_OPERATION;
 		if (shouldBuild) {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -43,7 +43,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		super();
 	}
 
-	public async cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, framworkPath?: string): Promise<void> {
+	public async cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, framworkPath?: string): Promise<void> {
 		for (let platform of platforms) {
 			let version: string = this.getCurrentPlatformVersion(platform, projectData);
 
@@ -57,7 +57,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	public async addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string): Promise<void> {
+	public async addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, frameworkPath?: string): Promise<void> {
 		const platformsDir = projectData.platformsDir;
 		this.$fs.ensureDirectoryExists(platformsDir);
 
@@ -84,7 +84,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return version;
 	}
 
-	private async addPlatform(platformParam: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, frameworkPath?: string, nativePrepare?: INativePrepare): Promise<void> {
+	private async addPlatform(platformParam: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, frameworkPath?: string, nativePrepare?: INativePrepare): Promise<void> {
 		let data = platformParam.split("@"),
 			platform = data[0].toLowerCase(),
 			version = data[1];
@@ -137,7 +137,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		this.$logger.out("Project successfully created.");
 	}
 
-	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, nativePrepare?: INativePrepare): Promise<string> {
+	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, nativePrepare?: INativePrepare): Promise<string> {
 		const coreModuleData = this.$fs.readJson(path.join(frameworkDir, "..", "package.json"));
 		const installedVersion = coreModuleData.version;
 		const customTemplateOptions = await this.getPathToPlatformTemplate(platformTemplate, platformData.frameworkPackageName, projectData.projectDir);
@@ -159,7 +159,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	}
 
-	private async addPlatformCoreNative(platformData: IPlatformData, frameworkDir: string, installedVersion: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+	private async addPlatformCoreNative(platformData: IPlatformData, frameworkDir: string, installedVersion: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
 		await platformData.platformProjectService.createProject(path.resolve(frameworkDir), installedVersion, projectData, config);
 		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
 		await platformData.platformProjectService.interpolateData(projectData, config);
@@ -213,7 +213,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	public getPreparedPlatforms(projectData: IProjectData): string[] {
 		return _.filter(this.$platformsData.platformsNames, p => { return this.isPlatformPrepared(p, projectData); });
 	}
-	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<boolean> {
+	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<boolean> {
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const changesInfo = await this.initialPrepare(platform, platformData, appFilesUpdaterOptions, platformTemplate, projectData, config, nativePrepare);
 		const requiresNativePrepare = (!nativePrepare || !nativePrepare.skipNativePrepare) && changesInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPrepare;
@@ -265,7 +265,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	private async initialPrepare(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, nativePrepare?: INativePrepare): Promise<IProjectChangesInfo> {
+	private async initialPrepare(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, nativePrepare?: INativePrepare): Promise<IProjectChangesInfo> {
 		this.validatePlatform(platform, projectData);
 
 		await this.trackProjectType(projectData);
@@ -532,7 +532,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		this.$logger.out(`Successfully installed on device with identifier '${device.deviceInfo.identifier}'.`);
 	}
 
-	public async deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+	public async deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
 		await this.preparePlatform(platform, appFilesUpdaterOptions, deployOptions.platformTemplate, projectData, config);
 		let options: Mobile.IDevicesServicesInitializationOptions = {
 			platform: platform, deviceId: deployOptions.device, emulator: deployOptions.emulator
@@ -623,7 +623,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return null;
 	}
 
-	public async cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+	public async cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
 		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, config);
 
 		const appSourceDirectoryPath = path.join(projectData.projectDir, constants.APP_FOLDER_NAME);
@@ -679,7 +679,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	public async updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+	public async updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
 		for (let platformParam of platforms) {
 			let data = platformParam.split("@"),
 				platform = data[0],
@@ -736,7 +736,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	public async ensurePlatformInstalled(platform: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions, nativePrepare?: INativePrepare): Promise<void> {
+	public async ensurePlatformInstalled(platform: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, nativePrepare?: INativePrepare): Promise<void> {
 		let requiresNativePlatformAdd = false;
 
 		if (!this.isPlatformInstalled(platform, projectData)) {
@@ -808,7 +808,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return this.getLatestApplicationPackage(outputPath || platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath, platformData.getValidPackageNames({ isForDevice: false, isReleaseBuild: buildConfig.release }));
 	}
 
-	private async updatePlatform(platform: string, version: string, platformTemplate: string, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+	private async updatePlatform(platform: string, version: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 
 		let data = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
@@ -841,7 +841,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	}
 
-	private async updatePlatformCore(platformData: IPlatformData, updateOptions: IUpdatePlatformOptions, projectData: IProjectData, config: IAddPlatformCoreOptions): Promise<void> {
+	private async updatePlatformCore(platformData: IPlatformData, updateOptions: IUpdatePlatformOptions, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
 		let packageName = platformData.normalizedPlatformName.toLowerCase();
 		await this.removePlatforms([packageName], projectData);
 		packageName = updateOptions.newVersion ? `${packageName}@${updateOptions.newVersion}` : packageName;

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -147,7 +147,7 @@ class DestinationFolderVerifier {
 
 describe('Platform Service Tests', () => {
 	let platformService: IPlatformService, testInjector: IInjector;
-	const config: IAddPlatformCoreOptions = {
+	const config: IPlatformOptions = {
 		ignoreScripts: false,
 		provision: null,
 		sdk: null,


### PR DESCRIPTION
Passing `--provision` to `tns run <ios>` is not respected. Fix this by including additional option in the deviceDescriptors. This allows us to pass different provisions for each device, however in CLI's commands we'll set one provision for all devices.

Also fix passing `--teamId` option - during previous refactoring we've broken the code for it and it has not been respected. Remove the unused alias `teamIdentifier` and use `teamId` in all cases.

Rename `IAddPlatformCoreOptions` to `IPlatformOptions` as it is better name of the purpose of the interface.