### PR TITLE
fix(livesync): delete files during livesync

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -152,7 +152,7 @@ interface IProjectDataComposition {
 /**
  * Desribes object that can be passed to ensureLatestAppPackageIsInstalledOnDevice method.
  */
-interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions extends IProjectDataComposition, IEnvOptions, IBundle, IRelease, ISkipNativeCheckOptional {
+interface IEnsureLatestAppPackageIsInstalledOnDeviceOptions extends IProjectDataComposition, IEnvOptions, IBundle, IRelease, ISkipNativeCheckOptional, IOptionalFilesToRemove, IOptionalFilesToSync {
 	device: Mobile.IDevice;
 	preparedPlatforms: string[];
 	rebuiltInformation: ILiveSyncBuildInfo[];

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -296,7 +296,7 @@ interface IPlatformDataComposition {
 	platformData: IPlatformData;
 }
 
-interface ICopyAppFilesData extends IProjectDataComposition, IAppFilesUpdaterOptionsComposition, IPlatformDataComposition, IOptionalFilesToSync { }
+interface ICopyAppFilesData extends IProjectDataComposition, IAppFilesUpdaterOptionsComposition, IPlatformDataComposition, IOptionalFilesToSync, IOptionalFilesToRemove { }
 
 interface IPreparePlatformService {
 	addPlatform(info: IAddPlatformInfo): Promise<void>;
@@ -329,10 +329,18 @@ interface IOptionalFilesToSync {
 	filesToSync?: string[];
 }
 
-interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync {
+interface IOptionalFilesToRemove {
+	filesToRemove?: string[];
+}
+
+interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync, IOptionalFilesToRemove {
 	nativePrepare?: INativePrepare;
 }
 
 interface IDeployPlatformInfo extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IPlatformConfig, IEnvOptions {
 	deployOptions: IDeployPlatformOptions
+}
+
+interface IUpdateAppOptions extends IOptionalFilesToSync, IOptionalFilesToRemove {
+	beforeCopyAction: (sourceFiles: string[]) => void;
 }

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -368,7 +368,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				projectData: options.projectData,
 				env: options.env,
 				nativePrepare: nativePrepare,
-				filesToSync: options.modifiedFiles,
+				filesToSync: options.filesToSync,
+				filesToRemove: options.filesToRemove,
 				platformTemplate: null,
 				skipModulesNativeCheck: options.skipModulesNativeCheck,
 				config: platformSpecificOptions
@@ -568,6 +569,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 										deviceBuildInfoDescriptor,
 										settings: latestAppPackageInstalledSettings,
 										modifiedFiles: allModifiedFiles,
+										filesToRemove: currentFilesToRemove,
+										filesToSync: currentFilesToSync,
 										bundle: liveSyncData.bundle,
 										release: liveSyncData.release,
 										env: liveSyncData.env,

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -209,6 +209,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				platformInfo.env,
 				changesInfo,
 				platformInfo.filesToSync,
+				platformInfo.filesToRemove,
 				platformInfo.nativePrepare,
 			);
 			this.$projectChangesService.savePrepareInfo(platformInfo.platform, platformInfo.projectData);
@@ -269,7 +270,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	/* Hooks are expected to use "filesToSync" parameter, as to give plugin authors additional information about the sync process.*/
 	@helpers.hook('prepare')
-	private async preparePlatformCore(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, env: Object, changesInfo?: IProjectChangesInfo, filesToSync?: string[], nativePrepare?: INativePrepare): Promise<void> {
+	private async preparePlatformCore(platform: string, appFilesUpdaterOptions: IAppFilesUpdaterOptions, projectData: IProjectData, platformSpecificData: IPlatformSpecificData, env: Object, changesInfo?: IProjectChangesInfo, filesToSync?: string[], filesToRemove?: string[], nativePrepare?: INativePrepare): Promise<void> {
 		this.$logger.out("Preparing project...");
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
@@ -283,6 +284,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			platformSpecificData,
 			changesInfo,
 			filesToSync,
+			filesToRemove,
 			env
 		});
 

--- a/lib/services/prepare-platform-service.ts
+++ b/lib/services/prepare-platform-service.ts
@@ -23,8 +23,13 @@ export class PreparePlatformService {
 		const appSourceDirectoryPath = path.join(copyAppFilesData.projectData.projectDir, constants.APP_FOLDER_NAME);
 
 		const appUpdater = new AppFilesUpdater(appSourceDirectoryPath, appDestinationDirectoryPath, copyAppFilesData.appFilesUpdaterOptions, this.$fs);
-		appUpdater.updateApp(sourceFiles => {
-			this.$xmlValidator.validateXmlFiles(sourceFiles);
-		}, copyAppFilesData.filesToSync);
+		const appUpdaterOptions: IUpdateAppOptions = {
+			beforeCopyAction: sourceFiles => {
+				this.$xmlValidator.validateXmlFiles(sourceFiles);
+			},
+			filesToSync: copyAppFilesData.filesToSync,
+			filesToRemove: copyAppFilesData.filesToRemove
+		};
+		appUpdater.updateApp(appUpdaterOptions);
 	}
 }


### PR DESCRIPTION
https://github.com/NativeScript/nativescript-cli/pull/3362 regressed deletion of files during LiveSync.
Fix this by implementing the following logic:
1. In case this is the first ever LiveSync (no file system watcher) clean the `app` directory located inside `platforms` and prepare all javascript files anew
1. In case this is an incremental LiveSync (an event from within the file system watcher) only delete the files that were actually deleted (e. g. `filesToRemove`)

Ping @rosen-vladimirov 