### PR TITLE
Only return debugInfo if url is passed

### DIFF
--- a/lib/services/debug-service.ts
+++ b/lib/services/debug-service.ts
@@ -95,13 +95,22 @@ export class DebugService extends EventEmitter implements IDebugService {
 	}
 
 	private getDebugInformation(fullUrl: string): IDebugInformation {
-		const parseQueryString = true;
-		const wsQueryParam = parse(fullUrl, parseQueryString).query.ws;
-		const hostPortSplit = wsQueryParam && wsQueryParam.split(":");
-		return {
+		let debugInfo: IDebugInformation = {
 			url: fullUrl,
-			port: hostPortSplit && +hostPortSplit[1]
+			port: 0
 		};
+
+		if (fullUrl) {
+			const parseQueryString = true;
+			const wsQueryParam = parse(fullUrl, parseQueryString).query.ws;
+			const hostPortSplit = wsQueryParam && wsQueryParam.split(":");
+			debugInfo = {
+				url: fullUrl,
+				port: hostPortSplit && +hostPortSplit[1]
+			};
+		}
+
+		return debugInfo;
 	}
 }
 


### PR DESCRIPTION
Whenever iOS inspector is used in favor of chrome, `null` is passed to `getDebugInformation` which causes `url.parse` to fail.

Add a `null` check in order to safeguard the method.

Ping @TsvetanMilanov @rosen-vladimirov 