### PR TITLE
Normalize platform version when determining android prepare routine

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -590,7 +590,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		const platformVersion = this.getCurrentPlatformVersion(this.getPlatformData(projectData), projectData);
 		const newRuntimeGradleRoutineVersion = "3.3.0";
 
-		return semver.gte(platformVersion, newRuntimeGradleRoutineVersion);
+		const normalizedPlatformVersion = `${semver.major(platformVersion)}.${semver.minor(platformVersion)}.0`;
+		return semver.gte(normalizedPlatformVersion, newRuntimeGradleRoutineVersion);
 	}
 }
 


### PR DESCRIPTION
The new logical branch in the android preparation step of the CLI should be used when the runtime version is detected to be `3.3.0` or greater. 

However the current version check of `is greater or equal than 3.3.0` does not satisfy `prerelease` versions in the form of `3.3.0-2017...`. 

In order to allow builds from the master branch of the `tns-android` package to be used, the validation of major + minor version should be sufficient.

Follow up of the previous PR https://github.com/NativeScript/nativescript-cli/pull/3032