### PR TITLE
Fix missing console.logs on Android when CLI is used as library

### DIFF
--- a/lib/nativescript-cli-lib-bootstrap.ts
+++ b/lib/nativescript-cli-lib-bootstrap.ts
@@ -9,7 +9,4 @@ $injector.requirePublic("companionAppsService", "./common/appbuilder/services/li
 $injector.requirePublicClass("deviceEmitter", "./common/appbuilder/device-emitter");
 $injector.requirePublicClass("deviceLogProvider", "./common/appbuilder/device-log-provider");
 
-// We need this because some services check if (!$options.justlaunch) to start the device log after some operation.
-// We don't want this behaviour when the CLI is required as library.
-$injector.resolve("options").justlaunch = true;
 $injector.resolve<IStaticConfig>("staticConfig").disableAnalytics = true;


### PR DESCRIPTION
In case CLI is used as a library, the device logs are no longer captured after application is restarted. The problem is the newly added logic for Android devices that stops the logcat process when CLI calls `stopApplication` and starts it when `startApplication` is called.
However, in `startApplication` there's a check if `$options.justlaunch` is false - only then the device log operation is started again.
When CLI is used as a library, we have hardcoded the `justlaunch` option to true in order to prevent duplicate logs for iOS devices. So the solution to resolve Android logs issues is to remove the setting of justlaunch option.
However, this caused the duplicate logs issue for iOS devices. Investigating it further, it turned out to be a memory leak when iOS device is detached. It's fixed in the submodule:

### Fix leaking handlers for iOS device logs
In case iOS Device is detached, the `IOSDevice` instance is kept alive. The reason is the handler for device logs, that `IOSDevice` passes to `iOSDeviceOperations`.
As `iOSDeviceOperations` is still alive, the `IOSDevice` instance is also alive. Reattaching the same device will cause duplicate logs. Detaching and attaching it again will lead to additional logs.

In order to fix the issue, convert `iOSDeviceOpertations` to event emitter and emit event when there's data for logging. Each `IOSDevice` will add handler for the event and will do its logic.
In case device is detached (i.e. `DeviceLost` event is fired in `DevicesService`), call a newly added method to the specific `IDevice` instance. It's purpose is to clean the used resource.
For iOS device, this method will remove the handler for `devceLogData` event of `iOSDeviceOperations`.