### PR TITLE
ignore .(anything) files when checking for changes

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -219,6 +219,12 @@ export class ProjectChangesService implements IProjectChangesService {
 	}
 
 	private containsNewerFiles(dir: string, skipDir: string, projectData: IProjectData, processFunc?: (filePath: string, projectData: IProjectData) => boolean): boolean {
+
+		const dirName = path.basename(dir);
+		if (_.startsWith(dirName, '.')) {
+		    return false;
+		}
+
 		const dirFileStat = this.$fs.getFsStats(dir);
 		if (this.isFileModified(dirFileStat, dir)) {
 			return true;

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -222,7 +222,7 @@ export class ProjectChangesService implements IProjectChangesService {
 
 		const dirName = path.basename(dir);
 		if (_.startsWith(dirName, '.')) {
-		    return false;
+			return false;
 		}
 
 		const dirFileStat = this.$fs.getFsStats(dir);


### PR DESCRIPTION
When checking if files are changed we should ignore all files ending in `.(something)` as these files are hidden on mac and usually shouldn't be modified anyway.
This will make livesync work a bit faster when `--sync-all-files` flag is used, because there are a number of `.(something)` directories inside.
