### PR TITLE
Plamen5kov/as compatible cli

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -18,6 +18,14 @@ export const XML_FILE_EXTENSION = ".xml";
 export const PLATFORMS_DIR_NAME = "platforms";
 export const CODE_SIGN_ENTITLEMENTS = "CODE_SIGN_ENTITLEMENTS";
 export const AWAIT_NOTIFICATION_TIMEOUT_SECONDS = 9;
+export const SRC_DIR = "src";
+export const MAIN_DIR = "main";
+export const ASSETS_DIR = "assets";
+export const MANIFEST_FILE_NAME = "AndroidManifest.xml";
+export const BUILD_DIR = "build";
+export const OUTPUTS_DIR = "outputs";
+export const APK_DIR = "apk";
+export const RESOURCES_DIR = "res";
 
 export class PackageVersion {
 	static NEXT = "next";

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -54,18 +54,20 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				this.$fs.exists(path.join(projectRoot, constants.NODE_MODULES_FOLDER_NAME, constants.TNS_ANDROID_RUNTIME_NAME, constants.PROJECT_FRAMEWORK_FOLDER_NAME, constants.APP_FOLDER_NAME))) {
 				this.isASTemplate = true;
 			}
-			let appDestinationDirectoryArr = ["src", "main", "assets"];
+
+			const appDestinationDirectoryArr = ["src", "main", "assets"];
 			if (this.isASTemplate) {
 				appDestinationDirectoryArr.unshift("app");
 			}
 			appDestinationDirectoryArr.unshift(projectRoot);
-			let configurationsDirectoryArr = ["src", "main", "AndroidManifest.xml"];
+
+			const configurationsDirectoryArr = ["src", "main", "AndroidManifest.xml"];
 			if (this.isASTemplate) {
 				configurationsDirectoryArr.unshift("app");
 			}
 			configurationsDirectoryArr.unshift(projectRoot);
 
-			let deviceBuildOutputArr = ["build", "outputs", "apk"];
+			const deviceBuildOutputArr = ["build", "outputs", "apk"];
 			if (this.isASTemplate) {
 				deviceBuildOutputArr.unshift("app");
 			}
@@ -117,9 +119,9 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 	public getAppResourcesDestinationDirectoryPath(projectData: IProjectData, frameworkVersion?: string): string {
 		if (this.canUseGradle(projectData, frameworkVersion)) {
-			let resourcePath: string[] = ["src", "main", "res"];
+			const resourcePath: string[] = ["src", "main", "res"];
 			if (this.isASTemplate) {
-				resourcePath.unshift("app")
+				resourcePath.unshift("app");
 			}
 
 			return path.join(this.getPlatformData(projectData).projectRoot, path.join.apply(null, resourcePath));
@@ -159,6 +161,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		if (this.isASTemplate) {
 			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "*", "-R");
 		} else {
+			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "libs", "-R");
+
 			if (config.pathToTemplate) {
 				const mainPath = path.join(this.getPlatformData(projectData).projectRoot, "src", "main");
 				this.$fs.createDirectory(mainPath);

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -639,7 +639,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 		if (!platformVersion) {
 			const tnsAndroidPackageJsonPath = path.join(projectData.projectDir, constants.NODE_MODULES_FOLDER_NAME, constants.TNS_ANDROID_RUNTIME_NAME, constants.PACKAGE_JSON_FILE_NAME);
-			if(this.$fs.exists(tnsAndroidPackageJsonPath)) {
+			if (this.$fs.exists(tnsAndroidPackageJsonPath)) {
 				const projectPackageJson: any = this.$fs.readJson(tnsAndroidPackageJsonPath);
 				if (projectPackageJson && projectPackageJson.version) {
 					platformVersion = projectPackageJson.version;

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -78,11 +78,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			this._platformData = {
 				frameworkPackageName: "tns-android",
 				normalizedPlatformName: "Android",
-				appDestinationDirectoryPath: path.join.apply(null, appDestinationDirectoryArr),
+				appDestinationDirectoryPath: path.join(...appDestinationDirectoryArr),
 				platformProjectService: this,
 				emulatorServices: this.$androidEmulatorServices,
 				projectRoot: projectRoot,
-				deviceBuildOutputPath: path.join.apply(null, deviceBuildOutputArr),
+				deviceBuildOutputPath: path.join(...deviceBuildOutputArr),
 				getValidPackageNames: (buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[] => {
 					const buildMode = buildOptions.isReleaseBuild ? Configurations.Release.toLowerCase() : Configurations.Debug.toLowerCase();
 
@@ -94,7 +94,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				},
 				frameworkFilesExtensions: [".jar", ".dat", ".so"],
 				configurationFileName: "AndroidManifest.xml",
-				configurationFilePath: path.join.apply(null, configurationsDirectoryArr),
+				configurationFilePath: path.join(...configurationsDirectoryArr),
 				relativeToFrameworkConfigurationFilePath: path.join("src", "main", "AndroidManifest.xml"),
 				fastLivesyncFileExtensions: [".jpg", ".gif", ".png", ".bmp", ".webp"] // http://developer.android.com/guide/appendix/media-formats.html
 			};
@@ -123,7 +123,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				resourcePath.unshift("app");
 			}
 
-			return path.join(this.getPlatformData(projectData).projectRoot, path.join.apply(null, resourcePath));
+			return path.join(this.getPlatformData(projectData).projectRoot, path.join(...resourcePath));
 		}
 
 		return path.join(this.getPlatformData(projectData).projectRoot, "res");


### PR DESCRIPTION
* CLI is now compatible with Android Studio project templates.
* CLI is backward compatible with previous version of the android runtime at least back to 3.0.0 [inclusive]

PR accommodates the new android runtime, project template: https://github.com/NativeScript/android-runtime/pull/875
related PR: https://github.com/NativeScript/nativescript-dev-webpack/pull/310