### PR TITLE
Emit deviceIdentifier in debuggerAttached event

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -30,6 +30,10 @@ const tns = require("nativescript");
 * [liveSyncService](#livesyncservice)
 	* [liveSync](#livesync)
 	* [stopLiveSync](#stopLiveSync)
+	* [enableDebugging](#enableDebugging)
+	* [attachDebugger](#attachDebugger)
+	* [disableDebugging](#disableDebugging)
+	* [getLiveSyncDeviceDescriptors](#getLiveSyncDeviceDescriptors)
 	* [events](#events)
 
 
@@ -454,9 +458,9 @@ The returned Promise will be rejected in case any error occurs. It will also be 
  * Starts debug operation based on the specified debug data.
  * @param {IDebugData} debugData Describes information for device and application that will be debugged.
  * @param {IDebugOptions} debugOptions Describe possible options to modify the behaivor of the debug operation, for example stop on the first line.
- * @returns {Promise<string>} URL that should be opened in Chrome DevTools.
+ * @returns {Promise<IDebugInformation>} Device Identifier, full url and port where the frontend client can be connected.
  */
-debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string>;
+debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<IDebugInformation>;
 ```
 
 The type of arguments that you can pass are described below:
@@ -515,6 +519,16 @@ interface IDebugOptions {
 	 * Default value is 02e6bde1bbe34e43b309d4ef774b1168d25fd024 which corresponds to 55.0.2883 Chrome version
 	 */
 	devToolsCommit?: string;
+
+	/**
+	 * Defines if Chrome DevTools should be used for debugging.
+	 */
+	chrome?: boolean;
+
+	/**
+	 * Defines if thе application is already started on device.
+	 */
+	start?: boolean;
 }
 ```
 
@@ -536,7 +550,7 @@ const debugOptions = {
 };
 
 tns.debugService.debug(debugData, debugOptions)
-	.then(url => console.log(`Open the following url in Chrome DevTools: ${url}`))
+	.then(debugInfo => console.log(`Open the following url in Chrome DevTools: ${debugInfo.url}, port is: ${debugInfo.port} and deviceIdentifier is: ${debugInfo.deviceIdentifier}`))
 	.catch(err => console.log(`Unable to start debug operation, reason: ${err.message}.`));
 ```
 
@@ -839,12 +853,12 @@ tns.liveSyncService.on("userInteractionNeeded", data => {
 });
 ```
 
-* debuggerAttached - raised whenever CLI attaches the backend debugging socket and a frontend debugging client may be attached. The event is raised with an object containing the device's identifier:
+* debuggerAttached - raised whenever CLI attaches the backend debugging socket and a frontend debugging client may be attached. The event is raised with an object containing the device's identifier, url for debugging and port
 
 Example:
 ```JavaScript
 tns.liveSyncService.on("debuggerAttached", debugInfo => {
-	console.log(`Backend client connected, frontend client may be connected at ${debugInfo.url}`);
+	console.log(`Backend client connected, frontend client may be connected at ${debugInfo.url} to debug app on device ${debugInfo.deviceIdentifier}. Port is: ${debugInfo.port}`);
 });
 ```
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -372,7 +372,7 @@ interface ICreateProjectOptions extends INpmInstallConfigurationOptionsBase {
 	pathToTemplate?: string;
 }
 
-interface IDebugInformation extends IPort {
+interface IDebugInformation extends IPort, Mobile.IDeviceIdentifier {
 	url: string;
 }
 

--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -105,7 +105,7 @@ interface IDebugServiceBase extends NodeJS.EventEmitter {
 	 * Starts debug operation based on the specified debug data.
 	 * @param {IDebugData} debugData Describes information for device and application that will be debugged.
 	 * @param {IDebugOptions} debugOptions Describe possible options to modify the behaivor of the debug operation, for example stop on the first line.
-	 * @returns {Promise<IDebugInformation>} Full url and port where the frontend client can be connected.
+	 * @returns {Promise<IDebugInformation>} Device Identifier, full url and port where the frontend client can be connected.
 	 */
 	debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<IDebugInformation>;
 }

--- a/lib/services/debug-service.ts
+++ b/lib/services/debug-service.ts
@@ -58,7 +58,7 @@ export class DebugService extends EventEmitter implements IDebugService {
 			result = await debugService.debug(debugData, debugOptions);
 		}
 
-		return this.getDebugInformation(result);
+		return this.getDebugInformation(result, device.deviceInfo.identifier);
 	}
 
 	public debugStop(deviceIdentifier: string): Promise<void> {
@@ -94,20 +94,18 @@ export class DebugService extends EventEmitter implements IDebugService {
 		platformDebugService.on(CONNECTION_ERROR_EVENT_NAME, connectionErrorHandler);
 	}
 
-	private getDebugInformation(fullUrl: string): IDebugInformation {
-		let debugInfo: IDebugInformation = {
+	private getDebugInformation(fullUrl: string, deviceIdentifier: string): IDebugInformation {
+		const debugInfo: IDebugInformation = {
 			url: fullUrl,
-			port: 0
+			port: 0,
+			deviceIdentifier
 		};
 
 		if (fullUrl) {
 			const parseQueryString = true;
 			const wsQueryParam = parse(fullUrl, parseQueryString).query.ws;
 			const hostPortSplit = wsQueryParam && wsQueryParam.split(":");
-			debugInfo = {
-				url: fullUrl,
-				port: hostPortSplit && +hostPortSplit[1]
-			};
+			debugInfo.port = hostPortSplit && +hostPortSplit[1];
 		}
 
 		return debugInfo;

--- a/test/services/debug-service.ts
+++ b/test/services/debug-service.ts
@@ -8,6 +8,8 @@ import { CONNECTION_ERROR_EVENT_NAME, DebugCommandErrors } from "../../lib/const
 
 const fakeChromeDebugPort = 123;
 const fakeChromeDebugUrl = `fakeChromeDebugUrl?experiments=true&ws=localhost:${fakeChromeDebugPort}`;
+const defaultDeviceIdentifier = "Nexus5";
+
 class PlatformDebugService extends EventEmitter /* implements IPlatformDebugService */ {
 	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
 		return fakeChromeDebugUrl;
@@ -18,6 +20,7 @@ interface IDebugTestDeviceInfo {
 	deviceInfo: {
 		status: string;
 		platform: string;
+		identifier: string;
 	};
 
 	isEmulator: boolean;
@@ -36,7 +39,8 @@ interface IDebugTestData {
 const getDefaultDeviceInformation = (platform?: string): IDebugTestDeviceInfo => ({
 	deviceInfo: {
 		status: constants.CONNECTED_STATUS,
-		platform: platform || "Android"
+		platform: platform || "Android",
+		identifier: defaultDeviceIdentifier
 	},
 
 	isEmulator: false
@@ -95,7 +99,7 @@ describe("debugService", () => {
 	describe("debug", () => {
 		const getDebugData = (deviceIdentifier?: string): IDebugData => ({
 			applicationIdentifier: "org.nativescript.app1",
-			deviceIdentifier: deviceIdentifier || "Nexus5",
+			deviceIdentifier: deviceIdentifier || defaultDeviceIdentifier,
 			projectDir: "/Users/user/app1",
 			projectName: "app1"
 		});
@@ -217,7 +221,8 @@ describe("debugService", () => {
 
 					assert.deepEqual(debugInfo, {
 						url: fakeChromeDebugUrl,
-						port: fakeChromeDebugPort
+						port: fakeChromeDebugPort,
+						deviceIdentifier: debugData.deviceIdentifier
 					});
 				});
 			});


### PR DESCRIPTION
`debuggerAttached` event should emit full information required for debugging. However, the deviceIdentifier is missing, so add it.
Update PublicAPI.md according to latest changes.