### PR TITLE
Separate native and JS prepare code

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -22,6 +22,8 @@ $injector.require("tnsModulesService", "./services/tns-modules-service");
 
 $injector.require("platformsData", "./platforms-data");
 $injector.require("platformService", "./services/platform-service");
+$injector.require("preparePlatformJSService", "./services/prepare-platform-js-service");
+$injector.require("preparePlatformNativeService", "./services/prepare-platform-native-service");
 
 $injector.require("debugDataService", "./services/debug-data-service");
 $injector.requirePublicClass("debugService", "./services/debug-service");

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -57,6 +57,15 @@ export class PublishIOS implements ICommand {
 			const platform = this.$devicePlatformsConstants.iOS;
 			// No .ipa path provided, build .ipa on out own.
 			const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+			const platformInfo: IPreparePlatformInfo = {
+				platform,
+				appFilesUpdaterOptions,
+				platformTemplate: this.$options.platformTemplate,
+				projectData: this.$projectData,
+				config: this.$options,
+				env: this.$options.env
+			};
+
 			if (mobileProvisionIdentifier || codeSignIdentity) {
 				const iOSBuildConfig: IBuildConfig = {
 					projectDir: this.$options.path,
@@ -70,12 +79,12 @@ export class PublishIOS implements ICommand {
 				};
 				this.$logger.info("Building .ipa with the selected mobile provision and/or certificate.");
 				// This is not very correct as if we build multiple targets we will try to sign all of them using the signing identity here.
-				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
+				await this.$platformService.preparePlatform(platformInfo);
 				await this.$platformService.buildPlatform(platform, iOSBuildConfig, this.$projectData);
 				ipaFilePath = this.$platformService.lastOutputPath(platform, iOSBuildConfig, this.$projectData);
 			} else {
 				this.$logger.info("No .ipa, mobile provision or certificate set. Perfect! Now we'll build .xcarchive and let Xcode pick the distribution certificate and provisioning profile for you when exporting .ipa for AppStore submission.");
-				await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
+				await this.$platformService.preparePlatform(platformInfo);
 
 				const platformData = this.$platformsData.getPlatformData(platform, this.$projectData);
 				const iOSProjectService = <IOSProjectService>platformData.platformProjectService;

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -13,7 +13,16 @@ export class BuildCommandBase {
 	public async executeCore(args: string[]): Promise<void> {
 		const platform = args[0].toLowerCase();
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
+		const platformInfo: IPreparePlatformInfo = {
+			platform,
+			appFilesUpdaterOptions,
+			platformTemplate: this.$options.platformTemplate,
+			projectData: this.$projectData,
+			config: this.$options,
+			env: this.$options.env
+		};
+
+		await this.$platformService.preparePlatform(platformInfo);
 		this.$options.clean = true;
 		const buildConfig: IBuildConfig = {
 			buildForDevice: this.$options.forDevice,

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -30,7 +30,17 @@ export class DeployOnDeviceCommand implements ICommand {
 			keyStorePassword: this.$options.keyStorePassword,
 			keyStorePath: this.$options.keyStorePath
 		};
-		return this.$platformService.deployPlatform(args[0], appFilesUpdaterOptions, deployOptions, this.$projectData, this.$options);
+
+		const deployPlatformInfo: IDeployPlatformInfo = {
+			platform: args[0],
+			appFilesUpdaterOptions,
+			deployOptions,
+			projectData: this.$projectData,
+			config: this.$options,
+			env: this.$options.env
+		};
+
+		return this.$platformService.deployPlatform(deployPlatformInfo);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -11,7 +11,16 @@ export class PrepareCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
-		await this.$platformService.preparePlatform(args[0], appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
+		const platformInfo: IPreparePlatformInfo = {
+			platform: args[0],
+			appFilesUpdaterOptions,
+			platformTemplate: this.$options.platformTemplate,
+			projectData: this.$projectData,
+			config: this.$options,
+			env: this.$options.env
+		};
+
+		await this.$platformService.preparePlatform(platformInfo);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -374,7 +374,7 @@ interface IPort {
 	port: Number;
 }
 
-interface IOptions extends ICommonOptions, IBundle, IPlatformTemplate, IEmulator, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, INpmInstallConfigurationOptions, IPort {
+interface IOptions extends ICommonOptions, IBundle, IPlatformTemplate, IEmulator, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, INpmInstallConfigurationOptions, IPort, IEnvOptions {
 	all: boolean;
 	client: boolean;
 	compileSdk: number;
@@ -395,11 +395,15 @@ interface IOptions extends ICommonOptions, IBundle, IPlatformTemplate, IEmulator
 	chrome: boolean;
 }
 
+interface IEnvOptions {
+	env: Object;
+}
+
 interface IAndroidBuildOptionsSettings extends IAndroidReleaseOptions, IRelease { }
 
 interface IAppFilesUpdaterOptions extends IBundle, IRelease { }
 
-interface IPlatformBuildData extends IAppFilesUpdaterOptions, IBuildConfig { }
+interface IPlatformBuildData extends IAppFilesUpdaterOptions, IBuildConfig, IEnvOptions { }
 
 interface IDeviceEmulator extends IEmulator, IDeviceIdentifier { }
 

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -111,7 +111,7 @@ interface ILiveSyncDeviceInfo extends IOptionalOutputPath, IOptionalDebuggingOpt
 /**
  * Describes a LiveSync operation.
  */
-interface ILiveSyncInfo extends IProjectDir {
+interface ILiveSyncInfo extends IProjectDir, IEnvOptions {
 	/**
 	 * Defines if the watcher should be skipped. If not passed, fs.Watcher will be started.
 	 */
@@ -145,14 +145,17 @@ interface ILiveSyncBuildInfo extends IIsEmulator, IPlatform {
 	pathToBuildItem: string;
 }
 
+interface IProjectDataComposition {
+	projectData: IProjectData;
+}
+
 /**
  * Desribes object that can be passed to ensureLatestAppPackageIsInstalledOnDevice method.
  */
-interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions {
+interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions extends IProjectDataComposition, IEnvOptions {
 	device: Mobile.IDevice;
 	preparedPlatforms: string[];
 	rebuiltInformation: ILiveSyncBuildInfo[];
-	projectData: IProjectData;
 	deviceBuildInfoDescriptor: ILiveSyncDeviceInfo;
 	settings: ILatestAppPackageInstalledSettings;
 	liveSyncData?: ILiveSyncInfo;
@@ -273,8 +276,7 @@ interface IShouldSkipEmitLiveSyncNotification {
 interface IAttachDebuggerOptions extends IDebuggingAdditionalOptions, IEnableDebuggingDeviceOptions, IIsEmulator, IPlatform, IOptionalOutputPath {
 }
 
-interface ILiveSyncWatchInfo {
-	projectData: IProjectData;
+interface ILiveSyncWatchInfo extends IProjectDataComposition {
 	filesToRemove: string[];
 	filesToSync: string[];
 	isReinstalled: boolean;
@@ -289,8 +291,7 @@ interface ILiveSyncResultInfo {
 	useLiveEdit?: boolean;
 }
 
-interface IFullSyncInfo {
-	projectData: IProjectData;
+interface IFullSyncInfo extends IProjectDataComposition {
 	device: Mobile.IDevice;
 	watch: boolean;
 	syncAllFiles: boolean;

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -290,3 +290,16 @@ interface IBuildInfo {
 	prepareTime: string;
 	buildTime: string;
 }
+
+interface IPreparePlatformService extends NodeJS.EventEmitter {
+	addPlatform(platformData: IPlatformData, frameworkDir: string, installedVersion: string, projectData: IProjectData, config: IPlatformOptions, platformTemplate?: string, ): Promise<void>;
+	preparePlatform(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>, projectFilesConfig?: IProjectFilesConfig): Promise<void>;
+}
+
+interface IPreparePlatformJSService extends IPreparePlatformService {
+
+}
+
+interface IPreparePlatformNativeService extends IPreparePlatformService {
+
+}

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -15,6 +15,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			forDevice: { type: OptionType.Boolean },
 			provision: { type: OptionType.Object },
 			client: { type: OptionType.Boolean, default: true },
+			env: { type: OptionType.Object },
 			production: { type: OptionType.Boolean },
 			debugTransport: { type: OptionType.Boolean },
 			keyStorePath: { type: OptionType.String },

--- a/lib/services/analytics/analytics-service.ts
+++ b/lib/services/analytics/analytics-service.ts
@@ -11,13 +11,13 @@ export class AnalyticsService extends AnalyticsServiceBase {
 
 	constructor(protected $logger: ILogger,
 		protected $options: IOptions,
+		protected $processService: IProcessService,
 		$staticConfig: Config.IStaticConfig,
 		$prompter: IPrompter,
 		$userSettingsService: UserSettings.IUserSettingsService,
 		$analyticsSettingsService: IAnalyticsSettingsService,
 		$osInfo: IOsInfo,
 		private $childProcess: IChildProcess,
-		protected $processService: IProcessService,
 		private $projectDataService: IProjectDataService,
 		private $mobileHelper: Mobile.IMobileHelper) {
 		super($logger, $options, $staticConfig, $processService, $prompter, $userSettingsService, $analyticsSettingsService, $osInfo);

--- a/lib/services/livesync/livesync-command-helper.ts
+++ b/lib/services/livesync/livesync-command-helper.ts
@@ -9,7 +9,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 		private $platformsData: IPlatformsData,
 		private $analyticsService: IAnalyticsService,
 		private $errors: IErrors) {
-			this.$analyticsService.setShouldDispose(this.$options.justlaunch || !this.$options.watch);
+		this.$analyticsService.setShouldDispose(this.$options.justlaunch || !this.$options.watch);
 	}
 
 	public getPlatformsForOperation(platform: string): string[] {
@@ -74,7 +74,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			projectDir: this.$projectData.projectDir,
 			skipWatcher: !this.$options.watch,
 			watchAllFiles: this.$options.syncAllFiles,
-			clean: this.$options.clean
+			clean: this.$options.clean,
+			env: this.$options.env
 		};
 
 		await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
@@ -95,7 +96,16 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 
 		const availablePlatforms = this.getPlatformsForOperation(platform);
 		for (const currentPlatform of availablePlatforms) {
-			await this.$platformService.deployPlatform(currentPlatform, this.$options, deployOptions, this.$projectData, this.$options);
+			const deployPlatformInfo: IDeployPlatformInfo = {
+				platform: currentPlatform,
+				appFilesUpdaterOptions: this.$options,
+				deployOptions,
+				projectData: this.$projectData,
+				config: this.$options,
+				env: this.$options.env
+			};
+
+			await this.$platformService.deployPlatform(deployPlatformInfo);
 			await this.$platformService.startApplication(currentPlatform, runPlatformOptions, this.$projectData.projectId);
 			this.$platformService.trackProjectType(this.$projectData);
 		}

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -359,10 +359,21 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 			options.preparedPlatforms.push(platform);
 
 			const platformSpecificOptions = options.deviceBuildInfoDescriptor.platformSpecificOptions || <IPlatformOptions>{};
-			await this.$platformService.preparePlatform(platform, {
-				bundle: false,
-				release: false,
-			}, null, options.projectData, platformSpecificOptions, options.modifiedFiles, nativePrepare);
+			const prepareInfo: IPreparePlatformInfo = {
+				platform,
+				appFilesUpdaterOptions: {
+					bundle: false,
+					release: false,
+				},
+				projectData: options.projectData,
+				env: options.env,
+				nativePrepare: nativePrepare,
+				filesToSync: options.modifiedFiles,
+				platformTemplate: null,
+				config: platformSpecificOptions
+			};
+
+			await this.$platformService.preparePlatform(prepareInfo);
 		}
 
 		const buildResult = await this.installedCachedAppPackage(platform, options);
@@ -447,7 +458,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					projectData,
 					deviceBuildInfoDescriptor,
 					liveSyncData,
-					settings
+					settings,
+					env: liveSyncData.env
 				}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
 				const liveSyncResultInfo = await this.getLiveSyncService(platform).fullSync({
@@ -551,7 +563,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 										projectData,
 										deviceBuildInfoDescriptor,
 										settings: latestAppPackageInstalledSettings,
-										modifiedFiles: allModifiedFiles
+										modifiedFiles: allModifiedFiles,
+										env: liveSyncData.env
 									}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
 									const service = this.getLiveSyncService(device.deviceInfo.platform);

--- a/lib/services/local-build-service.ts
+++ b/lib/services/local-build-service.ts
@@ -16,13 +16,22 @@ export class LocalBuildService extends EventEmitter implements ILocalBuildServic
 		}
 
 		this.$projectData.initializeProjectData(platformBuildOptions.projectDir);
-		await this.$platformService.preparePlatform(platform, platformBuildOptions, platformTemplate, this.$projectData, {
-			provision: platformBuildOptions.provision,
-			teamId: platformBuildOptions.teamId,
-			sdk: null,
-			frameworkPath: null,
-			ignoreScripts: false
-		});
+		const prepareInfo: IPreparePlatformInfo = {
+			platform,
+			appFilesUpdaterOptions: platformBuildOptions,
+			platformTemplate,
+			projectData: this.$projectData,
+			env: platformBuildOptions.env,
+			config: {
+				provision: platformBuildOptions.provision,
+				teamId: platformBuildOptions.teamId,
+				sdk: null,
+				frameworkPath: null,
+				ignoreScripts: false
+			}
+		};
+
+		await this.$platformService.preparePlatform(prepareInfo);
 		const handler = (data: any) => {
 			data.projectDir = platformBuildOptions.projectDir;
 			this.emit(BUILD_OUTPUT_EVENT_NAME, data);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -23,6 +23,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	private _trackedProjectFilePath: string = null;
 
 	constructor(private $devicesService: Mobile.IDevicesService,
+		private $preparePlatformNativeService: IPreparePlatformNativeService,
+		private $preparePlatformJSService: IPreparePlatformJSService,
 		private $errors: IErrors,
 		private $fs: IFileSystem,
 		private $logger: ILogger,
@@ -30,13 +32,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		private $platformsData: IPlatformsData,
 		private $projectDataService: IProjectDataService,
 		private $hooksService: IHooksService,
-		private $nodeModulesBuilder: INodeModulesBuilder,
 		private $pluginsService: IPluginsService,
 		private $projectFilesManager: IProjectFilesManager,
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $hostInfo: IHostInfo,
 		private $devicePathProvider: IDevicePathProvider,
-		private $xmlValidator: IXmlValidator,
 		private $npm: INodePackageManager,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $projectChangesService: IProjectChangesService,
@@ -141,60 +141,17 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, nativePrepare?: INativePrepare): Promise<string> {
 		const coreModuleData = this.$fs.readJson(path.join(frameworkDir, "..", "package.json"));
 		const installedVersion = coreModuleData.version;
-		const customTemplateOptions = await this.getPathToPlatformTemplate(platformTemplate, platformData.frameworkPackageName, projectData.projectDir);
-		config.pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
+
+		await this.$preparePlatformJSService.addPlatform(platformData, frameworkDir, installedVersion, projectData, config, platformTemplate);
 
 		if (!nativePrepare || !nativePrepare.skipNativePrepare) {
 			const platformDir = path.join(projectData.platformsDir, platformData.normalizedPlatformName.toLowerCase());
 			this.$fs.deleteDirectory(platformDir);
-			await this.addPlatformCoreNative(platformData, frameworkDir, installedVersion, projectData, config);
+			await this.$preparePlatformNativeService.addPlatform(platformData, frameworkDir, installedVersion, projectData, config);
 		}
-
-		const frameworkPackageNameData: any = { version: installedVersion };
-		if (customTemplateOptions) {
-			frameworkPackageNameData.template = customTemplateOptions.selectedTemplate;
-		}
-
-		this.$projectDataService.setNSValue(projectData.projectDir, platformData.frameworkPackageName, frameworkPackageNameData);
 
 		const coreModuleName = coreModuleData.name;
 		return coreModuleName;
-
-	}
-
-	private async addPlatformCoreNative(platformData: IPlatformData, frameworkDir: string, installedVersion: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
-		await platformData.platformProjectService.createProject(path.resolve(frameworkDir), installedVersion, projectData, config);
-		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
-		await platformData.platformProjectService.interpolateData(projectData, config);
-		platformData.platformProjectService.afterCreateProject(platformData.projectRoot, projectData);
-	}
-
-	private async getPathToPlatformTemplate(selectedTemplate: string, frameworkPackageName: string, projectDir: string): Promise<{ selectedTemplate: string, pathToTemplate: string }> {
-		if (!selectedTemplate) {
-			// read data from package.json's nativescript key
-			// check the nativescript.tns-<platform>.template value
-			const nativescriptPlatformData = this.$projectDataService.getNSValue(projectDir, frameworkPackageName);
-			selectedTemplate = nativescriptPlatformData && nativescriptPlatformData.template;
-		}
-
-		if (selectedTemplate) {
-			const tempDir = temp.mkdirSync("platform-template");
-			this.$fs.writeJson(path.join(tempDir, constants.PACKAGE_JSON_FILE_NAME), {});
-			try {
-				const npmInstallResult = await this.$npm.install(selectedTemplate, tempDir, {
-					disableNpmInstall: false,
-					frameworkPath: null,
-					ignoreScripts: false
-				});
-				const pathToTemplate = path.join(tempDir, constants.NODE_MODULES_FOLDER_NAME, npmInstallResult.name);
-				return { selectedTemplate, pathToTemplate };
-			} catch (err) {
-				this.$logger.trace("Error while trying to install specified template: ", err);
-				this.$errors.failWithoutHelp(`Unable to install platform template ${selectedTemplate}. Make sure the specified value is valid.`);
-			}
-		}
-
-		return null;
 	}
 
 	public getInstalledPlatforms(projectData: IProjectData): string[] {
@@ -216,8 +173,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	public getPreparedPlatforms(projectData: IProjectData): string[] {
 		return _.filter(this.$platformsData.platformsNames, p => { return this.isPlatformPrepared(p, projectData); });
 	}
+
 	public async preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, filesToSync?: Array<String>, nativePrepare?: INativePrepare): Promise<boolean> {
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
+
 		const changesInfo = await this.initialPrepare(platform, platformData, appFilesUpdaterOptions, platformTemplate, projectData, config, nativePrepare);
 		const requiresNativePrepare = (!nativePrepare || !nativePrepare.skipNativePrepare) && changesInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPrepare;
 
@@ -246,25 +205,6 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			}
 
 			return valid;
-		}
-	}
-
-	private async cleanProject(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformData: IPlatformData, projectData: IProjectData): Promise<void> {
-		// android build artifacts need to be cleaned up
-		// when switching between debug, release and webpack builds
-		if (platform.toLowerCase() !== "android") {
-			return;
-		}
-
-		const previousPrepareInfo = this.$projectChangesService.getPrepareInfo(platform, projectData);
-		if (!previousPrepareInfo) {
-			return;
-		}
-
-		const { release: previousWasRelease, bundle: previousWasBundle } = previousPrepareInfo;
-		const { release: currentIsRelease, bundle: currentIsBundle } = appFilesUpdaterOptions;
-		if ((previousWasRelease !== currentIsRelease) || (previousWasBundle !== currentIsBundle)) {
-			await platformData.platformProjectService.cleanProject(platformData.projectRoot, projectData);
 		}
 	}
 
@@ -298,10 +238,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const projectFilesConfig = helpers.getProjectFilesConfig({ isReleaseBuild: appFilesUpdaterOptions.release });
-		await this.preparePlatformCoreJS(platform, platformData, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo, filesToSync, projectFilesConfig);
+		await this.$preparePlatformJSService.preparePlatform(platform, platformData, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo, filesToSync, projectFilesConfig);
 
 		if (!nativePrepare || !nativePrepare.skipNativePrepare) {
-			await this.preparePlatformCoreNative(platform, platformData, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo, projectFilesConfig);
+			await this.$preparePlatformNativeService.preparePlatform(platform, platformData, appFilesUpdaterOptions, projectData, platformSpecificData, changesInfo, filesToSync, projectFilesConfig);
 		}
 
 		const directoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
@@ -313,95 +253,6 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		this.$projectFilesManager.processPlatformSpecificFiles(directoryPath, platform, projectFilesConfig, excludedDirs);
 
 		this.$logger.out(`Project successfully prepared (${platform})`);
-	}
-
-	private async preparePlatformCoreJS(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>, projectFilesConfig?: IProjectFilesConfig): Promise<void> {
-		if (!changesInfo || changesInfo.appFilesChanged) {
-			await this.copyAppFiles(platformData, appFilesUpdaterOptions, projectData);
-
-			// remove the App_Resources folder from the app/assets as here we're applying other files changes.
-			const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-			const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
-			if (this.$fs.exists(appResourcesDirectoryPath)) {
-				this.$fs.deleteDirectory(appResourcesDirectoryPath);
-			}
-		}
-
-		if (!changesInfo || changesInfo.modulesChanged) {
-			await this.copyTnsModules(platform, platformData, projectData, projectFilesConfig);
-		}
-	}
-
-	public async preparePlatformCoreNative(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, projectFilesConfig?: IProjectFilesConfig): Promise<void> {
-		if (changesInfo.hasChanges) {
-			await this.cleanProject(platform, appFilesUpdaterOptions, platformData, projectData);
-		}
-
-		if (!changesInfo || changesInfo.changesRequirePrepare) {
-			await this.copyAppFiles(platformData, appFilesUpdaterOptions, projectData);
-			this.copyAppResources(platformData, projectData);
-			await platformData.platformProjectService.prepareProject(projectData, platformSpecificData);
-		}
-
-		if (!changesInfo || changesInfo.modulesChanged || appFilesUpdaterOptions.bundle) {
-			await this.$pluginsService.validate(platformData, projectData);
-
-			const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-			const lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath) ? this.$fs.getFsStats(appDestinationDirectoryPath).mtime : null;
-
-			const tnsModulesDestinationPath = path.join(appDestinationDirectoryPath, constants.TNS_MODULES_FOLDER_NAME);
-			// Process node_modules folder
-			await this.$nodeModulesBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime, projectData, projectFilesConfig);
-		}
-
-		if (!changesInfo || changesInfo.configChanged || changesInfo.modulesChanged) {
-			await platformData.platformProjectService.processConfigurationFilesFromAppResources(appFilesUpdaterOptions.release, projectData);
-		}
-
-		platformData.platformProjectService.interpolateConfigurationFile(projectData, platformSpecificData);
-		this.$projectChangesService.setNativePlatformStatus(platform, projectData,
-			{ nativePlatformStatus: constants.NativePlatformStatus.alreadyPrepared });
-	}
-
-	private async copyAppFiles(platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData): Promise<void> {
-		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
-		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-
-		// Copy app folder to native project
-		this.$fs.ensureDirectoryExists(appDestinationDirectoryPath);
-		const appSourceDirectoryPath = path.join(projectData.projectDir, constants.APP_FOLDER_NAME);
-
-		const appUpdater = new AppFilesUpdater(appSourceDirectoryPath, appDestinationDirectoryPath, appFilesUpdaterOptions, this.$fs);
-		appUpdater.updateApp(sourceFiles => {
-			this.$xmlValidator.validateXmlFiles(sourceFiles);
-		});
-	}
-
-	private copyAppResources(platformData: IPlatformData, projectData: IProjectData): void {
-		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-		const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
-		if (this.$fs.exists(appResourcesDirectoryPath)) {
-			platformData.platformProjectService.prepareAppResources(appResourcesDirectoryPath, projectData);
-			const appResourcesDestination = platformData.platformProjectService.getAppResourcesDestinationDirectoryPath(projectData);
-			this.$fs.ensureDirectoryExists(appResourcesDestination);
-			shell.cp("-Rf", path.join(appResourcesDirectoryPath, platformData.normalizedPlatformName, "*"), appResourcesDestination);
-			this.$fs.deleteDirectory(appResourcesDirectoryPath);
-		}
-	}
-
-	private async copyTnsModules(platform: string, platformData: IPlatformData, projectData: IProjectData, projectFilesConfig?: IProjectFilesConfig): Promise<void> {
-		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-		const lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath) ? this.$fs.getFsStats(appDestinationDirectoryPath).mtime : null;
-
-		try {
-			const tnsModulesDestinationPath = path.join(appDestinationDirectoryPath, constants.TNS_MODULES_FOLDER_NAME);
-			// Process node_modules folder
-			await this.$nodeModulesBuilder.prepareJSNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime, projectData, projectFilesConfig);
-		} catch (error) {
-			this.$logger.debug(error);
-			shell.rm("-rf", appDestinationDirectoryPath);
-			this.$errors.failWithoutHelp(`Processing node_modules failed. ${error}`);
-		}
 	}
 
 	public async shouldBuild(platform: string, projectData: IProjectData, buildConfig: IBuildConfig, outputPath?: string): Promise<boolean> {

--- a/lib/services/prepare-platform-js-service.ts
+++ b/lib/services/prepare-platform-js-service.ts
@@ -1,0 +1,94 @@
+import * as constants from "../constants";
+import * as path from "path";
+import * as shell from "shelljs";
+import * as temp from "temp";
+import { PreparePlatformService } from "./prepare-platform-service";
+
+temp.track();
+
+export class PreparePlatformJSService extends PreparePlatformService implements IPreparePlatformNativeService {
+
+	constructor($fs: IFileSystem,
+		$xmlValidator: IXmlValidator,
+		private $errors: IErrors,
+		private $logger: ILogger,
+		private $projectDataService: IProjectDataService,
+		private $nodeModulesBuilder: INodeModulesBuilder,
+		private $npm: INodePackageManager) {
+		super($fs, $xmlValidator);
+	}
+
+	public async addPlatform(platformData: IPlatformData, frameworkDir: string, installedVersion: string, projectData: IProjectData, config: IPlatformOptions, platformTemplate: string, ): Promise<void> {
+		const customTemplateOptions = await this.getPathToPlatformTemplate(platformTemplate, platformData.frameworkPackageName, projectData.projectDir);
+		config.pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
+
+		const frameworkPackageNameData: any = { version: installedVersion };
+		if (customTemplateOptions) {
+			frameworkPackageNameData.template = customTemplateOptions.selectedTemplate;
+		}
+
+		this.$projectDataService.setNSValue(projectData.projectDir, platformData.frameworkPackageName, frameworkPackageNameData);
+	}
+
+	public async preparePlatform(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>, projectFilesConfig?: IProjectFilesConfig): Promise<void> {
+		if (!changesInfo || changesInfo.appFilesChanged) {
+			await this.copyAppFiles(platformData, appFilesUpdaterOptions, projectData);
+
+			// remove the App_Resources folder from the app/assets as here we're applying other files changes.
+			const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+			const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
+			if (this.$fs.exists(appResourcesDirectoryPath)) {
+				this.$fs.deleteDirectory(appResourcesDirectoryPath);
+			}
+		}
+
+		if (!changesInfo || changesInfo.modulesChanged) {
+			await this.copyTnsModules(platform, platformData, projectData, projectFilesConfig);
+		}
+	}
+
+	private async getPathToPlatformTemplate(selectedTemplate: string, frameworkPackageName: string, projectDir: string): Promise<{ selectedTemplate: string, pathToTemplate: string }> {
+		if (!selectedTemplate) {
+			// read data from package.json's nativescript key
+			// check the nativescript.tns-<platform>.template value
+			const nativescriptPlatformData = this.$projectDataService.getNSValue(projectDir, frameworkPackageName);
+			selectedTemplate = nativescriptPlatformData && nativescriptPlatformData.template;
+		}
+
+		if (selectedTemplate) {
+			const tempDir = temp.mkdirSync("platform-template");
+			this.$fs.writeJson(path.join(tempDir, constants.PACKAGE_JSON_FILE_NAME), {});
+			try {
+				const npmInstallResult = await this.$npm.install(selectedTemplate, tempDir, {
+					disableNpmInstall: false,
+					frameworkPath: null,
+					ignoreScripts: false
+				});
+				const pathToTemplate = path.join(tempDir, constants.NODE_MODULES_FOLDER_NAME, npmInstallResult.name);
+				return { selectedTemplate, pathToTemplate };
+			} catch (err) {
+				this.$logger.trace("Error while trying to install specified template: ", err);
+				this.$errors.failWithoutHelp(`Unable to install platform template ${selectedTemplate}. Make sure the specified value is valid.`);
+			}
+		}
+
+		return null;
+	}
+
+	private async copyTnsModules(platform: string, platformData: IPlatformData, projectData: IProjectData, projectFilesConfig?: IProjectFilesConfig): Promise<void> {
+		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+		const lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath) ? this.$fs.getFsStats(appDestinationDirectoryPath).mtime : null;
+
+		try {
+			const tnsModulesDestinationPath = path.join(appDestinationDirectoryPath, constants.TNS_MODULES_FOLDER_NAME);
+			// Process node_modules folder
+			await this.$nodeModulesBuilder.prepareJSNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime, projectData, projectFilesConfig);
+		} catch (error) {
+			this.$logger.debug(error);
+			shell.rm("-rf", appDestinationDirectoryPath);
+			this.$errors.failWithoutHelp(`Processing node_modules failed. ${error}`);
+		}
+	}
+}
+
+$injector.register("preparePlatformJSService", PreparePlatformJSService);

--- a/lib/services/prepare-platform-native-service.ts
+++ b/lib/services/prepare-platform-native-service.ts
@@ -1,0 +1,86 @@
+import * as constants from "../constants";
+import * as path from "path";
+import * as shell from "shelljs";
+import { PreparePlatformService } from "./prepare-platform-service";
+
+export class PreparePlatformNativeService extends PreparePlatformService implements IPreparePlatformNativeService {
+
+	constructor($fs: IFileSystem,
+		$xmlValidator: IXmlValidator,
+		private $nodeModulesBuilder: INodeModulesBuilder,
+		private $pluginsService: IPluginsService,
+		private $projectChangesService: IProjectChangesService) {
+		super($fs, $xmlValidator);
+	}
+
+	public async addPlatform(platformData: IPlatformData, frameworkDir: string, installedVersion: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
+		await platformData.platformProjectService.createProject(path.resolve(frameworkDir), installedVersion, projectData, config);
+		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
+		await platformData.platformProjectService.interpolateData(projectData, config);
+		platformData.platformProjectService.afterCreateProject(platformData.projectRoot, projectData);
+	}
+
+	public async preparePlatform(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, changesInfo?: IProjectChangesInfo, filesToSync?: Array<String>, projectFilesConfig?: IProjectFilesConfig): Promise<void> {
+		if (changesInfo.hasChanges) {
+			await this.cleanProject(platform, appFilesUpdaterOptions, platformData, projectData);
+		}
+
+		if (!changesInfo || changesInfo.changesRequirePrepare) {
+			await this.copyAppFiles(platformData, appFilesUpdaterOptions, projectData);
+			this.copyAppResources(platformData, projectData);
+			await platformData.platformProjectService.prepareProject(projectData, platformSpecificData);
+		}
+
+		if (!changesInfo || changesInfo.modulesChanged || appFilesUpdaterOptions.bundle) {
+			await this.$pluginsService.validate(platformData, projectData);
+
+			const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+			const lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath) ? this.$fs.getFsStats(appDestinationDirectoryPath).mtime : null;
+
+			const tnsModulesDestinationPath = path.join(appDestinationDirectoryPath, constants.TNS_MODULES_FOLDER_NAME);
+			// Process node_modules folder
+			await this.$nodeModulesBuilder.prepareNodeModules(tnsModulesDestinationPath, platform, lastModifiedTime, projectData, projectFilesConfig);
+		}
+
+		if (!changesInfo || changesInfo.configChanged || changesInfo.modulesChanged) {
+			await platformData.platformProjectService.processConfigurationFilesFromAppResources(appFilesUpdaterOptions.release, projectData);
+		}
+
+		platformData.platformProjectService.interpolateConfigurationFile(projectData, platformSpecificData);
+		this.$projectChangesService.setNativePlatformStatus(platform, projectData,
+			{ nativePlatformStatus: constants.NativePlatformStatus.alreadyPrepared });
+	}
+
+	private copyAppResources(platformData: IPlatformData, projectData: IProjectData): void {
+		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+		const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
+		if (this.$fs.exists(appResourcesDirectoryPath)) {
+			platformData.platformProjectService.prepareAppResources(appResourcesDirectoryPath, projectData);
+			const appResourcesDestination = platformData.platformProjectService.getAppResourcesDestinationDirectoryPath(projectData);
+			this.$fs.ensureDirectoryExists(appResourcesDestination);
+			shell.cp("-Rf", path.join(appResourcesDirectoryPath, platformData.normalizedPlatformName, "*"), appResourcesDestination);
+			this.$fs.deleteDirectory(appResourcesDirectoryPath);
+		}
+	}
+
+	private async cleanProject(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformData: IPlatformData, projectData: IProjectData): Promise<void> {
+		// android build artifacts need to be cleaned up
+		// when switching between debug, release and webpack builds
+		if (platform.toLowerCase() !== "android") {
+			return;
+		}
+
+		const previousPrepareInfo = this.$projectChangesService.getPrepareInfo(platform, projectData);
+		if (!previousPrepareInfo) {
+			return;
+		}
+
+		const { release: previousWasRelease, bundle: previousWasBundle } = previousPrepareInfo;
+		const { release: currentIsRelease, bundle: currentIsBundle } = appFilesUpdaterOptions;
+		if ((previousWasRelease !== currentIsRelease) || (previousWasBundle !== currentIsBundle)) {
+			await platformData.platformProjectService.cleanProject(platformData.projectRoot, projectData);
+		}
+	}
+}
+
+$injector.register("preparePlatformNativeService", PreparePlatformNativeService);

--- a/lib/services/prepare-platform-service.ts
+++ b/lib/services/prepare-platform-service.ts
@@ -1,0 +1,26 @@
+import * as constants from "../constants";
+import * as path from "path";
+import { AppFilesUpdater } from "./app-files-updater";
+import { EventEmitter } from "events";
+
+export class PreparePlatformService extends EventEmitter {
+
+	constructor(protected $fs: IFileSystem,
+		private $xmlValidator: IXmlValidator) {
+		super();
+	}
+
+	protected async copyAppFiles(platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData): Promise<void> {
+		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
+		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
+
+		// Copy app folder to native project
+		this.$fs.ensureDirectoryExists(appDestinationDirectoryPath);
+		const appSourceDirectoryPath = path.join(projectData.projectDir, constants.APP_FOLDER_NAME);
+
+		const appUpdater = new AppFilesUpdater(appSourceDirectoryPath, appDestinationDirectoryPath, appFilesUpdaterOptions, this.$fs);
+		appUpdater.updateApp(sourceFiles => {
+			this.$xmlValidator.validateXmlFiles(sourceFiles);
+		});
+	}
+}

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -69,7 +69,7 @@ export class ProjectChangesService implements IProjectChangesService {
 				projectData,
 				this.fileChangeRequiresBuild);
 
-			if (this._newFiles > 0) {
+			if (this._newFiles > 0 || this._changesInfo.nativeChanged) {
 				this._changesInfo.modulesChanged = true;
 			}
 			const platformResourcesDir = path.join(projectData.appResourcesDirectoryPath, platformData.normalizedPlatformName);

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -59,8 +59,16 @@ class TestExecutionService implements ITestExecutionService {
 					const socketIoJs = (await this.$httpClient.httpRequest(socketIoJsUrl)).body;
 					this.$fs.writeFile(path.join(projectDir, TestExecutionService.SOCKETIO_JS_FILE_NAME), socketIoJs);
 					const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+					const preparePlatformInfo: IPreparePlatformInfo = {
+						platform,
+						appFilesUpdaterOptions,
+						platformTemplate: this.$options.platformTemplate,
+						projectData,
+						config: this.$options,
+						env: this.$options.env
+					};
 
-					if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options)) {
+					if (!await this.$platformService.preparePlatform(preparePlatformInfo)) {
 						this.$errors.failWithoutHelp("Verify that listed files are well-formed and try again the operation.");
 					}
 
@@ -117,6 +125,7 @@ class TestExecutionService implements ITestExecutionService {
 						projectDir: projectData.projectDir,
 						skipWatcher: !this.$options.watch || this.$options.justlaunch,
 						watchAllFiles: this.$options.syncAllFiles,
+						env: this.$options.env
 					};
 
 					await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
@@ -175,9 +184,18 @@ class TestExecutionService implements ITestExecutionService {
 				}
 
 				const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+				const preparePlatformInfo: IPreparePlatformInfo = {
+					platform,
+					appFilesUpdaterOptions,
+					platformTemplate: this.$options.platformTemplate,
+					projectData,
+					config: this.$options,
+					env: this.$options.env
+				};
+
 				// Prepare the project AFTER the TestExecutionService.CONFIG_FILE_NAME file is created in node_modules
 				// so it will be sent to device.
-				if (!await this.$platformService.preparePlatform(platform, appFilesUpdaterOptions, this.$options.platformTemplate, projectData, this.$options)) {
+				if (!await this.$platformService.preparePlatform(preparePlatformInfo)) {
 					this.$errors.failWithoutHelp("Verify that listed files are well-formed and try again the operation.");
 				}
 
@@ -232,6 +250,7 @@ class TestExecutionService implements ITestExecutionService {
 						projectDir: projectData.projectDir,
 						skipWatcher: !this.$options.watch || this.$options.justlaunch,
 						watchAllFiles: this.$options.syncAllFiles,
+						env: this.$options.env
 					};
 
 					await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -14,10 +14,10 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		await npmPluginPrepare.preparePlugins(productionDependencies, platform, projectData, projectFilesConfig);
 	}
 
-	public async prepareJSNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void> {
-		const productionDependencies = this.initialPrepareNodeModules(absoluteOutputPath, platform, lastModifiedTime, projectData);
+	public async prepareJSNodeModules(jsNodeModulesData: IJsNodeModulesData): Promise<void> {
+		const productionDependencies = this.initialPrepareNodeModules(jsNodeModulesData.absoluteOutputPath, jsNodeModulesData.platform, jsNodeModulesData.lastModifiedTime, jsNodeModulesData.projectData);
 		const npmPluginPrepare: NpmPluginPrepare = this.$injector.resolve(NpmPluginPrepare);
-		await npmPluginPrepare.prepareJSPlugins(productionDependencies, platform, projectData, projectFilesConfig);
+		await npmPluginPrepare.prepareJSPlugins(productionDependencies, jsNodeModulesData.platform, jsNodeModulesData.projectData, jsNodeModulesData.projectFilesConfig);
 	}
 
 	public cleanNodeModules(absoluteOutputPath: string, platform: string): void {

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -16,6 +16,8 @@ import NodeModulesLib = require("../lib/tools/node-modules/node-modules-builder"
 import PluginsServiceLib = require("../lib/services/plugins-service");
 import ChildProcessLib = require("../lib/common/child-process");
 import ProjectFilesManagerLib = require("../lib/common/services/project-files-manager");
+import { PreparePlatformNativeService } from "../lib/services/prepare-platform-native-service";
+import { PreparePlatformJSService } from "../lib/services/prepare-platform-js-service";
 import { DeviceAppDataFactory } from "../lib/common/mobile/device-app-data/device-app-data-factory";
 import { LocalToDevicePathDataFactory } from "../lib/common/mobile/local-to-device-path-data-factory";
 import { MobileHelper } from "../lib/common/mobile/mobile-helper";
@@ -66,6 +68,8 @@ function createTestInjector(): IInjector {
 	testInjector.register("commandsServiceProvider", {
 		registerDynamicSubCommands: () => { /* intentionally left blank */ }
 	});
+	testInjector.register("preparePlatformNativeService", PreparePlatformNativeService);
+	testInjector.register("preparePlatformJSService", PreparePlatformJSService);
 	testInjector.register("pluginVariablesService", {});
 	testInjector.register("deviceAppDataFactory", DeviceAppDataFactory);
 	testInjector.register("localToDevicePathDataFactory", LocalToDevicePathDataFactory);
@@ -194,7 +198,14 @@ async function preparePlatform(testInjector: IInjector): Promise<void> {
 	projectData.initializeProjectData();
 	const options: IOptions = testInjector.resolve("options");
 
-	await platformService.preparePlatform("android", { bundle: options.bundle, release: options.release }, "", projectData, options);
+	await platformService.preparePlatform({
+		platform: "android",
+		appFilesUpdaterOptions: { bundle: options.bundle, release: options.release },
+		platformTemplate: "",
+		projectData,
+		config: options,
+		env: {}
+	});
 }
 
 describe("Npm support tests", () => {

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -138,6 +138,8 @@ function createTestInjector() {
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	testInjector.register("xmlValidator", XmlValidator);
 	testInjector.register("npm", {});
+	testInjector.register("preparePlatformNativeService", {});
+	testInjector.register("preparePlatformJSService", {});
 	testInjector.register("childProcess", ChildProcessLib.ChildProcess);
 	testInjector.register("projectChangesService", ProjectChangesLib.ProjectChangesService);
 	testInjector.register("emulatorPlatformService", stubs.EmulatorPlatformService);

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -16,6 +16,8 @@ import { ProjectFilesProvider } from "../lib/providers/project-files-provider";
 import { MobilePlatformsCapabilities } from "../lib/mobile-platforms-capabilities";
 import { DevicePlatformsConstants } from "../lib/common/mobile/device-platforms-constants";
 import { XmlValidator } from "../lib/xml-validator";
+import { PreparePlatformNativeService } from "../lib/services/prepare-platform-native-service";
+import { PreparePlatformJSService } from "../lib/services/prepare-platform-js-service";
 import * as ChildProcessLib from "../lib/common/child-process";
 import ProjectChangesLib = require("../lib/services/project-changes-service");
 import { Messages } from "../lib/common/messages/messages";
@@ -74,6 +76,8 @@ function createTestInjector() {
 	testInjector.register("mobilePlatformsCapabilities", MobilePlatformsCapabilities);
 	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	testInjector.register("xmlValidator", XmlValidator);
+	testInjector.register("preparePlatformNativeService", PreparePlatformNativeService);
+	testInjector.register("preparePlatformJSService", PreparePlatformJSService);
 	testInjector.register("npm", {
 		uninstall: async () => {
 			return true;
@@ -441,7 +445,14 @@ describe('Platform Service Tests', () => {
 
 			platformService = testInjector.resolve("platformService");
 			const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: false, release: release };
-			await platformService.preparePlatform(platformToTest, appFilesUpdaterOptions, "", projectData, { provision: null, teamId: null, sdk: null, frameworkPath: null, ignoreScripts: false });
+			await platformService.preparePlatform({
+				platform: platformToTest,
+				appFilesUpdaterOptions,
+				platformTemplate: "",
+				projectData,
+				config: { provision: null, teamId: null, sdk: null, frameworkPath: null, ignoreScripts: false },
+				env: {}
+			});
 		}
 
 		async function testPreparePlatform(platformToTest: string, release?: boolean): Promise<CreatedTestData> {
@@ -525,7 +536,7 @@ describe('Platform Service Tests', () => {
 			const data: any = {};
 			if (platform.toLowerCase() === "ios") {
 				data[path.join(appDestFolderPath, "app")] = {
-					missingFiles: ["test1.ios.js", "test2.android.js", "test2.js", "App_Resources"],
+					missingFiles: ["test1.ios.js", "test2.android.js", "test2.js"],
 					presentFiles: ["test1.js", "test2-android-js", "test1-ios-js", "main.js"]
 				};
 
@@ -868,7 +879,14 @@ describe('Platform Service Tests', () => {
 			try {
 				testInjector.resolve("$logger").warn = (text: string) => warnings += text;
 				const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: false, release: false };
-				await platformService.preparePlatform("android", appFilesUpdaterOptions, "", projectData, { provision: null, teamId: null, sdk: null, frameworkPath: null, ignoreScripts: false });
+				await platformService.preparePlatform({
+					platform: "android",
+					appFilesUpdaterOptions,
+					platformTemplate: "",
+					projectData,
+					config: { provision: null, teamId: null, sdk: null, frameworkPath: null, ignoreScripts: false },
+					env: {}
+				});
 			} finally {
 				testInjector.resolve("$logger").warn = oldLoggerWarner;
 			}

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -647,7 +647,7 @@ export class PlatformServiceStub extends EventEmitter implements IPlatformServic
 		return Promise.resolve();
 	}
 
-	public preparePlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string): Promise<boolean> {
+	public preparePlatform(platformInfo: IPreparePlatformInfo): Promise<boolean> {
 		return Promise.resolve(true);
 	}
 
@@ -667,7 +667,7 @@ export class PlatformServiceStub extends EventEmitter implements IPlatformServic
 		return Promise.resolve();
 	}
 
-	public deployPlatform(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, deployOptions: IDeployPlatformOptions): Promise<void> {
+	public deployPlatform(config: IDeployPlatformInfo): Promise<void> {
 		return Promise.resolve();
 	}
 

--- a/test/tns-appstore-upload.ts
+++ b/test/tns-appstore-upload.ts
@@ -98,8 +98,8 @@ class AppStore {
 
 	expectPreparePlatform() {
 		this.expectedPreparePlatformCalls = 1;
-		this.platformService.preparePlatform = (platform: string) => {
-			chai.assert.equal(platform, "iOS");
+		this.platformService.preparePlatform = (platformInfo: IPreparePlatformInfo) => {
+			chai.assert.equal(platformInfo.platform, "iOS");
 			this.preparePlatformCalls++;
 			return Promise.resolve(true);
 		};


### PR DESCRIPTION
Create interfaces to separate the prepare functionality in js and native parts.
Ensure better isolation and encapsulation of project preparation process.

Merge after https://github.com/telerik/mobile-cli-lib/pull/1018

https://github.com/NativeScript/nativescript-cli/issues/2968