### PR TITLE
Fix multiple typescript/sass watchers

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -60,7 +60,7 @@ interface ILiveSyncProcessInfo {
 	timer: NodeJS.Timer;
 	watcherInfo: {
 		watcher: IFSWatcher,
-		pattern: string | string[]
+		pattern: string[]
 	};
 	actionsChain: Promise<any>;
 	isStopped: boolean;

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -60,7 +60,7 @@ interface ILiveSyncProcessInfo {
 	timer: NodeJS.Timer;
 	watcherInfo: {
 		watcher: IFSWatcher,
-		pattern: string[]
+		patterns: string[]
 	};
 	actionsChain: Promise<any>;
 	isStopped: boolean;

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -526,8 +526,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		}
 
 		const currentWatcherInfo = this.liveSyncProcessesInfo[liveSyncData.projectDir].watcherInfo;
-
-		if (!currentWatcherInfo || currentWatcherInfo.pattern !== pattern) {
+		const areWatcherPatternsDifferent = () => _.difference(currentWatcherInfo.pattern, pattern).length || _.difference(pattern, currentWatcherInfo.pattern).length;
+		if (!currentWatcherInfo || areWatcherPatternsDifferent()) {
 			if (currentWatcherInfo) {
 				currentWatcherInfo.watcher.close();
 			}

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -513,20 +513,20 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	}
 
 	private async startWatcher(projectData: IProjectData, liveSyncData: ILiveSyncInfo): Promise<void> {
-		const pattern = [APP_FOLDER_NAME];
+		const patterns = [APP_FOLDER_NAME];
 
 		if (liveSyncData.watchAllFiles) {
 			const productionDependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir);
-			pattern.push(PACKAGE_JSON_FILE_NAME);
+			patterns.push(PACKAGE_JSON_FILE_NAME);
 
 			// watch only production node_module/packages same one prepare uses
 			for (const index in productionDependencies) {
-				pattern.push(productionDependencies[index].directory);
+				patterns.push(productionDependencies[index].directory);
 			}
 		}
 
 		const currentWatcherInfo = this.liveSyncProcessesInfo[liveSyncData.projectDir].watcherInfo;
-		const areWatcherPatternsDifferent = () => _.difference(currentWatcherInfo.pattern, pattern).length || _.difference(pattern, currentWatcherInfo.pattern).length;
+		const areWatcherPatternsDifferent = () => _.xor(currentWatcherInfo.patterns, patterns).length;
 		if (!currentWatcherInfo || areWatcherPatternsDifferent()) {
 			if (currentWatcherInfo) {
 				currentWatcherInfo.watcher.close();
@@ -630,7 +630,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				ignored: ["**/.*", ".*"] // hidden files
 			};
 
-			const watcher = choki.watch(pattern, watcherOptions)
+			const watcher = choki.watch(patterns, watcherOptions)
 				.on("all", async (event: string, filePath: string) => {
 					clearTimeout(timeoutTimer);
 
@@ -650,7 +650,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					}
 				});
 
-			this.liveSyncProcessesInfo[liveSyncData.projectDir].watcherInfo = { watcher, pattern };
+			this.liveSyncProcessesInfo[liveSyncData.projectDir].watcherInfo = { watcher, patterns };
 			this.liveSyncProcessesInfo[liveSyncData.projectDir].timer = timeoutTimer;
 
 			this.$processService.attachToProcessExitSignals(this, () => {

--- a/test/services/livesync-service.ts
+++ b/test/services/livesync-service.ts
@@ -94,7 +94,7 @@ describe("liveSyncService", () => {
 				watcher: <any>{
 					close: (): any => undefined
 				},
-				pattern: "pattern"
+				pattern: ["pattern"]
 			},
 			deviceDescriptors: []
 		});

--- a/test/services/livesync-service.ts
+++ b/test/services/livesync-service.ts
@@ -94,7 +94,7 @@ describe("liveSyncService", () => {
 				watcher: <any>{
 					close: (): any => undefined
 				},
-				pattern: ["pattern"]
+				patterns: ["pattern"]
 			},
 			deviceDescriptors: []
 		});


### PR DESCRIPTION
Whenever using CLI as a library, calling livesync multiple times leads to multiple typescript/sass watchers.
This happens due to the fact that `currentWatcherInfo.pattern` is an array and checking two arrays for equality with `!==` is bound to return `true` at all times. `toString()` both arrays and check the string literals instead.

Ping @KristianDD @rosen-vladimirov 