### PR TITLE
Always clean platforms/app when --bundle is passed (#3269)

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -271,15 +271,15 @@ interface IAppFilesUpdaterOptionsComposition {
 	appFilesUpdaterOptions: IAppFilesUpdaterOptions;
 }
 
-interface IJsNodeModulesData extends IPlatform, IProjectDataComposition, IAppFilesUpdaterOptionsComposition {
+interface INodeModulesData extends IPlatform, IProjectDataComposition, IAppFilesUpdaterOptionsComposition {
 	absoluteOutputPath: string;
 	lastModifiedTime: Date;
 	projectFilesConfig: IProjectFilesConfig;
 }
 
 interface INodeModulesBuilder {
-	prepareNodeModules(absoluteOutputPath: string, platform: string, lastModifiedTime: Date, projectData: IProjectData, projectFilesConfig: IProjectFilesConfig): Promise<void>;
-	prepareJSNodeModules(jsNodeModulesData: IJsNodeModulesData): Promise<void>;
+	prepareNodeModules(nodeModulesData: INodeModulesData): Promise<void>;
+	prepareJSNodeModules(jsNodeModulesData: INodeModulesData): Promise<void>;
 	cleanNodeModules(absoluteOutputPath: string, platform: string): void;
 }
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -194,7 +194,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		const requiresNativePrepare = (!platformInfo.nativePrepare || !platformInfo.nativePrepare.skipNativePrepare) && changesInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPrepare;
 
 		if (changesInfo.hasChanges || platformInfo.appFilesUpdaterOptions.bundle || requiresNativePrepare) {
-			if (changesInfo.bundleChanged) {
+			// Always clear up the app directory in platforms if `--bundle` value has changed in between builds or is passed in general
+			// this is done as user has full control over what goes in platforms when `--bundle` is passed
+			// and we may end up with duplicate symbols which would fail the build
+			if (changesInfo.bundleChanged || platformInfo.appFilesUpdaterOptions.bundle) {
 				await this.cleanDestinationApp(platformInfo);
 			}
 

--- a/lib/services/prepare-platform-native-service.ts
+++ b/lib/services/prepare-platform-native-service.ts
@@ -38,8 +38,17 @@ export class PreparePlatformNativeService extends PreparePlatformService impleme
 			const lastModifiedTime = this.$fs.exists(appDestinationDirectoryPath) ? this.$fs.getFsStats(appDestinationDirectoryPath).mtime : null;
 
 			const tnsModulesDestinationPath = path.join(appDestinationDirectoryPath, constants.TNS_MODULES_FOLDER_NAME);
+			const nodeModulesData: INodeModulesData = {
+				absoluteOutputPath: tnsModulesDestinationPath,
+				appFilesUpdaterOptions: config.appFilesUpdaterOptions,
+				lastModifiedTime,
+				platform: config.platform,
+				projectData: config.projectData,
+				projectFilesConfig: config.projectFilesConfig
+			};
+
 			// Process node_modules folder
-			await this.$nodeModulesBuilder.prepareNodeModules(tnsModulesDestinationPath, config.platform, lastModifiedTime, config.projectData, config.projectFilesConfig);
+			await this.$nodeModulesBuilder.prepareNodeModules(nodeModulesData);
 		}
 
 		if (!config.changesInfo || config.changesInfo.configChanged || config.changesInfo.modulesChanged) {


### PR DESCRIPTION
> NOTE: Cherry-picked from master

* Always clean platforms/app when `--bundle` is passed

* Do not use $options in $nodeModulesBuilder

Whenever CLI is required as a library `$options` flags are not set. Hence `$options` should only be used where one knows CLI is truly run as a command-line interface - i.e. in commands.