### PR TITLE
docs: update build instructions in readme and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ Before you submit a Pull Request, consider the following guidelines.
 ```bash
     git clone git@github.com:NativeScript/nativescript-cli.git
 ```
+* Install the node dependencies.
+```bash
+    npm install --ignore-scripts
+```
 * Initialize the submodule.
 ```bash
     git submodule init
@@ -57,15 +61,15 @@ Before you submit a Pull Request, consider the following guidelines.
 * Create your patch and include appropriate test cases.
 * Build your changes locally.
 ```bash
-    grunt
+    ./node_modules/.bin/grunt
 ```
 * Ensure all the tests pass.
 ```bash
-    grunt test
+    ./node_modules/.bin/grunt test
 ```
 * Ensure that your code passes the linter.
 ```bash
-    grunt lint
+    ./node_modules/.bin/grunt lint
 ```
 * Commit your changes and create a descriptive commit message (the commit message is used to generate release notes).
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,17 +42,9 @@ Before you submit a Pull Request, consider the following guidelines.
 ```bash
     git clone git@github.com:NativeScript/nativescript-cli.git
 ```
-* Install the node dependencies.
+* Run the setup script. This will initialize the git submodule, install the node dependencies and build with grunt.
 ```bash
-    npm install --ignore-scripts
-```
-* Initialize the submodule.
-```bash
-    git submodule init
-```
-* Fetch data from the submodule.
-```bash
-    git submodule update
+    npm run setup
 ```
 * Make your changes in a new `git` branch. We use the <a href="http://nvie.com/posts/a-successful-git-branching-model/">Gitflow branching model</a> so you will have to branch from our master branch.
 ```bash

--- a/README.md
+++ b/README.md
@@ -432,8 +432,8 @@ How to Build
 git clone https://github.com/NativeScript/nativescript-cli
 cd nativescript-cli
 git submodule update --init
-npm install
-grunt
+npm install --ignore-scripts
+./node_modules/.bin/grunt
 ```
 
 To use the locally built CLI instead `tns` you can call `PATH_TO_CLI_FOLDER/bin/tns`. For example:

--- a/README.md
+++ b/README.md
@@ -431,9 +431,7 @@ How to Build
 ```
 git clone https://github.com/NativeScript/nativescript-cli
 cd nativescript-cli
-git submodule update --init
-npm install --ignore-scripts
-./node_modules/.bin/grunt
+npm run setup
 ```
 
 To use the locally built CLI instead `tns` you can call `PATH_TO_CLI_FOLDER/bin/tns`. For example:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "main": "./lib/nativescript-cli-lib.js",
   "scripts": {
+    "setup": "git submodule update --init && npm i --ignore-scripts && ./node_modules/.bin/grunt",
     "test": "node test-scripts/istanbul.js",
     "postinstall": "node postinstall.js",
     "preuninstall": "node preuninstall.js",


### PR DESCRIPTION
The initial `npm install` in the repo is reporting errors because of the postinstall script, which expects that the 'ts' files are already transpiled. Maybe we should suggest running it with `--ignore-scripts`?
The other change is running grunt from the local installation of the package, because you may not have a global instance. Maybe the grunt invocation can be moved to a npm script?