### PR TITLE
fix: Do not print sysinfo if everything is fine

### DIFF
--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -71,7 +71,6 @@ class DoctorService implements IDoctorService {
 
 	public async canExecuteLocalBuild(platform?: string): Promise<boolean> {
 		const infos = await doctor.getInfos({ platform });
-		this.printInfosCore(infos);
 
 		const warnings = this.filterInfosByType(infos, constants.WARNING_TYPE_NAME);
 		if (warnings.length > 0) {


### PR DESCRIPTION
During commands like prepare, build, run, etc. CLI checks the local environment for specified platform. In case there are issues, the full system information should be printed.
However, in case everything is fine, CLI should not print the information. Fix this by removing incorrect line that prints all of the info.