### PR TITLE
fix(prepare): disregard app_resources's dir name when preparing in platforms/

### DIFF
--- a/lib/services/app-files-updater.ts
+++ b/lib/services/app-files-updater.ts
@@ -13,7 +13,12 @@ export class AppFilesUpdater {
 
 	public updateApp(updateAppOptions: IUpdateAppOptions, projectData: IProjectData): void {
 		this.cleanDestinationApp(updateAppOptions);
-		const sourceFiles = updateAppOptions.filesToSync || this.resolveAppSourceFiles(projectData);
+		let sourceFiles = updateAppOptions.filesToSync || this.resolveAppSourceFiles(projectData);
+
+		// exclude the app_resources directory from being enumerated
+		// for copying if it is present in the application sources dir
+		const appResourcesPathNormalized = path.normalize(projectData.appResourcesDirectoryPath + "\\");
+		sourceFiles = sourceFiles.filter(dirName => !path.normalize(dirName).startsWith(appResourcesPathNormalized));
 
 		updateAppOptions.beforeCopyAction(sourceFiles);
 		this.copyAppSourceFiles(sourceFiles);
@@ -75,11 +80,6 @@ export class AppFilesUpdater {
 		if (this.options.release) {
 			constants.LIVESYNC_EXCLUDED_FILE_PATTERNS.forEach(pattern => sourceFiles = sourceFiles.filter(file => !minimatch(file, pattern, { nocase: true })));
 		}
-
-		// exclude the app_resources directory from being enumerated
-		// for copying if it is present in the application sources dir
-		const appResourcesPathNormalized = path.normalize(projectData.appResourcesDirectoryPath);
-		sourceFiles = sourceFiles.filter(dirName => !path.normalize(dirName).startsWith(appResourcesPathNormalized));
 
 		return sourceFiles;
 	}

--- a/lib/services/prepare-platform-js-service.ts
+++ b/lib/services/prepare-platform-js-service.ts
@@ -42,7 +42,7 @@ export class PreparePlatformJSService extends PreparePlatformService implements 
 		if (config.changesInfo && !config.changesInfo.changesRequirePrepare) {
 			// remove the App_Resources folder from the app/assets as here we're applying other files changes.
 			const appDestinationDirectoryPath = path.join(config.platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
-			const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
+			const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, path.basename(config.projectData.appResourcesDirectoryPath));
 			if (this.$fs.exists(appResourcesDirectoryPath)) {
 				this.$fs.deleteDirectory(appResourcesDirectoryPath);
 			}
@@ -107,7 +107,7 @@ export class PreparePlatformJSService extends PreparePlatformService implements 
 		const appDestinationDirectoryPath = path.join(config.platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 		const appResourcesSourcePath = config.projectData.appResourcesDirectoryPath;
 
-		shell.cp("-Rf", appResourcesSourcePath, appDestinationDirectoryPath);
+		shell.cp("-Rf", appResourcesSourcePath, path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME));
 	}
 }
 

--- a/lib/services/prepare-platform-native-service.ts
+++ b/lib/services/prepare-platform-native-service.ts
@@ -63,6 +63,7 @@ export class PreparePlatformNativeService extends PreparePlatformService impleme
 	private copyAppResources(platformData: IPlatformData, projectData: IProjectData): void {
 		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 		const appResourcesDirectoryPath = path.join(appDestinationDirectoryPath, constants.APP_RESOURCES_FOLDER_NAME);
+
 		if (this.$fs.exists(appResourcesDirectoryPath)) {
 			platformData.platformProjectService.prepareAppResources(appResourcesDirectoryPath, projectData);
 			const appResourcesDestination = platformData.platformProjectService.getAppResourcesDestinationDirectoryPath(projectData);

--- a/test/app-files-updates.ts
+++ b/test/app-files-updates.ts
@@ -7,7 +7,7 @@ require("should");
 function createTestInjector(): IInjector {
 	const testInjector = new yok.Yok();
 
-	testInjector.register("projectData", { appResourcesDirectoryPath: "App_Resources"});
+	testInjector.register("projectData", { appResourcesDirectoryPath: "App_Resources" });
 
 	return testInjector;
 }
@@ -71,7 +71,7 @@ describe("App files copy", () => {
 
 	it("copies all app files but app_resources when not bundling", () => {
 		const updater = new CopyAppFilesUpdater([
-			"file1", "dir1/file2", "App_Resources/Android/blah.png"
+			"file1", "dir1/file2"
 		], { bundle: false });
 		updater.copy();
 		assert.deepEqual(["file1", "dir1/file2"], updater.copiedDestinationItems);


### PR DESCRIPTION
patches https://github.com/NativeScript/nativescript-cli/pull/3356

addresses #3400 and #3401 