### PR TITLE
Fix broken prepare platform on NPM 5.5.1

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -159,7 +159,7 @@ export class NodePackageManager implements INodePackageManager {
 			// Considering that the dependency is already installed we should
 			// find it in the `updated` key as a first element of the array.
 			if (!name && npm5Output.updated) {
-				const updatedDependency = npm5Output.updated[0];
+				const updatedDependency = npm5Output.updated.find(dependencyInfo => dependencyInfo.name === userSpecifiedPackageName);
 				return {
 					name: updatedDependency.name,
 					originalOutput,


### PR DESCRIPTION
Instead of taking the first updated dependency, we resolve the one passed by userSpecifiedPackageName) (#3217)