### PR TITLE
feat: introduce resources update command

### DIFF
--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -32,7 +32,7 @@ Command | Description
 [platform list](project/configuration/platform.html) | Lists all platforms that the project currently targets.
 [platform remove `<Platform>`](project/configuration/platform-remove.html) | Removes the selected platform from the platforms that the project currently targets. This operation deletes all platform-specific files and subdirectories from your project.
 [platform update `<Platform>`](project/configuration/platform-update.html) | Updates the NativeScript runtime for the specified platform.
-[resources-update](project/configuration/resources-update.html) | Updates the App_Resources/<platform>'s internal folder structure to conform to that of an Android project.
+[resources update](project/configuration/resources-update.html) | Updates the App_Resources/<platform>'s internal folder structure to conform to that of an Android Studio project.
 [prepare `<Platform>`](project/configuration/prepare.html) | Copies relevant content from the app directory to the subdirectory for the selected target platform to let you build the project.
 [build `<Platform>`](project/testing/build.html) | Builds the project for the selected target platform and produces an application package or an emulator package.
 [deploy `<Platform>`](project/testing/deploy.html) | Deploys the project to a connected physical or virtual device.

--- a/docs/man_pages/index.md
+++ b/docs/man_pages/index.md
@@ -32,6 +32,7 @@ Command | Description
 [platform list](project/configuration/platform.html) | Lists all platforms that the project currently targets.
 [platform remove `<Platform>`](project/configuration/platform-remove.html) | Removes the selected platform from the platforms that the project currently targets. This operation deletes all platform-specific files and subdirectories from your project.
 [platform update `<Platform>`](project/configuration/platform-update.html) | Updates the NativeScript runtime for the specified platform.
+[resources-update](project/configuration/resources-update.html) | Updates the App_Resources/<platform>'s internal folder structure to conform to that of an Android project.
 [prepare `<Platform>`](project/configuration/prepare.html) | Copies relevant content from the app directory to the subdirectory for the selected target platform to let you build the project.
 [build `<Platform>`](project/testing/build.html) | Builds the project for the selected target platform and produces an application package or an emulator package.
 [deploy `<Platform>`](project/testing/deploy.html) | Deploys the project to a connected physical or virtual device.

--- a/docs/man_pages/project/configuration/resources-update.md
+++ b/docs/man_pages/project/configuration/resources-update.md
@@ -1,0 +1,31 @@
+<% if (isJekyll) { %>---
+title: tns resources-update
+position: 9
+---<% } %>
+#tns resources-update
+==========
+
+Usage | Synopsis
+------|-------
+`$ tns resources-update` | Defaults to executing `$ tns resources-update android`. Updates the App_Resources/Android's folder structure.
+`$ tns resources-update android` | Updates the App_Resources/Android's folder structure.
+
+Updates the App_Resources/<platform>'s internal folder structure to conform to that of an Android project. Android resource files and directories will be located at the following paths:
+- `drawable-*`, `values`, `raw`, etc. can be found at  `App_Resources/Android/src/main/res` 
+- `AndroidManifest.xml` can be found at `App_Resources/Android/src/main/AndroidManifest.xml`
+- Java source files can be dropped in at `App_Resources/Android/src/main/java` after creating the proper package subdirectory structure
+- Additional arbitrary assets can be dropped in at `App_Resources/Android/src/main/assets`
+
+### Command Limitations
+
+* The command works only for the directory structure under `App_Resources/Android`. Running `$ tns resources-update ios` will have no effect.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[install](install.html) | Installs all platforms and dependencies described in the `package.json` file in the current directory.
+[platform add](platform-add.html) | Configures the current project to target the selected platform.
+[platform remove](platform-remove.html) | Removes the selected platform from the platforms that the project currently targets.
+[platform](platform.html) | Lists all platforms that the project currently targets.
+[prepare](prepare.html) | Copies common and relevant platform-specific content from the app directory to the subdirectory for the selected target platform in the platforms directory.

