### PR TITLE
fix: Move @types/ora as devDependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -70,12 +70,14 @@
     "@types/node": {
       "version": "6.0.61",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.61.tgz",
-      "integrity": "sha1-7qF0itmd7K8xm1cQFwGGMZdKxvA="
+      "integrity": "sha1-7qF0itmd7K8xm1cQFwGGMZdKxvA=",
+      "dev": true
     },
     "@types/ora": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/ora/-/ora-1.3.2.tgz",
-      "integrity": "sha512-YZjIN90YKxkQjmDZHr1CQP1Z20qUU3TLC10k+SnDqoRv0CNUxREwaaDc3aCRNcOfjCjktdoP2Z8Cxqf4wHjO2w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/ora/-/ora-1.3.3.tgz",
+      "integrity": "sha512-XaSVRyCfnGq1xGlb6iuoxnomMXPIlZnvIIkKiGNMTCeVOg7G1Si+FA9N1lPrykPEfiRHwbuZXuTCSoYcHyjcdg==",
+      "dev": true,
       "requires": {
         "@types/node": "6.0.61"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "mobile"
   ],
   "dependencies": {
-    "@types/ora": "1.3.2",
     "bufferpack": "0.0.6",
     "byline": "4.2.1",
     "chalk": "1.1.0",
@@ -94,6 +93,7 @@
     "@types/color": "3.0.0",
     "@types/lockfile": "1.0.0",
     "@types/node": "6.0.61",
+    "@types/ora": "1.3.3",
     "@types/qr-image": "3.2.0",
     "@types/request": "0.0.45",
     "@types/semver": "^5.3.31",


### PR DESCRIPTION
Ora's definition files are not needed in production package, so move it as devDependency.