### PR TITLE
Generate debug port in range for Chrome DevTools websocket - iOS (master branch)

### DIFF
--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -74,7 +74,7 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 
 	public async createWebSocketProxy(factory: () => Promise<net.Socket>): Promise<ws.Server> {
 		// NOTE: We will try to provide command line options to select ports, at least on the localhost.
-		const localPort = await this.$net.getFreePort();
+		const localPort = await this.$net.getAvailablePortInRange(41000);
 
 		this.$logger.info("\nSetting up debugger proxy...\nPress Ctrl + C to terminate, or disconnect.\n");
 

--- a/test/services/ios-debug-service.ts
+++ b/test/services/ios-debug-service.ts
@@ -48,6 +48,10 @@ const createTestInjector = (): IInjector => {
 		on: (event: string | symbol, listener: Function): any => undefined
 	});
 
+	testInjector.register("net", {
+		getAvailablePortInRange: async (startPort: number, endPort?: number): Promise<number> => 41000
+	});
+
 	return testInjector;
 };
 


### PR DESCRIPTION
Same as #3275, targets master

When generating a port to start a websocket on, use the same logic as is present in the android debug service - get the first available available port in a range, and reuse it for the next debug session of the same application if it is still available