### PR TITLE
feat(commands): Introduce postCommandAction

### DIFF
--- a/lib/commands/create-project.ts
+++ b/lib/commands/create-project.ts
@@ -1,10 +1,14 @@
 import * as constants from "../constants";
+import * as path from "path";
 
 export class CreateProjectCommand implements ICommand {
 	public enableHooks = false;
 	public allowedParameters: ICommandParameter[] = [this.$stringParameterBuilder.createMandatoryParameter("Project name cannot be empty.")];
 
+	private createdProjecData: ICreateProjectData;
+
 	constructor(private $projectService: IProjectService,
+		private $logger: ILogger,
 		private $errors: IErrors,
 		private $options: IOptions,
 		private $stringParameterBuilder: IStringParameterBuilder) { }
@@ -23,7 +27,7 @@ export class CreateProjectCommand implements ICommand {
 			selectedTemplate = this.$options.template;
 		}
 
-		await this.$projectService.createProject({
+		this.createdProjecData = await this.$projectService.createProject({
 			projectName: args[0],
 			template: selectedTemplate,
 			appId: this.$options.appid,
@@ -31,6 +35,13 @@ export class CreateProjectCommand implements ICommand {
 			force: this.$options.force,
 			ignoreScripts: this.$options.ignoreScripts
 		});
+	}
+
+	public async postCommandAction(args: string[]): Promise<void> {
+		const { projectDir } = this.createdProjecData;
+		const relativePath = path.relative(process.cwd(), projectDir);
+		this.$logger.printMarkdown(`Now you can navigate to your project with \`$ cd ${relativePath}\``);
+		this.$logger.printMarkdown(`After that you can run it on device/emulator by executing \`$ tns run <platform>\``);
 	}
 }
 

--- a/lib/commands/post-install.ts
+++ b/lib/commands/post-install.ts
@@ -18,6 +18,27 @@ export class PostInstallCliCommand extends PostInstallCommand {
 
 		await this.$subscriptionService.subscribeForNewsletter();
 	}
+
+	public async postCommandAction(args: string[]): Promise<void> {
+		this.$logger.info("You have successfully installed NativeScript CLI.");
+		this.$logger.info("In order to create a new project, you can use:".green);
+		this.$logger.printMarkdown("`tns create <app name>`");
+		this.$logger.info("To build your project locally you can use:".green);
+		this.$logger.printMarkdown("`tns build <platform>`");
+		this.$logger.printMarkdown("NOTE: Local builds require additional setup of your environment. You can find more information here: `https://docs.nativescript.org/start/quick-setup`");
+
+		// Add a new line just to ensure separation between local builds and cloud builds info.
+		this.$logger.info("");
+		this.$logger.info("To build your project in the cloud you can use:".green);
+		this.$logger.printMarkdown("`tns cloud build <platform>`");
+		this.$logger.printMarkdown("NOTE: Cloud builds require Telerik account. You can find more information here: `https://docs.nativescript.org/sidekick/intro/requirements`");
+
+		this.$logger.info("");
+		this.$logger.printMarkdown("In case you want to experiment quickly with NativeScript, you can try the Playground: `https://play.nativescript.org`");
+
+		this.$logger.info("");
+		this.$logger.printMarkdown("In case you have any questions, you can check our forum: `https://forum.nativescript.org` and our public Slack channel: `https://nativescriptcommunity.slack.com/`");
+	}
 }
 
 $injector.registerCommand("post-install-cli", PostInstallCliCommand);

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -37,13 +37,21 @@ interface IProjectSettings {
 	ignoreScripts?: boolean;
 }
 
+interface IProjectName {
+	projectName: string;
+}
+
+interface ICreateProjectData extends IProjectDir, IProjectName {
+
+}
+
 interface IProjectService {
 	/**
 	 * Creates new NativeScript application.
 	 * @param {any} projectSettings Options describing new project - its name, appId, path and template from which to be created.
 	 * @returns {Promise<void>}
 	 */
-	createProject(projectSettings: IProjectSettings): Promise<void>;
+	createProject(projectSettings: IProjectSettings): Promise<ICreateProjectData>;
 
 	/**
 	 * Checks if the specified project is valid NativeScript project.
@@ -58,8 +66,7 @@ interface INsConfig {
 	appResourcesPath?: string;
 }
 
-interface IProjectData extends IProjectDir {
-	projectName: string;
+interface IProjectData extends ICreateProjectData {
 	platformsDir: string;
 	projectFilePath: string;
 	projectId?: string;

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -18,7 +18,7 @@ export class ProjectService implements IProjectService {
 		private $npmInstallationManager: INpmInstallationManager) { }
 
 	@exported("projectService")
-	public async createProject(projectOptions: IProjectSettings): Promise<void> {
+	public async createProject(projectOptions: IProjectSettings): Promise<ICreateProjectData> {
 		let projectName = projectOptions.projectName;
 		let selectedTemplate = projectOptions.template;
 
@@ -74,6 +74,7 @@ export class ProjectService implements IProjectService {
 		}
 
 		this.$logger.printMarkdown("Project `%s` was successfully created.", projectName);
+		return { projectName, projectDir };
 	}
 
 	@exported("projectService")

--- a/test/project-commands.ts
+++ b/test/project-commands.ts
@@ -10,9 +10,10 @@ let isProjectCreated: boolean;
 const dummyArgs = ["dummyArgsString"];
 
 class ProjectServiceMock implements IProjectService {
-	async createProject(projectOptions: IProjectSettings): Promise<void> {
+	async createProject(projectOptions: IProjectSettings): Promise<ICreateProjectData> {
 		selectedTemplateName = projectOptions.template;
 		isProjectCreated = true;
+		return null;
 	}
 
 	isValidNativeScriptProject(pathToProject?: string): boolean {

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -59,7 +59,7 @@ class ProjectIntegrationTest {
 		this.createTestInjector();
 	}
 
-	public async createProject(projectOptions: IProjectSettings): Promise<void> {
+	public async createProject(projectOptions: IProjectSettings): Promise<ICreateProjectData> {
 		const projectService: IProjectService = this.testInjector.resolve("projectService");
 		if (!projectOptions.template) {
 			projectOptions.template = constants.RESERVED_TEMPLATE_NAMES["default"];


### PR DESCRIPTION
Introduce postCommandAction that is executed when the command succeeds.
Use the action to print additional information to user how to continue after command is finished.
Show some information on successful postinstall - instruct the users how to use local builds, cloud builds and playground.