### PR TITLE
Use proxy-lib package when working behind proxy

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -433,14 +433,6 @@ interface IInfoService {
 }
 
 /**
- * Describes standard username/password type credentials.
- */
-interface ICredentials {
-	username: string;
-	password: string;
-}
-
-/**
  * Describes properties needed for uploading a package to iTunes Connect
  */
 interface IITMSData extends ICredentials {

--- a/lib/services/analytics/google-analytics-provider.ts
+++ b/lib/services/analytics/google-analytics-provider.ts
@@ -10,7 +10,8 @@ export class GoogleAnalyticsProvider implements IGoogleAnalyticsProvider {
 	constructor(private clientId: string,
 		private $staticConfig: IStaticConfig,
 		private $analyticsSettingsService: IAnalyticsSettingsService,
-		private $logger: ILogger) {
+		private $logger: ILogger,
+		private $proxyService: IProxyService) {
 	}
 
 	public async trackHit(trackInfo: IGoogleAnalyticsData): Promise<void> {
@@ -27,11 +28,16 @@ export class GoogleAnalyticsProvider implements IGoogleAnalyticsProvider {
 	}
 
 	private async track(gaTrackingId: string, trackInfo: IGoogleAnalyticsData, sessionId: string): Promise<void> {
+		const proxySettings = await this.$proxyService.getCache();
+		const proxy = proxySettings && proxySettings.proxy;
 		const visitor = ua({
 			tid: gaTrackingId,
 			cid: this.clientId,
 			headers: {
 				["User-Agent"]: this.$analyticsSettingsService.getUserAgentString(`tnsCli/${this.$staticConfig.version}`)
+			},
+			requestOptions: {
+				proxy
 			}
 		});
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -74,6 +74,12 @@
       "integrity": "sha1-p6/cS+5xPAgRFM2BG1G+EJB9e64=",
       "dev": true
     },
+    "@types/sinon": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.0.0.tgz",
+      "integrity": "sha512-cuK4xM8Lg2wd8cxshcQa8RG4IK/xfyB6TNE6tNVvkrShR4xdrYgsV04q6Dp6v1Lp6biEFdzD8k8zg/ujQeiw+A==",
+      "dev": true
+    },
     "@types/source-map": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.0.tgz",
@@ -1466,6 +1472,15 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.15"
+      }
+    },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
       }
     },
     "fs.realpath": {
@@ -3359,6 +3374,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3475,6 +3496,12 @@
         "lodash._isiterateecall": "3.0.9"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -3512,6 +3539,12 @@
         "semver": "5.3.0",
         "streamroller": "0.2.2"
       }
+    },
+    "lolex": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -3771,6 +3804,27 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
       "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
     },
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        }
+      }
+    },
     "node-emoji": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.7.0.tgz",
@@ -3998,6 +4052,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -4176,6 +4247,25 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/properties-parser/-/properties-parser-0.2.3.tgz",
       "integrity": "sha1-91kSVfcHq7/yJ8e1a2N9uwNzoQ8="
+    },
+    "proxy-lib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/proxy-lib/-/proxy-lib-0.2.0.tgz",
+      "integrity": "sha1-xgmTDtxmvz8qoGgKnA1QI6EfjfM=",
+      "requires": {
+        "osenv": "0.1.4"
+      },
+      "dependencies": {
+        "osenv": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        }
+      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -4499,6 +4589,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -4610,6 +4706,44 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.3.1.tgz",
       "integrity": "sha1-p61lB/IYzl3+FsS/LWWSRkGeegY="
+    },
+    "sinon": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.2.tgz",
+      "integrity": "sha512-5uLBZPdCWl59Lpbf45ygKj7Z0LVol+ftBe7RDIXOQV/sF58pcFmbK8raA7bt6eljNuGnvBP+/ZxlicVn0emDjA==",
+      "dev": true,
+      "requires": {
+        "diff": "3.4.0",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.1",
+        "nise": "1.2.0",
+        "supports-color": "4.5.0",
+        "type-detect": "4.0.3"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -4882,6 +5016,12 @@
         "os-tmpdir": "1.0.2",
         "rimraf": "2.2.8"
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "plistlib": "0.2.1",
     "progress-stream": "1.1.1",
     "properties-parser": "0.2.3",
+    "proxy-lib": "0.2.0",
     "qr-image": "3.2.0",
     "request": "2.81.0",
     "semver": "5.3.0",


### PR DESCRIPTION
The `proxy-lib` package provides required methods for setting and getting proxy. Its implementation is more secure when stroing credentials, so switch to it instead of current implementation.
Remove the credentials-manager from CLI as it is no longer needed.
Remove the CredentialsManager.exe as well and its source code.

Fix the error `Cannot read property ExceptionMessage of null` when wokring behind proxy - add correct null checks.

Fix tracking to google analytics behind proxy - pass the proxy URL to Universal Analytics module.