### PR TITLE
Print warning when more than one package is produced from build

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -794,7 +794,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 
 		if (packages.length > 1) {
-			this.$logger.warn(`More than one ${packageExtName} found in ${buildOutputPath} directory. Using the last one produced from build.`)
+			this.$logger.warn(`More than one ${packageExtName} found in ${buildOutputPath} directory. Using the last one produced from build.`);
 		}
 
 		packages = _.sortBy(packages, pkg => pkg.time).reverse(); // We need to reverse because sortBy always sorts in ascending order

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -788,9 +788,13 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	private getLatestApplicationPackage(buildOutputPath: string, validBuildOutputData: IValidBuildOutputData): IApplicationPackage {
 		let packages = this.getApplicationPackages(buildOutputPath, validBuildOutputData);
+		const packageExtName = path.extname(validBuildOutputData.packageNames[0]);
 		if (packages.length === 0) {
-			const packageExtName = path.extname(validBuildOutputData.packageNames[0]);
-			this.$errors.fail("No %s found in %s directory", packageExtName, buildOutputPath);
+			this.$errors.fail(`No ${packageExtName} found in ${buildOutputPath} directory.`);
+		}
+
+		if (packages.length > 1) {
+			this.$logger.warn(`More than one ${packageExtName} found in ${buildOutputPath} directory. Using the last one produced from build.`)
 		}
 
 		packages = _.sortBy(packages, pkg => pkg.time).reverse(); // We need to reverse because sortBy always sorts in ascending order


### PR DESCRIPTION
In case when productFlavors or split option is used in .gradle file more than on .apk files are produced. Print warning that will be used the last one produced from build.