--- a/docs/man_pages/project/configuration/resources/resources-update.md
+++ b/docs/man_pages/project/configuration/resources/resources-update.md
@@ -1,16 +1,16 @@
 <% if (isJekyll) { %>---
-title: tns resources-update
+title: tns resources update
 position: 9
 ---<% } %>
-#tns resources-update
+#tns resources update
 ==========
 
 Usage | Synopsis
 ------|-------
-`$ tns resources-update` | Defaults to executing `$ tns resources-update android`. Updates the App_Resources/Android's folder structure.
-`$ tns resources-update android` | Updates the App_Resources/Android's folder structure.
+`$ tns resources update` | Defaults to executing `$ tns resources update android`. Updates the App_Resources/Android's folder structure.
+`$ tns resources update android` | Updates the App_Resources/Android's folder structure.
 
-Updates the App_Resources/<platform>'s internal folder structure to conform to that of an Android project. Android resource files and directories will be located at the following paths:
+Updates the App_Resources/<platform>'s internal folder structure to conform to that of an Android Studio project. Android resource files and directories will be located at the following paths:
 - `drawable-*`, `values`, `raw`, etc. can be found at  `App_Resources/Android/src/main/res` 
 - `AndroidManifest.xml` can be found at `App_Resources/Android/src/main/AndroidManifest.xml`
 - Java source files can be dropped in at `App_Resources/Android/src/main/java` after creating the proper package subdirectory structure

--- a/docs/man_pages/project/configuration/update.md
+++ b/docs/man_pages/project/configuration/update.md
@@ -22,3 +22,4 @@ Command | Description
 [platform](platform.html) | Lists all platforms that the project currently targets.
 [prepare](prepare.html) | Copies common and relevant platform-specific content from the app directory to the subdirectory for the selected target platform in the platforms directory.
 [platform update](platform-update.html) | Updates the NativeScript runtime for the specified platform.
+[resources-update android](resources-update.html) | Updates the App_Resources/Android directory to the new v4.0 directory structure

--- a/docs/man_pages/project/configuration/update.md
+++ b/docs/man_pages/project/configuration/update.md
@@ -22,4 +22,4 @@ Command | Description
 [platform](platform.html) | Lists all platforms that the project currently targets.
 [prepare](prepare.html) | Copies common and relevant platform-specific content from the app directory to the subdirectory for the selected target platform in the platforms directory.
 [platform update](platform-update.html) | Updates the NativeScript runtime for the specified platform.
-[resources-update android](resources-update.html) | Updates the App_Resources/Android directory to the new v4.0 directory structure
+[resources update android](resources-update.html) | Updates the App_Resources/Android directory to the new v4.0 directory structure

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -107,6 +107,9 @@ $injector.requireCommand("init", "./commands/init");
 $injector.require("infoService", "./services/info-service");
 $injector.requireCommand("info", "./commands/info");
 
+$injector.require("androidResourcesMigrationService", "./services/android-resources-migration-service");
+$injector.requireCommand("resources|update", "./commands/resources/resources-update");
+
 $injector.require("androidToolsInfo", "./android-tools-info");
 $injector.require("devicePathProvider", "./device-path-provider");
 

