### PR TITLE
fix: stop build twice for android

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -439,7 +439,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	}
 
 	private async installedCachedAppPackage(platform: string, options: IEnsureLatestAppPackageIsInstalledOnDeviceOptions): Promise<any> {
-		const rebuildInfo = _.find(options.rebuiltInformation, info => info.isEmulator === options.device.isEmulator && info.platform === platform);
+		const rebuildInfo = _.find(options.rebuiltInformation, info => info.platform === platform && (this.$mobileHelper.isAndroidPlatform(platform) || info.isEmulator === options.device.isEmulator));
 
 		if (rebuildInfo) {
 			// Case where we have three devices attached, a change that requires build is found,


### PR DESCRIPTION
In case the user has an android emulator and a device attached we shouldn't build twice - the build artifact is eligible to be installed on both devices.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3442

Ping @rosen-vladimirov 