### PR TITLE
refactor: allow pass buildaction

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -107,9 +107,12 @@ $injector.require("devicePathProvider", "./device-path-provider");
 
 $injector.requireCommand("platform|clean", "./commands/platform-clean");
 
+$injector.require("bundleValidatorHelper", "./helpers/bundle-validator-helper");
+$injector.require("liveSyncCommandHelper", "./helpers/livesync-command-helper");
+$injector.require("deployCommandHelper", "./helpers/deploy-command-helper");
+
 $injector.requirePublicClass("localBuildService", "./services/local-build-service");
 $injector.requirePublicClass("liveSyncService", "./services/livesync/livesync-service");
-$injector.require("liveSyncCommandHelper", "./services/livesync/livesync-command-helper");
 $injector.require("androidLiveSyncService", "./services/livesync/android-livesync-service");
 $injector.require("iOSLiveSyncService", "./services/livesync/ios-livesync-service");
 $injector.require("usbLiveSyncService", "./services/livesync/livesync-service"); // The name is used in https://github.com/NativeScript/nativescript-dev-typescript

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,14 +1,13 @@
 import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
-import { BundleBase } from "./base-bundler";
 
-export class BuildCommandBase extends BundleBase {
+export class BuildCommandBase {
 	constructor(protected $options: IOptions,
 		protected $errors: IErrors,
 		protected $projectData: IProjectData,
 		protected $platformsData: IPlatformsData,
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		protected $platformService: IPlatformService) {
-		super($projectData, $errors, $options);
+		protected $platformService: IPlatformService,
+		private $bundleValidatorHelper: IBundleValidatorHelper) {
 		this.$projectData.initializeProjectData();
 	}
 
@@ -50,7 +49,7 @@ export class BuildCommandBase extends BundleBase {
 			this.$errors.fail(`Applications for platform ${platform} can not be built on this OS`);
 		}
 
-		super.validateBundling();
+		this.$bundleValidatorHelper.validate();
 	}
 }
 