--- a/lib/commands/resources/resources-update.ts
+++ b/lib/commands/resources/resources-update.ts
@@ -1,0 +1,34 @@
+export class ResourcesUpdateCommand implements ICommand {
+	public allowedParameters: ICommandParameter[] = [];
+
+	constructor(private $projectData: IProjectData,
+		private $errors: IErrors,
+		private $androidResourcesMigrationService: IAndroidResourcesMigrationService) {
+		this.$projectData.initializeProjectData();
+	}
+
+	public async execute(args: string[]): Promise<void> {
+		await this.$androidResourcesMigrationService.migrate(this.$projectData.getAppResourcesDirectoryPath());
+	}
+
+	public async canExecute(args: string[]): Promise<boolean> {
+		if (!args || args.length === 0) {
+			// Command defaults to migrating the Android App_Resources, unless explicitly specified
+			args = ["android"];
+		}
+
+		for (const platform of args) {
+			if (!this.$androidResourcesMigrationService.canMigrate(platform)) {
+				this.$errors.failWithoutHelp(`The ${platform} does not need to have its resources updated.`);
+			}
+
+			if (this.$androidResourcesMigrationService.hasMigrated(this.$projectData.getAppResourcesDirectoryPath())) {
+				this.$errors.failWithoutHelp("The App_Resources have already been updated for the Android platform.");
+			}
+		}
+
+		return true;
+	}
+}
+
+$injector.registerCommand("resources|update", ResourcesUpdateCommand);

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -497,6 +497,12 @@ interface IInfoService {
 	printComponentsInfo(): Promise<void>;
 }
 
+interface IAndroidResourcesMigrationService {
+	canMigrate(platformString: string): boolean;
+	hasMigrated(appResourcesDir: string): boolean;
+	migrate(appResourcesDir: string): Promise<void>;
+}
+
 /**
  * Describes properties needed for uploading a package to iTunes Connect
  */

--- a/lib/services/android-resources-migration-service.ts
+++ b/lib/services/android-resources-migration-service.ts
@@ -1,0 +1,75 @@
+import * as path from "path";
+import * as shell from "shelljs";
+import * as constants from "../constants";
+
+export class AndroidResourcesMigrationService implements IAndroidResourcesMigrationService {
+	private static ANDROID_DIR = "Android";
+	private static ANDROID_DIR_TEMP = "Android-Updated";
+	private static ANDROID_DIR_OLD = "Android-Pre-v4";
+
+	constructor(private $fs: IFileSystem,
+		private $logger: ILogger,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+
+	public canMigrate(platformString: string): boolean {
+		return platformString.toLowerCase() === this.$devicePlatformsConstants.Android.toLowerCase();
+	}
+
+	public hasMigrated(appResourcesDir: string): boolean {
+		return this.$fs.exists(path.join(appResourcesDir, AndroidResourcesMigrationService.ANDROID_DIR, constants.SRC_DIR, constants.MAIN_DIR));
+	}
+
+	public async migrate(appResourcesDir: string): Promise<void> {
+		const originalAppResources = path.join(appResourcesDir, AndroidResourcesMigrationService.ANDROID_DIR);
+		const appResourcesDestination = path.join(appResourcesDir, AndroidResourcesMigrationService.ANDROID_DIR_TEMP);
+		const appMainSourceSet = path.join(appResourcesDestination, constants.SRC_DIR, constants.MAIN_DIR);
+		const appResourcesMainSourceSetResourcesDestination = path.join(appMainSourceSet, constants.RESOURCES_DIR);
+
+		this.$fs.ensureDirectoryExists(appResourcesDestination);
+		this.$fs.ensureDirectoryExists(appMainSourceSet);
+		// create /java, /res and /assets in the App_Resources/Android/src/main directory
+		this.$fs.ensureDirectoryExists(appResourcesMainSourceSetResourcesDestination);
+		this.$fs.ensureDirectoryExists(path.join(appMainSourceSet, "java"));
+		this.$fs.ensureDirectoryExists(path.join(appMainSourceSet, constants.ASSETS_DIR));
+
+		const isDirectory = (source: string) => this.$fs.getLsStats(source).isDirectory();
+		const getAllFiles = (source: string) => this.$fs.readDirectory(source).map(name => path.join(source, name));
+		const getDirectories = (files: string[]) => files.filter(isDirectory);
+		const getFiles = (files: string[]) => files.filter((file: string) => !isDirectory(file));
+
+		this.$fs.copyFile(path.join(originalAppResources, "app.gradle"), path.join(appResourcesDestination, "app.gradle"));
+
+		const appResourcesFiles = getAllFiles(originalAppResources);
+		const resourceDirectories = getDirectories(appResourcesFiles);
+		const resourceFiles = getFiles(appResourcesFiles);
+
+		resourceDirectories.forEach(dir => {
+			if (path.basename(dir) !== "libs") {
+				// don't copy /App_Resources/Android/libs into the src/main/res/libs directory
+				this.$fs.copyFile(dir, appResourcesMainSourceSetResourcesDestination);
+			} else {
+				// copy App_Resources/Android/libs to App_ResourcesNew/Android/libs
+				this.$fs.copyFile(dir, path.join(appResourcesDestination));
+			}
+		});
+
+		resourceFiles.forEach(file => {
+			const fileName = path.basename(file);
+			if (fileName !== constants.MANIFEST_FILE_NAME) {
+				// don't copy AndroidManifest into /App_Resources/Android as it needs to be inside src/main/
+				this.$fs.copyFile(file, path.join(appResourcesDestination, fileName));
+			}
+		});
+
+		this.$fs.copyFile(path.join(originalAppResources, constants.MANIFEST_FILE_NAME), path.join(appMainSourceSet, constants.MANIFEST_FILE_NAME));
+
+		// rename the legacy app_resources to ANDROID_DIR_OLD
+		shell.mv(originalAppResources, path.join(appResourcesDir, AndroidResourcesMigrationService.ANDROID_DIR_OLD));
+		// move the new, updated app_resources to App_Resources/Android, as  the de facto resources
+		shell.mv(appResourcesDestination, originalAppResources);
+
+		this.$logger.out(`Successfully updated your project's application resources '/Android' directory structure.\nThe previous version of your Android application resources has been renamed to '/${AndroidResourcesMigrationService.ANDROID_DIR_OLD}'`);
+	}
+}
+
+$injector.register("androidResourcesMigrationService", AndroidResourcesMigrationService);

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -78,6 +78,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("settingsService", SettingsService);
 	testInjector.register("androidPluginBuildService", stubs.AndroidPluginBuildServiceStub);
 	testInjector.register("platformEnvironmentRequirements", {});
+	testInjector.register("androidResourcesMigrationService", stubs.AndroidResourcesMigrationServiceStub);
 
 	return testInjector;
 }

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -97,6 +97,7 @@ function createTestInjector(): IInjector {
 		})
 	});
 	testInjector.register("httpClient", {});
