### PR TITLE
Fix hanging commands when webpack and unit tests are used

### DIFF
--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -4,8 +4,10 @@ function RunTestCommandFactory(platform: string) {
 	return function RunTestCommand(
 		$options: IOptions,
 		$testExecutionService: ITestExecutionService,
-		$projectData: IProjectData) {
+		$projectData: IProjectData,
+		$analyticsService: IAnalyticsService) {
 		$projectData.initializeProjectData();
+		$analyticsService.setShouldDispose($options.justlaunch || !$options.watch);
 		const projectFilesConfig = helpers.getProjectFilesConfig({ isReleaseBuild: $options.release });
 		this.execute = (args: string[]): Promise<void> => $testExecutionService.startTestRunner(platform, $projectData, projectFilesConfig);
 		this.allowedParameters = [];
@@ -16,8 +18,9 @@ $injector.registerCommand("dev-test|android", RunTestCommandFactory('android'));
 $injector.registerCommand("dev-test|ios", RunTestCommandFactory('iOS'));
 
 function RunKarmaTestCommandFactory(platform: string) {
-	return function RunKarmaTestCommand($options: IOptions, $testExecutionService: ITestExecutionService, $projectData: IProjectData) {
+	return function RunKarmaTestCommand($options: IOptions, $testExecutionService: ITestExecutionService, $projectData: IProjectData, $analyticsService: IAnalyticsService) {
 		$projectData.initializeProjectData();
+		$analyticsService.setShouldDispose($options.justlaunch || !$options.watch);
 		const projectFilesConfig = helpers.getProjectFilesConfig({ isReleaseBuild: $options.release });
 		this.execute = (args: string[]): Promise<void> => $testExecutionService.startKarmaServer(platform, $projectData, projectFilesConfig);
 		this.allowedParameters = [];

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -26,9 +26,7 @@ class TestExecutionService implements ITestExecutionService {
 		private $errors: IErrors,
 		private $debugService: IDebugService,
 		private $devicesService: Mobile.IDevicesService,
-		private $analyticsService: IAnalyticsService,
 		private $childProcess: IChildProcess) {
-		this.$analyticsService.setShouldDispose(this.$options.justlaunch || !this.$options.watch);
 	}
 
 	public platform: string;


### PR DESCRIPTION
In case you try using npm scripts that come with `nativescript-dev-webpack` and you also have `nativescript-unit-test-runner` in your project, the scripts hang. The problem is that `nativescript-unit-test-runner` has a hook that resolves `testExecutionService`. In its constructor it sets that analytics broker should not be disposed. However, this is incorrect - it should not be disposed only in case we execute tests with livesync enabled. In order to fix this, move the logic in the commands. This way the hook will not change the disposing of the analytics broker, so once CLI process finishes, analytics broker process will be disconnected and CLI's process will die gracefully.

Fixes: https://github.com/NativeScript/nativescript-cli/issues/3164

Also update submodule, where the following change is applied:
Fix execution of hooks outside of process

In case you need a hook to be executed outside of process, you should place correct shebang at the beginning of the file and CLI should spawn it.
However, this is not working at the moment, as when CLI detects that the hook should be spawned, it just does nothing. The code is incorrectly placed inside the `if` for in process execution. This causes another issue - in case a hook returns a function, which returns falsey value, we decide the hook should be executed outside of process and spawn a new Node.js process to execute the hook. So we execute it twice.

Fix the if-else logic, so the hooks will work correctly.