@@ -62,8 +61,9 @@ export class BuildIosCommand extends BuildCommandBase implements ICommand {
 		$projectData: IProjectData,
 		$platformsData: IPlatformsData,
 		$devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		$platformService: IPlatformService) {
-		super($options, $errors, $projectData, $platformsData, $devicePlatformsConstants, $platformService);
+		$platformService: IPlatformService,
+		$bundleValidatorHelper: IBundleValidatorHelper) {
+		super($options, $errors, $projectData, $platformsData, $devicePlatformsConstants, $platformService, $bundleValidatorHelper);
 	}
 
 	public async execute(args: string[]): Promise<void> {
@@ -86,8 +86,9 @@ export class BuildAndroidCommand extends BuildCommandBase implements ICommand {
 		$projectData: IProjectData,
 		$platformsData: IPlatformsData,
 		$devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		$platformService: IPlatformService) {
-		super($options, $errors, $projectData, $platformsData, $devicePlatformsConstants, $platformService);
+		$platformService: IPlatformService,
+		$bundleValidatorHelper: IBundleValidatorHelper) {
+		super($options, $errors, $projectData, $platformsData, $devicePlatformsConstants, $platformService, $bundleValidatorHelper);
 	}
 
 	public async execute(args: string[]): Promise<void> {

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -38,7 +38,9 @@ export class DebugPlatformCommand implements ICommand {
 		await this.$devicesService.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: this.platform });
 
 		await this.$liveSyncCommandHelper.executeLiveSyncOperation([selectedDeviceForDebug], this.platform, {
-			[selectedDeviceForDebug.deviceInfo.identifier]: true
+			[selectedDeviceForDebug.deviceInfo.identifier]: true,
+			// This will default in the liveSyncCommandHelper
+			buildPlatform: undefined
 		});
 	}
 

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -7,43 +7,22 @@ export class DeployOnDeviceCommand implements ICommand {
 		private $platformCommandParameter: ICommandParameter,
 		private $options: IOptions,
 		private $projectData: IProjectData,
+		private $deployCommandHelper: IDeployCommandHelper,
 		private $errors: IErrors,
 		private $mobileHelper: Mobile.IMobileHelper,
-		private $platformsData: IPlatformsData) {
+		private $platformsData: IPlatformsData,
+		private $bundleValidatorHelper: IBundleValidatorHelper) {
 		this.$projectData.initializeProjectData();
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
-		const deployOptions: IDeployPlatformOptions = {
-			clean: this.$options.clean,
-			device: this.$options.device,
-			projectDir: this.$options.path,
-			emulator: this.$options.emulator,
-			platformTemplate: this.$options.platformTemplate,
-			release: this.$options.release,
-			forceInstall: true,
-			provision: this.$options.provision,
-			teamId: this.$options.teamId,
-			keyStoreAlias: this.$options.keyStoreAlias,
-			keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
-			keyStorePassword: this.$options.keyStorePassword,
-			keyStorePath: this.$options.keyStorePath
-		};
-
-		const deployPlatformInfo: IDeployPlatformInfo = {
-			platform: args[0],
-			appFilesUpdaterOptions,
-			deployOptions,
-			projectData: this.$projectData,
-			config: this.$options,
-			env: this.$options.env
-		};
+		const deployPlatformInfo = this.$deployCommandHelper.getDeployPlatformInfo(args[0]);
 
 		return this.$platformService.deployPlatform(deployPlatformInfo);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
+		this.$bundleValidatorHelper.validate();
 		if (!args || !args.length || args.length > 1) {
 			return false;
 		}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -739,3 +739,26 @@ interface IXcprojInfo {
 	 */
 	xcprojAvailable: boolean;
 }
+
+/**
+ * Describes helper used during execution of deploy commands.
+ */
+interface IDeployCommandHelper {
+	/**
+	 * Retrieves data needed to execute deploy command.
+	 * @param {string} platform platform to which to deploy - could be android or ios.
+	 * @return {IDeployPlatformInfo} data needed to execute deploy command.
+	 */
+	getDeployPlatformInfo(platform: string): IDeployPlatformInfo;
+}
+
+/**
+ * Describes helper for validating bundling.
+ */
+interface IBundleValidatorHelper {
+	/**
+	 * Validates bundling options.
+	 * @return {void}
+	 */
+	validate(): void;
+}

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -1,4 +1,20 @@
-interface IPlatformService extends NodeJS.EventEmitter {
+/**
+ * Describes information about how to build the native project.
+ */
+interface IBuildPlatformAction {
+	/**
+	 * Builds the native project for the specified platform for device or emulator.
+	 * When finishes, build saves the .nsbuildinfo file in platform product folder.
+	 * This file points to the prepare that was used to build the project and allows skipping unnecessary builds and deploys.
+	 * @param {string} platform The platform to build.
+	 * @param {IBuildConfig} buildConfig Indicates whether the build is for device or emulator.
+	 * @param {IProjectData} projectData DTO with information about the project.
+	 * @returns {Promise<string>} The path to the built file.
+	 */
+	buildPlatform(platform: string, buildConfig: IBuildConfig, projectData: IProjectData): Promise<string>;
+}
+
+interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
 	cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, framework?: string): Promise<void>;
 
 	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, frameworkPath?: string): Promise<void>;
