### PR TITLE
Debug fixes when CLI is used as a library

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -587,6 +587,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			await this.trackActionForPlatform({ action: constants.TrackActionNames.Deploy, platform: device.deviceInfo.platform, isForDevice: !device.isEmulator, deviceOsVersion: device.deviceInfo.version });
 		};
 
+		if (deployOptions.device) {
+			const device = await this.$devicesService.getDevice(deployOptions.device);
+			deployOptions.device = device.deviceInfo.identifier;
+		}
+
 		await this.$devicesService.execute(action, this.getCanExecuteAction(platform, deployOptions));
 	}
 
@@ -599,6 +604,12 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		};
 
 		await this.$devicesService.initialize({ platform: platform, deviceId: runOptions.device });
+
+		if (runOptions.device) {
+			const device = await this.$devicesService.getDevice(runOptions.device);
+			runOptions.device = device.deviceInfo.identifier;
+		}
+
 		await this.$devicesService.execute(action, this.getCanExecuteAction(platform, runOptions));
 	}
 
@@ -715,10 +726,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	private getCanExecuteAction(platform: string, options: IDeviceEmulator): any {
 		const canExecute = (currentDevice: Mobile.IDevice): boolean => {
 			if (options.device && currentDevice && currentDevice.deviceInfo) {
-				const device = this.$devicesService.getDeviceByDeviceOption();
-				if (device && device.deviceInfo) {
-					return currentDevice.deviceInfo.identifier === device.deviceInfo.identifier;
-				}
+				return currentDevice.deviceInfo.identifier === options.device;
 			}
 
 			if (this.$mobileHelper.isiOSPlatform(platform) && this.$hostInfo.isDarwin) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -83,7 +83,7 @@
     "@types/universal-analytics": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/universal-analytics/-/universal-analytics-0.4.1.tgz",
-      "integrity": "sha512-AZSPpDUEZ4mAgO9geHc62dp/xCLmBJ1yIpbgTq5W/cWcVQsxmU/FyKwYKHXk2hnT9TAmYVFFdAijMrCdYjuHsA==",
+      "integrity": "sha1-7mESGwqJiwvqXuskcgCJjg+o8Jw=",
       "dev": true
     },
     "abbrev": {
@@ -2945,9 +2945,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.1.1.tgz",
-      "integrity": "sha1-AmL3x3N6ZnfyAI48rem2KMEIN6c=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.1.2.tgz",
+      "integrity": "sha1-Fq6f+F2gUE0K+4gyj73sCQafFG0=",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",
@@ -5186,7 +5186,7 @@
     "universal-analytics": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.15.tgz",
-      "integrity": "sha512-9Dt6WBWsHsmv74G+N/rmEgi6KFZxVvQXkVhr0disegeUryybQAUQwMD1l5EtqaOu+hSOGbhL/hPPQYisZIqPRw==",
+      "integrity": "sha1-SrxhsVn/52W+FE4Ht7c54O57iKs=",
       "requires": {
         "async": "1.2.1",
         "request": "2.81.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.9",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "3.1.1",
+    "ios-sim-portable": "3.1.2",
     "lockfile": "1.0.3",
     "lodash": "4.13.1",
     "log4js": "1.0.1",


### PR DESCRIPTION
### Fix UnhandledRejection error when failed to start application on iOS during debug

In case we are unable to start application on iOS device just before attaching a debugger, CLI will raise unhandled rejection. The problem is that we want to start two actions in parallel - start of application and attaching a debugger. We do not await the start application and when an error is raised in it, Unhandled Rejection is raised. In order to prevent this, use Promise.all - this way in case any of the operations fail, we'll receive it as error in the same method. 

### Fix attaching multiple times on deviceLost event

In LiveSync service we attach to deviceLost event in order to stop LiveSync operation in case device is detached. However we are attaching it on every change, so at some point CLI prints warning: `Warning: Possible EventEmitter memory leak detected. 11 deviceLost listeners added. Use emitter.setMaxListeners() to increase limit `  Fix this by attaching only once.

### Fix application is not started on iOS Simulator every other time

In case you are using iOS Simulator with version < 10, every second LiveSync operation does not start the app on device. The problem is that calling `simctl terminate` is not killing the app immediately. However the action is executed, so we call start application. After its been called, the terminate succeeds and kills the app. So the app is not running. When a change is applied we detect app is not running and just start it. So it works. Next change calls terminate and again the app seems like it has not been started.  The fix is in ios-sim-portable, so update its version. 

### Fix executing of deploy/start app on device, which is not passed to the method

In PlatformService we create a canExecute method that does not work correctly in cases when CLI is used as a library. The problem is that in this case methods like `deployPlatform` and `startApplication` receive the device on which to execute the action through their arguments. However, the canExecute method relies on the `devicesService.getDeviceByDeviceOption()` method, which works with the `$options.device`. The last is never set in cases when CLI is used as a library. So the canExecute is changed and now it will work only in case it receives deviceIdentifier as argument. This requires changes in `startApplication` and `deployPlatform` methods, so they will send the deviceIdentifier to canExecute method.

