### PR TITLE
Do not track help command when other command fails

### DIFF
--- a/lib/commands/generate-help.ts
+++ b/lib/commands/generate-help.ts
@@ -1,10 +1,10 @@
 export class GenerateHelpCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
-	constructor(private $htmlHelpService: IHtmlHelpService) { }
+	constructor(private $helpService: IHelpService) { }
 
 	public async execute(args: string[]): Promise<void> {
-		return this.$htmlHelpService.generateHtmlPages();
+		return this.$helpService.generateHtmlPages();
 	}
 }
 

--- a/lib/commands/post-install.ts
+++ b/lib/commands/post-install.ts
@@ -5,12 +5,12 @@ export class PostInstallCliCommand extends PostInstallCommand {
 		private $subscriptionService: ISubscriptionService,
 		$staticConfig: Config.IStaticConfig,
 		$commandsService: ICommandsService,
-		$htmlHelpService: IHtmlHelpService,
+		$helpService: IHelpService,
 		$options: ICommonOptions,
 		$doctorService: IDoctorService,
 		$analyticsService: IAnalyticsService,
 		$logger: ILogger) {
-		super($fs, $staticConfig, $commandsService, $htmlHelpService, $options, $doctorService, $analyticsService, $logger);
+		super($fs, $staticConfig, $commandsService, $helpService, $options, $doctorService, $analyticsService, $logger);
 	}
 
 	public async execute(args: string[]): Promise<void> {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -60,10 +60,6 @@ export class StaticConfig extends StaticConfigBase implements IStaticConfig {
 
 	public version = require("../package.json").version;
 
-	public get helpTextPath(): string {
-		return path.join(__dirname, "../resources/help.txt");
-	}
-
 	public get HTML_CLI_HELPERS_DIR(): string {
 		return path.join(__dirname, "../docs/helpers");
 	}

--- a/test/commands/post-install.ts
+++ b/test/commands/post-install.ts
@@ -18,7 +18,7 @@ const createTestInjector = (): IInjector => {
 		tryExecuteCommand: async (commandName: string, commandArguments: string[]): Promise<void> => undefined
 	});
 
-	testInjector.register("htmlHelpService", {
+	testInjector.register("helpService", {
 		generateHtmlPages: async (): Promise<void> => undefined
 	});
 

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -54,7 +54,7 @@ class ErrorsNoFailStub implements IErrors {
 		throw new Error();
 	}
 
-	async beginCommand(action: () => Promise<boolean>, printHelpCommand: () => Promise<boolean>): Promise<boolean> {
+	async beginCommand(action: () => Promise<boolean>, printHelpCommand: () => Promise<void>): Promise<boolean> {
 		let result = false;
 		try {
 			result = await action();
@@ -148,6 +148,9 @@ function createTestInjector() {
 	});
 	testInjector.register("messages", Messages);
 	testInjector.register("devicePathProvider", {});
+	testInjector.register("helpService", {
+		showCommandLineHelp: async (): Promise<void> => (undefined)
+	});
 
 	return testInjector;
 }

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -91,6 +91,9 @@ function createTestInjector() {
 	});
 	testInjector.register("messages", Messages);
 	testInjector.register("devicePathProvider", {});
+	testInjector.register("helpService", {
+		showCommandLineHelp: async (): Promise<void> => (undefined)
+	});
 
 	return testInjector;
 }

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -98,6 +98,9 @@ function createTestInjector() {
 	});
 	testInjector.register("xmlValidator", XmlValidator);
 	testInjector.register("config", StaticConfigLib.Configuration);
+	testInjector.register("helpService", {
+		showCommandLineHelp: async (): Promise<void> => (undefined)
+	});
 
 	return testInjector;
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -197,7 +197,7 @@ export class ErrorsStub implements IErrors {
 		throw new Error(message);
 	}
 
-	async beginCommand(action: () => Promise<boolean>, printHelpCommand: () => Promise<boolean>): Promise<boolean> {
+	async beginCommand(action: () => Promise<boolean>, printHelpCommand: () => Promise<void>): Promise<boolean> {
 		throw new Error("not supported");
 	}
 


### PR DESCRIPTION
In case any command fails, we execute help command in order to show the help content. This leads to multiple trackings, i.e. - user executes only one command, but in Analytics we see two commands.
Instead of executing help command, introduce new method in htmlHelpService, that prints the help to the terminal and call it instead. Use the same method in the help command itself.
Rename htmlHelpService to helpService - it has been incorrectly named from the beginning.
Remove `helpTextPath` from staticConfig interface - this property is not used for more than 2 years.
Introduce tests for `helpService` - get the tests from AppBuilder CLI.

Submodule PR: https://github.com/telerik/mobile-cli-lib/pull/1021