### PR TITLE
fix(livesync): dispose when stopping livesync

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -632,7 +632,7 @@ interface IProjectNameService {
 	 * @param {IOptions} current command options.
 	 * @return {Promise<strng>} returns the selected name of the project.
 	 */
-	ensureValidName(projectName: string, validateOptions?: { force: boolean }): Promise<string>;
+	ensureValidName(projectName: string, validateOptions?: IForceOption): Promise<string>;
 }
 
 /**

--- a/lib/services/analytics/analytics-service.ts
+++ b/lib/services/analytics/analytics-service.ts
@@ -104,8 +104,8 @@ export class AnalyticsService extends AnalyticsServiceBase {
 		await this.trackInGoogleAnalytics(googleAnalyticsEventData);
 	}
 
-	public dispose(): void {
-		if (this.brokerProcess && this.shouldDisposeInstance) {
+	public dispose(disposeOptions?: IForceOption): void {
+		if (this.brokerProcess && (disposeOptions && disposeOptions.force || this.shouldDisposeInstance)) {
 			this.brokerProcess.disconnect();
 		}
 	}

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -91,6 +91,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				// In case we are stopping the LiveSync we must set usbLiveSyncService.isInitialized to false,
 				// as in case we execute nativescript-dev-typescript's before-prepare hook again in the same process, it MUST transpile the files.
 				this.$usbLiveSyncService.isInitialized = false;
+				// After stopping LiveSync we need to dispose of everything in order for the process to end and release all resources
+				this.$injector.dispose({ force: true });
 			} else if (liveSyncProcessInfo.currentSyncAction && shouldAwaitPendingOperation) {
 				await liveSyncProcessInfo.currentSyncAction;
 			}

--- a/lib/services/project-name-service.ts
+++ b/lib/services/project-name-service.ts
@@ -6,7 +6,7 @@ export class ProjectNameService implements IProjectNameService {
 		private $logger: ILogger,
 		private $prompter: IPrompter) { }
 
-	public async ensureValidName(projectName: string, validateOptions?: { force: boolean }): Promise<string> {
+	public async ensureValidName(projectName: string, validateOptions?: IForceOption): Promise<string> {
 		if (validateOptions && validateOptions.force) {
 			return projectName;
 		}
@@ -41,7 +41,7 @@ export class ProjectNameService implements IProjectNameService {
 		return startsWithLetterExpression.test(projectName);
 	}
 
-	private async promptForNewName(warningMessage: string, projectName: string, validateOptions?: { force: boolean }): Promise<string> {
+	private async promptForNewName(warningMessage: string, projectName: string, validateOptions?: IForceOption): Promise<string> {
 		if (await this.promptForForceNameConfirm(warningMessage)) {
 			return projectName;
 		}


### PR DESCRIPTION
Whenever LiveSync fails to launch for the first time CLI doesn't break process execution because there are hanging child processes (ios-device detection, analytics).

If this is the case, force dispose those resources.

Fixes: https://github.com/NativeScript/nativescript-cli/issues/3375

Ping @rosen-vladimirov 