### PR TITLE
parse npm install results correctly 

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -156,10 +156,12 @@ export class NodePackageManager implements INodePackageManager {
 			});
 
 			// Npm 5 return different object after performing `npm install --dry-run`.
-			// Considering that the dependency is already installed we should
-			// find it in the `updated` key as a first element of the array.
+			// We find the correct dependency by searching for the `userSpecifiedPackageName` in the
+			// `npm5Output.updated` array and as a fallback, considering that the dependency is already installed,
+			// we find it as the first element.
 			if (!name && npm5Output.updated) {
-				const updatedDependency = npm5Output.updated[0];
+				const packageNameWithoutVersion = userSpecifiedPackageName.split('@')[0];
+				const updatedDependency = _.find(npm5Output.updated, ['name', packageNameWithoutVersion]) || npm5Output.updated[0];
 				return {
 					name: updatedDependency.name,
 					originalOutput,


### PR DESCRIPTION
Solves Issue https://github.com/NativeScript/nativescript-cli/issues/3217

This pull request changes the implementation to search for the correct object by name. It does no longer depend on the position and should be more reliable especially as the `--json` flag is experimental as described in the npm documentation: https://docs.npmjs.com/misc/config#json

As described in the comment of the current implementation of `parseNpmInstallResults` we just use the first object of the `updated` array.

https://github.com/NativeScript/nativescript-cli/blob/e181f034264d82f40d3cbbfbdfd6599f5b2064c7/lib/node-package-manager.ts#L158-L160

But when I execute the following command:
```
npm install tns-ios --json --dry-run
```
`tns-ios` is not the first element in the `updated` array. The output looks something like this:
```json
{
  "added": [],
  "removed": [],
  "updated": [
    {
      "action": "update",
      "name": "colors",
      "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
      "path": "<path to project>/node_modules/colors",
      "previousVersion": ""
    },
    {
      "action": "update",
      "name": "inherits",
      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
      "path": "<path to project>/node_modules/inherits",
      "previousVersion": ""
    },
    {
      "action": "update",
      "name": "tns-ios",
      "version": "3.3.0",
      "path": "<path to project>/node_modules/tns-ios",
      "previousVersion": "3.3.0"
    }
  ],
  "moved": [],
  "failed": [],
  "elapsed": 3113
}
```
Instead of the first element, `tns-ios` is the last element. 

I had an issue with the following command:
```
tns platform add ios
```
It always failed with the following error:
```
cp: no such file or directory: <path to project>/node_modules/<some random updated module>/framework/*
``` 
Now it works like a charm.