### PR TITLE
Add spinner when checking for NativeScript components versions

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -699,22 +699,16 @@ interface IVersionsService {
 	getRuntimesVersions(): Promise<IVersionInformation[]>;
 
 	/**
-	 * Checks version information about the nativescript components and prints available updates if any.
-	 */
-	checkComponentsForUpdate(): Promise<void>;
-
-	/**
 	 * Gets versions information about all nativescript components.
 	 * @return {Promise<IVersionInformation[]>} The version information.
 	 */
 	getAllComponentsVersions(): Promise<IVersionInformation[]>;
 
 	/**
-	 * Creates table with versions information.
-	 * @param {IVersionInformation[]} The versions information to push in the table.
-	 * @return {any} The created table.
+	 * Checks version information about the nativescript components and prints versions information.
+	 * @return {Promise<void>}
 	 */
-	createTableWithVersionsInformation(versionsInformation: IVersionInformation[]): any;
+	printVersionsInformation(): Promise<void>;
 }
 
 /**

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -47,7 +47,7 @@ class DoctorService implements IDoctorService {
 		}
 
 		try {
-			await this.$versionsService.checkComponentsForUpdate();
+			await this.$versionsService.printVersionsInformation();
 		} catch (err) {
 			this.$logger.error("Cannot get the latest versions information from npm. Please try again later.");
 		}

--- a/lib/services/info-service.ts
+++ b/lib/services/info-service.ts
@@ -1,14 +1,8 @@
 export class InfoService implements IInfoService {
-	constructor(private $versionsService: IVersionsService,
-		private $logger: ILogger) { }
+	constructor(private $versionsService: IVersionsService) { }
 
-	public async printComponentsInfo(): Promise<void> {
-		const allComponentsInfo = await this.$versionsService.getAllComponentsVersions();
-
-		const table: any = this.$versionsService.createTableWithVersionsInformation(allComponentsInfo);
-
-		this.$logger.out("All NativeScript components versions information");
-		this.$logger.out(table.toString());
+	public printComponentsInfo(): Promise<void> {
+		return this.$versionsService.printVersionsInformation();
 	}
 }
 


### PR DESCRIPTION
Currently when doctor command is executed, NativeScript components versions information is displayed as table. With this PR NativeScript components versions will be displayed with terminal spinners.

In case when component is up to date with latest available version, success spinner will be displayed.
In case when for component update is available, warn spinner will be displayed.
In case when component is not installed, fail spinner will be displayed.

This PR changes also the behaviour of `tns info` command. When `tns info` command is executed,  NativeScript components versions information also will be displayed with terminal spinners.

Should be merged with this PR https://github.com/telerik/mobile-cli-lib/pull/1066