### PR TITLE
Fix native platform add after cloud build.

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -144,6 +144,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		config.pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
 
 		if (!nativePrepare || !nativePrepare.skipNativePrepare) {
+			const platformDir = path.join(projectData.platformsDir, platformData.normalizedPlatformName.toLowerCase());
+			this.$fs.deleteDirectory(platformDir);
 			await this.addPlatformCoreNative(platformData, frameworkDir, installedVersion, projectData, config);
 		}
 


### PR DESCRIPTION
When we prepare the platform for cloud build we skip the native prepare.
After this partial prepare, the platform directory contains only .js files.
In order to make a local build we should add the native part of the platform
which fails with `ENOTEMPTY: directory not empty, rename`.