+	testInjector.register("androidResourcesMigrationService", stubs.AndroidResourcesMigrationServiceStub);
 
 	return testInjector;
 }

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -103,6 +103,7 @@ function createTestInjector() {
 			message: (): void => undefined
 		})
 	});
+	testInjector.register("androidResourcesMigrationService", stubs.AndroidResourcesMigrationServiceStub);
 
 	return testInjector;
 }

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -116,6 +116,7 @@ function createTestInjector() {
 	testInjector.register("analyticsSettingsService", {
 		getPlaygroundInfo: () => Promise.resolve(null)
 	});
+	testInjector.register("androidResourcesMigrationService", stubs.AndroidResourcesMigrationServiceStub);
 
 	testInjector.register("platformEnvironmentRequirements", {});
 	return testInjector;

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -811,3 +811,15 @@ export class EmulatorPlatformService implements IEmulatorPlatformService {
 		return Promise.resolve();
 	}
 }
+
+export class AndroidResourcesMigrationServiceStub implements IAndroidResourcesMigrationService {
+	canMigrate(platformString: string): boolean {
+		return true;
+	}
+	hasMigrated(appResourcesDir: string): boolean {
+		return false;
+	}
+	migrate(appResourcesDir: string): Promise<void> {
+		return Promise.resolve();
+	}
+}


### PR DESCRIPTION
Introduce the 'tns resources-update android' command. By design, upon execution it should migrate the directory structure of App_Resources/Android to the new v4 structure - the one that supports the inclusion of java source files, arbitrary assets, and any resource files in the App_Resources/Android/src/main directory structure. Additional, user-defined flavors can also be created taking advantage of the new dir structure.
