### PR TITLE
Expose API for getting installed applications

### DIFF
--- a/test/nativescript-cli-lib.ts
+++ b/test/nativescript-cli-lib.ts
@@ -22,7 +22,20 @@ describe("nativescript-cli-lib", () => {
 		extensibilityService: ["loadExtensions", "loadExtension", "getInstalledExtensions", "installExtension", "uninstallExtension"],
 		liveSyncService: ["liveSync", "stopLiveSync", "enableDebugging", "disableDebugging", "attachDebugger"],
 		debugService: ["debug"],
-		analyticsSettingsService: ["getClientId"]
+		analyticsSettingsService: ["getClientId"],
+		devicesService: [
+			"addDeviceDiscovery",
+			"deployOnDevices",
+			"getDebuggableApps",
+			"getDebuggableViews",
+			"getDevices",
+			"getInstalledApplications",
+			"initialize",
+			"isAppInstalledOnDevices",
+			"isCompanionAppInstalledOnDevices",
+			"mapAbstractToTcpPort",
+			"setLogLevel"
+		]
 	};
 
 	const pathToEntryPoint = path.join(__dirname, "..", "lib", "nativescript-cli-lib.js").replace(/\\/g, "\\\\");


### PR DESCRIPTION
Expose API for getting installed applications for a specific device when CLI is required as library. Add the new method to `devicesService`.
Add required tests for exposing methods from `devicesService`.