### PR TITLE
fix(debug): debug-brk option does not work for iOS Simulator

### DIFF
--- a/test/services/ios-debug-service.ts
+++ b/test/services/ios-debug-service.ts
@@ -17,9 +17,10 @@ class IOSDebugServiceInheritor extends IOSDebugService {
 		$iOSNotification: IiOSNotification,
 		$iOSSocketRequestExecutor: IiOSSocketRequestExecutor,
 		$processService: IProcessService,
-		$socketProxyFactory: ISocketProxyFactory) {
+		$socketProxyFactory: ISocketProxyFactory,
+		$net: INet) {
 		super(<any>{}, $devicesService, $platformService, $iOSEmulatorServices, $childProcess, $hostInfo, $logger, $errors,
-			$npmInstallationManager, $iOSNotification, $iOSSocketRequestExecutor, $processService, $socketProxyFactory);
+			$npmInstallationManager, $iOSNotification, $iOSSocketRequestExecutor, $processService, $socketProxyFactory, $net);
 	}
 
 	public getChromeDebugUrl(debugOptions: IDebugOptions, port: number): string {
@@ -49,7 +50,8 @@ const createTestInjector = (): IInjector => {
 	});
 
 	testInjector.register("net", {
-		getAvailablePortInRange: async (startPort: number, endPort?: number): Promise<number> => 41000
+		getAvailablePortInRange: async (startPort: number, endPort?: number): Promise<number> => 41000,
+		waitForPortToListen: async (opts: { port: number, timeout: number, interval?: number }): Promise<boolean> => true
 	});
 
 	return testInjector;


### PR DESCRIPTION
The `debug-brk` option was broken in a previous commit as we were trying to connect to the backend port (18181). The problem is that connecting to it makes the runtime thinks debugger is attached and it continues to next statements.
Instead of connecting to the port, check if it is in LISTEN state.
Fixes https://github.com/NativeScript/nativescript-cli/issues/3338