### PR TITLE
Fix xcode9 provision, provide --quiet by default, enable -allowProvisioningUpdates

### DIFF
--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -15,6 +15,7 @@ Builds the project for iOS and produces an `APP` or `IPA` that you can manually 
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 * `--for-device` - If set, produces an application package that you can deploy on device. Otherwise, produces a build that you can run only in the native iOS Simulator.
 * `--copy-to` - Specifies the file path where the built `.ipa` will be copied. If it points to a non-existent directory, it will be created. If the specified value is directory, the original file name will be used.
+* `--team-id` - If used without parameter, lists all team names and ids. If used with team name or id, it will switch to automatic signing mode and configure the .xcodeproj file of your app. In this case .xcconfig should not contain any provisioning/team id flags. This team id will be further used for codesigning the app. For Xcode 9.0+, xcodebuild will be allowed to update and modify automatically managed provisioning profiles.
 * `--provision` - If used without parameter, lists all eligible provisioning profiles. If used with UUID or name of your provisioning profile, it will switch to manual signing mode and configure the .xcodeproj file of your app. In this case xcconfig should not contain any provisioning/team id flags. This provisioning profile will be further used for codesigning the app.
 <% } %>
 <% if(isHtml) { %>

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -83,7 +83,7 @@ export class PublishIOS implements ICommand {
 				let archivePath = await iOSProjectService.archive(this.$projectData);
 				this.$logger.info("Archive at: " + archivePath);
 
-				let exportPath = await iOSProjectService.exportArchive(this.$projectData, { archivePath, teamID });
+				let exportPath = await iOSProjectService.exportArchive(this.$projectData, { archivePath, teamID, provision: mobileProvisionIdentifier || this.$options.provision });
 				this.$logger.info("Export at: " + exportPath);
 
 				ipaFilePath = exportPath;

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -57,7 +57,7 @@ export class BuildIosCommand extends BuildCommandBase implements ICommand {
 
 	public canExecute(args: string[]): Promise<boolean> {
 		super.validatePlatform(this.$devicePlatformsConstants.iOS);
-		return args.length === 0 && this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.iOS);
+		return args.length === 0 && this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.iOS);
 	}
 }
 
