### PR TITLE
Allow using Android SDK 27

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -6,7 +6,7 @@ import { appendZeroesToVersion } from './common/helpers';
 
 export class AndroidToolsInfo implements IAndroidToolsInfo {
 	private static ANDROID_TARGET_PREFIX = "android";
-	private static SUPPORTED_TARGETS = ["android-17", "android-18", "android-19", "android-21", "android-22", "android-23", "android-24", "android-25", "android-26"];
+	private static SUPPORTED_TARGETS = ["android-17", "android-18", "android-19", "android-21", "android-22", "android-23", "android-24", "android-25", "android-26", "android-27"];
 	private static MIN_REQUIRED_COMPILE_TARGET = 22;
 	private static REQUIRED_BUILD_TOOLS_RANGE_PREFIX = ">=23";
 	private static VERSION_REGEX = /((\d+\.){2}\d+)/;

--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -306,6 +306,10 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		if (this.androidHome && requiredAppCompatRange) {
 			const pathToAppCompat = path.join(this.androidHome, "extras", "android", "m2repository", "com", "android", "support", "appcompat-v7");
 			selectedAppCompatVersion = this.getMatchingDir(pathToAppCompat, requiredAppCompatRange);
+			if (!selectedAppCompatVersion) {
+				// get latest matching version, as there's no available appcompat versions for latest SDK versions.
+				selectedAppCompatVersion = this.getMatchingDir(pathToAppCompat, "*");
+			}
 		}
 
 		this.$logger.trace(`Selected AppCompat version is: ${selectedAppCompatVersion}`);


### PR DESCRIPTION
Add version 27 of Android SDK as verified, so users will use it by default when it is installed.

### Use latest available appCompat version

The current CLI logic finds appCompat version that matches the selected SDK version. However, the latest appCompat version is 26.0.0-alpha, so in case we have Android SDK 27, we are unable to find matchin appCompat.
In order to resolve the issue and allow using Android SDK 27, get latest available appCompat version when there's no matching one.