### PR TITLE
feat(create): Keep pluginsData key from template's package.json

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -41,7 +41,7 @@ export class LiveSyncTrackActionNames {
 	static DEVICE_INFO = `Device Info for ${liveSyncOperation}`;
 }
 
-export const PackageJsonKeysToKeep: Array<String> = ["name", "main", "android", "version"];
+export const PackageJsonKeysToKeep: Array<String> = ["name", "main", "android", "version", "pluginsData"];
 
 export class SaveOptions {
 	static PRODUCTION = "save";


### PR DESCRIPTION
In case project template has a preconfigured plugins data (for example API keys), it will be stored in the template's package.json.
After creating the project, CLI removes all keys except the one defined in `PackageJsonKeysToKeep` array from `app/package.json` file.
So it removes the predefined configuration of the pluginData.
Fix this by adding the entry "pluginsData" in the array, so we'll keep it as well.