### PR TITLE
fix(log-filtering): Fix wrongly filtering out multiline output.

### DIFF
--- a/lib/services/ios-log-filter.ts
+++ b/lib/services/ios-log-filter.ts
@@ -46,9 +46,9 @@ export class IOSLogFilter extends iOSLogFilterBase.IOSLogFilter implements Mobil
 						line = line.replace(pidRegex, "").trim();
 						this.getOriginalFileLocation(line);
 						result += this.getOriginalFileLocation(line) + "\n";
+					} else if (!line.match(this.infoFilterRegex)) {
+						continue;
 					}
-
-					continue;
 				}
 				if (skipLastLine && i === lines.length - 1 && lines.length > 1) {
 					this.partialLine = line;


### PR DESCRIPTION
`console.log` messages are wrongly filtered out when there is a `pid` (in cases when the app is run on a Simulator). The reason for this is that we split the data by `\n` and look for `pid` in each line to output it. When `console.log/console.dir` is called with a multiline output, the first line only is shown.

This is not the case when running the app on a device. We do not have a `pid` then and filter out only based on tokens matched by the `infoFilterRegex` regular expression.