### PR TITLE
Support multiple .apk files produced from gradle build

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -33,6 +33,7 @@ export const CONFIG_NS_FILE_NAME = "nsconfig.json";
 export const CONFIG_NS_APP_RESOURCES_ENTRY = "appResourcesPath";
 export const CONFIG_NS_APP_ENTRY = "appPath";
 export const DEPENDENCIES_JSON_NAME = "dependencies.json";
+export const APK_EXTENSION_NAME = ".apk";
 
 export class PackageVersion {
 	static NEXT = "next";

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -260,9 +260,9 @@ interface IPlatformData {
 	projectRoot: string;
 	normalizedPlatformName: string;
 	appDestinationDirectoryPath: string;
-	getDeviceBuildOutputPath(options: IRelease): string;
+	deviceBuildOutputPath: string;
 	emulatorBuildOutputPath?: string;
-	getValidPackageNames(buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[];
+	getValidBuildOutputData(buildOptions: IBuildOutputOptions): IValidBuildOutputData;
 	frameworkFilesExtensions: string[];
 	frameworkDirectoriesExtensions?: string[];
 	frameworkDirectoriesNames?: string[];
@@ -271,6 +271,16 @@ interface IPlatformData {
 	configurationFilePath?: string;
 	relativeToFrameworkConfigurationFilePath: string;
 	fastLivesyncFileExtensions: string[];
+}
+
+interface IValidBuildOutputData {
+	packageNames: string[];
+	regexes?: RegExp[];
+}
+
+interface IBuildOutputOptions {
+	isReleaseBuild?: boolean;
+	isForDevice?: boolean;
 }
 
 interface IPlatformsData {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -142,10 +142,6 @@ interface IBuildForDevice {
 	buildForDevice: boolean;
 }
 
-interface IShouldInstall extends IBuildForDevice, IRelease {
-	
-}
-
 interface INativePrepare {
 	skipNativePrepare: boolean;
 }

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -83,18 +83,19 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				platformProjectService: this,
 				emulatorServices: this.$androidEmulatorServices,
 				projectRoot: projectRoot,
-				getDeviceBuildOutputPath: (options: IRelease): string => {
-					return this.getDeviceBuildOutputPath(path.join(...deviceBuildOutputArr), projectData, options);
-				},
-				getValidPackageNames: (buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[] => {
+				deviceBuildOutputPath: path.join(...deviceBuildOutputArr),
+				getValidBuildOutputData: (buildOptions: IBuildOutputOptions): IValidBuildOutputData => {
 					const buildMode = buildOptions.isReleaseBuild ? Configurations.Release.toLowerCase() : Configurations.Debug.toLowerCase();
 
-					return [
-						`${packageName}-${buildMode}.apk`,
-						`${projectData.projectName}-${buildMode}.apk`,
-						`${projectData.projectName}.apk`,
-						`app-${buildMode}.apk`
-					];
+					return {
+						packageNames: [
+							`${packageName}-${buildMode}${constants.APK_EXTENSION_NAME}`,
+							`${projectData.projectName}-${buildMode}${constants.APK_EXTENSION_NAME}`,
+							`${projectData.projectName}${constants.APK_EXTENSION_NAME}`,
+							`${constants.APP_FOLDER_NAME}-${buildMode}${constants.APK_EXTENSION_NAME}`
+						],
+						regexes: [new RegExp(`${constants.APP_FOLDER_NAME}-.*-(${Configurations.Debug}|${Configurations.Release})${constants.APK_EXTENSION_NAME}`), new RegExp(`${packageName}-.*-(${Configurations.Debug}|${Configurations.Release})${constants.APK_EXTENSION_NAME}`)]
+					};
 				},
 				frameworkFilesExtensions: [".jar", ".dat", ".so"],
 				configurationFileName: constants.MANIFEST_FILE_NAME,
@@ -106,23 +107,6 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		}
 
 		return this._platformData;
-	}
-
-	private getDeviceBuildOutputPath(currentPath: string, projectData: IProjectData, options: IRelease): string {
-		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME);
-		const platformVersion = currentPlatformData && currentPlatformData[constants.VERSION_STRING];
-		const buildType = options.release === true ? "release" : "debug";
-		const normalizedPath = path.join(currentPath, buildType);
-
-		if (semver.valid(platformVersion)) {
-			const gradleAndroidPluginVersion3xx = "4.0.0";
-			const normalizedPlatformVersion = `${semver.major(platformVersion)}.${semver.minor(platformVersion)}.0`;
-			if (semver.lt(normalizedPlatformVersion, gradleAndroidPluginVersion3xx)) {
-				return currentPath;
-			}
-		}
-
-		return normalizedPath;
 	}
 
 	// TODO: Remove prior to the 4.0 CLI release @Pip3r4o @PanayotCankov

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -94,7 +94,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 							`${projectData.projectName}${constants.APK_EXTENSION_NAME}`,
 							`${constants.APP_FOLDER_NAME}-${buildMode}${constants.APK_EXTENSION_NAME}`
 						],
-						regexes: [new RegExp(`${constants.APP_FOLDER_NAME}-.*-(${Configurations.Debug}|${Configurations.Release})${constants.APK_EXTENSION_NAME}`), new RegExp(`${packageName}-.*-(${Configurations.Debug}|${Configurations.Release})${constants.APK_EXTENSION_NAME}`)]
+						regexes: [new RegExp(`${constants.APP_FOLDER_NAME}-.*-(${Configurations.Debug}|${Configurations.Release})${constants.APK_EXTENSION_NAME}`, "i"), new RegExp(`${packageName}-.*-(${Configurations.Debug}|${Configurations.Release})${constants.APK_EXTENSION_NAME}`, "i")]
 					};
 				},
 				frameworkFilesExtensions: [".jar", ".dat", ".so"],

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -72,8 +72,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				platformProjectService: this,
 				emulatorServices: this.$iOSEmulatorServices,
 				projectRoot: projectRoot,
