### PR TITLE
Fix prepare of scoped packages

### DIFF
--- a/lib/tools/node-modules/node-modules-dest-copy.ts
+++ b/lib/tools/node-modules/node-modules-dest-copy.ts
@@ -65,7 +65,9 @@ export class TnsModulesCopy {
 			const dependencies = _.flatten(this.$fs.readDirectory(dependenciesFolder)
 				.map(dir => {
 					if (_.startsWith(dir, "@")) {
-						return this.$fs.readDirectory(path.join(dependenciesFolder, dir));
+						const pathToDir = path.join(dependenciesFolder, dir);
+						const contents = this.$fs.readDirectory(pathToDir);
+						return _.map(contents, subDir => `${dir}/${subDir}`);
 					}
 
 					return dir;


### PR DESCRIPTION
In case a plugin depends on a scoped package, for example `@angular/core`, trying to use the plugin from local path with npm 5 will fail.
The recommended approach is to declare the scoped package (`@angular/core`) as a devDependency of the plugin. After that, declare both the plugin and the scoped package as dependencies of your project. In case the plugin is installed from local directory, npm 5 creates symlink in node_modules. This means that all files inside `<plugins dir>/node_modules` will be visible for CLI, including the dev dependencies. During project preparation CLI copies `node_modules` from the project to `<project dir>/platforms/<platform>...` directory. We have a specific logic to process only dependencies of each package, i.e. we should remove `@angular/core` from the plugin's node_modules direcotry. However, the logic is not working correctly as instead of using the name `@angular/core` it's been trying to remove `core` only.
Fix getting names of the dependencies, so we'll be able to remove the scoped packages as well.


Fix for https://github.com/NativeScript/nativescript-facebook/issues/65