### PR TITLE
Fail if --bundle is specified but no bundler

### DIFF
--- a/docs/man_pages/project/testing/build-android.md
+++ b/docs/man_pages/project/testing/build-android.md
@@ -3,7 +3,7 @@ build android
 
 Usage | Synopsis
 ---|---
-General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--static-bindings] [--copy-to <File Path>]`
+General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--static-bindings] [--copy-to <File Path>] [--bundle [<value>] [--env.*]]`
 
 Builds the project for Android and produces an APK that you can manually deploy on device or in the native emulator.
 
@@ -15,6 +15,8 @@ Builds the project for Android and produces an APK that you can manually deploy 
 * `--key-store-alias` - Provides the alias for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-alias-password` - Provides the password for the alias specified with `--key-store-alias-password`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--copy-to` - Specifies the file path where the built `.apk` will be copied. If it points to a non-existent directory, it will be created. If the specified value is directory, the original file name will be used.
+* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `webpack`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
 
 ### Attributes
 `<API Level>` is a valid Android API level. For example: 22, 23.<% if(isHtml) { %> For a complete list of the Android API levels and their corresponding Android versions, click [here](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#platform).<% } %>

--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -3,7 +3,7 @@ build ios
 
 Usage | Synopsis
 ---|---
-General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [--provision [<UUID/name>]]`
+General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [--provision [<UUID/name>]] [--bundle [<value>] [--env.*]]`
 
 Builds the project for iOS and produces an `APP` or `IPA` that you can manually deploy in the iOS Simulator or on device, respectively.
 
@@ -17,6 +17,8 @@ Builds the project for iOS and produces an `APP` or `IPA` that you can manually 
 * `--copy-to` - Specifies the file path where the built `.ipa` will be copied. If it points to a non-existent directory, it will be created. If the specified value is directory, the original file name will be used.
 * `--team-id` - If used without parameter, lists all team names and ids. If used with team name or id, it will switch to automatic signing mode and configure the .xcodeproj file of your app. In this case .xcconfig should not contain any provisioning/team id flags. This team id will be further used for codesigning the app. For Xcode 9.0+, xcodebuild will be allowed to update and modify automatically managed provisioning profiles.
 * `--provision` - If used without parameter, lists all eligible provisioning profiles. If used with UUID or name of your provisioning profile, it will switch to manual signing mode and configure the .xcodeproj file of your app. In this case xcconfig should not contain any provisioning/team id flags. This provisioning profile will be further used for codesigning the app.
+* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `nativescript-dev-webpack`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
 <% } %>
 <% if(isHtml) { %>
 ### Command Limitations

--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -17,7 +17,7 @@ Builds the project for iOS and produces an `APP` or `IPA` that you can manually 
 * `--copy-to` - Specifies the file path where the built `.ipa` will be copied. If it points to a non-existent directory, it will be created. If the specified value is directory, the original file name will be used.
 * `--team-id` - If used without parameter, lists all team names and ids. If used with team name or id, it will switch to automatic signing mode and configure the .xcodeproj file of your app. In this case .xcconfig should not contain any provisioning/team id flags. This team id will be further used for codesigning the app. For Xcode 9.0+, xcodebuild will be allowed to update and modify automatically managed provisioning profiles.
 * `--provision` - If used without parameter, lists all eligible provisioning profiles. If used with UUID or name of your provisioning profile, it will switch to manual signing mode and configure the .xcodeproj file of your app. In this case xcconfig should not contain any provisioning/team id flags. This provisioning profile will be further used for codesigning the app.
-* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `nativescript-dev-webpack`.
+* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `webpack`.
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
 <% } %>
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -3,9 +3,9 @@ run android
 
 Usage | Synopsis
 ---|---
-Run on all connected devices and running emulators | `$ tns run android [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch]`
-Run on a selected connected device or running emulator. Will start emulator with specified `Device Identifier`, if not already running. | `$ tns run android --device <Device ID> [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch]`
-Start a default emulator if none are running, or run application on all connected emulators. | `$ tns run android --emulator [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch]`
+Run on all connected devices and running emulators | `$ tns run android [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--bundle [<value>] [--env.*]]`
+Run on a selected connected device or running emulator. Will start emulator with specified `Device Identifier`, if not already running. | `$ tns run android --device <Device ID> [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--bundle [<value>] [--env.*]]`
+Start a default emulator if none are running, or run application on all connected emulators. | `$ tns run android --emulator [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--bundle [<value>] [--env.*]]`
 
 Runs your project on a connected Android device or in a native Android emulator, if configured. This is shorthand for prepare, build and deploy. While your app is running, prints the output from the application in the console and watches for changes in your code. Once a change is detected, it synchronizes the change with all selected devices and restarts/refreshes the application.
 
@@ -20,6 +20,8 @@ Runs your project on a connected Android device or in a native Android emulator,
 * `--key-store-password` - Provides the password for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-alias` - Provides the alias for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-alias-password` - Provides the password for the alias specified with `--key-store-alias-password`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
+* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `nativescript-dev-webpack`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
 
 ### Attributes
 * `<Device ID>` is the index or `Device Identifier` of the target device as listed by `$ tns device android --available-devices`

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -20,7 +20,7 @@ Runs your project on a connected Android device or in a native Android emulator,
 * `--key-store-password` - Provides the password for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-alias` - Provides the alias for the keystore file specified with `--key-store-path`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--key-store-alias-password` - Provides the password for the alias specified with `--key-store-alias-password`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
-* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `nativescript-dev-webpack`.
+* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `webpack`.
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
 
 ### Attributes

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -20,7 +20,7 @@ Runs your project on a connected iOS device or in the iOS Simulator, if configur
 * `--clean` - If set, forces rebuilding the native application.
 * `--no-watch` - If set, changes in your code will not be reflected during the execution of this command.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
-* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `nativescript-dev-webpack`.
+* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `webpack`.
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
 
 ### Attributes

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -3,9 +3,9 @@ run ios
 
 Usage | Synopsis
 ---|---
-Run on all connected devices | `$ tns run ios [--release] [--justlaunch]`
-Run on a selected connected device. Will start simulator with specified `Device Identifier`, if not already running. | `$ tns run ios [--device <Device ID>] [--release] [--justlaunch]`
-Start an emulator and run the app inside it | `$ tns run ios --emulator [--release]`
+Run on all connected devices | `$ tns run ios [--release] [--justlaunch] [--bundle [<value>] [--env.*]]`
+Run on a selected connected device. Will start simulator with specified `Device Identifier`, if not already running. | `$ tns run ios [--device <Device ID>] [--release] [--justlaunch] [--bundle [<value>] [--env.*]]`
+Start an emulator and run the app inside it | `$ tns run ios --emulator [--release] [--bundle [<value>] [--env.*]]`
 
 Runs your project on a connected iOS device or in the iOS Simulator, if configured. This is shorthand for prepare, build and deploy. While your app is running, prints the output from the application in the console and watches for changes in your code. Once a change is detected, it synchronizes the change with all selected devices and restarts/refreshes the application.
 
@@ -20,6 +20,8 @@ Runs your project on a connected iOS device or in the iOS Simulator, if configur
 * `--clean` - If set, forces rebuilding the native application.
 * `--no-watch` - If set, changes in your code will not be reflected during the execution of this command.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
+* `--bundle` - Specifies that a bundler (e.g. webpack) should be used if one is present. If no value is passed will default to `nativescript-dev-webpack`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
 
 ### Attributes
 * `<Device ID>` is the index or `Device Identifier` of the target device as listed by `$ tns device ios --available-devices`

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -56,7 +56,7 @@ export class PublishIOS implements ICommand {
 		if (!ipaFilePath) {
 			const platform = this.$devicePlatformsConstants.iOS;
 			// No .ipa path provided, build .ipa on out own.
-			const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+			const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
 			const platformInfo: IPreparePlatformInfo = {
 				platform,
 				appFilesUpdaterOptions,

--- a/lib/commands/base-bundler.ts
+++ b/lib/commands/base-bundler.ts
@@ -1,4 +1,8 @@
 export abstract class BundleBase {
+	private bundlersMap: IStringDictionary = {
+		webpack: "nativescript-dev-webpack"
+	};
+
 	constructor(protected $projectData: IProjectData,
 		protected $errors: IErrors,
 		protected $options: IOptions) {
@@ -6,8 +10,11 @@ export abstract class BundleBase {
 	}
 
 	protected validateBundling(): void {
-		if (this.$options.bundle && !this.$projectData.devDependencies[this.$options.bundle] && !this.$projectData.dependencies[this.$options.bundle]) {
-			this.$errors.fail("Passing --bundle requires a bundling plugin.");
+		if (this.$options.bundle) {
+			const bundlePluginName = this.bundlersMap[this.$options.bundle];
+			if (!bundlePluginName || (!this.$projectData.devDependencies[bundlePluginName] && !this.$projectData.dependencies[bundlePluginName])) {
+				this.$errors.fail("Passing --bundle requires a bundling plugin. No bundling plugin found or the specified bundling plugin is invalid.");
+			}
 		}
 	}
 }

--- a/lib/commands/base-bundler.ts
+++ b/lib/commands/base-bundler.ts
@@ -1,0 +1,14 @@
+export abstract class BundleBase {
+	constructor(protected $projectData: IProjectData,
+		protected $errors: IErrors,
+		protected $options: IOptions) {
+		this.$projectData.initializeProjectData();
+	}
+
+	protected validateBundling(): void {
+		const bundlerPluginName = "nativescript-dev-webpack";
+		if (!this.$projectData.devDependencies[bundlerPluginName] && !this.$projectData.dependencies[bundlerPluginName] && this.$options.bundle) {
+			this.$errors.fail("Passing --bundle requires a bundling plugin.");
+		}
+	}
+}

--- a/lib/commands/base-bundler.ts
+++ b/lib/commands/base-bundler.ts
@@ -6,8 +6,7 @@ export abstract class BundleBase {
 	}
 
 	protected validateBundling(): void {
-		const bundlerPluginName = "nativescript-dev-webpack";
-		if (!this.$projectData.devDependencies[bundlerPluginName] && !this.$projectData.dependencies[bundlerPluginName] && this.$options.bundle) {
+		if (this.$options.bundle && !this.$projectData.devDependencies[this.$options.bundle] && !this.$projectData.dependencies[this.$options.bundle]) {
 			this.$errors.fail("Passing --bundle requires a bundling plugin.");
 		}
 	}

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -14,7 +14,7 @@ export class BuildCommandBase extends BundleBase {
 
 	public async executeCore(args: string[]): Promise<void> {
 		const platform = args[0].toLowerCase();
-		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
 		const platformInfo: IPreparePlatformInfo = {
 			platform,
 			appFilesUpdaterOptions,

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,12 +1,14 @@
 import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
+import { BundleBase } from "./base-bundler";
 
-export class BuildCommandBase {
+export class BuildCommandBase extends BundleBase {
 	constructor(protected $options: IOptions,
 		protected $errors: IErrors,
 		protected $projectData: IProjectData,
 		protected $platformsData: IPlatformsData,
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		protected $platformService: IPlatformService) {
+		super($projectData, $errors, $options);
 		this.$projectData.initializeProjectData();
 	}
 
@@ -47,6 +49,8 @@ export class BuildCommandBase {
 		if (!this.$platformService.isPlatformSupportedForOS(platform, this.$projectData)) {
 			this.$errors.fail(`Applications for platform ${platform} can not be built on this OS`);
 		}
+
+		super.validateBundling();
 	}
 }
 

--- a/lib/commands/clean-app.ts
+++ b/lib/commands/clean-app.ts
@@ -14,7 +14,7 @@ export class CleanAppCommandBase implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
 		return this.$platformService.cleanDestinationApp(this.platform.toLowerCase(), appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
 	}
 

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -14,7 +14,7 @@ export class DeployOnDeviceCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
 		const deployOptions: IDeployPlatformOptions = {
 			clean: this.$options.clean,
 			device: this.$options.device,

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -10,7 +10,7 @@ export class PrepareCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
 		const platformInfo: IPreparePlatformInfo = {
 			platform: args[0],
 			appFilesUpdaterOptions,

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -1,8 +1,9 @@
 import { ERROR_NO_VALID_SUBCOMMAND_FORMAT } from "../common/constants";
 import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
 import { cache } from "../common/decorators";
+import { BundleBase } from "./base-bundler";
 
-export class RunCommandBase implements ICommand {
+export class RunCommandBase extends BundleBase implements ICommand {
 
 	public platform: string;
 	constructor(protected $platformService: IPlatformService,
@@ -14,7 +15,9 @@ export class RunCommandBase implements ICommand {
 		protected $platformsData: IPlatformsData,
 		private $hostInfo: IHostInfo,
 		private $liveSyncCommandHelper: ILiveSyncCommandHelper
-	) { }
+	) {
+		super($projectData, $errors, $options);
+	}
 
 	public allowedParameters: ICommandParameter[] = [];
 	public async execute(args: string[]): Promise<void> {
@@ -39,6 +42,8 @@ export class RunCommandBase implements ICommand {
 			const platformProjectService = platformData.platformProjectService;
 			await platformProjectService.validate(this.$projectData);
 		}
+
+		super.validateBundling();
 
 		return true;
 	}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -326,6 +326,10 @@ interface IBundle {
 	bundle: boolean;
 }
 
+interface IBundleString {
+	bundle: string;
+}
+
 interface IPlatformTemplate {
 	platformTemplate: string;
 }
@@ -374,7 +378,7 @@ interface IPort {
 	port: Number;
 }
 
-interface IOptions extends ICommonOptions, IBundle, IPlatformTemplate, IEmulator, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, INpmInstallConfigurationOptions, IPort, IEnvOptions {
+interface IOptions extends ICommonOptions, IBundleString, IPlatformTemplate, IEmulator, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, INpmInstallConfigurationOptions, IPort, IEnvOptions {
 	all: boolean;
 	client: boolean;
 	compileSdk: number;

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -30,7 +30,7 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 			ng: { type: OptionType.Boolean },
 			tsc: { type: OptionType.Boolean },
 			androidTypings: { type: OptionType.Boolean },
-			bundle: { type: OptionType.Boolean },
+			bundle: { type: OptionType.String },
 			all: { type: OptionType.Boolean },
 			teamId: { type: OptionType.Object },
 			syncAllFiles: { type: OptionType.Boolean, default: false },

--- a/lib/services/app-files-updater.ts
+++ b/lib/services/app-files-updater.ts
@@ -7,7 +7,7 @@ export class AppFilesUpdater {
 	constructor(
 		private appSourceDirectoryPath: string,
 		private appDestinationDirectoryPath: string,
-		public options: { release: boolean; bundle: boolean },
+		public options: IAppFilesUpdaterOptions,
 		public fs: IFileSystem
 	) {
 	}

--- a/lib/services/livesync/livesync-command-helper.ts
+++ b/lib/services/livesync/livesync-command-helper.ts
@@ -98,7 +98,10 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 		for (const currentPlatform of availablePlatforms) {
 			const deployPlatformInfo: IDeployPlatformInfo = {
 				platform: currentPlatform,
-				appFilesUpdaterOptions: this.$options,
+				appFilesUpdaterOptions: {
+					bundle: !!this.$options.bundle,
+					release: this.$options.release
+				},
 				deployOptions,
 				projectData: this.$projectData,
 				config: this.$options,

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -56,7 +56,7 @@ class TestExecutionService implements ITestExecutionService {
 					const socketIoJsUrl = `http://localhost:${this.$options.port}/socket.io/socket.io.js`;
 					const socketIoJs = (await this.$httpClient.httpRequest(socketIoJsUrl)).body;
 					this.$fs.writeFile(path.join(projectDir, TestExecutionService.SOCKETIO_JS_FILE_NAME), socketIoJs);
-					const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+					const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
 					const preparePlatformInfo: IPreparePlatformInfo = {
 						platform,
 						appFilesUpdaterOptions,
@@ -181,7 +181,7 @@ class TestExecutionService implements ITestExecutionService {
 					this.$fs.writeFile(path.join(projectDir, TestExecutionService.CONFIG_FILE_NAME), configJs);
 				}
 
-				const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: this.$options.bundle, release: this.$options.release };
+				const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
 				const preparePlatformInfo: IPreparePlatformInfo = {
 					platform,
 					appFilesUpdaterOptions,

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -201,7 +201,7 @@ async function preparePlatform(testInjector: IInjector): Promise<void> {
 
 	await platformService.preparePlatform({
 		platform: "android",
-		appFilesUpdaterOptions: { bundle: options.bundle, release: options.release },
+		appFilesUpdaterOptions: { bundle: !!options.bundle, release: options.release },
 		platformTemplate: "",
 		projectData,
 		config: options,


### PR DESCRIPTION
If `--bundle` is passed a bundling plugin needs to be present to process the option, else undefined behavior will follow, especially if one makes use of plugins like `nativescript-dev-typescript` that have logic regarding `--bundle` option.

Part of https://github.com/NativeScript/NativeScript/issues/5129

Ping @PanayotCankov @dtopuzov @MartoYankov 