### PR TITLE
fix(ios-inspector): Update cached inspector package to latest compatible version

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -38,7 +38,7 @@ interface INpmInstallationManager {
 	install(packageName: string, packageDir: string, options?: INpmInstallOptions): Promise<any>;
 	getLatestVersion(packageName: string): Promise<string>;
 	getNextVersion(packageName: string): Promise<string>;
-	getLatestCompatibleVersion(packageName: string): Promise<string>;
+	getLatestCompatibleVersion(packageName: string, referenceVersion?: string): Promise<string>;
 	getInspectorFromCache(inspectorNpmPackageName: string, projectDir: string): Promise<string>;
 }
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -64,7 +64,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			const projectRoot = path.join(projectData.platformsDir, this.$devicePlatformsConstants.iOS.toLowerCase());
 
 			this._platformData = {
-				frameworkPackageName: "tns-ios",
+				frameworkPackageName: constants.TNS_IOS_RUNTIME_NAME,
 				normalizedPlatformName: "iOS",
 				appDestinationDirectoryPath: path.join(projectRoot, projectData.projectName),
 				platformProjectService: this,

--- a/test/npm-installation-manager.ts
+++ b/test/npm-installation-manager.ts
@@ -10,6 +10,7 @@ import * as StaticConfigLib from "../lib/config";
 import * as yok from "../lib/common/yok";
 import ChildProcessLib = require("../lib/common/child-process");
 import { SettingsService } from "../lib/common/test/unit-tests/stubs";
+import { ProjectDataService } from "../lib/services/project-data-service";
 
 function createTestInjector(): IInjector {
 	const testInjector = new yok.Yok();
@@ -23,6 +24,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("staticConfig", StaticConfigLib.StaticConfig);
 	testInjector.register("childProcess", ChildProcessLib.ChildProcess);
 	testInjector.register("settingsService", SettingsService);
+	testInjector.register("projectDataService", ProjectDataService);
 
 	testInjector.register("npmInstallationManager", NpmInstallationManagerLib.NpmInstallationManager);
 
@@ -58,120 +60,136 @@ interface ITestData {
 	cliVersion: string;
 
 	/**
+	 * Version, based on which the version of the package that will be installed is detected.
+	 * Used when semantically the correct reference version is different than the CLI version.
+	 * (e.g. inspector package version should be determined by the project's ios runtime version)
+	 */
+	referenceVersion?: string;
+
+	/**
 	 * Expected result
 	 */
 	expectedResult: string;
 }
 
 describe("Npm installation manager tests", () => {
-	const testData: IDictionary<ITestData> = {
-		"when there's only one available version and it matches CLI's version": {
-			versions: ["1.4.0"],
-			packageLatestVersion: "1.4.0",
-			cliVersion: "1.4.0",
-			expectedResult: "1.4.0"
-		},
+	describe("getLatestCompatibleVersion", () => {
+		const testData: IDictionary<ITestData> = {
+			"when there's only one available version and it matches CLI's version": {
+				versions: ["1.4.0"],
+				packageLatestVersion: "1.4.0",
+				cliVersion: "1.4.0",
+				expectedResult: "1.4.0"
+			},
 
-		"when there's only one available version and it is higher than match CLI's version": {
-			versions: ["1.4.0"],
-			packageLatestVersion: "1.4.0",
-			cliVersion: "1.2.0",
-			expectedResult: "1.4.0"
-		},
+			"when there's only one available version and it is higher than match CLI's version": {
+				versions: ["1.4.0"],
+				packageLatestVersion: "1.4.0",
+				cliVersion: "1.2.0",
+				expectedResult: "1.4.0"
+			},
 
-		"when there's only one available version and it is lower than CLI's version": {
-			versions: ["1.4.0"],
-			packageLatestVersion: "1.4.0",
-			cliVersion: "1.6.0",
-			expectedResult: "1.4.0"
-		},
+			"when there's only one available version and it is lower than CLI's version": {
+				versions: ["1.4.0"],
+				packageLatestVersion: "1.4.0",
+				cliVersion: "1.6.0",
+				expectedResult: "1.4.0"
+			},
 
-		"when there are multiple package versions and the latest one matches ~<cli-version>": {
-			versions: ["1.2.0", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.4.0"],
-			packageLatestVersion: "1.3.3",
-			cliVersion: "1.3.0",
-			expectedResult: "1.3.3"
-		},
+			"when there are multiple package versions and the latest one matches ~<cli-version>": {
+				versions: ["1.2.0", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.4.0"],
+				packageLatestVersion: "1.3.3",
+				cliVersion: "1.3.0",
+				expectedResult: "1.3.3"
+			},
 
-		"when there are multiple package versions and the latest one matches ~<cli-version> when there are newer matching versions but they are not under latest tag": {
-			versions: ["1.2.0", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.4.0"],
-			packageLatestVersion: "1.3.2",
-			cliVersion: "1.3.0",
-			expectedResult: "1.3.2"
-		},
+			"when there are multiple package versions and the latest one matches ~<cli-version> when there are newer matching versions but they are not under latest tag": {
+				versions: ["1.2.0", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.4.0"],
+				packageLatestVersion: "1.3.2",
+				cliVersion: "1.3.0",
+				expectedResult: "1.3.2"
+			},
 
-		"when there are multiple package versions and the latest one is lower than ~<cli-version>": {
-			versions: ["1.2.0", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.4.0"],
-			packageLatestVersion: "1.4.0",
-			cliVersion: "1.5.0",
-			expectedResult: "1.4.0"
-		},
+			"when there are multiple package versions and the latest one is lower than ~<cli-version>": {
+				versions: ["1.2.0", "1.3.0", "1.3.1", "1.3.2", "1.3.3", "1.4.0"],
+				packageLatestVersion: "1.4.0",
+				cliVersion: "1.5.0",
+				expectedResult: "1.4.0"
+			},
 
-		"when there are multiple package versions and there's beta version matching CLI's semver": {
-			versions: ["1.2.0", "1.3.0", "1.3.1", "1.4.0", "1.5.0-2016-02-25-182"],
-			packageLatestVersion: "1.4.0",
-			cliVersion: "1.5.0",
-			expectedResult: "1.4.0"
-		},
+			"when there are multiple package versions and there's beta version matching CLI's semver": {
+				versions: ["1.2.0", "1.3.0", "1.3.1", "1.4.0", "1.5.0-2016-02-25-182"],
+				packageLatestVersion: "1.4.0",
+				cliVersion: "1.5.0",
+				expectedResult: "1.4.0"
+			},
 
-		"when there are multiple package versions and package's latest version is greater than CLI's version": {
-			versions: ["1.2.0", "1.3.0", "1.3.1", "1.4.0", "1.5.0-2016-02-25-182", "1.5.0", "1.6.0"],
-			packageLatestVersion: "1.6.0",
-			cliVersion: "1.5.0",
-			expectedResult: "1.5.0"
-		},
+			"when there are multiple package versions and package's latest version is greater than CLI's version": {
+				versions: ["1.2.0", "1.3.0", "1.3.1", "1.4.0", "1.5.0-2016-02-25-182", "1.5.0", "1.6.0"],
+				packageLatestVersion: "1.6.0",
+				cliVersion: "1.5.0",
+				expectedResult: "1.5.0"
+			},
 
-		"when there are multiple versions latest one does not match CLI's semver and other versions are not matching either": {
-			versions: ["1.0.0", "1.0.1", "1.2.0", "1.3.1", "1.4.0", "1.5.0-2016-02-25-182", "1.5.0"],
-			packageLatestVersion: "1.0.0",
-			cliVersion: "1.1.0",
-			expectedResult: "1.0.0"
-		},
+			"when there are multiple versions latest one does not match CLI's semver and other versions are not matching either": {
+				versions: ["1.0.0", "1.0.1", "1.2.0", "1.3.1", "1.4.0", "1.5.0-2016-02-25-182", "1.5.0"],
+				packageLatestVersion: "1.0.0",
+				cliVersion: "1.1.0",
+				expectedResult: "1.0.0"
+			},
 
-		"when CLI's version is beta (has dash) latest matching beta version is returned": {
-			versions: ["1.0.0", "1.0.1", "1.4.0", "1.5.0-2016-02-25-182", "1.5.0-2016-02-26-202"],
-			packageLatestVersion: "1.4.0",
-			cliVersion: "1.5.0-182",
-			expectedResult: "1.5.0-2016-02-26-202"
-		},
+			"when CLI's version is beta (has dash) latest matching beta version is returned": {
+				versions: ["1.0.0", "1.0.1", "1.4.0", "1.5.0-2016-02-25-182", "1.5.0-2016-02-26-202"],
+				packageLatestVersion: "1.4.0",
+				cliVersion: "1.5.0-182",
+				expectedResult: "1.5.0-2016-02-26-202"
+			},
 
-		"when CLI's version is beta (has dash) latest matching official version is returned when beta versions do not match": {
-			versions: ["1.0.0", "1.0.1", "1.4.0", "1.5.0-2016-02-25-182", "1.5.0-2016-02-26-202"],
-			packageLatestVersion: "1.4.0",
-			cliVersion: "1.6.0-2016-03-01-182",
-			expectedResult: "1.4.0"
-		},
+			"when CLI's version is beta (has dash) latest matching official version is returned when beta versions do not match": {
+				versions: ["1.0.0", "1.0.1", "1.4.0", "1.5.0-2016-02-25-182", "1.5.0-2016-02-26-202"],
+				packageLatestVersion: "1.4.0",
+				cliVersion: "1.6.0-2016-03-01-182",
+				expectedResult: "1.4.0"
+			},
 
-		"when CLI's version is beta (has dash) latest matching official version is returned when beta versions do not match (when the prerelease of CLI is higher than prerelease version of runtime)": {
-			versions: ["1.0.0", "1.0.1", "1.4.0", "1.6.0-2016-02-25-182", "1.6.0-2016-02-26-202"],
-			packageLatestVersion: "1.4.0",
-			cliVersion: "1.6.0-2016-10-01-182",
-			expectedResult: "1.4.0"
-		},
-		"When CLI Version has patch version larger than an existing package, should return max compliant package from the same major.minor version": {
-			versions: ["1.0.0", "1.0.1", "1.4.0", "2.5.0", "2.5.1", "2.5.2", "3.0.0"],
-			packageLatestVersion: "3.0.0",
-			cliVersion: "2.5.4",
-			expectedResult: "2.5.2"
-		}
-	};
+			"when CLI's version is beta (has dash) latest matching official version is returned when beta versions do not match (when the prerelease of CLI is higher than prerelease version of runtime)": {
+				versions: ["1.0.0", "1.0.1", "1.4.0", "1.6.0-2016-02-25-182", "1.6.0-2016-02-26-202"],
+				packageLatestVersion: "1.4.0",
+				cliVersion: "1.6.0-2016-10-01-182",
+				expectedResult: "1.4.0"
+			},
+			"When CLI Version has patch version larger than an existing package, should return max compliant package from the same major.minor version": {
+				versions: ["1.0.0", "1.0.1", "1.4.0", "2.5.0", "2.5.1", "2.5.2", "3.0.0"],
+				packageLatestVersion: "3.0.0",
+				cliVersion: "2.5.4",
+				expectedResult: "2.5.2"
+			},
+			"When reference version is specified as argument": {
+				versions: ["122.0.4", "123.0.0", "123.0.1", "123.1.0", "124.0.0"],
+				packageLatestVersion: "124.0.0",
+				cliVersion: "0.0.0", // should not matter
+				expectedResult: "123.0.1",
+				referenceVersion: "123.0.5"
+			}
+		};
 
-	_.each(testData, (currentTestData: ITestData, testName: string) => {
-		it(`returns correct latest compatible version, ${testName}`, async () => {
-			const testInjector = createTestInjector();
+		_.each(testData, (currentTestData: ITestData, testName: string) => {
+			it(`returns correct latest compatible version, ${testName}`, async () => {
+				const testInjector = createTestInjector();
 
-			mockNpm(testInjector, currentTestData.versions, currentTestData.packageLatestVersion);
+				mockNpm(testInjector, currentTestData.versions, currentTestData.packageLatestVersion);
 
-			// Mock staticConfig.version
-			const staticConfig = testInjector.resolve("staticConfig");
-			staticConfig.version = currentTestData.cliVersion;
+				// Mock staticConfig.version
+				const staticConfig = testInjector.resolve("staticConfig");
+				staticConfig.version = currentTestData.cliVersion;
 
-			// Mock npmInstallationManager.getLatestVersion
-			const npmInstallationManager = testInjector.resolve("npmInstallationManager");
-			npmInstallationManager.getLatestVersion = (packageName: string) => Promise.resolve(currentTestData.packageLatestVersion);
+				// Mock npmInstallationManager.getLatestVersion
+				const npmInstallationManager = testInjector.resolve("npmInstallationManager");
+				npmInstallationManager.getLatestVersion = (packageName: string) => Promise.resolve(currentTestData.packageLatestVersion);
 
-			const actualLatestCompatibleVersion = await npmInstallationManager.getLatestCompatibleVersion("");
-			assert.equal(actualLatestCompatibleVersion, currentTestData.expectedResult);
+				const actualLatestCompatibleVersion = await npmInstallationManager.getLatestCompatibleVersion("", currentTestData.referenceVersion);
+				assert.equal(actualLatestCompatibleVersion, currentTestData.expectedResult);
+			});
 		});
 	});
 });


### PR DESCRIPTION
* Currently it is never updated and is left at the first version ever installed in `~/.local`.
As a result newly published inspector packages are not used unless the user installs
them explicitly in the project or deletes the cache manually.
* The iOS inspector package version must be determined according to project's iOS runtime
version instead of the version of CLI as it has been till now