### PR TITLE
fix(assets): Fix asset genration 

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -162,4 +162,7 @@ export class AssetConstants {
 	public static assets = "assets";
 
 	public static sizeDelimiter = "x";
+
+	public static defaultScale = 1;
+	public static defaultOverlayImageScale = 0.8;
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -157,7 +157,7 @@ interface IAssetItem {
 	height: number;
 	filename: string;
 	directory: string;
-	scale: number;
+	scale: string;
 	idiom: string;
 	resizeOperation?: string;
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -160,6 +160,7 @@ interface IAssetItem {
 	scale: string;
 	idiom: string;
 	resizeOperation?: string;
+	overlayImageScale?: number;
 }
 
 interface IAssetSubGroup {

--- a/lib/services/assets-generation/assets-generation-service.ts
+++ b/lib/services/assets-generation/assets-generation-service.ts
@@ -1,7 +1,7 @@
 import * as Jimp from "jimp";
 import * as Color from "color";
 import { exported } from "../../common/decorators";
-import { AssetConstants } from "../../constants";
+import { AssetConstants } from '../../constants';
 
 export const enum Operations {
 	OverlayWith = "overlayWith",
@@ -66,7 +66,7 @@ export class AssetsGenerationService implements IAssetsGenerationService {
 				}
 			}
 
-			const scale = tempScale || 1;
+			const scale = tempScale || AssetConstants.defaultScale;
 
 			const outputPath = assetItem.path;
 			const width = assetItem.width * scale;
@@ -74,7 +74,7 @@ export class AssetsGenerationService implements IAssetsGenerationService {
 
 			switch (operation) {
 				case Operations.OverlayWith:
-					const overlayImageScale = assetItem.overlayImageScale || 0.8;
+					const overlayImageScale = assetItem.overlayImageScale || AssetConstants.defaultOverlayImageScale;
 					const imageResize = Math.round(Math.min(width, height) * overlayImageScale);
 					const image = await this.resize(generationData.imagePath, imageResize, imageResize);
 					await this.generateImage(generationData.background, width, height, outputPath, image);

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -159,6 +159,9 @@ export class ProjectDataService implements IProjectDataService {
 						image.size = image.size || `${assetItem.width}${AssetConstants.sizeDelimiter}${assetItem.height}`;
 					}
 
+					image.resizeOperation = image.resizeOperation || assetItem.resizeOperation;
+					image.overlayImageScale = image.overlayImageScale || assetItem.overlayImageScale;
+
 					// break each
 					return false;
 				}

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -137,25 +137,32 @@ export class ProjectDataService implements IProjectDataService {
 				image.path = path.join(dirPath, image.filename);
 			}
 
-			if (image.size) {
-				// size is basically <width>x<height>
-				const [width, height] = image.size.toString().split(AssetConstants.sizeDelimiter);
-				if (width && height) {
-					image.width = +width;
-					image.height = +height;
-				}
-			} else {
-				// Find the image size based on the hardcoded values in the image-definitions.json
-				_.each(imageDefinitions, (assetSubGroup: IAssetItem[]) => {
-					_.each(assetSubGroup, assetItem => {
-						if (assetItem.filename === image.filename && path.basename(assetItem.directory) === path.basename(dirPath)) {
-							image.width = assetItem.width;
-							image.height = assetItem.height;
-							image.size = `${assetItem.width}${AssetConstants.sizeDelimiter}${assetItem.height}`;
+			// Find the image size based on the hardcoded values in the image-definitions.json
+			_.each(imageDefinitions, (assetSubGroup: IAssetItem[]) => {
+				const assetItem = _.find(assetSubGroup, assetElement =>
+					assetElement.filename === image.filename && path.basename(assetElement.directory) === path.basename(dirPath)
+				);
+
+				if (assetItem) {
+					if (image.size) {
+						// size is basically <width>x<height>
+						const [width, height] = image.size.toString().split(AssetConstants.sizeDelimiter);
+						if (width && height) {
+							image.width = +width;
+							image.height = +height;
 						}
-					});
-				});
-			}
+					}
+
+					if (!image.width || !image.height) {
+						image.width = assetItem.width;
+						image.height = assetItem.height;
+						image.size = image.size || `${assetItem.width}${AssetConstants.sizeDelimiter}${assetItem.height}`;
+					}
+
+					// break each
+					return false;
+				}
+			});
 		});
 
 		return content;

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -161,7 +161,7 @@ export class ProjectDataService implements IProjectDataService {
 
 					image.resizeOperation = image.resizeOperation || assetItem.resizeOperation;
 					image.overlayImageScale = image.overlayImageScale || assetItem.overlayImageScale;
-
+					image.scale = image.scale || assetItem.scale;
 					// break each
 					return false;
 				}

--- a/resources/assets/image-definitions.json
+++ b/resources/assets/image-definitions.json
@@ -2,124 +2,144 @@
 	"ios": {
 		"icons": [
 			{
-				"width": 180,
-				"height": 180,
+				"width": 60,
+				"height": 60,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-60@3x.png"
-			},
-			{
-				"width": 120,
-				"height": 120,
-				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-60@2x.png"
-			},
-			{
-				"width": 40,
-				"height": 40,
-				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-40.png"
-			},
-			{
-				"width": 80,
-				"height": 80,
-				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-40@2x.png"
-			},
-			{
-				"width": 120,
-				"height": 120,
-				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-40@3x.png"
-			},
-			{
-				"width": 50,
-				"height": 50,
-				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-50.png"
-			},
-			{
-				"width": 100,
-				"height": 100,
-				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-50@2x.png"
+				"filename": "icon-60@3x.png",
+				"scale": "3x"
 			},
 			{
 				"width": 60,
 				"height": 60,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-60.png"
+				"filename": "icon-60@2x.png",
+				"scale": "3x"
+			},
+			{
+				"width": 40,
+				"height": 40,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-40.png",
+				"scale": "1x"
+			},
+			{
+				"width": 40,
+				"height": 40,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-40@2x.png",
+				"scale": "2x"
+			},
+			{
+				"width": 40,
+				"height": 40,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-40@3x.png",
+				"scale": "3x"
+			},
+			{
+				"width": 50,
+				"height": 50,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-50.png",
+				"scale": "1x"
+			},
+			{
+				"width": 50,
+				"height": 50,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-50@2x.png",
+				"scale": "2x"
+			},
+			{
+				"width": 60,
+				"height": 60,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-60.png",
+				"scale": "1x"
 			},
 			{
 				"width": 72,
 				"height": 72,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-72.png"
+				"filename": "icon-72.png",
+				"scale": "1x"
 			},
 			{
-				"width": 144,
-				"height": 144,
+				"width": 72,
+				"height": 72,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-72@2x.png"
+				"filename": "icon-72@2x.png",
+				"scale": "2x"
 			},
 			{
 				"width": 76,
 				"height": 76,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-76.png"
+				"filename": "icon-76.png",
+				"scale": "1x"
 			},
 			{
-				"width": 152,
-				"height": 152,
+				"width": 76,
+				"height": 76,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-76@2x.png"
+				"filename": "icon-76@2x.png",
+				"scale": "2x"
 			},
 			{
-				"width": 167,
-				"height": 167,
+				"width": 83.5,
+				"height": 83.5,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-83.5@2x.png"
+				"filename": "icon-83.5@2x.png",
+				"scale": "2x"
 			},
 			{
 				"width": 120,
 				"height": 120,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-120.png"
+				"filename": "icon-120.png",
+				"scale": "1x"
 			},
 			{
 				"width": 29,
 				"height": 29,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-29.png"
+				"filename": "icon-29.png",
+				"scale": "1x"
 			},
 			{
-				"width": 58,
-				"height": 58,
+				"width": 29,
+				"height": 29,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-29@2x.png"
+				"filename": "icon-29@2x.png",
+				"scale": "2x"
 			},
 			{
-				"width": 87,
-				"height": 87,
+				"width": 29,
+				"height": 29,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-29@3x.png"
+				"filename": "icon-29@3x.png",
+				"scale": "3x"
 			},
 			{
 				"width": 57,
 				"height": 57,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-57.png"
+				"filename": "icon-57.png",
+				"scale": "1x"
 			},
 			{
-				"width": 114,
-				"height": 114,
+				"width": 57,
+				"height": 57,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-57@2x.png"
+				"filename": "icon-57@2x.png",
+				"scale": "2x"
 			},
 			{
 				"width": 1024,
 				"height": 1024,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
-				"filename": "icon-1024.png"
+				"filename": "icon-1024.png",
+				"scale": "1x"
 			}
 		],
 		"splashBackgrounds": [
@@ -128,21 +148,24 @@
 				"height": 1024,
 				"directory": "Assets.xcassets/LaunchScreen.AspectFill.imageset",
 				"filename": "LaunchScreen-AspectFill.png",
-				"resizeOperation": "blank"
+				"resizeOperation": "blank",
+				"scale": "1x"
 			},
 			{
-				"width": 1536,
-				"height": 2048,
+				"width": 768,
+				"height": 1024,
 				"directory": "Assets.xcassets/LaunchScreen.AspectFill.imageset",
 				"filename": "LaunchScreen-AspectFill@2x.png",
-				"resizeOperation": "blank"
+				"resizeOperation": "blank",
+				"scale": "2x"
 			},
 			{
-				"width": 2304,
-				"height": 3072,
+				"width": 768,
+				"height": 1024,
 				"directory": "Assets.xcassets/LaunchScreen.AspectFill.imageset",
 				"filename": "LaunchScreen-AspectFill@3x.png",
-				"resizeOperation": "blank"
+				"resizeOperation": "blank",
+				"scale": "3x"
 			}
 		],
 		"splashCenterImages": [
@@ -151,107 +174,122 @@
 				"height": 512,
 				"directory": "Assets.xcassets/LaunchScreen.Center.imageset",
 				"filename": "LaunchScreen-Center.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
-				"width": 768,
-				"height": 1024,
+				"width": 384,
+				"height": 512,
 				"directory": "Assets.xcassets/LaunchScreen.Center.imageset",
 				"filename": "LaunchScreen-Center@2x.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "2x"
 			}
 		],
 		"splashImages": [
 			{
-				"width": 640,
-				"height": 1136,
+				"width": 320,
+				"height": 568,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-568h@2x.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "2x"
 			},
 			{
 				"width": 1024,
 				"height": 768,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-Landscape.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
-				"width": 2048,
-				"height": 1536,
+				"width": 1024,
+				"height": 768,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-Landscape@2x.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "2x"
 			},
 			{
-				"width": 2208,
-				"height": 1242,
+				"width": 736,
+				"height": 414,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-Landscape@3x.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "3x"
 			},
 			{
-				"width": 1536,
-				"height": 2048,
+				"width": 768,
+				"height": 1024,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-Portrait@2x.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "2x"
 			},
 			{
 				"width": 768,
 				"height": 1024,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-Portrait.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
-				"width": 640,
-				"height": 960,
+				"width": 320,
+				"height": 480,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default@2x.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "2x"
 			},
 			{
 				"width": 320,
 				"height": 480,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
-				"width": 750,
-				"height": 1344,
+				"width": 375,
+				"height": 667,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-667h@2x.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "2x"
 			},
 			{
-				"width": 1242,
-				"height": 2208,
+				"width": 414,
+				"height": 736,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-736h@3x.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "3x"
 			},
 			{
 				"width": 2208,
 				"height": 1242,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-Landscape-736h.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 1125,
 				"height": 2436,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-1125h.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 2436,
 				"height": 1125,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Default-Landscape-X.png",
-				"resizeOperation": "overlayWith"
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			}
 		]
 	},

--- a/resources/assets/image-definitions.json
+++ b/resources/assets/image-definitions.json
@@ -13,7 +13,7 @@
 				"height": 60,
 				"directory": "Assets.xcassets/AppIcon.appiconset",
 				"filename": "icon-60@2x.png",
-				"scale": "3x"
+				"scale": "2x"
 			},
 			{
 				"width": 40,


### PR DESCRIPTION
Fix the generation of asset - the filter is incorrect and fails with `Cannot read property 'splashImages' of null, TypeError: Cannot read property 'splashImages' of null`
Also fix the scale - it has been incorrectly declared as number, when it is string (1x, 2x, etc.). Use the scale correctly by parsing it and use it when generate the image.
Also fix the using of resizeOperation property - it was not passed correctly for iOS assets.


chore: Update to latest common lib