### PR TITLE
refactor: rename skipenv variable

### DIFF
--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -25,7 +25,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 	};
 
 	public async checkEnvironmentRequirements(platform: string): Promise<boolean> {
-		if (process.env.SKIP_ENV_CHECK) {
+		if (process.env.NS_SKIP_ENV_CHECK) {
 			return true;
 		}
 


### PR DESCRIPTION
Rename the generic `SKIP_ENV_CHECK` to `NS_SKIP_ENV_CHECK` in order to mitigate any potential clashes with other tools.

Ping @Fatme @rosen-vladimirov 