### PR TITLE
feat(extensibility): Add hint how to get access to a command from extension

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -32,6 +32,20 @@ interface INodePackageManager {
 	 * @return {Promise<string>}                The output of the uninstallation.
 	 */
 	search(filter: string[], config: IDictionary<string | boolean>): Promise<string>;
+
+	/**
+	 * Searches for npm packages in npms by keyword.
+	 * @param {string} keyword The keyword based on which the search action will be executed.
+	 * @returns {INpmsResult} The information about found npm packages.
+	 */
+	searchNpms(keyword: string): Promise<INpmsResult>;
+
+	/**
+	 * Gets information for a specified package from registry.npmjs.org.
+	 * @param {string} packageName The name of the package.
+	 * @returns {any} The full data from registry.npmjs.org for this package.
+	 */
+	getRegistryPackageData(packageName: string): Promise<any>;
 }
 
 interface INpmInstallationManager {
@@ -304,6 +318,57 @@ interface IDependencyData {
 	 * Dependencies of the current module.
 	 */
 	dependencies?: string[];
+}
+
+interface INpmsResult {
+	total: number;
+	results: INpmsSingleResultData[];
+}
+
+interface INpmsSingleResultData {
+	package: INpmsPackageData;
+	flags: INpmsFlags;
+	score: INpmsScore;
+	searchScore: number;
+}
+
+interface INpmsPackageData {
+	name: string;
+	// unscoped in case package is not in a scope
+	// scope name in case part of a scope "angular" for example for @angular/core
+	scope: string;
+	version: string;
+	description: string;
+	keywords: string[];
+	date: string;
+	links: { npm: string };
+	author: { name: string };
+	publisher: INpmsUser;
+	maintainers: INpmsUser[];
+}
+
+interface IUsername {
+	username: string;
+}
+
+interface INpmsUser extends IUsername {
+	email: string;
+}
+
+interface INpmsFlags {
+	unstable: boolean;
+	insecure: number;
+	// Describes the reason for deprecation.
+	deprecated: string;
+}
+
+interface INpmsScore {
+	final: number;
+	detail: {
+		quality: number;
+		popularity: number;
+		maintenance: number;
+	}
 }
 
 interface IStaticConfig extends Config.IStaticConfig { }

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -117,6 +117,7 @@ function createTestInjector(projectPath: string, projectName: string): IInjector
 	testInjector.register("npm", NodePackageManager);
 	testInjector.register("xCConfigService", XCConfigService);
 	testInjector.register("settingsService", SettingsService);
+	testInjector.register("httpClient", {});
 
 	return testInjector;
 }

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -96,6 +96,7 @@ function createTestInjector(): IInjector {
 			message: (): void => undefined
 		})
 	});
+	testInjector.register("httpClient", {});
 
 	return testInjector;
 }

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -160,6 +160,7 @@ function createTestInjector() {
 			message: (): void => undefined
 		})
 	});
+	testInjector.register("extensibilityService", {});
 
 	return testInjector;
 }

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -110,7 +110,8 @@ function createTestInjector() {
 			message: (): void => undefined
 		})
 	});
-
+	testInjector.register("httpClient", {});
+	testInjector.register("extensibilityService", {});
 	return testInjector;
 }
 

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -9,7 +9,6 @@ import * as ProjectHelperLib from "../lib/common/project-helper";
 import { StaticConfig } from "../lib/config";
 import * as NpmLib from "../lib/node-package-manager";
 import { NpmInstallationManager } from "../lib/npm-installation-manager";
-import * as HttpClientLib from "../lib/common/http-client";
 import { FileSystem } from "../lib/common/file-system";
 import * as path from "path";
 import temp = require("temp");
@@ -145,7 +144,7 @@ class ProjectIntegrationTest {
 
 		this.testInjector.register("npmInstallationManager", NpmInstallationManager);
 		this.testInjector.register("npm", NpmLib.NodePackageManager);
-		this.testInjector.register("httpClient", HttpClientLib.HttpClient);
+		this.testInjector.register("httpClient", {});
 
 		this.testInjector.register("options", Options);
 		this.testInjector.register("hostInfo", HostInfo);


### PR DESCRIPTION
In case user executes any command that is registered in extension, but this extension is not installed, they'll receive error:
`Unknown command ...`. Instead of showing this, it is better to tell them how to get access to this command.
In order to achieve this, implement a new logic in `extensibilityService` to find commands registered in all extensions. CLI searches npm (via npms API) for packages that have the keyword `nativescript:extension`.
After that, CLI gets the package.json of the latest version of each dependency (via registry.npmjs.org) and searches for nativescript key in it. In case it has nativescript key, CLI reads the commands value inside it. The value should be string array containg all commands registered in extension's bootstrap.
When user writes down a command that is not registered in CLI, we check if there's such command and in case it is found, CLI will instruct the user how to install the respective extension.
Same will happen in case user tries to access the help content of a command that is registered in extension.