### PR TITLE
fix(userSettings): Don't fail when user settings file is not a valid json

### DIFF
--- a/lib/services/user-settings-service.ts
+++ b/lib/services/user-settings-service.ts
@@ -4,9 +4,10 @@ import * as userSettingsServiceBaseLib from "../common/services/user-settings-se
 class UserSettingsService extends userSettingsServiceBaseLib.UserSettingsServiceBase {
 	constructor($fs: IFileSystem,
 		$settingsService: ISettingsService,
-		$lockfile: ILockFile) {
+		$lockfile: ILockFile,
+		$logger: ILogger) {
 		const userSettingsFilePath = path.join($settingsService.getProfileDir(), "user-settings.json");
-		super(userSettingsFilePath, $fs, $lockfile);
+		super(userSettingsFilePath, $fs, $lockfile, $logger);
 	}
 
 	public async loadUserSettingsFile(): Promise<void> {


### PR DESCRIPTION
In case when user executes some command and by some reasons user settings file is not a valid json, {N} CLI throws "Unexpected token in JSON at position 0" error. After that user is not able to execute any cli command until the file exists.