### PR TITLE
fix(CLI): Increase inspector installer memory buffer.

### DIFF
--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -79,7 +79,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		}
 
 		if (shouldInstall) {
-			await this.$childProcess.exec(`npm install ${inspectorNpmPackageName}@${version} --prefix ${cachePath}`);
+			await this.$childProcess.exec(`npm install ${inspectorNpmPackageName}@${version} --prefix ${cachePath}`, { maxBuffer: 250 * 1024 });
 		}
 
 		this.$logger.out("Using inspector from cache.");


### PR DESCRIPTION
This addresses an out-of-memory problem with the installation of the tns-ios-inspector module from @next. There is a `maxBuffer` size allowed for the `stdout` or `stderr` of the child process. It seems with the updated inspector sources we exceed that. The default `maxBuffer` size is `200 * 1024` bytes according to NodeJS' docs. 50KB more seem to resolve the problem.