### PR TITLE
Respect --bundle option in run command

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -589,6 +589,8 @@ const liveSyncData = {
 	projectDir,
 	skipWatcher: false,
 	watchAllFiles: false,
+	bundle: false,
+	release: false,
 	useLiveEdit: false
 };
 

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -111,7 +111,7 @@ interface ILiveSyncDeviceInfo extends IOptionalOutputPath, IOptionalDebuggingOpt
 /**
  * Describes a LiveSync operation.
  */
-interface ILiveSyncInfo extends IProjectDir, IEnvOptions {
+interface ILiveSyncInfo extends IProjectDir, IEnvOptions, IBundle, IRelease {
 	/**
 	 * Defines if the watcher should be skipped. If not passed, fs.Watcher will be started.
 	 */
@@ -152,7 +152,7 @@ interface IProjectDataComposition {
 /**
  * Desribes object that can be passed to ensureLatestAppPackageIsInstalledOnDevice method.
  */
-interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions extends IProjectDataComposition, IEnvOptions {
+interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions extends IProjectDataComposition, IEnvOptions, IBundle, IRelease {
 	device: Mobile.IDevice;
 	preparedPlatforms: string[];
 	rebuiltInformation: ILiveSyncBuildInfo[];

--- a/lib/services/livesync/livesync-command-helper.ts
+++ b/lib/services/livesync/livesync-command-helper.ts
@@ -32,7 +32,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			this.$iosDeviceOperations.setShouldDispose(false);
 		}
 
-		if (this.$options.release || this.$options.bundle) {
+		if (this.$options.release) {
 			await this.runInReleaseMode(platform);
 			return;
 		}
@@ -75,11 +75,12 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			skipWatcher: !this.$options.watch,
 			watchAllFiles: this.$options.syncAllFiles,
 			clean: this.$options.clean,
+			bundle: !!this.$options.bundle,
+			release: this.$options.release,
 			env: this.$options.env
 		};
 
 		await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
-
 	}
 
 	private async runInReleaseMode(platform: string): Promise<void> {

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -362,8 +362,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 			const prepareInfo: IPreparePlatformInfo = {
 				platform,
 				appFilesUpdaterOptions: {
-					bundle: false,
-					release: false,
+					bundle: options.bundle,
+					release: options.release,
 				},
 				projectData: options.projectData,
 				env: options.env,
@@ -459,6 +459,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					deviceBuildInfoDescriptor,
 					liveSyncData,
 					settings,
+					bundle: liveSyncData.bundle,
+					release: liveSyncData.release,
 					env: liveSyncData.env
 				}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
@@ -564,6 +566,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 										deviceBuildInfoDescriptor,
 										settings: latestAppPackageInstalledSettings,
 										modifiedFiles: allModifiedFiles,
+										bundle: liveSyncData.bundle,
+										release: liveSyncData.release,
 										env: liveSyncData.env
 									}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -123,6 +123,8 @@ class TestExecutionService implements ITestExecutionService {
 						projectDir: projectData.projectDir,
 						skipWatcher: !this.$options.watch || this.$options.justlaunch,
 						watchAllFiles: this.$options.syncAllFiles,
+						bundle: !!this.$options.bundle,
+						release: this.$options.release,
 						env: this.$options.env
 					};
 
@@ -248,6 +250,8 @@ class TestExecutionService implements ITestExecutionService {
 						projectDir: projectData.projectDir,
 						skipWatcher: !this.$options.watch || this.$options.justlaunch,
 						watchAllFiles: this.$options.syncAllFiles,
+						bundle: !!this.$options.bundle,
+						release: this.$options.release,
 						env: this.$options.env
 					};
 


### PR DESCRIPTION
Drop the logic that special cases `release` or `bundle` builds and rely on the service instead.

@rosen-vladimirov @KristianDD 

Fixes https://github.com/NativeScript/nativescript-dev-webpack/issues/342