### PR TITLE
README.md - CLI Command --help to load info in the console

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Quick Start
 
 ## The Commands
 
-Run `tns help` to view all available commands in the browser. Run `tns help <Command>` to view more information about a selected command in the browser.
+Run `tns help` to view all available commands in the browser. Run `tns help <Command>` to view more information about a selected command in the browser. `tns --help` opens console help, where help information is shown in the console.
 
 [Back to Top][1]
 


### PR DESCRIPTION
Added a single line to document this small and simple but important feature `tns --help` to load HELP info in the console rather than launching in a browser or text editor window.

Read a few issues where users have asked about preventing HELP loading in the browser (including a `-nobrowser` request) or text editor (when users computer has set a text editor as default app to open HTML files) and found the `--help` command hidden in a response from @Fatme, so I thought it would be great to add that little command into the CLI command docs :)