### PR TITLE
fix(livesync): respect rapid file changes

### DIFF
--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -58,7 +58,7 @@ export abstract class PlatformLiveSyncServiceBase {
 		const syncInfo = _.merge<IFullSyncInfo>({ device, watch: true }, liveSyncInfo);
 		const deviceAppData = await this.getAppData(syncInfo);
 
-		const modifiedLocalToDevicePaths: Mobile.ILocalToDevicePathData[] = [];
+		let modifiedLocalToDevicePaths: Mobile.ILocalToDevicePathData[] = [];
 		if (liveSyncInfo.filesToSync.length) {
 			const filesToSync = liveSyncInfo.filesToSync;
 			const mappedFiles = _.map(filesToSync, filePath => this.$projectFilesProvider.mapFilePath(filePath, device.deviceInfo.platform, projectData));
@@ -77,7 +77,7 @@ export abstract class PlatformLiveSyncServiceBase {
 				const localToDevicePaths = await this.$projectFilesManager.createLocalToDevicePaths(deviceAppData,
 					projectFilesPath, existingFiles, []);
 				modifiedLocalToDevicePaths.push(...localToDevicePaths);
-				await this.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, false);
+				modifiedLocalToDevicePaths = await this.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, false);
 			}
 		}
 
@@ -105,11 +105,11 @@ export abstract class PlatformLiveSyncServiceBase {
 	}
 
 	protected async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean): Promise<Mobile.ILocalToDevicePathData[]> {
-		let transferredFiles = localToDevicePaths;
+		let transferredFiles: Mobile.ILocalToDevicePathData[] = [];
 		if (isFullSync) {
 			transferredFiles = await deviceAppData.device.fileSystem.transferDirectory(deviceAppData, localToDevicePaths, projectFilesPath);
 		} else {
-			await deviceAppData.device.fileSystem.transferFiles(deviceAppData, localToDevicePaths);
+			transferredFiles = await deviceAppData.device.fileSystem.transferFiles(deviceAppData, localToDevicePaths);
 		}
 
 		this.logFilesSyncInformation(transferredFiles, "Successfully transferred %s.", this.$logger.info);

--- a/lib/services/prepare-platform-service.ts
+++ b/lib/services/prepare-platform-service.ts
@@ -26,9 +26,13 @@ export class PreparePlatformService {
 			beforeCopyAction: sourceFiles => {
 				this.$xmlValidator.validateXmlFiles(sourceFiles);
 			},
-			filesToSync: copyAppFilesData.filesToSync,
 			filesToRemove: copyAppFilesData.filesToRemove
 		};
+		// TODO: consider passing filesToSync in appUpdaterOptions
+		// this would currently lead to the following problem: imagine changing two files rapidly one after the other (transpilation for example)
+		// the first file would trigger the whole LiveSync process and the second will be queued
+		// after the first LiveSync is done the .nsprepare file is written and the second file is later on wrongly assumed as having been prepared
+		// because .nsprepare was written after both file changes
 		appUpdater.updateApp(appUpdaterOptions, copyAppFilesData.projectData);
 	}
 }


### PR DESCRIPTION
Fix LiveSync not respecting rapid file changes (like transpilation, or copying directories for example).

Fix this by not passing `filesToSync` to `updateApp` method of `AppFilesUpdater`. This way each file will be copied upon every LiveSync action and we won't miss out any files.

Ping @rosen-vladimirov 