### PR TITLE
fix: find correct apk name when --release passed

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -81,7 +81,7 @@ interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
 	 * @param {string} @optional outputPath Directory containing build information and artifacts.
 	 * @returns {Promise<boolean>} true indicates that the application should be installed.
 	 */
-	shouldInstall(device: Mobile.IDevice, projectData: IProjectData, outputPath?: string): Promise<boolean>;
+	shouldInstall(device: Mobile.IDevice, projectData: IProjectData, release: boolean, outputPath?: string): Promise<boolean>;
 
 	/**
 	 * Determines whether the project should undergo the prepare process.
@@ -260,7 +260,7 @@ interface IPlatformData {
 	projectRoot: string;
 	normalizedPlatformName: string;
 	appDestinationDirectoryPath: string;
-	deviceBuildOutputPath: string;
+	deviceBuildOutputPath(options: IRelease): string;
 	emulatorBuildOutputPath?: string;
 	getValidPackageNames(buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[];
 	frameworkFilesExtensions: string[];

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -81,7 +81,7 @@ interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
 	 * @param {string} @optional outputPath Directory containing build information and artifacts.
 	 * @returns {Promise<boolean>} true indicates that the application should be installed.
 	 */
-	shouldInstall(device: Mobile.IDevice, projectData: IProjectData, release: boolean, outputPath?: string): Promise<boolean>;
+	shouldInstall(device: Mobile.IDevice, projectData: IProjectData, release: IRelease, outputPath?: string): Promise<boolean>;
 
 	/**
 	 * Determines whether the project should undergo the prepare process.
@@ -260,7 +260,7 @@ interface IPlatformData {
 	projectRoot: string;
 	normalizedPlatformName: string;
 	appDestinationDirectoryPath: string;
-	deviceBuildOutputPath(options: IRelease): string;
+	getDeviceBuildOutputPath(options: IRelease): string;
 	emulatorBuildOutputPath?: string;
 	getValidPackageNames(buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[];
 	frameworkFilesExtensions: string[];

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -140,6 +140,7 @@ interface IPlatformProjectServiceBase {
 
 interface IBuildForDevice {
 	buildForDevice: boolean;
+	release: boolean;
 }
 
 interface INativePrepare {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -140,7 +140,10 @@ interface IPlatformProjectServiceBase {
 
 interface IBuildForDevice {
 	buildForDevice: boolean;
-	release: boolean;
+}
+
+interface IShouldInstall extends IBuildForDevice, IRelease {
+	
 }
 
 interface INativePrepare {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -83,7 +83,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				platformProjectService: this,
 				emulatorServices: this.$androidEmulatorServices,
 				projectRoot: projectRoot,
-				deviceBuildOutputPath: (options: IRelease): string => {
+				getDeviceBuildOutputPath: (options: IRelease): string => {
 					return this.getDeviceBuildOutputPath(path.join(...deviceBuildOutputArr), projectData, options);
 				},
 				getValidPackageNames: (buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[] => {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -83,7 +83,9 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				platformProjectService: this,
 				emulatorServices: this.$androidEmulatorServices,
 				projectRoot: projectRoot,
-				deviceBuildOutputPath: this.getDeviceBuildOutputPath(path.join(...deviceBuildOutputArr), projectData),
+				deviceBuildOutputPath: (options: IRelease): string => {
+					return this.getDeviceBuildOutputPath(path.join(...deviceBuildOutputArr), projectData, options);
+				},
 				getValidPackageNames: (buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[] => {
 					const buildMode = buildOptions.isReleaseBuild ? Configurations.Release.toLowerCase() : Configurations.Debug.toLowerCase();
 
@@ -106,10 +108,10 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		return this._platformData;
 	}
 
-	private getDeviceBuildOutputPath(currentPath: string, projectData: IProjectData): string {
+	private getDeviceBuildOutputPath(currentPath: string, projectData: IProjectData, options: IRelease): string {
 		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME);
 		const platformVersion = currentPlatformData && currentPlatformData[constants.VERSION_STRING];
-		const buildType = this.$options.release === true ? "release" : "debug";
+		const buildType = options.release === true ? "release" : "debug";
 		const normalizedPath = path.join(currentPath, buildType);
 
 		if (semver.valid(platformVersion)) {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -109,7 +109,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	private getDeviceBuildOutputPath(currentPath: string, projectData: IProjectData): string {
 		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME);
 		const platformVersion = currentPlatformData && currentPlatformData[constants.VERSION_STRING];
-		const normalizedPath = path.join(currentPath, "debug");
+		const buildType = this.$options.release === true ? "release" : "debug";
+		const normalizedPath = path.join(currentPath, buildType);
 
 		if (semver.valid(platformVersion)) {
 			const gradleAndroidPluginVersion3xx = "4.0.0";

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -71,7 +71,9 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				platformProjectService: this,
 				emulatorServices: this.$iOSEmulatorServices,
 				projectRoot: projectRoot,
-				deviceBuildOutputPath: path.join(projectRoot, "build", "device"),
+				deviceBuildOutputPath: (options: IRelease): string => {
+					return path.join(projectRoot, "build", "device");
+				},
 				emulatorBuildOutputPath: path.join(projectRoot, "build", "emulator"),
 				getValidPackageNames: (buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[] => {
 					if (buildOptions.isForDevice) {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -71,7 +71,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				platformProjectService: this,
 				emulatorServices: this.$iOSEmulatorServices,
 				projectRoot: projectRoot,
-				deviceBuildOutputPath: (options: IRelease): string => {
+				getDeviceBuildOutputPath: (options: IRelease): string => {
 					return path.join(projectRoot, "build", "device");
 				},
 				emulatorBuildOutputPath: path.join(projectRoot, "build", "emulator"),

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -413,7 +413,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 		await this.trackAction(action, platform, options);
 
-		const shouldInstall = await this.$platformService.shouldInstall(options.device, options.projectData, options.deviceBuildInfoDescriptor.outputPath);
+		const shouldInstall = await this.$platformService.shouldInstall(options.device, options.projectData, options.release, options.deviceBuildInfoDescriptor.outputPath);
 		if (shouldInstall) {
 			await this.$platformService.installApplication(options.device, { release: false }, options.projectData, pathToBuildItem, options.deviceBuildInfoDescriptor.outputPath);
 			appInstalledOnDeviceResult.appInstalled = true;

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -413,7 +413,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 		await this.trackAction(action, platform, options);
 
-		const shouldInstall = await this.$platformService.shouldInstall(options.device, options.projectData, options.release, options.deviceBuildInfoDescriptor.outputPath);
+		const shouldInstall = await this.$platformService.shouldInstall(options.device, options.projectData, options, options.deviceBuildInfoDescriptor.outputPath);
 		if (shouldInstall) {
 			await this.$platformService.installApplication(options.device, { release: false }, options.projectData, pathToBuildItem, options.deviceBuildInfoDescriptor.outputPath);
 			appInstalledOnDeviceResult.appInstalled = true;

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -433,7 +433,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		this.$fs.writeJson(buildInfoFile, buildInfo);
 	}
 
-	public async shouldInstall(device: Mobile.IDevice, projectData: IProjectData, isRelease: IRelease, outputPath?: string): Promise<boolean> {
+	public async shouldInstall(device: Mobile.IDevice, projectData: IProjectData, release: IBuildConfig, outputPath?: string): Promise<boolean> {
 		const platform = device.deviceInfo.platform;
 		if (!(await device.applicationManager.isApplicationInstalled(projectData.projectId))) {
 			return true;
@@ -441,7 +441,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const deviceBuildInfo: IBuildInfo = await this.getDeviceBuildInfo(device, projectData);
-		const localBuildInfo = this.getBuildInfo(platform, platformData, { buildForDevice: !device.isEmulator, release: isRelease.release }, outputPath);
+		const localBuildInfo = this.getBuildInfo(platform, platformData, { buildForDevice: !device.isEmulator, release: release.release }, outputPath);
 		return !localBuildInfo || !deviceBuildInfo || deviceBuildInfo.buildTime !== localBuildInfo.buildTime;
 	}
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -333,7 +333,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const forDevice = !buildConfig || buildConfig.buildForDevice;
-		outputPath = outputPath || (forDevice ? platformData.deviceBuildOutputPath : platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath);
+		outputPath = outputPath || (forDevice ? platformData.deviceBuildOutputPath(buildConfig) : platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath(buildConfig));
 		if (!this.$fs.exists(outputPath)) {
 			return true;
 		}
@@ -433,7 +433,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		this.$fs.writeJson(buildInfoFile, buildInfo);
 	}
 
-	public async shouldInstall(device: Mobile.IDevice, projectData: IProjectData, outputPath?: string): Promise<boolean> {
+	public async shouldInstall(device: Mobile.IDevice, projectData: IProjectData, release: boolean, outputPath?: string): Promise<boolean> {
 		const platform = device.deviceInfo.platform;
 		if (!(await device.applicationManager.isApplicationInstalled(projectData.projectId))) {
 			return true;
@@ -441,7 +441,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const deviceBuildInfo: IBuildInfo = await this.getDeviceBuildInfo(device, projectData);
-		const localBuildInfo = this.getBuildInfo(platform, platformData, { buildForDevice: !device.isEmulator }, outputPath);
+		const localBuildInfo = this.getBuildInfo(platform, platformData, { buildForDevice: !device.isEmulator, release: false }, outputPath);
 		return !localBuildInfo || !deviceBuildInfo || deviceBuildInfo.buildTime !== localBuildInfo.buildTime;
 	}
 
@@ -469,7 +469,9 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		if (!buildConfig.release) {
 			const deviceFilePath = await this.getDeviceBuildInfoFilePath(device, projectData);
-			const buildInfoFilePath = outputFilePath || this.getBuildOutputPath(device.deviceInfo.platform, platformData, { buildForDevice: !device.isEmulator });
+			const options = buildConfig;
+			options.buildForDevice = !device.isEmulator;
+			const buildInfoFilePath = outputFilePath || this.getBuildOutputPath(device.deviceInfo.platform, platformData, options);
 			const appIdentifier = projectData.projectId;
 
 			await device.fileSystem.putFile(path.join(buildInfoFilePath, buildInfoFileName), deviceFilePath, appIdentifier);
@@ -515,8 +517,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				this.$logger.out("Skipping package build. No changes detected on the native side. This will be fast!");
 			}
 
-			if (deployInfo.deployOptions.forceInstall || shouldBuild || (await this.shouldInstall(device, deployInfo.projectData))) {
-				await this.installApplication(device, buildConfig, deployInfo.projectData, installPackageFile, deployInfo.outputPath);
+			if (deployInfo.deployOptions.forceInstall || shouldBuild || (await this.shouldInstall(device, deployInfo.projectData, buildConfig.release))) {
+				await this.installApplication(device, buildConfig, deployInfo.projectData);
 			} else {
 				this.$logger.out("Skipping install.");
 			}
@@ -552,10 +554,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	private getBuildOutputPath(platform: string, platformData: IPlatformData, options: IBuildForDevice): string {
 		if (platform.toLowerCase() === this.$devicePlatformsConstants.iOS.toLowerCase()) {
-			return options.buildForDevice ? platformData.deviceBuildOutputPath : platformData.emulatorBuildOutputPath;
+			return options.buildForDevice ? platformData.deviceBuildOutputPath(options) : platformData.emulatorBuildOutputPath;
 		}
 
-		return platformData.deviceBuildOutputPath;
+		return platformData.deviceBuildOutputPath(options);
 	}
 
 	private async getDeviceBuildInfoFilePath(device: Mobile.IDevice, projectData: IProjectData): Promise<string> {
@@ -765,11 +767,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	public getLatestApplicationPackageForDevice(platformData: IPlatformData, buildConfig: IBuildConfig, outputPath?: string): IApplicationPackage {
-		return this.getLatestApplicationPackage(outputPath || platformData.deviceBuildOutputPath, platformData.getValidPackageNames({ isForDevice: true, isReleaseBuild: buildConfig.release }));
+		return this.getLatestApplicationPackage(outputPath || platformData.deviceBuildOutputPath(buildConfig), platformData.getValidPackageNames({ isForDevice: true, isReleaseBuild: buildConfig.release }));
 	}
 
 	public getLatestApplicationPackageForEmulator(platformData: IPlatformData, buildConfig: IBuildConfig, outputPath?: string): IApplicationPackage {
-		return this.getLatestApplicationPackage(outputPath || platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath, platformData.getValidPackageNames({ isForDevice: false, isReleaseBuild: buildConfig.release }));
+		return this.getLatestApplicationPackage(outputPath || platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath(buildConfig), platformData.getValidPackageNames({ isForDevice: false, isReleaseBuild: buildConfig.release }));
 	}
 
 	private async updatePlatform(platform: string, version: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -333,7 +333,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const forDevice = !buildConfig || buildConfig.buildForDevice;
-		outputPath = outputPath || (forDevice ? platformData.deviceBuildOutputPath(buildConfig) : platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath(buildConfig));
+		outputPath = outputPath || (forDevice ? platformData.getDeviceBuildOutputPath(buildConfig) : platformData.emulatorBuildOutputPath || platformData.getDeviceBuildOutputPath(buildConfig));
 		if (!this.$fs.exists(outputPath)) {
 			return true;
 		}
@@ -433,7 +433,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		this.$fs.writeJson(buildInfoFile, buildInfo);
 	}
 
-	public async shouldInstall(device: Mobile.IDevice, projectData: IProjectData, release: boolean, outputPath?: string): Promise<boolean> {
+	public async shouldInstall(device: Mobile.IDevice, projectData: IProjectData, isRelease: IRelease, outputPath?: string): Promise<boolean> {
 		const platform = device.deviceInfo.platform;
 		if (!(await device.applicationManager.isApplicationInstalled(projectData.projectId))) {
 			return true;
@@ -441,7 +441,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const deviceBuildInfo: IBuildInfo = await this.getDeviceBuildInfo(device, projectData);
-		const localBuildInfo = this.getBuildInfo(platform, platformData, { buildForDevice: !device.isEmulator, release: false }, outputPath);
+		const localBuildInfo = this.getBuildInfo(platform, platformData, { buildForDevice: !device.isEmulator, release: isRelease.release }, outputPath);
 		return !localBuildInfo || !deviceBuildInfo || deviceBuildInfo.buildTime !== localBuildInfo.buildTime;
 	}
 
@@ -517,7 +517,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				this.$logger.out("Skipping package build. No changes detected on the native side. This will be fast!");
 			}
 
-			if (deployInfo.deployOptions.forceInstall || shouldBuild || (await this.shouldInstall(device, deployInfo.projectData, buildConfig.release))) {
+			if (deployInfo.deployOptions.forceInstall || shouldBuild || (await this.shouldInstall(device, deployInfo.projectData, buildConfig))) {
 				await this.installApplication(device, buildConfig, deployInfo.projectData);
 			} else {
 				this.$logger.out("Skipping install.");
@@ -552,12 +552,12 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		await this.$devicesService.execute(action, this.getCanExecuteAction(platform, runOptions));
 	}
 
-	private getBuildOutputPath(platform: string, platformData: IPlatformData, options: IBuildForDevice): string {
+	private getBuildOutputPath(platform: string, platformData: IPlatformData, options: IShouldInstall): string {
 		if (platform.toLowerCase() === this.$devicePlatformsConstants.iOS.toLowerCase()) {
-			return options.buildForDevice ? platformData.deviceBuildOutputPath(options) : platformData.emulatorBuildOutputPath;
+			return options.buildForDevice ? platformData.getDeviceBuildOutputPath(options) : platformData.emulatorBuildOutputPath;
 		}
 
-		return platformData.deviceBuildOutputPath(options);
+		return platformData.getDeviceBuildOutputPath(options);
 	}
 
 	private async getDeviceBuildInfoFilePath(device: Mobile.IDevice, projectData: IProjectData): Promise<string> {
@@ -577,7 +577,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	private getBuildInfo(platform: string, platformData: IPlatformData, options: IBuildForDevice, buildOutputPath?: string): IBuildInfo {
+	private getBuildInfo(platform: string, platformData: IPlatformData, options: IShouldInstall, buildOutputPath?: string): IBuildInfo {
 		buildOutputPath = buildOutputPath || this.getBuildOutputPath(platform, platformData, options);
 		const buildInfoFile = path.join(buildOutputPath, buildInfoFileName);
 		if (this.$fs.exists(buildInfoFile)) {
@@ -767,11 +767,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	public getLatestApplicationPackageForDevice(platformData: IPlatformData, buildConfig: IBuildConfig, outputPath?: string): IApplicationPackage {
-		return this.getLatestApplicationPackage(outputPath || platformData.deviceBuildOutputPath(buildConfig), platformData.getValidPackageNames({ isForDevice: true, isReleaseBuild: buildConfig.release }));
+		return this.getLatestApplicationPackage(outputPath || platformData.getDeviceBuildOutputPath(buildConfig), platformData.getValidPackageNames({ isForDevice: true, isReleaseBuild: buildConfig.release }));
 	}
 
 	public getLatestApplicationPackageForEmulator(platformData: IPlatformData, buildConfig: IBuildConfig, outputPath?: string): IApplicationPackage {
-		return this.getLatestApplicationPackage(outputPath || platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath(buildConfig), platformData.getValidPackageNames({ isForDevice: false, isReleaseBuild: buildConfig.release }));
+		return this.getLatestApplicationPackage(outputPath || platformData.emulatorBuildOutputPath || platformData.getDeviceBuildOutputPath(buildConfig), platformData.getValidPackageNames({ isForDevice: false, isReleaseBuild: buildConfig.release }));
 	}
 
 	private async updatePlatform(platform: string, version: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -35,7 +35,7 @@ class PlatformData implements IPlatformData {
 	};
 	emulatorServices: Mobile.IEmulatorPlatformServices = null;
 	projectRoot = "";
-	deviceBuildOutputPath = (buildTypeOption: IRelease) => {
+	getDeviceBuildOutputPath = (buildTypeOption: IRelease) => {
 		return "";
 	}
 	getValidPackageNames = (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [""];

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -35,7 +35,9 @@ class PlatformData implements IPlatformData {
 	};
 	emulatorServices: Mobile.IEmulatorPlatformServices = null;
 	projectRoot = "";
-	deviceBuildOutputPath = "";
+	deviceBuildOutputPath = (buildTypeOption: IRelease) => {
+		return "";
+	}
 	getValidPackageNames = (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [""];
 	validPackageNamesForDevice: string[] = [];
 	frameworkFilesExtensions = [".jar", ".dat"];

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -304,7 +304,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 			platformProjectService: this,
 			emulatorServices: undefined,
 			projectRoot: "",
-			deviceBuildOutputPath: (buildTypeOption: IRelease) => {
+			getDeviceBuildOutputPath: (buildTypeOption: IRelease) => {
 				return "";
 			},
 			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
@@ -417,7 +417,7 @@ export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
 			projectRoot: "",
 			normalizedPlatformName: "",
 			appDestinationDirectoryPath: "",
-			deviceBuildOutputPath: (buildTypeOption: IRelease) => {
+			getDeviceBuildOutputPath: (buildTypeOption: IRelease) => {
 				return "";
 			},
 			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -304,7 +304,9 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 			platformProjectService: this,
 			emulatorServices: undefined,
 			projectRoot: "",
-			deviceBuildOutputPath: "",
+			deviceBuildOutputPath: (buildTypeOption: IRelease) => {
+				return "";
+			},
 			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
 			frameworkFilesExtensions: [],
 			appDestinationDirectoryPath: "",
@@ -415,7 +417,9 @@ export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
 			projectRoot: "",
 			normalizedPlatformName: "",
 			appDestinationDirectoryPath: "",
-			deviceBuildOutputPath: "",
+			deviceBuildOutputPath: (buildTypeOption: IRelease) => {
+				return "";
+			},
 			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
 			frameworkFilesExtensions: [],
 			relativeToFrameworkConfigurationFilePath: "",


### PR DESCRIPTION
_problem_
The CLI can't find `.apk` file to install on passed `--release` option. Read more [in this issue](https://github.com/NativeScript/nativescript-cli/issues/3411)

_solution_
respect `--release` option when generating apk find path