### PR TITLE
refactor: allow pass skipnativeprepare

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -42,7 +42,8 @@ export class DebugPlatformCommand implements ICommand {
 				[selectedDeviceForDebug.deviceInfo.identifier]: true
 			},
 			// This will default in the liveSyncCommandHelper
-			buildPlatform: undefined
+			buildPlatform: undefined,
+			skipNativePrepare: false
 		});
 	}
 

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -384,7 +384,7 @@ interface IDevicePathProvider {
 /**
  * Describes additional options, that can be passed to LiveSyncCommandHelper.
  */
-interface ILiveSyncCommandHelperAdditionalOptions extends IBuildPlatformAction {
+interface ILiveSyncCommandHelperAdditionalOptions extends IBuildPlatformAction, INativePrepare {
 	/**
 	 * A map representing devices which have debugging enabled initially.
 	 */

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -90,7 +90,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 					debugggingEnabled: additionalOptions && additionalOptions.deviceDebugMap && additionalOptions.deviceDebugMap[d.deviceInfo.identifier],
 					debugOptions: this.$options,
 					outputPath: additionalOptions && additionalOptions.getOutputDirectory && additionalOptions.getOutputDirectory({
-						platform,
+						platform: d.deviceInfo.platform,
 						emulator: d.isEmulator,
 						projectDir: this.$projectData.projectDir
 					}),

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -93,7 +93,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 						platform,
 						emulator: d.isEmulator,
 						projectDir: this.$projectData.projectDir
-					})
+					}),
+					skipNativePrepare: additionalOptions && additionalOptions.skipNativePrepare
 				};
 
 				return info;


### PR DESCRIPTION
Allow passing of `skipNativePrepare` for the LiveSync operation. Whenever building in the cloud one wouldn't need to prepare the project natively

Merge after https://github.com/telerik/mobile-cli-lib/pull/1065

Ping @rosen-vladimirov 