### PR TITLE
Clean app directory when bundle flag is switched

### DIFF
--- a/lib/commands/clean-app.ts
+++ b/lib/commands/clean-app.ts
@@ -15,7 +15,16 @@ export class CleanAppCommandBase implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
-		return this.$platformService.cleanDestinationApp(this.platform.toLowerCase(), appFilesUpdaterOptions, this.$options.platformTemplate, this.$projectData, this.$options);
+		const platformInfo: IPreparePlatformInfo = {
+			appFilesUpdaterOptions,
+			platform: this.platform.toLowerCase(),
+			config: this.$options,
+			platformTemplate: this.$options.platformTemplate,
+			projectData: this.$projectData,
+			env: this.$options.env
+		};
+
+		return this.$platformService.cleanDestinationApp(platformInfo);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -115,7 +115,7 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 */
 	startApplication(platform: string, runOptions: IRunPlatformOptions, projectId: string): Promise<void>;
 
-	cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void>;
+	cleanDestinationApp(platformInfo: IPreparePlatformInfo): Promise<void>;
 	validatePlatformInstalled(platform: string, projectData: IProjectData): void;
 
 	/**

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -15,6 +15,7 @@ interface IProjectChangesInfo extends IAddedNativePlatform {
 	configChanged: boolean;
 	packageChanged: boolean;
 	nativeChanged: boolean;
+	bundleChanged: boolean;
 	signingChanged: boolean;
 
 	readonly hasChanges: boolean;

--- a/lib/services/app-files-updater.ts
+++ b/lib/services/app-files-updater.ts
@@ -21,12 +21,6 @@ export class AppFilesUpdater {
 	}
 
 	public cleanDestinationApp(): void {
-		if (this.options.bundle) {
-			//Assuming an the bundle has updated the dest folder already.
-			//Skip cleaning up completely.
-			return;
-		}
-
 		// Delete the destination app in order to prevent EEXIST errors when symlinks are used.
 		let destinationAppContents = this.readDestinationDir();
 		destinationAppContents = destinationAppContents.filter(

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -194,6 +194,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		const requiresNativePrepare = (!platformInfo.nativePrepare || !platformInfo.nativePrepare.skipNativePrepare) && changesInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPrepare;
 
 		if (changesInfo.hasChanges || platformInfo.appFilesUpdaterOptions.bundle || requiresNativePrepare) {
+			if (changesInfo.bundleChanged) {
+				await this.cleanDestinationApp(platformInfo);
+			}
+
 			await this.preparePlatformCore(
 				platformInfo.platform,
 				platformInfo.appFilesUpdaterOptions,
@@ -553,13 +557,13 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return null;
 	}
 
-	public async cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
-		await this.ensurePlatformInstalled(platform, platformTemplate, projectData, config);
+	public async cleanDestinationApp(platformInfo: IPreparePlatformInfo): Promise<void> {
+		await this.ensurePlatformInstalled(platformInfo.platform, platformInfo.platformTemplate, platformInfo.projectData, platformInfo.config);
 
-		const appSourceDirectoryPath = path.join(projectData.projectDir, constants.APP_FOLDER_NAME);
-		const platformData = this.$platformsData.getPlatformData(platform, projectData);
+		const appSourceDirectoryPath = path.join(platformInfo.projectData.projectDir, constants.APP_FOLDER_NAME);
+		const platformData = this.$platformsData.getPlatformData(platformInfo.platform, platformInfo.projectData);
 		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-		const appUpdater = new AppFilesUpdater(appSourceDirectoryPath, appDestinationDirectoryPath, appFilesUpdaterOptions, this.$fs);
+		const appUpdater = new AppFilesUpdater(appSourceDirectoryPath, appDestinationDirectoryPath, platformInfo.appFilesUpdaterOptions, this.$fs);
 		appUpdater.cleanDestinationApp();
 	}
 

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -12,6 +12,7 @@ class ProjectChangesInfo implements IProjectChangesInfo {
 	public configChanged: boolean;
 	public packageChanged: boolean;
 	public nativeChanged: boolean;
+	public bundleChanged: boolean;
 	public signingChanged: boolean;
 	public nativePlatformStatus: NativePlatformStatus;
 
@@ -93,6 +94,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			this._changesInfo.appFilesChanged = true;
 			this._changesInfo.appResourcesChanged = true;
 			this._changesInfo.modulesChanged = true;
+			this._changesInfo.bundleChanged = true;
 			this._changesInfo.configChanged = true;
 			this._prepareInfo.release = projectChangesOptions.release;
 			this._prepareInfo.bundle = projectChangesOptions.bundle;

--- a/test/app-files-updates.ts
+++ b/test/app-files-updates.ts
@@ -27,20 +27,14 @@ describe("App files cleanup", () => {
 		}
 	}
 
-	it("cleans up entire app when not bundling", () => {
-		const updater = new CleanUpAppFilesUpdater([
-			"file1", "dir1/file2", "App_Resources/Android/blah.png"
-		], { bundle: false });
-		updater.clean();
-		assert.deepEqual(["file1", "dir1/file2", "App_Resources/Android/blah.png"], updater.deletedDestinationItems);
-	});
-
-	it("does not clean up destination when bundling", () => {
-		const updater = new CleanUpAppFilesUpdater([
-			"file1", "dir1/file2", "App_Resources/Android/blah.png"
-		], { bundle: true });
-		updater.clean();
-		assert.deepEqual([], updater.deletedDestinationItems);
+	_.each([true, false], bundle => {
+		it(`cleans up entire app when bundle is ${bundle}`, () => {
+			const updater = new CleanUpAppFilesUpdater([
+				"file1", "dir1/file2", "App_Resources/Android/blah.png"
+			], { bundle });
+			updater.clean();
+			assert.deepEqual(["file1", "dir1/file2", "App_Resources/Android/blah.png"], updater.deletedDestinationItems);
+		});
 	});
 });
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -678,7 +678,7 @@ export class PlatformServiceStub extends EventEmitter implements IPlatformServic
 		return Promise.resolve();
 	}
 
-	public cleanDestinationApp(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string): Promise<void> {
+	public cleanDestinationApp(platformInfo: IPreparePlatformInfo): Promise<void> {
 		return Promise.resolve();
 	}
 


### PR DESCRIPTION
When switching the value of `--bundle` (i.e. passing it or not passing it) between two builds the latter build should clear the app directory inside platforms prior to building.

Ping @rosen-vladimirov @KristianDD 