### PR TITLE
Fix execution of before-prepare hooks in a long living process

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -36,6 +36,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		private $errors: IErrors,
 		private $debugDataService: IDebugDataService,
 		private $analyticsService: IAnalyticsService,
+		private $usbLiveSyncService: DeprecatedUsbLiveSyncService,
 		private $injector: IInjector) {
 		super();
 	}
@@ -86,6 +87,10 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 						projectData
 					}
 				});
+
+				// In case we are stopping the LiveSync we must set usbLiveSyncService.isInitialized to false,
+				// as in case we execute nativescript-dev-typescript's before-prepare hook again in the same process, it MUST transpile the files.
+				this.$usbLiveSyncService.isInitialized = false;
 			} else if (liveSyncProcessInfo.currentSyncAction && shouldAwaitPendingOperation) {
 				await liveSyncProcessInfo.currentSyncAction;
 			}
@@ -321,7 +326,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 		if (!liveSyncData.skipWatcher && this.liveSyncProcessesInfo[projectData.projectDir].deviceDescriptors.length) {
 			// Should be set after prepare
-			this.$injector.resolve<DeprecatedUsbLiveSyncService>("usbLiveSyncService").isInitialized = true;
+			this.$usbLiveSyncService.isInitialized = true;
 
 			await this.startWatcher(projectData, liveSyncData);
 		}


### PR DESCRIPTION
When LiveSync operation is started we set `usbLiveSyncService.isInitialized` to true. This variable is used in several `before-prepare` hooks.
For example `nativescript-dev-typescript` has the following logic:
- When before-prepare hook is executed it checks if the `usbLiveSyncService.isInitialized` property is set to true. In this case it does nothing. The idea is that when LiveSync watch process is started, the plugin has started `tsc --watch` process, so there's no need to do anything on `before-prepare`.
However, in a long living process, where the project may be changed, whenever we stop LiveSync process, we must set usbLiveSyncService to false. In case we do not do it, the property remains true and the before-prepare hook of the other project does nothing and the project is not transpiled.