### PR TITLE
feat(analytics): Track Vue.js project type

### DIFF
--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -23,6 +23,10 @@ export class ProjectData implements IProjectData {
 			requiredDependencies: ["@angular/core", "nativescript-angular"]
 		},
 		{
+			type: "Vue.js",
+			requiredDependencies: ["nativescript-vue"]
+		},
+		{
 			type: "Pure TypeScript",
 			requiredDependencies: ["typescript", "nativescript-dev-typescript"]
 		}

--- a/test/project-data.ts
+++ b/test/project-data.ts
@@ -64,6 +64,14 @@ describe("projectData", () => {
 			assertProjectType({ "nativescript-angular": "*" }, null, "Angular");
 		});
 
+		it("detects project as Vue.js when nativescript-vue exists as dependency", () => {
+			assertProjectType({ "nativescript-vue": "*" }, null, "Vue.js");
+		});
+
+		it("detects project as Vue.js when nativescript-vue exists as dependency and typescript is devDependency", () => {
+			assertProjectType({ "nativescript-vue": "*" }, { "typescript": "*" }, "Vue.js");
+		});
+
 		it("detects project as TypeScript when nativescript-dev-typescript exists as dependency", () => {
 			assertProjectType(null, { "nativescript-dev-typescript": "*" }, "Pure TypeScript");
 		});


### PR DESCRIPTION
Currently CLI tracks Angular, TypeScript and JavaScript project types. Add a new project category - `Vue.js`. The project will be tracked as `Vue.js` when it has nativscript-vue in the package.json.