-				deviceBuildOutputPath: path.join(projectRoot, "build", "device"),
-				emulatorBuildOutputPath: path.join(projectRoot, "build", "emulator"),
+				deviceBuildOutputPath: path.join(projectRoot, constants.BUILD_DIR, "device"),
+				emulatorBuildOutputPath: path.join(projectRoot, constants.BUILD_DIR, "emulator"),
 				getValidBuildOutputData: (buildOptions: IBuildOutputOptions): IValidBuildOutputData => {
 					if (buildOptions.isForDevice) {
 						return {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -72,16 +72,18 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				platformProjectService: this,
 				emulatorServices: this.$iOSEmulatorServices,
 				projectRoot: projectRoot,
-				getDeviceBuildOutputPath: (options: IRelease): string => {
-					return path.join(projectRoot, "build", "device");
-				},
+				deviceBuildOutputPath: path.join(projectRoot, "build", "device"),
 				emulatorBuildOutputPath: path.join(projectRoot, "build", "emulator"),
-				getValidPackageNames: (buildOptions: { isReleaseBuild?: boolean, isForDevice?: boolean }): string[] => {
+				getValidBuildOutputData: (buildOptions: IBuildOutputOptions): IValidBuildOutputData => {
 					if (buildOptions.isForDevice) {
-						return [`${projectData.projectName}.ipa`];
+						return {
+							packageNames: [`${projectData.projectName}.ipa`]
+						};
 					}
 
-					return [`${projectData.projectName}.app`, `${projectData.projectName}.zip`];
+					return {
+						packageNames: [`${projectData.projectName}.app`, `${projectData.projectName}.zip`]
+					};
 				},
 				frameworkFilesExtensions: [".a", ".framework", ".bin"],
 				frameworkDirectoriesExtensions: [".framework"],

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -342,13 +342,13 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const forDevice = !buildConfig || buildConfig.buildForDevice;
-		outputPath = outputPath || (forDevice ? platformData.getDeviceBuildOutputPath(buildConfig) : platformData.emulatorBuildOutputPath || platformData.getDeviceBuildOutputPath(buildConfig));
+		outputPath = outputPath || (forDevice ? platformData.deviceBuildOutputPath : platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath);
 		if (!this.$fs.exists(outputPath)) {
 			return true;
 		}
 
-		const packageNames = platformData.getValidPackageNames({ isForDevice: forDevice });
-		const packages = this.getApplicationPackages(outputPath, packageNames);
+		const validBuildOutputData = platformData.getValidBuildOutputData({ isForDevice: forDevice });
+		const packages = this.getApplicationPackages(outputPath, validBuildOutputData);
 		if (packages.length === 0) {
 			return true;
 		}
@@ -450,7 +450,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const deviceBuildInfo: IBuildInfo = await this.getDeviceBuildInfo(device, projectData);
-		const localBuildInfo = this.getBuildInfo(platform, platformData, { buildForDevice: !device.isEmulator, release: release.release }, outputPath);
+		const localBuildInfo = this.getBuildInfo(platform, platformData, { buildForDevice: !device.isEmulator }, outputPath);
 		return !localBuildInfo || !deviceBuildInfo || deviceBuildInfo.buildTime !== localBuildInfo.buildTime;
 	}
 
@@ -561,12 +561,12 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		await this.$devicesService.execute(action, this.getCanExecuteAction(platform, runOptions));
 	}
 
-	private getBuildOutputPath(platform: string, platformData: IPlatformData, options: IShouldInstall): string {
+	private getBuildOutputPath(platform: string, platformData: IPlatformData, options: IBuildForDevice): string {
 		if (platform.toLowerCase() === this.$devicePlatformsConstants.iOS.toLowerCase()) {
-			return options.buildForDevice ? platformData.getDeviceBuildOutputPath(options) : platformData.emulatorBuildOutputPath;
+			return options.buildForDevice ? platformData.deviceBuildOutputPath : platformData.emulatorBuildOutputPath;
 		}
 
-		return platformData.getDeviceBuildOutputPath(options);
+		return platformData.deviceBuildOutputPath;
 	}
 
 	private async getDeviceBuildInfoFilePath(device: Mobile.IDevice, projectData: IProjectData): Promise<string> {
@@ -586,7 +586,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	private getBuildInfo(platform: string, platformData: IPlatformData, options: IShouldInstall, buildOutputPath?: string): IBuildInfo {
+	private getBuildInfo(platform: string, platformData: IPlatformData, options: IBuildForDevice, buildOutputPath?: string): IBuildInfo {
 		buildOutputPath = buildOutputPath || this.getBuildOutputPath(platform, platformData, options);
 		const buildInfoFile = path.join(buildOutputPath, buildInfoFileName);
 		if (this.$fs.exists(buildInfoFile)) {
@@ -746,27 +746,50 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return platformData.platformProjectService.isPlatformPrepared(platformData.projectRoot, projectData);
 	}
 
-	private getApplicationPackages(buildOutputPath: string, validPackageNames: string[]): IApplicationPackage[] {
+	private getApplicationPackages(buildOutputPath: string, validBuildOutputData: IValidBuildOutputData): IApplicationPackage[] {
 		// Get latest package` that is produced from build
-		const candidates = this.$fs.readDirectory(buildOutputPath);
-		const packages = _.filter(candidates, candidate => {
-			return _.includes(validPackageNames, candidate);
-		}).map(currentPackage => {
-			currentPackage = path.join(buildOutputPath, currentPackage);
+		let result = this.getApplicationPackagesCore(this.$fs.readDirectory(buildOutputPath).map(filename => path.join(buildOutputPath, filename)), validBuildOutputData.packageNames);
+		if (result) {
+			return result;
+		}
 
-			return {
-				packageName: currentPackage,
-				time: this.$fs.getFsStats(currentPackage).mtime
-			};
-		});
+		const candidates = this.$fs.enumerateFilesInDirectorySync(buildOutputPath);
+		result = this.getApplicationPackagesCore(candidates, validBuildOutputData.packageNames);
+		if (result) {
+			return result;
+		}
 
-		return packages;
+		if (validBuildOutputData.regexes && validBuildOutputData.regexes.length) {
+			return this.createApplicationPackages(candidates.filter(filepath => _.some(validBuildOutputData.regexes, regex => regex.test(path.basename(filepath)))));
+		}
+
+		return [];
 	}
 
-	private getLatestApplicationPackage(buildOutputPath: string, validPackageNames: string[]): IApplicationPackage {
-		let packages = this.getApplicationPackages(buildOutputPath, validPackageNames);
+	private getApplicationPackagesCore(candidates: string[], validPackageNames: string[]): IApplicationPackage[] {
+		const packages = candidates.filter(filePath => _.includes(validPackageNames, path.basename(filePath)));
+		if (packages.length > 0) {
+			return this.createApplicationPackages(packages);
+		}
+
+		return null;
+	}
+
+	private createApplicationPackages(packages: string[]): IApplicationPackage[] {
+		return packages.map(filepath => this.createApplicationPackage(filepath));
+	}
+
+	private createApplicationPackage(filepath: string): IApplicationPackage {
+		return {
+			packageName: filepath,
+			time: this.$fs.getFsStats(filepath).mtime
+		};
+	}
+
+	private getLatestApplicationPackage(buildOutputPath: string, validBuildOutputData: IValidBuildOutputData): IApplicationPackage {
+		let packages = this.getApplicationPackages(buildOutputPath, validBuildOutputData);
 		if (packages.length === 0) {
-			const packageExtName = path.extname(validPackageNames[0]);
+			const packageExtName = path.extname(validBuildOutputData.packageNames[0]);
 			this.$errors.fail("No %s found in %s directory", packageExtName, buildOutputPath);
 		}
 
@@ -776,11 +799,11 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	public getLatestApplicationPackageForDevice(platformData: IPlatformData, buildConfig: IBuildConfig, outputPath?: string): IApplicationPackage {
-		return this.getLatestApplicationPackage(outputPath || platformData.getDeviceBuildOutputPath(buildConfig), platformData.getValidPackageNames({ isForDevice: true, isReleaseBuild: buildConfig.release }));
+		return this.getLatestApplicationPackage(outputPath || platformData.deviceBuildOutputPath, platformData.getValidBuildOutputData({ isForDevice: true, isReleaseBuild: buildConfig.release }));
 	}
 
 	public getLatestApplicationPackageForEmulator(platformData: IPlatformData, buildConfig: IBuildConfig, outputPath?: string): IApplicationPackage {
-		return this.getLatestApplicationPackage(outputPath || platformData.emulatorBuildOutputPath || platformData.getDeviceBuildOutputPath(buildConfig), platformData.getValidPackageNames({ isForDevice: false, isReleaseBuild: buildConfig.release }));
+		return this.getLatestApplicationPackage(outputPath || platformData.emulatorBuildOutputPath || platformData.deviceBuildOutputPath, platformData.getValidBuildOutputData({ isForDevice: false, isReleaseBuild: buildConfig.release }));
 	}
 
 	private async updatePlatform(platform: string, version: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void> {
@@ -813,7 +836,6 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		} else {
 			this.$errors.failWithoutHelp("Native Platform cannot be updated.");
 		}
-
 	}
 
 	private async updatePlatformCore(platformData: IPlatformData, updateOptions: IUpdatePlatformOptions, projectData: IProjectData, config: IPlatformOptions): Promise<void> {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -779,10 +779,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		return packages.map(filepath => this.createApplicationPackage(filepath));
 	}
 
-	private createApplicationPackage(filepath: string): IApplicationPackage {
+	private createApplicationPackage(packageName: string): IApplicationPackage {
 		return {
-			packageName: filepath,
-			time: this.$fs.getFsStats(filepath).mtime
+			packageName,
+			time: this.$fs.getFsStats(packageName).mtime
 		};
 	}
 

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -35,10 +35,8 @@ class PlatformData implements IPlatformData {
 	};
 	emulatorServices: Mobile.IEmulatorPlatformServices = null;
 	projectRoot = "";
-	getDeviceBuildOutputPath = (buildTypeOption: IRelease) => {
-		return "";
-	}
-	getValidPackageNames = (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [""];
+	deviceBuildOutputPath = "";
+	getValidBuildOutputData = (buildOptions: IBuildOutputOptions) => ({ packageNames: [""] });
 	validPackageNamesForDevice: string[] = [];
 	frameworkFilesExtensions = [".jar", ".dat"];
 	appDestinationDirectoryPath = "";

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -304,10 +304,8 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 			platformProjectService: this,
 			emulatorServices: undefined,
 			projectRoot: "",
-			getDeviceBuildOutputPath: (buildTypeOption: IRelease) => {
-				return "";
-			},
-			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
+			deviceBuildOutputPath: "",
+			getValidBuildOutputData: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => ({ packageNames: [] }),
 			frameworkFilesExtensions: [],
 			appDestinationDirectoryPath: "",
 			relativeToFrameworkConfigurationFilePath: "",
@@ -417,10 +415,8 @@ export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
 			projectRoot: "",
 			normalizedPlatformName: "",
 			appDestinationDirectoryPath: "",
-			getDeviceBuildOutputPath: (buildTypeOption: IRelease) => {
-				return "";
-			},
-			getValidPackageNames: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => [],
+			deviceBuildOutputPath: "",
+			getValidBuildOutputData: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => ({ packageNames: []}),
 			frameworkFilesExtensions: [],
 			relativeToFrameworkConfigurationFilePath: "",
 			fastLivesyncFileExtensions: []

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -305,7 +305,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 			emulatorServices: undefined,
 			projectRoot: "",
 			deviceBuildOutputPath: "",
-			getValidBuildOutputData: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => ({ packageNames: [] }),
+			getValidBuildOutputData: (buildOptions: IBuildOutputOptions) => ({ packageNames: [] }),
 			frameworkFilesExtensions: [],
 			appDestinationDirectoryPath: "",
 			relativeToFrameworkConfigurationFilePath: "",
@@ -416,7 +416,7 @@ export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
 			normalizedPlatformName: "",
 			appDestinationDirectoryPath: "",
 			deviceBuildOutputPath: "",
-			getValidBuildOutputData: (buildOptions: { isForDevice?: boolean, isReleaseBuild?: boolean }) => ({ packageNames: []}),
+			getValidBuildOutputData: (buildOptions: IBuildOutputOptions) => ({ packageNames: []}),
 			frameworkFilesExtensions: [],
 			relativeToFrameworkConfigurationFilePath: "",
 			fastLivesyncFileExtensions: []


### PR DESCRIPTION
This PR adds support for multiple .apk files produced from gradle build in following cases:

1. When productFlavors are used
 Add this to `app/App_Resources/app.gradle` file
```
flavorDimensions "arch", "mode"

  productFlavors {
    demo {
      dimension "mode"
    }
    full {
      dimension "mode"
    }
    x86 {
      dimension "arch"
    }
    arm {
      dimension "arch"
    }
    arm64 {
      dimension "arch"
    }
  }
```

2. When splits option is used
Add this to `app/App_Resources/app.gradle` file
```
splits {
    abi {
      enable true //enables the ABIs split mechanism
      reset() //reset the list of ABIs to be included to an empty string
      include 'arm64-v8a', 'armeabi-v7a', 'x86'
      universalApk true
    }
  }
```