### PR TITLE
refactor(livesync): speedup livesync

### DIFF
--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -60,6 +60,7 @@ export class PublishIOS implements ICommand {
 			const platformInfo: IPreparePlatformInfo = {
 				platform,
 				appFilesUpdaterOptions,
+				skipModulesNativeCheck: !this.$options.syncAllFiles,
 				platformTemplate: this.$options.platformTemplate,
 				projectData: this.$projectData,
 				config: this.$options,

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -18,6 +18,7 @@ export class BuildCommandBase extends BundleBase {
 		const platformInfo: IPreparePlatformInfo = {
 			platform,
 			appFilesUpdaterOptions,
+			skipModulesNativeCheck: !this.$options.syncAllFiles,
 			platformTemplate: this.$options.platformTemplate,
 			projectData: this.$projectData,
 			config: this.$options,

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -14,6 +14,7 @@ export class PrepareCommand implements ICommand {
 		const platformInfo: IPreparePlatformInfo = {
 			platform: args[0],
 			appFilesUpdaterOptions,
+			skipModulesNativeCheck: !this.$options.syncAllFiles,
 			platformTemplate: this.$options.platformTemplate,
 			projectData: this.$projectData,
 			config: this.$options,

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -152,7 +152,7 @@ interface IProjectDataComposition {
 /**
  * Desribes object that can be passed to ensureLatestAppPackageIsInstalledOnDevice method.
  */
-interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions extends IProjectDataComposition, IEnvOptions, IBundle, IRelease {
+interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions extends IProjectDataComposition, IEnvOptions, IBundle, IRelease, ISkipNativeCheckOptional {
 	device: Mobile.IDevice;
 	preparedPlatforms: string[];
 	rebuiltInformation: ILiveSyncBuildInfo[];

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -296,7 +296,7 @@ interface IPlatformDataComposition {
 	platformData: IPlatformData;
 }
 
-interface ICopyAppFilesData extends IProjectDataComposition, IAppFilesUpdaterOptionsComposition, IPlatformDataComposition { }
+interface ICopyAppFilesData extends IProjectDataComposition, IAppFilesUpdaterOptionsComposition, IPlatformDataComposition, IOptionalFilesToSync { }
 
 interface IPreparePlatformService {
 	addPlatform(info: IAddPlatformInfo): Promise<void>;
@@ -319,14 +319,17 @@ interface IPreparePlatformCoreInfo extends IPreparePlatformInfoBase {
 	changesInfo?: IProjectChangesInfo;
 }
 
-interface IPreparePlatformInfo extends IPreparePlatformInfoBase, IPlatformConfig, IPlatformTemplate { }
+interface IPreparePlatformInfo extends IPreparePlatformInfoBase, IPlatformConfig, IPlatformTemplate, ISkipNativeCheckOptional { }
 
 interface IPlatformConfig {
 	config: IPlatformOptions;
 }
 
-interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions {
+interface IOptionalFilesToSync {
 	filesToSync?: string[];
+}
+
+interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync {
 	nativePrepare?: INativePrepare;
 }
 

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -23,7 +23,17 @@ interface IProjectChangesInfo extends IAddedNativePlatform {
 	readonly changesRequirePrepare: boolean;
 }
 
-interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision, ITeamIdentifier {
+/**
+ * Describes interface for controlling checking node_modules for native changes.
+ */
+interface ISkipNativeCheckOptional {
+	/**
+	 * Designates node_modules should not be checked for native changes.
+	 */
+	skipModulesNativeCheck?: boolean;
+}
+
+interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision, ITeamIdentifier, ISkipNativeCheckOptional {
 	nativePlatformStatus?: "1" | "2" | "3";
 }
 

--- a/lib/services/app-files-updater.ts
+++ b/lib/services/app-files-updater.ts
@@ -4,17 +4,15 @@ import * as constants from "../constants";
 import * as fs from "fs";
 
 export class AppFilesUpdater {
-	constructor(
-		private appSourceDirectoryPath: string,
+	constructor(private appSourceDirectoryPath: string,
 		private appDestinationDirectoryPath: string,
 		public options: IAppFilesUpdaterOptions,
 		public fs: IFileSystem
 	) {
 	}
 
-	public updateApp(beforeCopyAction: (sourceFiles: string[]) => void): void {
-		this.cleanDestinationApp();
-		const sourceFiles = this.resolveAppSourceFiles();
+	public updateApp(beforeCopyAction: (sourceFiles: string[]) => void, filesToSync?: string[]): void {
+		const sourceFiles = filesToSync || this.resolveAppSourceFiles();
 
 		beforeCopyAction(sourceFiles);
 		this.copyAppSourceFiles(sourceFiles);

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -370,6 +370,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				nativePrepare: nativePrepare,
 				filesToSync: options.modifiedFiles,
 				platformTemplate: null,
+				skipModulesNativeCheck: options.skipModulesNativeCheck,
 				config: platformSpecificOptions
 			};
 
@@ -459,6 +460,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					deviceBuildInfoDescriptor,
 					liveSyncData,
 					settings,
+					skipModulesNativeCheck: !liveSyncData.watchAllFiles,
 					bundle: liveSyncData.bundle,
 					release: liveSyncData.release,
 					env: liveSyncData.env
@@ -568,7 +570,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 										modifiedFiles: allModifiedFiles,
 										bundle: liveSyncData.bundle,
 										release: liveSyncData.release,
-										env: liveSyncData.env
+										env: liveSyncData.env,
+										skipModulesNativeCheck: !liveSyncData.watchAllFiles
 									}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
 									const service = this.getLiveSyncService(device.deviceInfo.platform);

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -190,7 +190,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	public async preparePlatform(platformInfo: IPreparePlatformInfo): Promise<boolean> {
 		const platformData = this.$platformsData.getPlatformData(platformInfo.platform, platformInfo.projectData);
 
-		const changesInfo = await this.initialPrepare(platformInfo.platform, platformData, platformInfo.appFilesUpdaterOptions, platformInfo.platformTemplate, platformInfo.projectData, platformInfo.config, platformInfo.nativePrepare);
+		const changesInfo = await this.initialPrepare(platformInfo.platform, platformData, platformInfo.appFilesUpdaterOptions, platformInfo.platformTemplate, platformInfo.projectData, platformInfo.config, platformInfo.nativePrepare, platformInfo);
 		const requiresNativePrepare = (!platformInfo.nativePrepare || !platformInfo.nativePrepare.skipNativePrepare) && changesInfo.nativePlatformStatus === constants.NativePlatformStatus.requiresPrepare;
 
 		if (changesInfo.hasChanges || platformInfo.appFilesUpdaterOptions.bundle || requiresNativePrepare) {
@@ -237,7 +237,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	private async initialPrepare(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, nativePrepare?: INativePrepare): Promise<IProjectChangesInfo> {
+	private async initialPrepare(platform: string, platformData: IPlatformData, appFilesUpdaterOptions: IAppFilesUpdaterOptions, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, nativePrepare?: INativePrepare, skipNativeCheckOptions?: ISkipNativeCheckOptional): Promise<IProjectChangesInfo> {
 		this.validatePlatform(platform, projectData);
 
 		await this.trackProjectType(projectData);
@@ -254,7 +254,14 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const bundle = appFilesUpdaterOptions.bundle;
 		const nativePlatformStatus = (nativePrepare && nativePrepare.skipNativePrepare) ? constants.NativePlatformStatus.requiresPlatformAdd : constants.NativePlatformStatus.requiresPrepare;
-		const changesInfo = await this.$projectChangesService.checkForChanges(platform, projectData, { bundle, release: appFilesUpdaterOptions.release, provision: config.provision, teamId: config.teamId, nativePlatformStatus });
+		const changesInfo = await this.$projectChangesService.checkForChanges(platform, projectData, {
+			bundle,
+			release: appFilesUpdaterOptions.release,
+			provision: config.provision,
+			teamId: config.teamId,
+			nativePlatformStatus,
+			skipModulesNativeCheck: skipNativeCheckOptions.skipModulesNativeCheck
+		});
 
 		this.$logger.trace("Changes info in prepare platform:", changesInfo);
 		return changesInfo;

--- a/lib/services/prepare-platform-service.ts
+++ b/lib/services/prepare-platform-service.ts
@@ -25,6 +25,6 @@ export class PreparePlatformService {
 		const appUpdater = new AppFilesUpdater(appSourceDirectoryPath, appDestinationDirectoryPath, copyAppFilesData.appFilesUpdaterOptions, this.$fs);
 		appUpdater.updateApp(sourceFiles => {
 			this.$xmlValidator.validateXmlFiles(sourceFiles);
-		});
+		}, copyAppFilesData.filesToSync);
 	}
 }

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -63,8 +63,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			this._changesInfo.appFilesChanged = this.containsNewerFiles(projectData.appDirectoryPath, projectData.appResourcesDirectoryPath, projectData);
 			this._changesInfo.packageChanged = this.isProjectFileChanged(projectData, platform);
 			this._changesInfo.appResourcesChanged = this.containsNewerFiles(projectData.appResourcesDirectoryPath, null, projectData);
-			/*done because currently all node_modules are traversed, a possible improvement could be traversing only the production dependencies*/
-			this._changesInfo.nativeChanged = this.containsNewerFiles(
+			this._changesInfo.nativeChanged = projectChangesOptions.skipModulesNativeCheck ? false : this.containsNewerFiles(
 				path.join(projectData.projectDir, NODE_MODULES_FOLDER_NAME),
 				path.join(projectData.projectDir, NODE_MODULES_FOLDER_NAME, "tns-ios-inspector"),
 				projectData,

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -60,6 +60,7 @@ class TestExecutionService implements ITestExecutionService {
 					const preparePlatformInfo: IPreparePlatformInfo = {
 						platform,
 						appFilesUpdaterOptions,
+						skipModulesNativeCheck: !this.$options.syncAllFiles,
 						platformTemplate: this.$options.platformTemplate,
 						projectData,
 						config: this.$options,
@@ -187,6 +188,7 @@ class TestExecutionService implements ITestExecutionService {
 				const preparePlatformInfo: IPreparePlatformInfo = {
 					platform,
 					appFilesUpdaterOptions,
+					skipModulesNativeCheck: !this.$options.syncAllFiles,
 					platformTemplate: this.$options.platformTemplate,
 					projectData,
 					config: this.$options,


### PR DESCRIPTION
Speedup LiveSync with the following optimizations:
* Upon a file change **do not check all of node_modules for changes** unless `--syncAllFiles` is passed. This was unnecessary and leads to a **2 s delay** in angular projects
* With the previous implementation, whenever a file change was detected CLI used to delete all files in `platforms/.../app` directory, then **copy all files from the project's app directory** and then **only upload the changed ones**. Change the implementation so that **only changed files are copied and uploaded**.

Ping @rosen-vladimirov @KristianDD 