### PR TITLE
Introduce interface for localBuildService

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -105,6 +105,7 @@ $injector.require("devicePathProvider", "./device-path-provider");
 
 $injector.requireCommand("platform|clean", "./commands/platform-clean");
 
+$injector.requirePublicClass("localBuildService", "./services/local-build-service");
 $injector.requirePublicClass("liveSyncService", "./services/livesync/livesync-service");
 $injector.require("liveSyncCommandHelper", "./services/livesync/livesync-command-helper");
 $injector.require("androidLiveSyncService", "./services/livesync/android-livesync-service");

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,3 +1,5 @@
+import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
+
 export class BuildCommandBase {
 	constructor(protected $options: IOptions,
 		protected $errors: IErrors,
@@ -82,7 +84,7 @@ export class BuildAndroidCommand extends BuildCommandBase implements ICommand {
 	public async canExecute(args: string[]): Promise<boolean> {
 		super.validatePlatform(this.$devicePlatformsConstants.Android);
 		if (this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
-			this.$errors.fail("When producing a release build, you need to specify all --key-store-* options.");
+			this.$errors.fail(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
 		}
 
 		const platformData = this.$platformsData.getPlatformData(this.$devicePlatformsConstants.Android, this.$projectData);

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -1,3 +1,5 @@
+import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
+
 export class DeployOnDeviceCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
@@ -41,7 +43,7 @@ export class DeployOnDeviceCommand implements ICommand {
 		}
 
 		if (this.$mobileHelper.isAndroidPlatform(args[0]) && this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
-			this.$errors.fail("When producing a release build, you need to specify all --key-store-* options.");
+			this.$errors.fail(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
 		}
 
 		const platformData = this.$platformsData.getPlatformData(args[0], this.$projectData);

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -1,4 +1,5 @@
 import { ERROR_NO_VALID_SUBCOMMAND_FORMAT } from "../common/constants";
+import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
 import { cache } from "../common/decorators";
 
 export class RunCommandBase implements ICommand {
@@ -137,7 +138,7 @@ export class RunAndroidCommand implements ICommand {
 		}
 
 		if (this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
-			this.$errors.fail("When producing a release build, you need to specify all --key-store-* options.");
+			this.$errors.fail(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
 		}
 		return this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.Android);
 	}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -91,6 +91,7 @@ export const DEBUGGER_DETACHED_EVENT_NAME = "debuggerDetached";
 export const VERSION_STRING = "version";
 export const INSPECTOR_CACHE_DIRNAME = "ios-inspector";
 export const POST_INSTALL_COMMAND_NAME = "post-install-cli";
+export const ANDROID_RELEASE_BUILD_ERROR_MESSAGE = "When producing a release build, you need to specify all --key-store-* options.";
 
 export class DebugCommandErrors {
 	public static UNABLE_TO_USE_FOR_DEVICE_AND_EMULATOR = "The options --for-device and --emulator cannot be used simultaneously. Please use only one of them.";

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -155,6 +155,20 @@ interface IiOSBuildConfig extends IBuildForDevice, IDeviceIdentifier, IProvision
 	codeSignIdentity?: string;
 }
 
+/**
+ * Describes service used for building a project locally.
+ */
+interface ILocalBuildService {
+	/**
+	 * Builds a project locally.
+	 * @param {string} platform Platform for which to build.
+	 * @param {IPlatformBuildData} platformBuildOptions Additional options for controlling the build.
+	 * @param {string} platformTemplate The name of the template.
+	 * @return {Promise<string>} Path to the build output.
+	 */
+	build(platform: string, platformBuildOptions: IPlatformBuildData, platformTemplate?: string): Promise<string>;
+}
+
 interface IPlatformProjectService extends NodeJS.EventEmitter {
 	getPlatformData(projectData: IProjectData): IPlatformData;
 	validate(projectData: IProjectData): Promise<void>;

--- a/lib/nativescript-cli-lib-bootstrap.ts
+++ b/lib/nativescript-cli-lib-bootstrap.ts
@@ -8,7 +8,6 @@ $injector.overrideAlreadyRequiredModule = true;
 $injector.requirePublic("companionAppsService", "./common/appbuilder/services/livesync/companion-apps-service");
 $injector.requirePublicClass("deviceEmitter", "./common/appbuilder/device-emitter");
 $injector.requirePublicClass("deviceLogProvider", "./common/appbuilder/device-log-provider");
-$injector.requirePublicClass("localBuildService", "./services/local-build-service");
 
 // We need this because some services check if (!$options.justlaunch) to start the device log after some operation.
 // We don't want this behaviour when the CLI is required as library.

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -2,8 +2,6 @@ import * as commonOptionsLibPath from "./common/options";
 import * as osenv from "osenv";
 import * as path from "path";
 
-const OptionType = commonOptionsLibPath.OptionType;
-
 export class Options extends commonOptionsLibPath.OptionsBase {
 	constructor($errors: IErrors,
 		$staticConfig: IStaticConfig,

--- a/lib/services/local-build-service.ts
+++ b/lib/services/local-build-service.ts
@@ -1,14 +1,20 @@
 import { EventEmitter } from "events";
-import { BUILD_OUTPUT_EVENT_NAME } from "../constants";
+import { BUILD_OUTPUT_EVENT_NAME, ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
 import { attachAwaitDetach } from "../common/helpers";
 
-export class LocalBuildService extends EventEmitter {
+export class LocalBuildService extends EventEmitter implements ILocalBuildService {
 	constructor(private $projectData: IProjectData,
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $errors: IErrors,
 		private $platformService: IPlatformService) {
 		super();
 	}
 
 	public async build(platform: string, platformBuildOptions: IPlatformBuildData, platformTemplate?: string): Promise<string> {
+		if (this.$mobileHelper.isAndroidPlatform(platform) && platformBuildOptions.release && (!platformBuildOptions.keyStorePath || !platformBuildOptions.keyStorePassword || !platformBuildOptions.keyStoreAlias || !platformBuildOptions.keyStoreAliasPassword)) {
+			this.$errors.fail(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
+		}
+
 		this.$projectData.initializeProjectData(platformBuildOptions.projectDir);
 		await this.$platformService.preparePlatform(platform, platformBuildOptions, platformTemplate, this.$projectData, {
 			provision: platformBuildOptions.provision,


### PR DESCRIPTION
* Introduce `ILocalBuildService` so that it can be reused
* Register `localBuildService` so that other services can use it
* Fail in `localBuildService` if building for `android` in `release` but not all of the `--key*` flags have been passed.

Merge after https://github.com/telerik/mobile-cli-lib/pull/1014

Ping @rosen-vladimirov @TsvetanMilanov 