### PR TITLE
fix: stop printing double spaces

### DIFF
--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -136,7 +136,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 	}
 
 	private async npmInstall(packageName: string, pathToSave: string, version: string, dependencyType: string): Promise<INpmInstallResultInfo> {
-		this.$logger.out("Installing ", packageName);
+		this.$logger.out(`Installing ${packageName}`);
 
 		packageName = packageName + (version ? `@${version}` : "");
 


### PR DESCRIPTION
Whenever installing the platform `tns-android` or `tns-ios` do not print `Installing  <platform>` (with two spaces) but instead print only a single space between the words

Ping @rosen-vladimirov @Fatme 
