### PR TITLE
Fix tracking of Node.js version, LiveSync action and user sessions count

### DIFF
--- a/lib/services/analytics/analytics-service.ts
+++ b/lib/services/analytics/analytics-service.ts
@@ -17,10 +17,10 @@ export class AnalyticsService extends AnalyticsServiceBase {
 		$analyticsSettingsService: IAnalyticsSettingsService,
 		$osInfo: IOsInfo,
 		private $childProcess: IChildProcess,
-		private $processService: IProcessService,
+		protected $processService: IProcessService,
 		private $projectDataService: IProjectDataService,
 		private $mobileHelper: Mobile.IMobileHelper) {
-		super($logger, $options, $staticConfig, $prompter, $userSettingsService, $analyticsSettingsService, $osInfo);
+		super($logger, $options, $staticConfig, $processService, $prompter, $userSettingsService, $analyticsSettingsService, $osInfo);
 	}
 
 	public track(featureName: string, featureValue: string): Promise<void> {
@@ -189,7 +189,11 @@ export class AnalyticsService extends AnalyticsServiceBase {
 					broker.send(message, resolve);
 				} catch (err) {
 					this.$logger.trace("Error while trying to send message to broker:", err);
+					resolve();
 				}
+			} else {
+				this.$logger.trace("Broker not found or not connected.");
+				resolve();
 			}
 		});
 	}

--- a/lib/services/analytics/eqatec-analytics-provider.ts
+++ b/lib/services/analytics/eqatec-analytics-provider.ts
@@ -15,12 +15,13 @@ export class EqatecAnalyticsProvider extends AnalyticsServiceBase implements IAn
 
 	constructor(protected $logger: ILogger,
 		protected $options: IOptions,
+		$processService: IProcessService,
 		$staticConfig: Config.IStaticConfig,
 		$prompter: IPrompter,
 		$userSettingsService: UserSettings.IUserSettingsService,
 		$analyticsSettingsService: IAnalyticsSettingsService,
 		$osInfo: IOsInfo) {
-		super($logger, $options, $staticConfig, $prompter, $userSettingsService, $analyticsSettingsService, $osInfo);
+		super($logger, $options, $staticConfig, $processService, $prompter, $userSettingsService, $analyticsSettingsService, $osInfo);
 	}
 
 	public async trackInformation(data: IFeatureTrackingInformation): Promise<void> {

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -375,13 +375,13 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 			pathToBuildItem = await options.deviceBuildInfoDescriptor.buildAction();
 			options.rebuiltInformation.push({ isEmulator: options.device.isEmulator, platform, pathToBuildItem });
 			action = LiveSyncTrackActionNames.LIVESYNC_OPERATION_BUILD;
+		} else {
+			await this.$analyticsService.trackEventActionInGoogleAnalytics({
+				action: TrackActionNames.LiveSync,
+				device: options.device,
+				projectDir: options.projectData.projectDir
+			});
 		}
-
-		await this.$analyticsService.trackEventActionInGoogleAnalytics({
-			action: TrackActionNames.LiveSync,
-			device: options.device,
-			projectDir: options.projectData.projectDir
-		});
 
 		await this.trackAction(action, platform, options);
 


### PR DESCRIPTION
Fix tracking of LiveSync action - it has been always tracked even when Build is required, so the workflow of user seemed like:
- Build
- LiveSync
- Deploy
- LiveSync

Now it will be:
- Build
- Deploy
- LiveSync

Also update common lib, where the following changes are applied:

Fix tracking of Node.js version in Eqatec and user sessions count

Whenever a new eqatec monitor is started, we should track the version of Node.js. However, the current code was calling `trackFeatureCore` which always tracks to the Eqatec Analytics projects used for Feature trackings.
This way, when any eqatec monitor is started, we've been sending information for Node.js version to the feature tracking projects. Fix this by passing the api key of the project in which we want to track the information.

Also fix the user sessions count - whenever `start` method is called, we are constructing analytics settings (which increases the counter of current user sessions with 1) and pass this to `startEqatecMonitor` method.
At this point we check if we've already started this monitor and in case not, we do not call start again. However, the values in `user-settings.json` for sessions count remains incorrect. Fix this by adding the check for already started monitor in the beginning of `start` method.

Add unit tests to verify tracking in multiple projects. Change some of the already exising verifications to use arrays instead of strings for easier comparison.