### PR TITLE
Assign debug options to device not to whole live sync data

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -80,7 +80,7 @@ interface IOptionalOutputPath {
 /**
  * Describes information for LiveSync on a device.
  */
-interface ILiveSyncDeviceInfo extends IOptionalOutputPath {
+interface ILiveSyncDeviceInfo extends IOptionalOutputPath, IOptionalDebuggingOptions {
 	/**
 	 * Device identifier.
 	 */
@@ -111,7 +111,7 @@ interface ILiveSyncDeviceInfo extends IOptionalOutputPath {
 /**
  * Describes a LiveSync operation.
  */
-interface ILiveSyncInfo extends IProjectDir, IOptionalDebuggingOptions {
+interface ILiveSyncInfo extends IProjectDir {
 	/**
 	 * Defines if the watcher should be skipped. If not passed, fs.Watcher will be started.
 	 */

--- a/lib/services/livesync/livesync-command-helper.ts
+++ b/lib/services/livesync/livesync-command-helper.ts
@@ -63,7 +63,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 						const result = await this.$platformService.lastOutputPath(d.deviceInfo.platform, buildConfig, this.$projectData);
 						return result;
 					},
-					debugggingEnabled: deviceDebugMap && deviceDebugMap[d.deviceInfo.identifier]
+					debugggingEnabled: deviceDebugMap && deviceDebugMap[d.deviceInfo.identifier],
+					debugOptions: this.$options
 				};
 
 				return info;
@@ -73,8 +74,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			projectDir: this.$projectData.projectDir,
 			skipWatcher: !this.$options.watch,
 			watchAllFiles: this.$options.syncAllFiles,
-			clean: this.$options.clean,
-			debugOptions: this.$options
+			clean: this.$options.clean
 		};
 
 		await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -243,6 +243,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		}
 
 		currentDeviceDescriptor.debugggingEnabled = true;
+		currentDeviceDescriptor.debugOptions = deviceOption.debugOptions;
 		const currentDeviceInstance = this.$devicesService.getDeviceByIdentifier(deviceOption.deviceIdentifier);
 		const attachDebuggerOptions: IAttachDebuggerOptions = {
 			deviceIdentifier: deviceOption.deviceIdentifier,
@@ -451,7 +452,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					watch: !liveSyncData.skipWatcher
 				});
 				await this.$platformService.trackActionForPlatform({ action: "LiveSync", platform: device.deviceInfo.platform, isForDevice: !device.isEmulator, deviceOsVersion: device.deviceInfo.version });
-				await this.refreshApplication(projectData, liveSyncResultInfo, liveSyncData.debugOptions, deviceBuildInfoDescriptor.outputPath);
+				await this.refreshApplication(projectData, liveSyncResultInfo, deviceBuildInfoDescriptor.debugOptions, deviceBuildInfoDescriptor.outputPath);
 
 				this.emit(LiveSyncEvents.liveSyncStarted, {
 					projectDir: projectData.projectDir,
@@ -559,7 +560,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 									};
 
 									const liveSyncResultInfo = await service.liveSyncWatchAction(device, settings);
-									await this.refreshApplication(projectData, liveSyncResultInfo, liveSyncData.debugOptions, deviceBuildInfoDescriptor.outputPath);
+									await this.refreshApplication(projectData, liveSyncResultInfo, deviceBuildInfoDescriptor.debugOptions, deviceBuildInfoDescriptor.outputPath);
 								},
 									(device: Mobile.IDevice) => {
 										const liveSyncProcessInfo = this.liveSyncProcessesInfo[projectData.projectDir];

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -28,7 +28,7 @@ class TestExecutionService implements ITestExecutionService {
 		private $devicesService: Mobile.IDevicesService,
 		private $analyticsService: IAnalyticsService,
 		private $childProcess: IChildProcess) {
-			this.$analyticsService.setShouldDispose(this.$options.justlaunch || !this.$options.watch);
+		this.$analyticsService.setShouldDispose(this.$options.justlaunch || !this.$options.watch);
 	}
 
 	public platform: string;
@@ -106,7 +106,8 @@ class TestExecutionService implements ITestExecutionService {
 									await this.$platformService.buildPlatform(d.deviceInfo.platform, buildConfig, projectData);
 									const pathToBuildResult = await this.$platformService.lastOutputPath(d.deviceInfo.platform, buildConfig, projectData);
 									return pathToBuildResult;
-								}
+								},
+								debugOptions: this.$options
 							};
 
 							return info;
@@ -116,7 +117,6 @@ class TestExecutionService implements ITestExecutionService {
 						projectDir: projectData.projectDir,
 						skipWatcher: !this.$options.watch || this.$options.justlaunch,
 						watchAllFiles: this.$options.syncAllFiles,
-						debugOptions: this.$options
 					};
 
 					await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
@@ -221,7 +221,8 @@ class TestExecutionService implements ITestExecutionService {
 									await this.$platformService.buildPlatform(d.deviceInfo.platform, buildConfig, projectData);
 									const pathToBuildResult = await this.$platformService.lastOutputPath(d.deviceInfo.platform, buildConfig, projectData);
 									return pathToBuildResult;
-								}
+								},
+								debugOptions: this.$options
 							};
 
 							return info;
@@ -231,7 +232,6 @@ class TestExecutionService implements ITestExecutionService {
 						projectDir: projectData.projectDir,
 						skipWatcher: !this.$options.watch || this.$options.justlaunch,
 						watchAllFiles: this.$options.syncAllFiles,
-						debugOptions: this.$options
 					};
 
 					await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);


### PR DESCRIPTION
If there are attached multiple devices to be livesynced and only one to be
debugged, the debug options should be applied only to this one device.
Having them in live sync data is incorrect.