### PR TITLE
Kddimitrov/add platform application identifier setting

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -33,11 +33,10 @@ export class DebugPlatformCommand extends ValidatePlatformCommandBase implements
 
 		const debugOptions = <IDebugOptions>_.cloneDeep(this.$options.argv);
 
-		const debugData = this.$debugDataService.createDebugData(this.$projectData, this.$options);
-
 		await this.$platformService.trackProjectType(this.$projectData);
 		const selectedDeviceForDebug = await this.getDeviceForDebug();
-		debugData.deviceIdentifier = selectedDeviceForDebug.deviceInfo.identifier;
+
+		const debugData = this.$debugDataService.createDebugData(this.$projectData, {device: selectedDeviceForDebug.deviceInfo.identifier});
 
 		if (this.$options.start) {
 			await this.$liveSyncService.printDebugInformation(await this.$debugService.debug(debugData, debugOptions));

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -187,7 +187,7 @@ interface ILiveSyncEventData {
 	deviceIdentifier: string,
 	applicationIdentifier?: string,
 	projectDir: string,
-	syncedFiles?: Object
+	syncedFiles?: string[],
 	error? : Error,
 	notification?: string,
 	isFullSync?: boolean

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -183,6 +183,16 @@ interface IHasUseHotModuleReloadOption {
 	useHotModuleReload: boolean;
 }
 
+interface ILiveSyncEventData {
+	deviceIdentifier: string,
+	applicationIdentifier?: string,
+	projectDir: string,
+	syncedFiles?: Object
+	error? : Error,
+	notification?: string,
+	isFullSync?: boolean
+}
+
 interface ILatestAppPackageInstalledSettings extends IDictionary<IDictionary<boolean>> { /* empty */ }
 
 interface IIsEmulator {

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -50,40 +50,39 @@ interface IPluginVariablesService {
 	/**
 	 * Saves plugin variables in project package.json file.
 	 * @param  {IPluginData}		pluginData for the plugin.
-	 * @param {IProjectData} projectData DTO with information about the project.
+	 * @param {string} projectDir: Specifies the directory of the project.
 	 * @return {Promise<void>}
 	 */
-	savePluginVariablesInProjectFile(pluginData: IPluginData, projectData: IProjectData): Promise<void>;
+	savePluginVariablesInProjectFile(pluginData: IPluginData, projectDir: string): Promise<void>;
 
 	/**
 	 * Removes plugin variables from project package.json file.
 	 * @param  {string}		pluginName Name of the plugin.
-	 * @param {IProjectData} projectData DTO with information about the project.
+	 * @param {string} projectDir: Specifies the directory of the project.
 	 * @return {void}
 	 */
-	removePluginVariablesFromProjectFile(pluginName: string, projectData: IProjectData): void;
+	removePluginVariablesFromProjectFile(pluginName: string, projectDir: string): void;
 
 	/**
 	 * Replaces all plugin variables with their corresponding values.
 	 * @param {IPluginData}		pluginData for the plugin.
 	 * @param {pluginConfigurationFilePath}		pluginConfigurationFilePath for the plugin.
-	 * @param {IProjectData} projectData DTO with information about the project.
+	 * @param {string} projectDir: Specifies the directory of the project.
 	 * @return {Promise<void>}
 	 */
-	interpolatePluginVariables(pluginData: IPluginData, pluginConfigurationFilePath: string, projectData: IProjectData): Promise<void>;
+	interpolatePluginVariables(pluginData: IPluginData, pluginConfigurationFilePath: string, projectDir: string): Promise<void>;
 
 	/**
 	 * Replaces {nativescript.id} expression with the application identifier from package.json.
 	 * @param {pluginConfigurationFilePath}	pluginConfigurationFilePath for the plugin.
-	 * @param {IProjectData} projectData DTO with information about the project.
 	 * @return {void}
 	 */
-	interpolateAppIdentifier(pluginConfigurationFilePath: string, projectData: IProjectData): void;
+	interpolateAppIdentifier(pluginConfigurationFilePath: string, projectIdentifier: string): void;
 
 	/**
 	 * Replaces both plugin variables and appIdentifier
 	 */
-	interpolate(pluginData: IPluginData, pluginConfigurationFilePath: string, projectData: IProjectData): Promise<void>;
+	interpolate(pluginData: IPluginData, pluginConfigurationFilePath: string, projectDir: string, projectIdentifier: string): Promise<void>;
 
 	/**
 	 * Returns the

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -77,7 +77,8 @@ interface INsConfig {
 interface IProjectData extends ICreateProjectData {
 	platformsDir: string;
 	projectFilePath: string;
-	projectId?: string;
+	projectId: string;
+	projectIdentifiers?: Mobile.IProjectIdentifier;
 	dependencies: any;
 	devDependencies: IStringDictionary;
 	appDirectoryPath: string;

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -167,7 +167,15 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			};
 
 			await this.$platformService.deployPlatform(deployPlatformInfo);
-			await this.$platformService.startApplication(currentPlatform, runPlatformOptions, { appId: this.$projectData.projectId, projectName: this.$projectData.projectName });
+
+			await this.$platformService.startApplication(
+				currentPlatform,
+				runPlatformOptions,
+				{
+					appId: this.$projectData.projectIdentifiers[currentPlatform.toLowerCase()],
+					projectName: this.$projectData.projectName
+				}
+			);
 			await this.$platformService.trackProjectType(this.$projectData);
 		}
 	}

--- a/lib/services/debug-data-service.ts
+++ b/lib/services/debug-data-service.ts
@@ -1,7 +1,12 @@
 export class DebugDataService implements IDebugDataService {
+	constructor(
+		private $devicesService: Mobile.IDevicesService
+	) { }
 	public createDebugData(projectData: IProjectData, options: IDeviceIdentifier): IDebugData {
+		const device = this.$devicesService.getDeviceByIdentifier(options.device);
+
 		return {
-			applicationIdentifier: projectData.projectId,
+			applicationIdentifier: projectData.projectIdentifiers[device.deviceInfo.platform.toLowerCase()],
 			projectDir: projectData.projectDir,
 			deviceIdentifier: options.device,
 			projectName: projectData.projectName

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -246,7 +246,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		if (options && options.provision) {
 			plistTemplate += `    <key>provisioningProfiles</key>
     <dict>
-        <key>${projectData.projectId}</key>
+        <key>${projectData.projectIdentifiers.ios}</key>
         <string>${options.provision}</string>
     </dict>`;
 		}
@@ -295,7 +295,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		if (options && options.provision) {
 			plistTemplate += `    <key>provisioningProfiles</key>
 <dict>
-	<key>${projectData.projectId}</key>
+	<key>${projectData.projectIdentifiers.ios}</key>
 	<string>${options.provision}</string>
 </dict>`;
 		}
@@ -512,7 +512,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 			if (shouldUpdateXcode) {
 				const pickStart = Date.now();
-				const mobileprovision = mobileProvisionData || await this.$iOSProvisionService.pick(provision, projectData.projectId);
+				const mobileprovision = mobileProvisionData || await this.$iOSProvisionService.pick(provision, projectData.projectIdentifiers.ios);
 				const pickEnd = Date.now();
 				this.$logger.trace("Searched and " + (mobileprovision ? "found" : "failed to find ") + " matching provisioning profile. (" + (pickEnd - pickStart) + "ms.)");
 				if (!mobileprovision) {
@@ -777,10 +777,10 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 		await this.$iOSEntitlementsService.merge(projectData);
 		await this.mergeProjectXcconfigFiles(release, projectData);
 		for (const pluginData of await this.getAllInstalledPlugins(projectData)) {
-			await this.$pluginVariablesService.interpolatePluginVariables(pluginData, this.getPlatformData(projectData).configurationFilePath, projectData);
+			await this.$pluginVariablesService.interpolatePluginVariables(pluginData, this.getPlatformData(projectData).configurationFilePath, projectData.projectDir);
 		}
 
-		this.$pluginVariablesService.interpolateAppIdentifier(this.getPlatformData(projectData).configurationFilePath, projectData);
+		this.$pluginVariablesService.interpolateAppIdentifier(this.getPlatformData(projectData).configurationFilePath, projectData.projectIdentifiers.ios);
 	}
 
 	private getInfoPlistPath(projectData: IProjectData): string {
@@ -841,7 +841,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 
 		makePatch(infoPlistPath);
 
-		if (projectData.projectId) {
+		if (projectData.projectIdentifiers && projectData.projectIdentifiers.ios) {
 			session.patch({
 				name: "CFBundleIdentifier from package.json nativescript.id",
 				read: () =>
@@ -850,13 +850,13 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 						<plist version="1.0">
 						<dict>
 							<key>CFBundleIdentifier</key>
-							<string>${projectData.projectId}</string>
+							<string>${projectData.projectIdentifiers.ios}</string>
 						</dict>
 						</plist>`
 			});
 		}
 
-		if (!buildOptions.release && projectData.projectId) {
+		if (!buildOptions.release && projectData.projectIdentifiers && projectData.projectIdentifiers.ios) {
 			session.patch({
 				name: "CFBundleURLTypes from package.json nativescript.id",
 				read: () =>
@@ -871,7 +871,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 									<string>Editor</string>
 									<key>CFBundleURLSchemes</key>
 									<array>
-										<string>${projectData.projectId.replace(/[^A-Za-z0-9]/g, "")}</string>
+										<string>${projectData.projectIdentifiers.ios.replace(/[^A-Za-z0-9]/g, "")}</string>
 									</array>
 								</dict>
 							</array>

--- a/lib/services/itmstransporter-service.ts
+++ b/lib/services/itmstransporter-service.ts
@@ -110,7 +110,7 @@ export class ITMSTransporterService implements IITMSTransporterService {
 	private async getBundleIdentifier(ipaFileFullPath?: string): Promise<string> {
 		if (!this._bundleIdentifier) {
 			if (!ipaFileFullPath) {
-				this._bundleIdentifier = this.$projectData.projectId;
+				this._bundleIdentifier = this.$projectData.projectIdentifiers.ios;
 			} else {
 				if (!this.$fs.exists(ipaFileFullPath) || path.extname(ipaFileFullPath) !== ".ipa") {
 					this.$errors.failWithoutHelp(`Cannot use specified ipa file ${ipaFileFullPath}. File either does not exist or is not an ipa file.`);

--- a/lib/services/livesync/android-device-livesync-sockets-service.ts
+++ b/lib/services/livesync/android-device-livesync-sockets-service.ts
@@ -32,7 +32,7 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 		this.$fs.writeFile(pathToLiveSyncFile, "");
 		await this.device.fileSystem.putFile(pathToLiveSyncFile, this.getPathToLiveSyncFileOnDevice(deviceAppData.appIdentifier), deviceAppData.appIdentifier);
 		await this.device.applicationManager.startApplication({ appId: deviceAppData.appIdentifier, projectName: this.data.projectName, justLaunch: true });
-		await this.connectLivesyncTool(this.data.projectId);
+		await this.connectLivesyncTool(this.data.projectIdentifiers.android);
 	}
 
 	private getPathToLiveSyncFileOnDevice(appIdentifier: string): string {

--- a/lib/services/livesync/ios-device-livesync-service.ts
+++ b/lib/services/livesync/ios-device-livesync-service.ts
@@ -26,16 +26,18 @@ export class IOSDeviceLiveSyncService extends DeviceLiveSyncServiceBase implemen
 			return true;
 		}
 
+		const appId = projectData.projectIdentifiers.ios;
+
 		if (this.device.isEmulator) {
-			await this.$iOSEmulatorServices.postDarwinNotification(this.$iOSNotification.getAttachRequest(projectData.projectId, this.device.deviceInfo.identifier), this.device.deviceInfo.identifier);
-			const port = await this.$iOSDebuggerPortService.getPort({ projectDir: projectData.projectDir, deviceId: this.device.deviceInfo.identifier, appId: projectData.projectId });
+			await this.$iOSEmulatorServices.postDarwinNotification(this.$iOSNotification.getAttachRequest(appId, this.device.deviceInfo.identifier), this.device.deviceInfo.identifier);
+			const port = await this.$iOSDebuggerPortService.getPort({ projectDir: projectData.projectDir, deviceId: this.device.deviceInfo.identifier, appId });
 			this.socket = await this.$iOSEmulatorServices.connectToPort({ port });
 			if (!this.socket) {
 				return false;
 			}
 		} else {
-			await this.$iOSSocketRequestExecutor.executeAttachRequest(this.device, constants.AWAIT_NOTIFICATION_TIMEOUT_SECONDS, projectData.projectId);
-			const port = await this.$iOSDebuggerPortService.getPort({ projectDir: projectData.projectDir, deviceId: this.device.deviceInfo.identifier, appId: projectData.projectId });
+			await this.$iOSSocketRequestExecutor.executeAttachRequest(this.device, constants.AWAIT_NOTIFICATION_TIMEOUT_SECONDS, appId);
+			const port = await this.$iOSDebuggerPortService.getPort({ projectDir: projectData.projectDir, deviceId: this.device.deviceInfo.identifier, appId });
 			this.socket = await this.device.connectToPort(port);
 		}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -794,6 +794,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	}
 
 	public emitLivesyncEvent (event: string, livesyncData: ILiveSyncEventData): boolean {
+		this.$logger.trace(`Will emit event ${event} with data`, livesyncData);
 		return this.emit(event, livesyncData);
 	}
 

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -14,9 +14,10 @@ export abstract class PlatformLiveSyncServiceBase {
 		private $projectFilesProvider: IProjectFilesProvider) { }
 
 	public getDeviceLiveSyncService(device: Mobile.IDevice, projectData: IProjectData): INativeScriptDeviceLiveSyncService {
+		const platform = device.deviceInfo.platform.toLowerCase();
 		const platformData = this.$platformsData.getPlatformData(device.deviceInfo.platform, projectData);
 		const frameworkVersion = platformData.platformProjectService.getFrameworkVersion(projectData);
-		const key = getHash(`${device.deviceInfo.identifier}${projectData.projectId}${projectData.projectDir}${frameworkVersion}`);
+		const key = getHash(`${device.deviceInfo.identifier}${projectData.projectIdentifiers[platform]}${projectData.projectDir}${frameworkVersion}`);
 		if (!this._deviceLiveSyncServicesCache[key]) {
 			this._deviceLiveSyncServicesCache[key] = this._getDeviceLiveSyncService(device, projectData, frameworkVersion);
 		}
@@ -125,9 +126,11 @@ export abstract class PlatformLiveSyncServiceBase {
 	}
 
 	protected async getAppData(syncInfo: IFullSyncInfo): Promise<Mobile.IDeviceAppData> {
-		const deviceProjectRootOptions: IDeviceProjectRootOptions = _.assign({ appIdentifier: syncInfo.projectData.projectId }, syncInfo);
+		const platform = syncInfo.device.deviceInfo.platform.toLowerCase();
+		const appIdentifier = syncInfo.projectData.projectIdentifiers[platform];
+		const deviceProjectRootOptions: IDeviceProjectRootOptions = _.assign({ appIdentifier }, syncInfo);
 		return {
-			appIdentifier: syncInfo.projectData.projectId,
+			appIdentifier,
 			device: syncInfo.device,
 			platform: syncInfo.device.deviceInfo.platform,
 			getDeviceProjectRootPath: () => this.$devicePathProvider.getDeviceProjectRootPath(syncInfo.device, deviceProjectRootOptions),

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -97,7 +97,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		// Log the values for project
 		this.$logger.trace("Creating NativeScript project for the %s platform", platform);
 		this.$logger.trace("Path: %s", platformData.projectRoot);
-		this.$logger.trace("Package: %s", projectData.projectId);
+		this.$logger.trace("Package: %s", projectData.projectIdentifiers[platform]);
 		this.$logger.trace("Name: %s", projectData.projectName);
 
 		this.$logger.out("Copying template files...");
@@ -260,14 +260,24 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			platform = this.$mobileHelper.normalizePlatformName(platform);
 			this.$logger.trace("Validate options for platform: " + platform);
 			const platformData = this.$platformsData.getPlatformData(platform, projectData);
-			const result = await platformData.platformProjectService.validateOptions(projectData.projectId, provision, teamId);
+
+			const result = await platformData.platformProjectService.validateOptions(
+				projectData.projectIdentifiers[platform.toLowerCase()],
+				provision,
+				teamId
+			);
+
 			return result;
 		} else {
 			let valid = true;
 			for (const availablePlatform in this.$platformsData.availablePlatforms) {
 				this.$logger.trace("Validate options for platform: " + availablePlatform);
 				const platformData = this.$platformsData.getPlatformData(availablePlatform, projectData);
-				valid = valid && await platformData.platformProjectService.validateOptions(projectData.projectId, provision, teamId);
+				valid = valid && await platformData.platformProjectService.validateOptions(
+					projectData.projectIdentifiers[availablePlatform.toLowerCase()],
+					provision,
+					teamId
+				);
 			}
 
 			return valid;
@@ -459,7 +469,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	public async shouldInstall(device: Mobile.IDevice, projectData: IProjectData, release: IBuildConfig, outputPath?: string): Promise<boolean> {
 		const platform = device.deviceInfo.platform;
-		if (!(await device.applicationManager.isApplicationInstalled(projectData.projectId))) {
+		if (!(await device.applicationManager.isApplicationInstalled(projectData.projectIdentifiers[platform.toLowerCase()]))) {
 			return true;
 		}
 
@@ -489,11 +499,12 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		await platformData.platformProjectService.cleanDeviceTempFolder(device.deviceInfo.identifier, projectData);
 
-		await device.applicationManager.reinstallApplication(projectData.projectId, packageFile);
+		const platform = device.deviceInfo.platform.toLowerCase();
+		await device.applicationManager.reinstallApplication(projectData.projectIdentifiers[platform], packageFile);
 
 		await this.updateHashesOnDevice({
 			device,
-			appIdentifier: projectData.projectId,
+			appIdentifier: projectData.projectIdentifiers[platform],
 			outputFilePath,
 			platformData
 		});
@@ -503,7 +514,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			const options = buildConfig;
 			options.buildForDevice = !device.isEmulator;
 			const buildInfoFilePath = outputFilePath || this.getBuildOutputPath(device.deviceInfo.platform, platformData, options);
-			const appIdentifier = projectData.projectId;
+			const appIdentifier = projectData.projectIdentifiers[platform];
 
 			await device.fileSystem.putFile(path.join(buildInfoFilePath, buildInfoFileName), deviceFilePath, appIdentifier);
 		}
@@ -608,8 +619,9 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	private async getDeviceBuildInfoFilePath(device: Mobile.IDevice, projectData: IProjectData): Promise<string> {
+		const platform = device.deviceInfo.platform.toLowerCase();
 		const deviceRootPath = await this.$devicePathProvider.getDeviceProjectRootPath(device, {
-			appIdentifier: projectData.projectId,
+			appIdentifier: projectData.projectIdentifiers[platform],
 			getDirname: true
 		});
 		return helpers.fromWindowsRelativePathToUnix(path.join(deviceRootPath, buildInfoFileName));
@@ -918,8 +930,9 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	public async readFile(device: Mobile.IDevice, deviceFilePath: string, projectData: IProjectData): Promise<string> {
 		temp.track();
 		const uniqueFilePath = temp.path({ suffix: ".tmp" });
+		const platform = device.deviceInfo.platform.toLowerCase();
 		try {
-			await device.fileSystem.getFile(deviceFilePath, projectData.projectId, uniqueFilePath);
+			await device.fileSystem.getFile(deviceFilePath, projectData.projectIdentifiers[platform], uniqueFilePath);
 		} catch (e) {
 			return null;
 		}

--- a/lib/services/plugin-variables-service.ts
+++ b/lib/services/plugin-variables-service.ts
@@ -13,42 +13,42 @@ export class PluginVariablesService implements IPluginVariablesService {
 		return `${pluginName}-${PluginVariablesService.PLUGIN_VARIABLES_KEY}`;
 	}
 
-	public async savePluginVariablesInProjectFile(pluginData: IPluginData, projectData: IProjectData): Promise<void> {
+	public async savePluginVariablesInProjectFile(pluginData: IPluginData, projectDir: string): Promise<void> {
 		const values = Object.create(null);
 		await this.executeForAllPluginVariables(pluginData, async (pluginVariableData: IPluginVariableData) => {
 			const pluginVariableValue = await this.getPluginVariableValue(pluginVariableData);
 			this.ensurePluginVariableValue(pluginVariableValue, `Unable to find value for ${pluginVariableData.name} plugin variable from ${pluginData.name} plugin. Ensure the --var option is specified or the plugin variable has default value.`);
 			values[pluginVariableData.name] = pluginVariableValue;
-		}, projectData);
+		}, projectDir);
 
 		if (!_.isEmpty(values)) {
-			this.$projectDataService.setNSValue(projectData.projectDir, this.getPluginVariablePropertyName(pluginData.name), values);
+			this.$projectDataService.setNSValue(projectDir, this.getPluginVariablePropertyName(pluginData.name), values);
 		}
 	}
 
-	public removePluginVariablesFromProjectFile(pluginName: string, projectData: IProjectData): void {
-		this.$projectDataService.removeNSProperty(projectData.projectDir, this.getPluginVariablePropertyName(pluginName));
+	public removePluginVariablesFromProjectFile(pluginName: string, projectDir: string): void {
+		this.$projectDataService.removeNSProperty(projectDir, this.getPluginVariablePropertyName(pluginName));
 	}
 
-	public async interpolatePluginVariables(pluginData: IPluginData, pluginConfigurationFilePath: string, projectData: IProjectData): Promise<void> {
+	public async interpolatePluginVariables(pluginData: IPluginData, pluginConfigurationFilePath: string, projectDir: string): Promise<void> {
 		let pluginConfigurationFileContent = this.$fs.readText(pluginConfigurationFilePath);
 		await this.executeForAllPluginVariables(pluginData, async (pluginVariableData: IPluginVariableData) => {
 			this.ensurePluginVariableValue(pluginVariableData.value, `Unable to find the value for ${pluginVariableData.name} plugin variable into project package.json file. Verify that your package.json file is correct and try again.`);
 			pluginConfigurationFileContent = this.interpolateCore(pluginVariableData.name, pluginVariableData.value, pluginConfigurationFileContent);
-		}, projectData);
+		}, projectDir);
 
 		this.$fs.writeFile(pluginConfigurationFilePath, pluginConfigurationFileContent);
 	}
 
-	public interpolateAppIdentifier(pluginConfigurationFilePath: string, projectData: IProjectData): void {
+	public interpolateAppIdentifier(pluginConfigurationFilePath: string, projectIdentifier: string): void {
 		const pluginConfigurationFileContent = this.$fs.readText(pluginConfigurationFilePath);
-		const newContent = this.interpolateCore("nativescript.id", projectData.projectId, pluginConfigurationFileContent);
+		const newContent = this.interpolateCore("nativescript.id", projectIdentifier, pluginConfigurationFileContent);
 		this.$fs.writeFile(pluginConfigurationFilePath, newContent);
 	}
 
-	public async interpolate(pluginData: IPluginData, pluginConfigurationFilePath: string, projectData: IProjectData): Promise<void> {
-		await this.interpolatePluginVariables(pluginData, pluginConfigurationFilePath, projectData);
-		this.interpolateAppIdentifier(pluginConfigurationFilePath, projectData);
+	public async interpolate(pluginData: IPluginData, pluginConfigurationFilePath: string, projectDir: string, projectIdentifier: string): Promise<void> {
+		await this.interpolatePluginVariables(pluginData, pluginConfigurationFilePath, projectDir);
+		this.interpolateAppIdentifier(pluginConfigurationFilePath, projectIdentifier);
 	}
 
 	private interpolateCore(name: string, value: string, content: string): string {
@@ -83,18 +83,18 @@ export class PluginVariablesService implements IPluginVariablesService {
 		return value;
 	}
 
-	private async executeForAllPluginVariables(pluginData: IPluginData, action: (pluginVariableData: IPluginVariableData) => Promise<void>, projectData: IProjectData): Promise<void> {
+	private async executeForAllPluginVariables(pluginData: IPluginData, action: (pluginVariableData: IPluginVariableData) => Promise<void>, projectDir: string): Promise<void> {
 		const pluginVariables = pluginData.pluginVariables;
 		const pluginVariablesNames = _.keys(pluginVariables);
-		await Promise.all(_.map(pluginVariablesNames, pluginVariableName => action(this.createPluginVariableData(pluginData, pluginVariableName, projectData))));
+		await Promise.all(_.map(pluginVariablesNames, pluginVariableName => action(this.createPluginVariableData(pluginData, pluginVariableName, projectDir))));
 	}
 
-	private createPluginVariableData(pluginData: IPluginData, pluginVariableName: string, projectData: IProjectData): IPluginVariableData {
+	private createPluginVariableData(pluginData: IPluginData, pluginVariableName: string, projectDir: string): IPluginVariableData {
 		const variableData = pluginData.pluginVariables[pluginVariableName];
 
 		variableData.name = pluginVariableName;
 
-		const pluginVariableValues = this.$projectDataService.getNSValue(projectData.projectDir, this.getPluginVariablePropertyName(pluginData.name));
+		const pluginVariableValues = this.$projectDataService.getNSValue(projectDir, this.getPluginVariablePropertyName(pluginData.name));
 		variableData.value = pluginVariableValues ? pluginVariableValues[pluginVariableName] : undefined;
 
 		return variableData;

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -62,7 +62,7 @@ export class PluginsService implements IPluginsService {
 			await this.executeForAllInstalledPlatforms(action, projectData);
 
 			try {
-				await this.$pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData);
+				await this.$pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData.projectDir);
 			} catch (err) {
 				// Revert package.json
 				this.$projectDataService.removeNSProperty(projectData.projectDir, this.$pluginVariablesService.getPluginVariablePropertyName(pluginData.name));
@@ -85,7 +85,7 @@ export class PluginsService implements IPluginsService {
 			await platformData.platformProjectService.removePluginNativeCode(pluginData, projectData);
 		};
 
-		this.$pluginVariablesService.removePluginVariablesFromProjectFile(pluginName.toLowerCase(), projectData);
+		this.$pluginVariablesService.removePluginVariablesFromProjectFile(pluginName.toLowerCase(), projectData.projectDir);
 		await this.executeForAllInstalledPlatforms(removePluginNativeCodeAction, projectData);
 
 		await this.executeNpmCommand(PluginsService.UNINSTALL_COMMAND_NAME, pluginName, projectData);

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -103,7 +103,7 @@ export class ProjectService implements IProjectService {
 		try {
 			const projectData = this.$projectDataService.getProjectData(pathToProject);
 
-			return !!projectData && !!projectData.projectDir && !!projectData.projectId;
+			return !!projectData && !!projectData.projectDir && !!(projectData.projectIdentifiers.ios && projectData.projectIdentifiers.android);
 		} catch (e) {
 			return false;
 		}

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -69,7 +69,9 @@ function createTestInjector(projectPath: string, projectName: string, xcode?: IX
 		platformsDir: path.join(projectPath, "platforms"),
 		projectName: projectName,
 		projectPath: projectPath,
-		projectFilePath: path.join(projectPath, "package.json")
+		projectFilePath: path.join(projectPath, "package.json"),
+		projectId: "",
+		projectIdentifiers: { android: "", ios: ""}
 	});
 	testInjector.register("projectData", projectData);
 	testInjector.register("projectHelper", {});

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -191,6 +191,7 @@ describe('Platform Service Tests', () => {
 	beforeEach(() => {
 		testInjector = createTestInjector();
 		testInjector.register("fs", stubs.FileSystemStub);
+		testInjector.resolve("projectData").initializeProjectData();
 		platformService = testInjector.resolve("platformService");
 	});
 
@@ -389,6 +390,7 @@ describe('Platform Service Tests', () => {
 			testInjector = createTestInjector();
 			testInjector.register("fs", fsLib.FileSystem);
 			fs = testInjector.resolve("fs");
+			testInjector.resolve("projectData").initializeProjectData();
 		});
 
 		function prepareDirStructure() {

--- a/test/plugin-variables-service.ts
+++ b/test/plugin-variables-service.ts
@@ -56,7 +56,9 @@ async function createProjectFile(testInjector: IInjector): Promise<string> {
 
 	const projectData = {
 		"name": "myProject",
-		"nativescript": {}
+		"nativescript": {
+			id: { android: "", ios: ""}
+		}
 	};
 	testInjector.resolve("fs").writeJson(path.join(tempFolder, "package.json"), projectData);
 
@@ -105,7 +107,7 @@ describe("Plugin Variables service", () => {
 			let actualError: string = null;
 
 			try {
-				await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData);
+				await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData.projectDir);
 			} catch (err) {
 				actualError = err.message;
 			}
@@ -125,7 +127,7 @@ describe("Plugin Variables service", () => {
 			const pluginVariablesService: IPluginVariablesService = testInjector.resolve("pluginVariablesService");
 			const projectData: IProjectData = testInjector.resolve("projectData");
 			projectData.initializeProjectData();
-			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData);
+			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData.projectDir);
 
 			const fs = testInjector.resolve("fs");
 			const staticConfig: IStaticConfig = testInjector.resolve("staticConfig");
@@ -143,7 +145,7 @@ describe("Plugin Variables service", () => {
 			const projectData = testInjector.resolve("projectData");
 			projectData.initializeProjectData();
 
-			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData);
+			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData.projectDir);
 
 			const fs = testInjector.resolve("fs");
 			const staticConfig: IStaticConfig = testInjector.resolve("staticConfig");
@@ -170,7 +172,7 @@ describe("Plugin Variables service", () => {
 			const pluginVariablesService: IPluginVariablesService = testInjector.resolve("pluginVariablesService");
 			const projectData = testInjector.resolve("projectData");
 			projectData.initializeProjectData();
-			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData);
+			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData.projectDir);
 
 			const fs = testInjector.resolve("fs");
 			const staticConfig: IStaticConfig = testInjector.resolve("staticConfig");
@@ -188,7 +190,7 @@ describe("Plugin Variables service", () => {
 			const projectData = testInjector.resolve("projectData");
 			projectData.initializeProjectData();
 
-			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData);
+			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData.projectDir);
 
 			const fs = testInjector.resolve("fs");
 			const staticConfig: IStaticConfig = testInjector.resolve("staticConfig");
@@ -209,7 +211,7 @@ describe("Plugin Variables service", () => {
 			const pluginVariablesService: IPluginVariablesService = testInjector.resolve("pluginVariablesService");
 			const projectData = testInjector.resolve("projectData");
 			projectData.initializeProjectData();
-			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData);
+			await pluginVariablesService.savePluginVariablesInProjectFile(pluginData, projectData.projectDir);
 
 			const fs = testInjector.resolve("fs");
 			const staticConfig: IStaticConfig = testInjector.resolve("staticConfig");
@@ -237,7 +239,7 @@ describe("Plugin Variables service", () => {
 			const expectedError = "Unable to find the value for MY_VAR plugin variable into project package.json file. Verify that your package.json file is correct and try again.";
 			let error: string = null;
 			try {
-				await pluginVariablesService.interpolatePluginVariables(pluginData, filePath, projectData);
+				await pluginVariablesService.interpolatePluginVariables(pluginData, filePath, projectData.projectDir);
 			} catch (err) {
 				error = err.message;
 			}
@@ -272,7 +274,7 @@ describe("Plugin Variables service", () => {
 			const filePath = path.join(tempFolder, "myfile");
 			fs.writeFile(filePath, pluginConfigurationFileContent);
 
-			await pluginVariablesService.interpolatePluginVariables(pluginData, filePath, projectData);
+			await pluginVariablesService.interpolatePluginVariables(pluginData, filePath, projectData.projectDir);
 
 			const result = fs.readText(filePath);
 			const expectedResult = '<?xml version="1.0" encoding="UTF-8"?>' +
@@ -312,7 +314,7 @@ describe("Plugin Variables service", () => {
 			const filePath = path.join(tempFolder, "myfile");
 			fs.writeFile(filePath, pluginConfigurationFileContent);
 
-			await pluginVariablesService.interpolatePluginVariables(pluginData, filePath, projectData);
+			await pluginVariablesService.interpolatePluginVariables(pluginData, filePath, projectData.projectDir);
 
 			const result = fs.readText(filePath);
 			const expectedResult = '<?xml version="1.0" encoding="UTF-8"?>' +
@@ -353,7 +355,7 @@ describe("Plugin Variables service", () => {
 			const filePath = path.join(tempFolder, "myfile");
 			fs.writeFile(filePath, pluginConfigurationFileContent);
 
-			await pluginVariablesService.interpolatePluginVariables(pluginData, filePath, projectData);
+			await pluginVariablesService.interpolatePluginVariables(pluginData, filePath, projectData.projectDir);
 
 			const result = fs.readText(filePath);
 			const expectedResult = '<?xml version="1.0" encoding="UTF-8"?>' +

--- a/test/project-data.ts
+++ b/test/project-data.ts
@@ -50,7 +50,9 @@ describe("projectData", () => {
 			fs.exists = (filePath: string) => filePath && path.basename(filePath) === "package.json";
 
 			fs.readText = () => (JSON.stringify({
-				nativescript: {},
+				nativescript: {
+					id: "com.test.testid"
+				},
 				dependencies: dependencies,
 				devDependencies: devDependencies
 			}));

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -459,7 +459,8 @@ describe("Project Service Tests", () => {
 			const projectDataService = testInjector.resolve<IProjectDataService>("projectDataService");
 			const projectData: any = {
 				projectDir: "projectDir",
-				projectId: "projectId"
+				projectId: "projectId",
+				projectIdentifiers: { android: "projectId", ios: "projectId"}
 			};
 
 			let returnedProjectData: any = null;

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -446,7 +446,8 @@ describe("Project Service Tests", () => {
 		it("returns true when getProjectData does not throw, projectDir and projectId are valid", () => {
 			const testInjector = getTestInjector({
 				projectDir: "projectDir",
-				projectId: "projectId"
+				projectId: "projectId",
+				projectIdentifiers: { android: "projectId", ios: "projectId"},
 			});
 
 			const projectService: IProjectService = testInjector.resolve(ProjectServiceLib.ProjectService);

--- a/test/services/debug-service.ts
+++ b/test/services/debug-service.ts
@@ -102,8 +102,8 @@ describe("debugService", () => {
 
 	describe("debug", () => {
 		const getDebugData = (deviceIdentifier?: string): IDebugData => ({
-			applicationIdentifier: "org.nativescript.app1",
 			deviceIdentifier: deviceIdentifier || defaultDeviceIdentifier,
+			applicationIdentifier: "org.nativescript.app1",
 			projectDir: "/Users/user/app1",
 			projectName: "app1"
 		});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -247,9 +247,10 @@ export class ProjectDataStub implements IProjectData {
 	projectDir: string;
 	projectName: string;
 	get platformsDir(): string {
-		return "";
+		return this.plafromsDir;
 	}
 	set platformsDir(value) {
+		this.plafromsDir = value;
 	}
 	projectFilePath: string;
 	projectIdentifiers: Mobile.IProjectIdentifier;
@@ -260,6 +261,7 @@ export class ProjectDataStub implements IProjectData {
 	devDependencies: IStringDictionary;
 	projectType: string;
 	appResourcesDirectoryPath: string;
+	private plafromsDir: string = "";
 	public androidManifestPath: string;
 	public infoPlistPath: string;
 	public appGradlePath: string;

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -252,6 +252,7 @@ export class ProjectDataStub implements IProjectData {
 	set platformsDir(value) {
 	}
 	projectFilePath: string;
+	projectIdentifiers: Mobile.IProjectIdentifier;
 	projectId: string;
 	dependencies: any;
 	nsConfig: any;
@@ -267,6 +268,8 @@ export class ProjectDataStub implements IProjectData {
 
 	public initializeProjectData(projectDir?: string): void {
 		this.projectDir = this.projectDir || projectDir;
+		this.projectIdentifiers = { android: "", ios: ""};
+		this.projectId = "";
 	}
 	public initializeProjectDataFromContent(): void {
 		return;


### PR DESCRIPTION
DO NOT MERGE

###  Allow adding separate application identifiers for each platform inside package.json

### Description
While still overwrite of applicationId from app.gradle is possible, user is able to specify a platform specific identifier inside package.json. This addresses problems related to livesync not working when applicationId is changed inside app.gradle.

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[Issue Number]. -->
Fixes https://github.com/NativeScript/nativescript-cli/issues/3040.

### Related Pull Requests
https://github.com/NativeScript/android-runtime/pull/848

### Does your pull request have [unit tests]

