### PR TITLE
Make debug-ios default to Chrome DevTools

### DIFF
--- a/docs/man_pages/project/testing/debug-ios.md
+++ b/docs/man_pages/project/testing/debug-ios.md
@@ -26,7 +26,8 @@ While debugging, prints the output from the application in the console and watch
 * `--timeout` - Sets the number of seconds that NativeScript CLI will wait for the simulator/device to boot. If not set, the default timeout is 90 seconds.
 * `--no-watch` - If set, changes in your code will not be reflected during the execution of this command.
 * `--clean` - If set, forces rebuilding the native application.
-* `--chrome` - Allows debugging in Chrome Developer Tools. If set Safari Web Inspector is not started and debugging is attached to Chrome Developer Tools.
+* `--chrome` - Deprecated - default behavior uses '--chrome' implicitly. Allows debugging in Chrome Developer Tools. If set, Safari Web Inspector is not started and debugging is attached to Chrome Developer Tools.
+* `--inspector` - If set, the developer tools in the Safari Web Inspector are used for debugging the application.
 
 ### Attributes
 * `<Device ID>` is the device identifier of the target device as listed by `$ tns device ios`

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -393,6 +393,7 @@ interface IOptions extends ICommonOptions, IBundle, IPlatformTemplate, IEmulator
 	syncAllFiles: boolean;
 	liveEdit: boolean;
 	chrome: boolean;
+	inspector: boolean; // the counterpart to --chrome
 }
 
 interface IEnvOptions {

--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -82,6 +82,11 @@ interface IDebugOptions {
 	 * Default value is 02e6bde1bbe34e43b309d4ef774b1168d25fd024 which corresponds to 55.0.2883 Chrome version
 	 */
 	devToolsCommit?: string;
+
+	/**
+	 * Defines if the iOS App Inspector should be used instead of providing URL to debug the application with Chrome DevTools
+	 */
+	inspector?: boolean;
 }
 
 /**

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -201,14 +201,17 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 	}
 
 	private async wireDebuggerClient(debugData: IDebugData, debugOptions: IDebugOptions, device?: Mobile.IiOSDevice): Promise<string> {
-		if (debugOptions.chrome || !this.$hostInfo.isDarwin) {
-			this._socketProxy = await this.$socketProxyFactory.createWebSocketProxy(this.getSocketFactory(device));
-
-			return this.getChromeDebugUrl(debugOptions, this._socketProxy.options.port);
-		} else {
+		if (debugOptions.inspector && this.$hostInfo.isDarwin) {
 			this._socketProxy = await this.$socketProxyFactory.createTCPSocketProxy(this.getSocketFactory(device));
 			await this.openAppInspector(this._socketProxy.address(), debugData, debugOptions);
 			return null;
+		} else {
+			if (debugOptions.chrome) {
+				this.$logger.info("'--chrome' is the default behavior. Use --inspector to debug iOS applications using the Safari Web Inspector.");
+			}
+
+			this._socketProxy = await this.$socketProxyFactory.createWebSocketProxy(this.getSocketFactory(device));
+			return this.getChromeDebugUrl(debugOptions, this._socketProxy.options.port);
 		}
 	}
 


### PR DESCRIPTION
Changes in this PR:
 - add the `--inspector` flag - a counterpart to `--chrome` which will open the Safari Web Inspector to debug the iOS application with
 - add a message when using the `--chrome` flag that it is a default now
 - update the `tns debug ios help` to reflect the changes in `--chrome` and the addition of `--inspector`

Addresses https://github.com/NativeScript/nativescript-cli/issues/3171