@@ -89,7 +89,7 @@ export class BuildAndroidCommand extends BuildCommandBase implements ICommand {
 		const platformProjectService = platformData.platformProjectService;
 		await platformProjectService.validate(this.$projectData);
 
-		return args.length === 0 && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.Android);
+		return args.length === 0 && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.Android);
 	}
 }
 

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -154,7 +154,7 @@ export class DebugIOSCommand implements ICommand {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.iOS} can not be built on this OS`);
 		}
 
-		return await this.debugPlatformCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.iOS);
+		return await this.debugPlatformCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.iOS);
 	}
 
 	public platform = this.$devicePlatformsConstants.iOS;
@@ -186,7 +186,7 @@ export class DebugAndroidCommand implements ICommand {
 		return this.debugPlatformCommand.execute(args);
 	}
 	public async canExecute(args: string[]): Promise<boolean> {
-		return await this.debugPlatformCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.Android);
+		return await this.debugPlatformCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.Android);
 	}
 
 	public platform = this.$devicePlatformsConstants.Android;

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -48,7 +48,7 @@ export class DeployOnDeviceCommand implements ICommand {
 		const platformProjectService = platformData.platformProjectService;
 		await platformProjectService.validate(this.$projectData);
 
-		return this.$platformService.validateOptions(this.$options.provision, this.$projectData, args[0]);
+		return this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, args[0]);
 	}
 }
 

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -16,7 +16,7 @@ export class PrepareCommand implements ICommand {
 
 	public async canExecute(args: string[]): Promise<boolean> {
 		const platform = args[0];
-		const result = await this.$platformCommandParameter.validate(platform) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, platform);
+		const result = await this.$platformCommandParameter.validate(platform) && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, platform);
 		if (result) {
 			const platformData = this.$platformsData.getPlatformData(platform, this.$projectData);
 			const platformProjectService = platformData.platformProjectService;

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -97,7 +97,7 @@ export class RunIosCommand implements ICommand {
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
-		return await this.runCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.iOS);
+		return await this.runCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.iOS);
 	}
 }
 
@@ -140,7 +140,7 @@ export class RunAndroidCommand implements ICommand {
 		if (this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
 			this.$errors.fail("When producing a release build, you need to specify all --key-store-* options.");
 		}
-		return this.$platformService.validateOptions(this.$options.provision, this.$projectData, this.$platformsData.availablePlatforms.Android);
+		return this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.Android);
 	}
 }
 

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -101,7 +101,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * If no platform is provided or a falsy (null, undefined, "", false...) platform is provided,
 	 * the options will be validated for all available platforms.
 	 */
-	validateOptions(provision: any, projectData: IProjectData, platform?: string): Promise<boolean>;
+	validateOptions(provision: true | string, teamId: true | string, projectData: IProjectData, platform?: string): Promise<boolean>;
 
 	/**
 	 * Executes prepare, build and installOnPlatform when necessary to ensure that the latest version of the app is installed on specified platform.
@@ -218,7 +218,7 @@ interface IPlatformOptions extends IPlatformSpecificData, ICreateProjectOptions 
 /**
  * Platform specific data required for project preparation.
  */
-interface IPlatformSpecificData extends IProvision {
+interface IPlatformSpecificData extends IProvision, ITeamIdentifier {
 	/**
 	 * Target SDK for Android.
 	 */

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -22,12 +22,12 @@ interface IProjectChangesInfo extends IAddedNativePlatform {
 	readonly changesRequirePrepare: boolean;
 }
 
-interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision {
+interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision, ITeamIdentifier {
 	nativePlatformStatus?: "1" | "2" | "3";
 }
 
 interface IProjectChangesService {
-	checkForChanges(platform: string, projectData: IProjectData, buildOptions: IProjectChangesOptions): IProjectChangesInfo;
+	checkForChanges(platform: string, projectData: IProjectData, buildOptions: IProjectChangesOptions): Promise<IProjectChangesInfo>;
 	getPrepareInfo(platform: string, projectData: IProjectData): IPrepareInfo;
 	savePrepareInfo(platform: string, projectData: IProjectData): void;
 	getPrepareInfoFilePath(platform: string, projectData: IProjectData): string;

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -178,7 +178,7 @@ interface IPlatformProjectService extends NodeJS.EventEmitter {
 	 * @param {any} provision UUID of the provisioning profile used in iOS option validation.
 	 * @returns {void}
 	 */
-	validateOptions(projectId?: string, provision?: true | string): Promise<boolean>;
+	validateOptions(projectId?: string, provision?: true | string, teamId?: true | string): Promise<boolean>;
 
 	validatePlugins(projectData: IProjectData): Promise<void>;
 
@@ -265,7 +265,7 @@ interface IPlatformProjectService extends NodeJS.EventEmitter {
 	 * Check the current state of the project, and validate against the options.
 	 * If there are parts in the project that are inconsistent with the desired options, marks them in the changeset flags.
 	 */
-	checkForChanges(changeset: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): void;
+	checkForChanges(changeset: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): Promise<void>;
 }
 
 interface IAndroidProjectPropertiesManager {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -34,7 +34,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			androidTypings: { type: OptionType.Boolean },
 			bundle: { type: OptionType.Boolean },
 			all: { type: OptionType.Boolean },
-			teamId: { type: OptionType.String },
+			teamId: { type: OptionType.Object },
 			syncAllFiles: { type: OptionType.Boolean, default: false },
 			liveEdit: { type: OptionType.Boolean },
 			chrome: { type: OptionType.Boolean },

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -517,12 +517,18 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		if (this.$androidToolsInfo.getToolsInfo().androidHomeEnvVar) {
 			const gradlew = this.$hostInfo.isWindows ? "gradlew.bat" : "./gradlew";
 
+			const localArgs = [...gradleArgs];
+			if (this.$logger.getLevel() === "INFO") {
+				localArgs.push("--quiet");
+				this.$logger.info(`${gradlew} ${localArgs.join(" ")}`);
+			}
+
 			childProcessOpts = childProcessOpts || {};
 			childProcessOpts.cwd = childProcessOpts.cwd || projectRoot;
 			childProcessOpts.stdio = childProcessOpts.stdio || "inherit";
 
 			return await this.spawn(gradlew,
-				gradleArgs,
+				localArgs,
 				childProcessOpts,
 				spawnFromEventOptions);
 		}

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -447,7 +447,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		await adb.executeShellCommand(["rm", "-rf", deviceRootPath]);
 	}
 
-	public checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): void {
+	public async checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): Promise<void> {
 		// Nothing android specific to check yet.
 	}
 

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -520,7 +520,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			const localArgs = [...gradleArgs];
 			if (this.$logger.getLevel() === "INFO") {
 				localArgs.push("--quiet");
-				this.$logger.info(`${gradlew} ${localArgs.join(" ")}`);
+				this.$logger.info("Gradle build...");
 			}
 
 			childProcessOpts = childProcessOpts || {};

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -433,8 +433,12 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	private async xcodebuild(args: string[], cwd: string, stdio: any = "inherit"): Promise<ISpawnResult> {
 		const localArgs = [...args];
 		const xcodeBuildVersion = await this.getXcodeVersion();
-		if (helpers.versionCompare(xcodeBuildVersion, "9.0") >= 0) {
-			localArgs.push("-allowProvisioningUpdates");
+		try {
+			if (helpers.versionCompare(xcodeBuildVersion, "9.0") >= 0) {
+				localArgs.push("-allowProvisioningUpdates");
+			}
+		} catch (e) {
+			console.warn("Failed to use xcodebuild with -allowProvisioningUpdates due to error: " + e);
 		}
 		if (this.$logger.getLevel() === "INFO") {
 			localArgs.push("-quiet");
@@ -1283,9 +1287,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 		}
 
 		let splitedXcodeBuildVersion = xcodeBuildVersion.split(".");
-		if (splitedXcodeBuildVersion.length === 3) {
-			xcodeBuildVersion = `${splitedXcodeBuildVersion[0]}.${splitedXcodeBuildVersion[1]}`;
-		}
+		xcodeBuildVersion = `${splitedXcodeBuildVersion[0] || 0}.${splitedXcodeBuildVersion[1] || 0}`;
 
 		return xcodeBuildVersion;
 	}

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -429,7 +429,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		}
 		if (this.$logger.getLevel() === "INFO") {
 			localArgs.push("-quiet");
-			this.$logger.info(`xcodebuild ${localArgs.join(" ")}`);
+			this.$logger.info("Xcode build...");
 		}
 		return this.$childProcess.spawnFromEvent("xcodebuild",
 			localArgs,

--- a/lib/services/ios-provision-service.ts
+++ b/lib/services/ios-provision-service.ts
@@ -1,17 +1,9 @@
 import * as mobileprovision from "ios-mobileprovision-finder";
-import { createTable } from "../common/helpers";
+import { createTable, quoteString } from "../common/helpers";
 
 const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 function formatDate(date: Date): string {
 	return `${date.getDay()} ${months[date.getMonth()]} ${date.getFullYear()}`;
-}
-
-/**
- * Formats the argument so it can easily be copied from the terminal and provided as value for an option.
- * @param arg The string to format.
- */
-function cmdEscape(arg: string): string {
-	return `"${arg}"`;
 }
 
 export class IOSProvisionService {
@@ -57,7 +49,7 @@ export class IOSProvisionService {
 
 		function pushProvision(prov: mobileprovision.provision.MobileProvision) {
 			table.push(["", "", "", ""]);
-			table.push([cmdEscape(prov.Name), prov.TeamName, prov.Type, formatTotalDeviceCount(prov)]);
+			table.push([quoteString(prov.Name), prov.TeamName, prov.Type, formatTotalDeviceCount(prov)]);
 			table.push([prov.UUID, prov.TeamIdentifier && prov.TeamIdentifier.length > 0 ? "(" + prov.TeamIdentifier[0] + ")" : "", formatDate(prov.ExpirationDate), formatSupportedDeviceCount(prov)]);
 			table.push([prov.Entitlements["application-identifier"], "", "", ""]);
 		}
@@ -71,7 +63,7 @@ export class IOSProvisionService {
 
 	public async listTeams(): Promise<void> {
 		const teams = await this.getDevelopmentTeams();
-		const table = createTable(["Team Name", "Team ID"], teams.map(team => [cmdEscape(team.name), team.id]));
+		const table = createTable(["Team Name", "Team ID"], teams.map(team => [quoteString(team.name), team.id]));
 		this.$logger.out(table.toString());
 	}
 

--- a/lib/services/local-build-service.ts
+++ b/lib/services/local-build-service.ts
@@ -12,6 +12,7 @@ export class LocalBuildService extends EventEmitter {
 		this.$projectData.initializeProjectData(platformBuildOptions.projectDir);
 		await this.$platformService.preparePlatform(platform, platformBuildOptions, platformTemplate, this.$projectData, {
 			provision: platformBuildOptions.provision,
+			teamId: platformBuildOptions.teamId,
 			sdk: null,
 			frameworkPath: null,
 			ignoreScripts: false

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -228,18 +228,18 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return true;
 	}
 
-	public async validateOptions(provision: true | string, projectData: IProjectData, platform?: string): Promise<boolean> {
+	public async validateOptions(provision: true | string, teamId: true | string, projectData: IProjectData, platform?: string): Promise<boolean> {
 		if (platform) {
 			platform = this.$mobileHelper.normalizePlatformName(platform);
 			this.$logger.trace("Validate options for platform: " + platform);
 			let platformData = this.$platformsData.getPlatformData(platform, projectData);
-			return await platformData.platformProjectService.validateOptions(projectData.projectId, provision);
+			return await platformData.platformProjectService.validateOptions(projectData.projectId, provision, teamId);
 		} else {
 			let valid = true;
 			for (let availablePlatform in this.$platformsData.availablePlatforms) {
 				this.$logger.trace("Validate options for platform: " + availablePlatform);
 				let platformData = this.$platformsData.getPlatformData(availablePlatform, projectData);
-				valid = valid && await platformData.platformProjectService.validateOptions(projectData.projectId, provision);
+				valid = valid && await platformData.platformProjectService.validateOptions(projectData.projectId, provision, teamId);
 			}
 
 			return valid;
@@ -282,7 +282,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const bundle = appFilesUpdaterOptions.bundle;
 		const nativePlatformStatus = (nativePrepare && nativePrepare.skipNativePrepare) ? constants.NativePlatformStatus.requiresPlatformAdd : constants.NativePlatformStatus.requiresPrepare;
-		const changesInfo = this.$projectChangesService.checkForChanges(platform, projectData, { bundle, release: appFilesUpdaterOptions.release, provision: config.provision, nativePlatformStatus });
+		const changesInfo = await this.$projectChangesService.checkForChanges(platform, projectData, { bundle, release: appFilesUpdaterOptions.release, provision: config.provision, teamId: config.teamId, nativePlatformStatus });
 
 		this.$logger.trace("Changes info in prepare platform:", changesInfo);
 		return changesInfo;

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -54,7 +54,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		return this._changesInfo;
 	}
 
-	public checkForChanges(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): IProjectChangesInfo {
+	public async checkForChanges(platform: string, projectData: IProjectData, projectChangesOptions: IProjectChangesOptions): Promise<IProjectChangesInfo> {
 		let platformData = this.$platformsData.getPlatformData(platform, projectData);
 		this._changesInfo = new ProjectChangesInfo();
 		if (!this.ensurePrepareInfo(platform, projectData, projectChangesOptions)) {
@@ -87,7 +87,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		}
 
 		let projectService = platformData.platformProjectService;
-		projectService.checkForChanges(this._changesInfo, projectChangesOptions, projectData);
+		await projectService.checkForChanges(this._changesInfo, projectChangesOptions, projectData);
 
 		if (projectChangesOptions.bundle !== this._prepareInfo.bundle || projectChangesOptions.release !== this._prepareInfo.release) {
 			this._changesInfo.appFilesChanged = true;

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -611,12 +611,12 @@ describe("iOS Project Service Signing", () => {
 	});
 
 	describe("Check for Changes", () => {
-		it("sets signingChanged if no Xcode project exists", () => {
+		it("sets signingChanged if no Xcode project exists", async () => {
 			let changes = <IProjectChangesInfo>{};
-			iOSProjectService.checkForChanges(changes, { bundle: false, release: false, provision: "NativeScriptDev" }, projectData);
+			await iOSProjectService.checkForChanges(changes, { bundle: false, release: false, provision: "NativeScriptDev", teamId: undefined }, projectData);
 			assert.isTrue(!!changes.signingChanged);
 		});
-		it("sets signingChanged if the Xcode projects is configured with Automatic signing, but proivsion is specified", () => {
+		it("sets signingChanged if the Xcode projects is configured with Automatic signing, but proivsion is specified", async () => {
 			files[pbxproj] = "";
 			pbxprojDomXcode.Xcode.open = <any>function (path: string) {
 				assert.equal(path, pbxproj);
@@ -627,10 +627,10 @@ describe("iOS Project Service Signing", () => {
 				};
 			};
 			let changes = <IProjectChangesInfo>{};
-			iOSProjectService.checkForChanges(changes, { bundle: false, release: false, provision: "NativeScriptDev" }, projectData);
+			await iOSProjectService.checkForChanges(changes, { bundle: false, release: false, provision: "NativeScriptDev", teamId: undefined }, projectData);
 			assert.isTrue(!!changes.signingChanged);
 		});
-		it("sets signingChanged if the Xcode projects is configured with Manual signing, but the proivsion specified differs the selected in the pbxproj", () => {
+		it("sets signingChanged if the Xcode projects is configured with Manual signing, but the proivsion specified differs the selected in the pbxproj", async () => {
 			files[pbxproj] = "";
 			pbxprojDomXcode.Xcode.open = <any>function (path: string) {
 				assert.equal(path, pbxproj);
@@ -646,10 +646,10 @@ describe("iOS Project Service Signing", () => {
 				};
 			};
 			let changes = <IProjectChangesInfo>{};
-			iOSProjectService.checkForChanges(changes, { bundle: false, release: false, provision: "NativeScriptDev" }, projectData);
+			await iOSProjectService.checkForChanges(changes, { bundle: false, release: false, provision: "NativeScriptDev", teamId: undefined }, projectData);
 			assert.isTrue(!!changes.signingChanged);
 		});
-		it("does not set signingChanged if the Xcode projects is configured with Manual signing and proivsion matches", () => {
+		it("does not set signingChanged if the Xcode projects is configured with Manual signing and proivsion matches", async () => {
 			files[pbxproj] = "";
 			pbxprojDomXcode.Xcode.open = <any>function (path: string) {
 				assert.equal(path, pbxproj);
@@ -665,7 +665,7 @@ describe("iOS Project Service Signing", () => {
 				};
 			};
 			let changes = <IProjectChangesInfo>{};
-			iOSProjectService.checkForChanges(changes, { bundle: false, release: false, provision: "NativeScriptDev" }, projectData);
+			await iOSProjectService.checkForChanges(changes, { bundle: false, release: false, provision: "NativeScriptDev", teamId: undefined }, projectData);
 			assert.isFalse(!!changes.signingChanged);
 		});
 	});
@@ -684,7 +684,7 @@ describe("iOS Project Service Signing", () => {
 			});
 			it("fails with proper error if the provision can not be found", async () => {
 				try {
-					await iOSProjectService.prepareProject(projectData, { sdk: undefined, provision: "NativeScriptDev2" });
+					await iOSProjectService.prepareProject(projectData, { sdk: undefined, provision: "NativeScriptDev2", teamId: undefined });
 				} catch (e) {
 					assert.isTrue(e.toString().indexOf("Failed to find mobile provision with UUID or Name: NativeScriptDev2") >= 0);
 				}
@@ -705,7 +705,7 @@ describe("iOS Project Service Signing", () => {
 						}
 					};
 				};
-				await iOSProjectService.prepareProject(projectData, { sdk: undefined, provision: "NativeScriptDev" });
+				await iOSProjectService.prepareProject(projectData, { sdk: undefined, provision: "NativeScriptDev", teamId: undefined });
 				assert.deepEqual(stack, [{ targetName: projectDirName, manualSigning: { team: "TKID101", uuid: "12345", name: "NativeScriptDev", identity: "iPhone Developer" } }, "save()"]);
 			});
 			it("succeds if the provision name is provided for distribution cert", async () => {
@@ -724,7 +724,7 @@ describe("iOS Project Service Signing", () => {
 						}
 					};
 				};
-				await iOSProjectService.prepareProject(projectData, { sdk: undefined, provision: "NativeScriptDist" });
+				await iOSProjectService.prepareProject(projectData, { sdk: undefined, provision: "NativeScriptDist", teamId: undefined });
 				assert.deepEqual(stack, [{ targetName: projectDirName, manualSigning: { team: "TKID202", uuid: "6789", name: "NativeScriptDist", identity: "iPhone Distribution" } }, "save()"]);
 			});
 			it("succeds if the provision name is provided for adhoc cert", async () => {
@@ -743,7 +743,7 @@ describe("iOS Project Service Signing", () => {
 						}
 					};
 				};
-				await iOSProjectService.prepareProject(projectData, { sdk: undefined, provision: "NativeScriptAdHoc" });
+				await iOSProjectService.prepareProject(projectData, { sdk: undefined, provision: "NativeScriptAdHoc", teamId: undefined });
 				assert.deepEqual(stack, [{ targetName: projectDirName, manualSigning: { team: "TKID303", uuid: "1010", name: "NativeScriptAdHoc", identity: "iPhone Distribution" } }, "save()"]);
 			});
 		});

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -46,11 +46,11 @@ class PlatformData implements IPlatformData {
 class ErrorsNoFailStub implements IErrors {
 	printCallStack: boolean = false;
 
-	fail(formatStr: string, ...args: any[]): void;
-	fail(opts: { formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean }, ...args: any[]): void;
+	fail(formatStr: string, ...args: any[]): never;
+	fail(opts: { formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean }, ...args: any[]): never;
 
-	fail(...args: any[]) { throw new Error(); }
-	failWithoutHelp(message: string, ...args: any[]): void {
+	fail(...args: any[]): never { throw new Error(); }
+	failWithoutHelp(message: string, ...args: any[]): never {
 		throw new Error();
 	}
 

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -150,6 +150,7 @@ describe('Platform Service Tests', () => {
 	const config: IPlatformOptions = {
 		ignoreScripts: false,
 		provision: null,
+		teamId: null,
 		sdk: null,
 		frameworkPath: null
 	};
@@ -441,7 +442,7 @@ describe('Platform Service Tests', () => {
 
 			platformService = testInjector.resolve("platformService");
 			const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: false, release: release };
-			await platformService.preparePlatform(platformToTest, appFilesUpdaterOptions, "", projectData, { provision: null, sdk: null, frameworkPath: null, ignoreScripts: false });
+			await platformService.preparePlatform(platformToTest, appFilesUpdaterOptions, "", projectData, { provision: null, teamId: null, sdk: null, frameworkPath: null, ignoreScripts: false });
 		}
 
 		async function testPreparePlatform(platformToTest: string, release?: boolean): Promise<CreatedTestData> {
@@ -868,7 +869,7 @@ describe('Platform Service Tests', () => {
 			try {
 				testInjector.resolve("$logger").warn = (text: string) => warnings += text;
 				const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: false, release: false };
-				await platformService.preparePlatform("android", appFilesUpdaterOptions, "", projectData, { provision: null, sdk: null, frameworkPath: null, ignoreScripts: false });
+				await platformService.preparePlatform("android", appFilesUpdaterOptions, "", projectData, { provision: null, teamId: null, sdk: null, frameworkPath: null, ignoreScripts: false });
 			} finally {
 				testInjector.resolve("$logger").warn = oldLoggerWarner;
 			}

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -141,10 +141,10 @@ describe("Project Changes Service Tests", () => {
 	});
 
 	describe("Accumulates Changes From Project Services", () => {
-		it("accumulates changes from the project service", () => {
-			let iOSChanges = serviceTest.projectChangesService.checkForChanges("ios", serviceTest.projectData, { bundle: false, release: false, provision: undefined });
+		it("accumulates changes from the project service", async () => {
+			let iOSChanges = await serviceTest.projectChangesService.checkForChanges("ios", serviceTest.projectData, { bundle: false, release: false, provision: undefined, teamId: undefined });
 			assert.isTrue(!!iOSChanges.signingChanged, "iOS signingChanged expected to be true");
-			let androidChanges = serviceTest.projectChangesService.checkForChanges("android", serviceTest.projectData, { bundle: false, release: false, provision: undefined });
+			let androidChanges = await serviceTest.projectChangesService.checkForChanges("android", serviceTest.projectData, { bundle: false, release: false, provision: undefined, teamId: undefined });
 			assert.isFalse(!!androidChanges.signingChanged, "Android signingChanged expected to be false");
 		});
 	});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -178,14 +178,14 @@ export class FileSystemStub implements IFileSystem {
 }
 
 export class ErrorsStub implements IErrors {
-	fail(formatStr: string, ...args: any[]): void;
-	fail(opts: { formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean }, ...args: any[]): void;
+	fail(formatStr: string, ...args: any[]): never;
+	fail(opts: { formatStr?: string; errorCode?: number; suppressCommandHelp?: boolean }, ...args: any[]): never;
 
-	fail(...args: any[]) {
+	fail(...args: any[]): never {
 		throw new Error(require("util").format.apply(null, args || []));
 	}
 
-	failWithoutHelp(message: string, ...args: any[]): void {
+	failWithoutHelp(message: string, ...args: any[]): never {
 		throw new Error(message);
 	}
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -333,7 +333,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	async cleanProject(projectRoot: string, projectData: IProjectData): Promise<void> {
 		return Promise.resolve();
 	}
-	checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): void {
+	async checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): Promise<void> {
 		// Nothing yet.
 	}
 }
@@ -556,7 +556,7 @@ export class ChildProcessStub {
 }
 
 export class ProjectChangesService implements IProjectChangesService {
-	public checkForChanges(platform: string): IProjectChangesInfo {
+	public async checkForChanges(platform: string): Promise<IProjectChangesInfo> {
 		return <IProjectChangesInfo>{};
 	}
 


### PR DESCRIPTION
Depends on:
https://github.com/NativeScript/nativescript-cli/pull/3069

This PR will:

 - Update the export options plist and list the provisioning profile so Xcode9 can export when working with manual signing style and the --provision switch.
 - Provide --quiet to xcodebuild and -quiet to the gradle tools so they log only errors by default. The command line args with which these commands are called will be printed in place of the verbose output. You can switch to --log trace for full output.
 - Provide -allowProvisioningUpdates to xcodebuild when working with Xcode version > 9.0 so when passing team, xcodebuild may generate automatically managed provisioning profiles for you  
  (THIS ONE IS MY FAVOURITE!!!)
 - --teamId now behaves like --provision, it will require prepare if the last time other teamId was issued, it will print all teams if no arg is provided, it will switch to automatic signing
 - using --teamId and --provision will throw that they are mutually exclusive
 - teamId should work with team name, if we find a provision that has the team name and id  
  (we should improve that by somehow looking in the accounts registered in Xcode)  
