### PR TITLE
Do not use spinner in CI environment

### DIFF
--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -2,7 +2,6 @@ import { EOL } from "os";
 import * as semver from "semver";
 import * as path from "path";
 import * as helpers from "../common/helpers";
-const clui = require("clui");
 
 class DoctorService implements IDoctorService {
 	private static PROJECT_NAME_PLACEHOLDER = "__PROJECT_NAME__";
@@ -166,7 +165,7 @@ class DoctorService implements IDoctorService {
 		};
 		this.$fs.writeJson(path.join(projDir, "package.json"), packageJsonData);
 
-		const spinner = new clui.Spinner("Installing iOS runtime.");
+		const spinner = this.$progressIndicator.getSpinner("Installing iOS runtime.");
 		try {
 			spinner.start();
 			await this.$npm.install("tns-ios", projDir, {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -9,7 +9,6 @@ import { AppFilesUpdater } from "./app-files-updater";
 import { attachAwaitDetach } from "../common/helpers";
 import * as temp from "temp";
 temp.track();
-const clui = require("clui");
 
 const buildInfoFileName = ".nsbuildinfo";
 
@@ -25,6 +24,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	constructor(private $devicesService: Mobile.IDevicesService,
 		private $preparePlatformNativeService: IPreparePlatformService,
 		private $preparePlatformJSService: IPreparePlatformService,
+		private $progressIndicator: IProgressIndicator,
 		private $errors: IErrors,
 		private $fs: IFileSystem,
 		private $logger: ILogger,
@@ -115,7 +115,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			npmOptions["version"] = version;
 		}
 
-		const spinner = new clui.Spinner("Installing " + packageToInstall);
+		const spinner = this.$progressIndicator.getSpinner("Installing " + packageToInstall);
 		const projectDir = projectData.projectDir;
 		const platformPath = path.join(projectData.platformsDir, platform);
 

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -89,6 +89,13 @@ function createTestInjector(): IInjector {
 	testInjector.register("nodeModulesDependenciesBuilder", NodeModulesDependenciesBuilder);
 	testInjector.register("settingsService", SettingsService);
 	testInjector.register("devicePathProvider", {});
+	testInjector.register("progressIndicator", {
+		getSpinner: (msg: string) => ({
+			start: (): void => undefined,
+			stop: (): void => undefined,
+			message: (): void => undefined
+		})
+	});
 
 	return testInjector;
 }

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -153,6 +153,13 @@ function createTestInjector() {
 		showCommandLineHelp: async (): Promise<void> => (undefined)
 	});
 	testInjector.register("settingsService", SettingsService);
+	testInjector.register("progressIndicator", {
+		getSpinner: (msg: string) => ({
+			start: (): void => undefined,
+			stop: (): void => undefined,
+			message: (): void => undefined
+		})
+	});
 
 	return testInjector;
 }

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -96,6 +96,13 @@ function createTestInjector() {
 		showCommandLineHelp: async (): Promise<void> => (undefined)
 	});
 	testInjector.register("settingsService", SettingsService);
+	testInjector.register("progressIndicator", {
+		getSpinner: (msg: string) => ({
+			start: (): void => undefined,
+			stop: (): void => undefined,
+			message: (): void => undefined
+		})
+	});
 
 	return testInjector;
 }

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -103,6 +103,13 @@ function createTestInjector() {
 		showCommandLineHelp: async (): Promise<void> => (undefined)
 	});
 	testInjector.register("settingsService", SettingsService);
+	testInjector.register("progressIndicator", {
+		getSpinner: (msg: string) => ({
+			start: (): void => undefined,
+			stop: (): void => undefined,
+			message: (): void => undefined
+		})
+	});
 
 	return testInjector;
 }


### PR DESCRIPTION
In case terminal is not interactive, the spinner we are using during `tns doctor` or `tns platform add ...` is printing a lot of messages and polutes the output.
So in case we are in non-interactive environment, print the spinner message a single time. In order to achieve this, use the newly introduce method in $progressIndicatior from submodule;

Add getSpinner method to $progressIndicator

Add `getSpinner` method to $progressIndicator - it will return a new instance of clui.Spinner in case terminal is interactive. In case it is not - a mocked instance will be returned.
This way in CI builds the spinner will not print tons of repeated messages.

Implements https://github.com/NativeScript/nativescript-cli/issues/2127

Merge after https://github.com/telerik/mobile-cli-lib/pull/1040