### PR TITLE
fix: pass all args to installapplication

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -518,7 +518,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			}
 
 			if (deployInfo.deployOptions.forceInstall || shouldBuild || (await this.shouldInstall(device, deployInfo.projectData, buildConfig))) {
-				await this.installApplication(device, buildConfig, deployInfo.projectData);
+				await this.installApplication(device, buildConfig, deployInfo.projectData, installPackageFile, deployInfo.outputPath);
 			} else {
 				this.$logger.out("Skipping install.");
 			}


### PR DESCRIPTION
Pass all arguments to install application - during cloud build the package file's location may already be known.

Ping @rosen-vladimirov 