### PR TITLE
fix(prepare): clean appresources after bundle flag is passed

### DIFF
--- a/lib/services/prepare-platform-native-service.ts
+++ b/lib/services/prepare-platform-native-service.ts
@@ -26,7 +26,7 @@ export class PreparePlatformNativeService extends PreparePlatformService impleme
 			await this.cleanProject(config.platform, config.appFilesUpdaterOptions, config.platformData, config.projectData);
 		}
 
-		if (!config.changesInfo || config.changesInfo.changesRequirePrepare) {
+		if (!config.changesInfo || config.changesInfo.changesRequirePrepare || config.appFilesUpdaterOptions.bundle) {
 			this.copyAppResources(config.platformData, config.projectData);
 			await config.platformData.platformProjectService.prepareProject(config.projectData, config.platformSpecificData);
 		}


### PR DESCRIPTION
[This PR](https://github.com/NativeScript/nativescript-cli/pull/3269) doesn't take into account the whole CLI logic which deals with preparing the project, so this is an augmentation to make it work.

fix for: https://github.com/NativeScript/nativescript-cli/issues/3280