### PR TITLE
fix-next(prepare): clean platforms/.../app/ on bundle

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -209,7 +209,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			// Always clear up the app directory in platforms if `--bundle` value has changed in between builds or is passed in general
 			// this is done as user has full control over what goes in platforms when `--bundle` is passed
 			// and we may end up with duplicate symbols which would fail the build
-			if (changesInfo.bundleChanged) {
+			if (changesInfo.bundleChanged || platformInfo.appFilesUpdaterOptions.bundle) {
 				await this.cleanDestinationApp(platformInfo);
 			}
 


### PR DESCRIPTION
If prepare of the project is required and the bundle option is passed,
the platforms/.../app/ dir should be deleted as there may be old assets
left.

Ex.
When the app bundled with snapshot enabled:
```
tns build android --bundle --env.snapshot
```
this produces some assets:
```
platforms/android/.../app/vendor.js
platforms/android/.../app/_embedded_script.js
// ...
```

Then, if the project is bundled without snapshot:
```
tns build android --bundle
```
the produced assets will override the ones that are already in
`platforms/android/.../app`. However, since the build is without
snapshot, an `_embedded_script.js` won't be generated to override the one
that's left in `platforms/android/.../app` from the previous build.

fixes https://github.com/NativeScript/nativescript-dev-webpack/issues/463