### PR TITLE
refactor: add logic for finding apk name

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -106,16 +106,14 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	private getDeviceBuildOutputPath(currentPath: string, projectData: IProjectData): string {
-		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME),
-			platformVersion = currentPlatformData && currentPlatformData[constants.VERSION_STRING],
-			normalizedPath = path.join(currentPath, "debug");
+		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME);
+		const platformVersion = currentPlatformData && currentPlatformData[constants.VERSION_STRING];
+		const normalizedPath = path.join(currentPath, "debug");
 
 		if (semver.valid(platformVersion)) {
 			const gradleAndroidPluginVersion3xx = "4.0.0";
 			const normalizedPlatformVersion = `${semver.major(platformVersion)}.${semver.minor(platformVersion)}.0`;
-			if (semver.gte(normalizedPlatformVersion, gradleAndroidPluginVersion3xx)) {
-				return normalizedPath;
-			} else {
+			if (semver.lt(normalizedPlatformVersion, gradleAndroidPluginVersion3xx)) {
 				return currentPath;
 			}
 		}

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -106,22 +106,21 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	private getDeviceBuildOutputPath(currentPath: string, projectData: IProjectData): string {
-		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME);
-		const platformVersion = currentPlatformData && currentPlatformData[constants.VERSION_STRING];
+		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME),
+			platformVersion = currentPlatformData && currentPlatformData[constants.VERSION_STRING],
+			normalizedPath = path.join(currentPath, "debug");
 
-		if (!platformVersion ||
-			platformVersion === constants.PackageVersion.NEXT ||
-			platformVersion === constants.PackageVersion.LATEST) {
-			return currentPath;
+		if (semver.valid(platformVersion)) {
+			const gradleAndroidPluginVersion3xx = "4.0.0";
+			const normalizedPlatformVersion = `${semver.major(platformVersion)}.${semver.minor(platformVersion)}.0`;
+			if (semver.gte(normalizedPlatformVersion, gradleAndroidPluginVersion3xx)) {
+				return normalizedPath;
+			} else {
+				return currentPath;
+			}
 		}
 
-		const gradleAndroidPluginVersion3xx = "4.0.0";
-		const normalizedPlatformVersion = `${semver.major(platformVersion)}.${semver.minor(platformVersion)}.0`;
-
-		if (semver.gte(normalizedPlatformVersion, gradleAndroidPluginVersion3xx)) {
-			return path.join(currentPath, "debug");
-		}
-		return currentPath;
+		return normalizedPath;
 	}
 
 	// TODO: Remove prior to the 4.0 CLI release @Pip3r4o @PanayotCankov


### PR DESCRIPTION
With the [update of the android plugin for gradle to `3.0.1`](https://github.com/NativeScript/android-runtime/issues/938) there's a breaking change in the folder structure where the CLI searches for the application file:

old search path: `<project_name>/platforms/android/app/build/outputs/apk/`
new search path: `<project_name>/platforms/android/app/build/outputs/apk/debug/`

Another change will also be introduced in the `tns-android@4.0.0` project template which will stop renaming the final application file:

old default name: `<project-name>-<build-version>[-abi].apk`
new default name: `app-<build-version>.apk`

This PR handles both scenarios and is backward compatible.