### PR TITLE
Check for changes fails on infinite deep directories after symlink

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -220,7 +220,15 @@ export class ProjectChangesService implements IProjectChangesService {
 		return false;
 	}
 
-	private containsNewerFiles(dir: string, skipDir: string, projectData: IProjectData, processFunc?: (filePath: string, projectData: IProjectData) => boolean): boolean {
+	private containsNewerFiles(dir: string, skipDir: string, projectData: IProjectData, processFunc?: (filePath: string, projectData: IProjectData) => boolean, visitedRealPaths?: Set<string>): boolean {
+
+		visitedRealPaths = visitedRealPaths || new Set<string>();
+
+		const dirRPath = this.$fs.realpath(dir);
+		if (visitedRealPaths.has(dirRPath)) {
+			return false;
+		}
+		visitedRealPaths.add(dirRPath);
 
 		const dirName = path.basename(dir);
 		if (_.startsWith(dirName, '.')) {
@@ -255,7 +263,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			}
 
 			if (fileStats.isDirectory()) {
-				if (this.containsNewerFiles(filePath, skipDir, projectData, processFunc)) {
+				if (this.containsNewerFiles(filePath, skipDir, projectData, processFunc, visitedRealPaths)) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Check for changes fails where:
```
nativescript-dev-plugin/
  demo/SampleApp/
    node_modules/nativescript-dev-plugin (symlink to the root dir)
    app/...
```
The check for changes follows to a infinite deep directory:
`naitvescript-dev-plugin/demo/SampleApp/node_modules/nativescript-dev-plugin/demo/SampleApp/node_modules...`
It will now stop the DFS when it finds it have visited already the file or directory's real path. 