### PR TITLE
Fix (publish): Remove binary-plist and use simple-plist instead

### DIFF
--- a/lib/definitions/simple-plist.d.ts
+++ b/lib/definitions/simple-plist.d.ts
@@ -1,4 +1,0 @@
-declare module "simple-plist" {
-	export function readFile(filePath: string, callback?:(err: Error, obj: any) => void): void;
-	export function readFileSync(filePath: string): any;
-}

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -13,7 +13,6 @@ import * as plist from "plist";
 import { IOSProvisionService } from "./ios-provision-service";
 import { IOSEntitlementsService } from "./ios-entitlements-service";
 import { XCConfigService } from "./xcconfig-service";
-import * as simplePlist from "simple-plist";
 import * as mobileprovision from "ios-mobileprovision-finder";
 import { SpawnOptions } from "child_process";
 import { BUILD_XCCONFIG_FILE_NAME } from "../constants";
@@ -51,6 +50,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		private $xcode: IXcode,
 		private $iOSEntitlementsService: IOSEntitlementsService,
 		private $platformEnvironmentRequirements: IPlatformEnvironmentRequirements,
+		private $plistParser: IPlistParser,
 		private $sysInfo: ISysInfo,
 		private $xCConfigService: XCConfigService) {
 			super($fs, $projectDataService);
@@ -1045,7 +1045,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 			this.$errors.failWithoutHelp("The bundle at %s does not contain an Info.plist file.", libraryPath);
 		}
 
-		const plistJson = simplePlist.readFileSync(infoPlistPath);
+		const plistJson = this.$plistParser.parseFileSync(infoPlistPath);
 		const packageType = plistJson["CFBundlePackageType"];
 
 		if (packageType !== "FMWK") {

--- a/lib/services/itmstransporter-service.ts
+++ b/lib/services/itmstransporter-service.ts
@@ -10,7 +10,7 @@ export class ITMSTransporterService implements IITMSTransporterService {
 	private _itunesConnectApplications: IiTunesConnectApplication[] = null;
 	private _bundleIdentifier: string = null;
 
-	constructor(private $bplistParser: IBinaryPlistParser,
+	constructor(private $plistParser: IPlistParser,
 		private $childProcess: IChildProcess,
 		private $errors: IErrors,
 		private $fs: IFileSystem,
@@ -135,8 +135,8 @@ export class ITMSTransporterService implements IITMSTransporterService {
 				}
 				const appFile = path.join(payloadDir, allApps[0]);
 
-				const plistObject = await this.$bplistParser.parseFile(path.join(appFile, INFO_PLIST_FILE_NAME));
-				const bundleId = plistObject && plistObject[0] && plistObject[0].CFBundleIdentifier;
+				const plistObject = await this.$plistParser.parseFile(path.join(appFile, INFO_PLIST_FILE_NAME));
+				const bundleId = plistObject && plistObject.CFBundleIdentifier;
 				if (!bundleId) {
 					this.$errors.failWithoutHelp(`Unable to determine bundle identifier from ${ipaFileFullPath}.`);
 				}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -434,11 +434,6 @@
         "stream-buffers": "2.2.0"
       }
     },
-    "bplist-parser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.0.tgz",
-      "integrity": "sha1-Ywgj8gVkN9Tb78IOhAF/i6xI4Ag="
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   ],
   "dependencies": {
     "@types/ora": "1.3.2",
-    "bplist-parser": "0.1.0",
     "bufferpack": "0.0.6",
     "byline": "4.2.1",
     "chalk": "1.1.0",

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -120,6 +120,7 @@ function createTestInjector(projectPath: string, projectName: string): IInjector
 	testInjector.register("settingsService", SettingsService);
 	testInjector.register("httpClient", {});
 	testInjector.register("platformEnvironmentRequirements", {});
+	testInjector.register("plistParser", {});
 
 	return testInjector;
 }


### PR DESCRIPTION
In case when produced Info.plist is not a binary file, `tns publish ios` command fails because `bplist-parser` is not able to parse non-binary plist files. This PR replaces `bplist-parser` module with `sample-plist` that is able to parse binary and xml files.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3470