### PR TITLE
Safeguard bundle option check

### DIFF
--- a/lib/commands/base-bundler.ts
+++ b/lib/commands/base-bundler.ts
@@ -12,7 +12,9 @@ export abstract class BundleBase {
 	protected validateBundling(): void {
 		if (this.$options.bundle) {
 			const bundlePluginName = this.bundlersMap[this.$options.bundle];
-			if (!bundlePluginName || (!this.$projectData.devDependencies[bundlePluginName] && !this.$projectData.dependencies[bundlePluginName])) {
+			const hasBundlerPluginAsDependency = this.$projectData.dependencies && this.$projectData.dependencies[bundlePluginName];
+			const hasBundlerPluginAsDevDependency = this.$projectData.devDependencies && this.$projectData.devDependencies[bundlePluginName];
+			if (!bundlePluginName || (!hasBundlerPluginAsDependency && !hasBundlerPluginAsDevDependency)) {
 				this.$errors.fail("Passing --bundle requires a bundling plugin. No bundling plugin found or the specified bundling plugin is invalid.");
 			}
 		}


### PR DESCRIPTION
In case the project does not have dependencies or dev-dependencies CLI should fail with correct message when `--bundle` is passed.

Ping @rosen-vladimirov @KristianDD 