### PR TITLE
refactor: provide platforms to before-watchPatterns hooks

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -212,9 +212,11 @@ interface IDebugLiveSyncService extends ILiveSyncService {
 	/**
 	 * Method used to retrieve the glob patterns which CLI will watch for file changes. Defaults to the whole app directory.
 	 * @param {ILiveSyncInfo} liveSyncData Information needed for livesync - for example if bundle is passed or if a release build should be performed.
+	 * @param  {IProjectData} projectData Project data.
+	 * @param  {string[]} platforms Platforms to start the watcher for.
 	 * @returns {Promise<string[]>} The glob patterns.
 	 */
-	getWatcherPatterns(liveSyncData: ILiveSyncInfo, projectData: IProjectData): Promise<string[]>;
+	getWatcherPatterns(liveSyncData: ILiveSyncInfo, projectData: IProjectData, platforms: string[]): Promise<string[]>;
 
 	/**
 	 * Prints debug information.

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -290,8 +290,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	}
 
 	@hook('watchPatterns')
-	public async getWatcherPatterns(liveSyncData: ILiveSyncInfo, projectData: IProjectData): Promise<string[]> {
-		// liveSyncData is used by plugins that make use of the watchPatterns hook
+	public async getWatcherPatterns(liveSyncData: ILiveSyncInfo, projectData: IProjectData, platforms: string[]): Promise<string[]> {
+		// liveSyncData and platforms are used by plugins that make use of the watchPatterns hook
 		return [projectData.getAppDirectoryRelativePath(), projectData.getAppResourcesRelativeDirectoryPath()];
 	}
 
@@ -525,7 +525,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	}
 
 	private async startWatcher(projectData: IProjectData, liveSyncData: ILiveSyncInfo, platforms: string[]): Promise<void> {
-		const patterns = await this.getWatcherPatterns(liveSyncData, projectData);
+		const patterns = await this.getWatcherPatterns(liveSyncData, projectData, platforms);
 
 		if (liveSyncData.watchAllFiles) {
 			const productionDependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir);


### PR DESCRIPTION
The target platforms may be used in plugins that implement the `before-watchPatterns` hook. See https://github.com/NativeScript/nativescript-dev-webpack/pull/454.