### PR TITLE
fix: deal with multiple build apk files

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -741,7 +741,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		// Get latest package` that is produced from build
 		const candidates = this.$fs.readDirectory(buildOutputPath);
 		const packages = _.filter(candidates, candidate => {
-			return _.includes(validPackageNames, candidate);
+			return _.includes(validPackageNames, candidate) || /app-.*-(debug|release).apk/.test(candidate);
 		}).map(currentPackage => {
 			currentPackage = path.join(buildOutputPath, currentPackage);
 
@@ -763,6 +763,9 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		packages = _.sortBy(packages, pkg => pkg.time).reverse(); // We need to reverse because sortBy always sorts in ascending order
 
+		if (packages.length > 1) {
+			this.$logger.warn(`More than one package found:\n${packages.map((entry) => { return entry.packageName; })}.\nReturning the first one.`);
+		}
 		return packages[0];
 	}
 


### PR DESCRIPTION
_problem_
When there's a build that generates multiple `.apk` files, by using [splits](https://developer.android.com/studio/build/configure-apk-splits.html) or [build variants](https://developer.android.com/studio/build/build-variants.html), the CLI can't handle the output.

_proposed solution_
Give a warning that more than one `.apk` files are generated and return the first one for backward compatibility

>Note: this behavior is only a suggestion for how the CLI should behave.