### PR TITLE
Fix livesync + debug on iOS Simulator

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -424,7 +424,7 @@ Provides methods for debugging applications on devices. The service is also even
 * Usage:
 ```JavaScript
 tns.debugService.on("connectionError", errorData => {
-	console.log(`Unable to start debug operation on device ${errorData.deviceId}. Error is: ${errorData.message}.`);
+	console.log(`Unable to start debug operation on device ${errorData.deviceIdentifier}. Error is: ${errorData.message}.`);
 });
 ```
 
@@ -522,7 +522,7 @@ interface IDebugOptions {
 * Usage:
 ```JavaScript
 tns.debugService.on("connectionError", errorData => {
-	console.log(`Unable to start debug operation on device ${errorData.deviceId}. Error is: ${errorData.message}.`);
+	console.log(`Unable to start debug operation on device ${errorData.deviceIdentifier}. Error is: ${errorData.message}.`);
 });
 
 const debugData = {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -544,7 +544,7 @@ interface IAndroidToolsInfoData {
 
 interface ISocketProxyFactory extends NodeJS.EventEmitter {
 	createTCPSocketProxy(factory: () => Promise<any>): Promise<any>;
-	createWebSocketProxy(factory: () => Promise<any>): Promise<any>;
+	createWebSocketProxy(factory: () => Promise<any>, deviceIdentifier: string): Promise<any>;
 }
 
 interface IiOSNotification {

--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -72,7 +72,7 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 		return server;
 	}
 
-	public async createWebSocketProxy(factory: () => Promise<net.Socket>): Promise<ws.Server> {
+	public async createWebSocketProxy(factory: () => Promise<net.Socket>, deviceIdentifier: string): Promise<ws.Server> {
 		// NOTE: We will try to provide command line options to select ports, at least on the localhost.
 		const localPort = await this.$net.getAvailablePortInRange(41000);
 
@@ -92,6 +92,7 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 				try {
 					_socket = await factory();
 				} catch (err) {
+					err.deviceIdentifier = deviceIdentifier;
 					this.$logger.trace(err);
 					this.emit(CONNECTION_ERROR_EVENT_NAME, err);
 					this.$errors.failWithoutHelp("Cannot connect to device socket.");

--- a/lib/services/livesync/ios-device-livesync-service.ts
+++ b/lib/services/livesync/ios-device-livesync-service.ts
@@ -1,4 +1,3 @@
-import * as helpers from "../../common/helpers";
 import * as constants from "../../constants";
 import * as minimatch from "minimatch";
 import * as net from "net";
@@ -30,10 +29,8 @@ export class IOSDeviceLiveSyncService extends DeviceLiveSyncServiceBase implemen
 
 		if (this.device.isEmulator) {
 			await this.$iOSEmulatorServices.postDarwinNotification(this.$iOSNotification.getAttachRequest(projectId));
-			try {
-				this.socket = await helpers.connectEventuallyUntilTimeout(() => net.connect(IOSDeviceLiveSyncService.BACKEND_PORT), 5000);
-			} catch (e) {
-				this.$logger.debug(e);
+			this.socket = await this.$iOSEmulatorServices.connectToPort({ port: IOSDeviceLiveSyncService.BACKEND_PORT });
+			if (!this.socket) {
 				return false;
 			}
 		} else {

--- a/test/services/debug-service.ts
+++ b/test/services/debug-service.ts
@@ -203,7 +203,7 @@ describe("debugService", () => {
 					const debugData = getDebugData();
 					await assert.isFulfilled(debugService.debug(debugData, null));
 
-					const expectedErrorData = { deviceId: "deviceId", message: "my message", code: 2048 };
+					const expectedErrorData = { deviceIdentifier: "deviceId", message: "my message", code: 2048 };
 					const platformDebugService = testInjector.resolve<IPlatformDebugService>(`${platform}DebugService`);
 					platformDebugService.emit(CONNECTION_ERROR_EVENT_NAME, expectedErrorData);
 					assert.deepEqual(dataRaisedForConnectionError, expectedErrorData);

--- a/test/services/ios-debug-service.ts
+++ b/test/services/ios-debug-service.ts
@@ -8,7 +8,7 @@ const expectedDevToolsCommitSha = "02e6bde1bbe34e43b309d4ef774b1168d25fd024";
 class IOSDebugServiceInheritor extends IOSDebugService {
 	constructor(protected $devicesService: Mobile.IDevicesService,
 		$platformService: IPlatformService,
-		$iOSEmulatorServices: Mobile.IEmulatorPlatformServices,
+		$iOSEmulatorServices: Mobile.IiOSSimulatorService,
 		$childProcess: IChildProcess,
 		$hostInfo: IHostInfo,
 		$logger: ILogger,


### PR DESCRIPTION
When `tns debug ios` is used, each change of application's code will trigger restart of app and Chrome DevTools will be disconnected. CLI prints the "new" URL and in case you copy it and paste it immediately in the browser, you'll receive empty DevTools. The problem is that the URL is printed before application is launched successfully on simulator.
In order to resolve this issue, try connection on port 18181 - the connection will be successfull only when the application is running. Wait 10 seconds to connect and throw error in case we are unable to connect for this time.

Also fix incorrect behavior of connectionError event - the thrown error should contain the deviceIdentifier, but it was missing.

NOTE: Merge after https://github.com/telerik/mobile-cli-lib/pull/1041