### PR TITLE
Fix tns_modules added to app dir

### DIFF
--- a/lib/device-path-provider.ts
+++ b/lib/device-path-provider.ts
@@ -6,17 +6,17 @@ import * as path from "path";
 export class DevicePathProvider implements IDevicePathProvider {
 	constructor(private $mobileHelper: Mobile.IMobileHelper,
 		private $injector: IInjector,
-		private $iOSSimResolver: Mobile.IiOSSimResolver) {
+		private $iOSSimResolver: Mobile.IiOSSimResolver,
+		private $errors: IErrors) {
 	}
 
 	public async getDeviceProjectRootPath(device: Mobile.IDevice, options: IDeviceProjectRootOptions): Promise<string> {
 		let projectRoot = "";
 		if (this.$mobileHelper.isiOSPlatform(device.deviceInfo.platform)) {
-			if (device.isEmulator) {
-				const applicationPath = this.$iOSSimResolver.iOSSim.getApplicationPath(device.deviceInfo.identifier, options.appIdentifier);
-				projectRoot = path.join(applicationPath);
-			} else {
-				projectRoot = LiveSyncPaths.IOS_DEVICE_PROJECT_ROOT_PATH;
+			projectRoot = device.isEmulator ? this.$iOSSimResolver.iOSSim.getApplicationPath(device.deviceInfo.identifier, options.appIdentifier) : LiveSyncPaths.IOS_DEVICE_PROJECT_ROOT_PATH;
+
+			if (!projectRoot) {
+				this.$errors.failWithoutHelp("Unable to get application path on device.");
 			}
 
 			if (!options.getDirname) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2144,6 +2144,13 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2151,13 +2158,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2945,9 +2945,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.1.2.tgz",
-      "integrity": "sha1-Fq6f+F2gUE0K+4gyj73sCQafFG0=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.1.3.tgz",
+      "integrity": "sha1-B6UWaabdwSP/m/ER3nPXD4kVyew=",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",
@@ -4739,6 +4739,14 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4753,14 +4761,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
       "integrity": "sha1-aybpvTr8qnvjtCabUm3huCAArHg="
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.10",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "3.1.2",
+    "ios-sim-portable": "3.1.3",
     "lockfile": "1.0.3",
     "lodash": "4.13.1",
     "log4js": "1.0.1",


### PR DESCRIPTION
In some cases `tns_modules` dir may appear in project's app dir. The issue is caused by sending Ctrl + C while `ios-sim-portable` is executing `xcrun simctl` command.
In this case, it returns empty string for applicationPath instead of breaking the CLI process. Add new check if the projectRoot on device is not empty string and update ios-sim-portable.

https://github.com/NativeScript/nativescript-cli/issues/3016