### PR TITLE
fix: pass devices for debugging correctly

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -38,7 +38,9 @@ export class DebugPlatformCommand implements ICommand {
 		await this.$devicesService.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: this.platform });
 
 		await this.$liveSyncCommandHelper.executeLiveSyncOperation([selectedDeviceForDebug], this.platform, {
-			[selectedDeviceForDebug.deviceInfo.identifier]: true,
+			deviceDebugMap: {
+				[selectedDeviceForDebug.deviceInfo.identifier]: true
+			},
 			// This will default in the liveSyncCommandHelper
 			buildPlatform: undefined
 		});


### PR DESCRIPTION
Pass `deviceDebugMap` correctly in order to fix `tns debug`
It is used [like this](https://github.com/NativeScript/nativescript-cli/blob/7bb22488067fe7ea6079a1c00972bce8589f4761/lib/helpers/livesync-command-helper.ts#L90)

Ping @Fatme @rosen-vladimirov 