### PR TITLE
fix(plugin-build): strip npm scope names from android plugin names

### DIFF
--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import { MANIFEST_FILE_NAME, INCLUDE_GRADLE_NAME, ASSETS_DIR, RESOURCES_DIR } from "../constants";
+import { getShortPluginName } from "../common/helpers";
 import { Builder, parseString } from "xml2js";
 import { ILogger } from "log4js";
 
@@ -35,15 +36,6 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 	private getManifest(platformsDir: string): string {
 		const manifest = path.join(platformsDir, MANIFEST_FILE_NAME);
 		return this.$fs.exists(manifest) ? manifest : null;
-	}
-
-	private getShortPluginName(pluginName: string): string {
-		return this.sanitizePluginName(pluginName).replace(/[\-]/g, "_");
-	}
-
-	private sanitizePluginName(pluginName: string): string {
-		// avoid long plugin names, exclude the npm module scope (@scope/nativescript-plugin) from the android plugin name
-		return pluginName.split("/").pop();
 	}
 
 	private async updateManifestContent(oldManifestContent: string, defaultPackageName: string): Promise<string> {
@@ -169,7 +161,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		// IDEA: apply app.gradle here in order to get any and all user-defined variables
 		// IDEA: apply the entire include.gradle here instead of copying over the repositories {} and dependencies {} scopes
 
-		const shortPluginName = this.getShortPluginName(options.pluginName);
+		const shortPluginName = getShortPluginName(options.pluginName);
 		const newPluginDir = path.join(options.tempPluginDirPath, shortPluginName);
 		const newPluginMainSrcDir = path.join(newPluginDir, "src", "main");
 		const defaultPackageName = "org.nativescript." + shortPluginName;

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -38,7 +38,12 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 	}
 
 	private getShortPluginName(pluginName: string): string {
-		return pluginName.replace(/[\-]/g, "_");
+		return this.sanitizePluginName(pluginName).replace(/[\-]/g, "_");
+	}
+
+	private sanitizePluginName(pluginName: string): string {
+		// avoid long plugin names, exclude the npm module scope (@scope/nativescript-plugin) from the android plugin name
+		return pluginName.split("/").pop();
 	}
 
 	private async updateManifestContent(oldManifestContent: string, defaultPackageName: string): Promise<string> {


### PR DESCRIPTION
Don't merge before: https://github.com/telerik/mobile-cli-lib/pull/1063

Problem:
Plugins contained within an npm scope, like `@nota/nativescript-accessibility-ext` fail to build because their android plugin name becomes `@nota/nativescript-accessibility-ext`, both `@` and `/` are illegal characters in an Android package name.

Proposed solution:
Split the plugin name string by a forward slash (`/`) and take the last element, effectively removing all forward slashes, and omitting the npm scope name, if any.