@@ -55,17 +71,6 @@ interface IPlatformService extends NodeJS.EventEmitter {
 	 * @returns {boolean} true indicates that the platform should be build.
 	 */
 	shouldBuild(platform: string, projectData: IProjectData, buildConfig?: IBuildConfig, outputPath?: string): Promise<boolean>;
-
-	/**
-	 * Builds the native project for the specified platform for device or emulator.
-	 * When finishes, build saves the .nsbuildinfo file in platform product folder.
-	 * This file points to the prepare that was used to build the project and allows skipping unnecessary builds and deploys.
-	 * @param {string} platform The platform to build.
-	 * @param {IBuildConfig} buildConfig Indicates whether the build is for device or emulator.
-	 * @param {IProjectData} projectData DTO with information about the project.
-	 * @returns {void}
-	 */
-	buildPlatform(platform: string, buildConfig: IBuildConfig, projectData: IProjectData): Promise<void>;
 
 	/**
 	 * Determines whether installation is necessary. It is necessary when one of the following is true:
@@ -347,11 +352,13 @@ interface IOptionalFilesToRemove {
 	filesToRemove?: string[];
 }
 
-interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync, IOptionalFilesToRemove {
+interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync, IOptionalFilesToRemove, IOptionalNativePrepareComposition { }
+
+interface IOptionalNativePrepareComposition {
 	nativePrepare?: INativePrepare;
 }
 
-interface IDeployPlatformInfo extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IPlatformConfig, IEnvOptions {
+interface IDeployPlatformInfo extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IPlatformConfig, IEnvOptions, IOptionalNativePrepareComposition, IOptionalOutputPath, IBuildPlatformAction {
 	deployOptions: IDeployPlatformOptions
 }
 

--- a/lib/helpers/bundle-validator-helper.ts
+++ b/lib/helpers/bundle-validator-helper.ts
@@ -1,4 +1,4 @@
-export abstract class BundleBase {
+export class BundleValidatorHelper implements IBundleValidatorHelper {
 	private bundlersMap: IStringDictionary = {
 		webpack: "nativescript-dev-webpack"
 	};
@@ -9,7 +9,7 @@ export abstract class BundleBase {
 		this.$projectData.initializeProjectData();
 	}
 
-	protected validateBundling(): void {
+	public validate(): void {
 		if (this.$options.bundle) {
 			const bundlePluginName = this.bundlersMap[this.$options.bundle];
 			const hasBundlerPluginAsDependency = this.$projectData.dependencies && this.$projectData.dependencies[bundlePluginName];
@@ -20,3 +20,5 @@ export abstract class BundleBase {
 		}
 	}
 }
+
+$injector.register("bundleValidatorHelper", BundleValidatorHelper);

--- a/lib/helpers/deploy-command-helper.ts
+++ b/lib/helpers/deploy-command-helper.ts
@@ -1,0 +1,42 @@
+export class DeployCommandHelper implements IDeployCommandHelper {
+
+	constructor(private $options: IOptions,
+		private $platformService: IPlatformService,
+		private $projectData: IProjectData) {
+		this.$projectData.initializeProjectData();
+	}
+
+	public getDeployPlatformInfo(platform: string): IDeployPlatformInfo {
+		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = { bundle: !!this.$options.bundle, release: this.$options.release };
+		const deployOptions: IDeployPlatformOptions = {
+			clean: this.$options.clean,
+			device: this.$options.device,
+			projectDir: this.$projectData.projectDir,
+			emulator: this.$options.emulator,
+			platformTemplate: this.$options.platformTemplate,
+			release: this.$options.release,
+			forceInstall: true,
+			provision: this.$options.provision,
+			teamId: this.$options.teamId,
+			keyStoreAlias: this.$options.keyStoreAlias,
+			keyStoreAliasPassword: this.$options.keyStoreAliasPassword,
+			keyStorePassword: this.$options.keyStorePassword,
+			keyStorePath: this.$options.keyStorePath
+		};
+
+		const deployPlatformInfo: IDeployPlatformInfo = {
+			platform,
+			appFilesUpdaterOptions,
+			deployOptions,
+			projectData: this.$projectData,
+			buildPlatform: this.$platformService.buildPlatform.bind(this.$platformService),
+			config: this.$options,
+			env: this.$options.env,
+
+		};
+
+		return deployPlatformInfo;
+	}
+}
+
+$injector.register("deployCommandHelper", DeployCommandHelper);

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -691,8 +691,8 @@ export class PlatformServiceStub extends EventEmitter implements IPlatformServic
 		return Promise.resolve(true);
 	}
 
-	public buildPlatform(platform: string, buildConfig?: IBuildConfig): Promise<void> {
-		return Promise.resolve();
+	public buildPlatform(platform: string, buildConfig?: IBuildConfig): Promise<string> {
+		return Promise.resolve("");
 	}
 
 	public async shouldInstall(device: Mobile.IDevice): Promise<boolean> {


### PR DESCRIPTION
Includes:
* Refactor CLI so that it allows passing a `buildAction` parameter to services that execute `run` and `deploy` commands
* Introduce `helpers` directory - place classes/files here that are neither commands, nor services
* Refactor logic for verifying bundle options - extract it into a helper and reuse it instead of using the inheritance approach
* Add forgotten bundle options check in `deploy` command

Ping @rosen-vladimirov 
