### PR TITLE
docs: Fix the help of `tns generate splashes` command

### DIFF
--- a/docs/man_pages/project/configuration/resources/resources-generate-splashes.md
+++ b/docs/man_pages/project/configuration/resources/resources-generate-splashes.md
@@ -6,13 +6,16 @@ position: 12
 
 Usage | Synopsis
 ------|-------
-`$ tns resources generate splashes <Path to image> [<background>]` | Generate all splashscreens for Android and iOS based on the specified image.
+`$ tns resources generate splashes <Path to image> [--background <Color>]` | Generate all splashscreens for Android and iOS based on the specified image.
 
-Generates all icons for Android and iOS platforms and places the generated images in the correct directories under `App_Resources/<platform>` directory.
+Generates all splashscreens for Android and iOS platforms and places the generated images in the correct directories under `App_Resources/<platform>` directory.
+
+### Options
+* `--background` Sets the background color of the splashscreen. Defaults to white in case it is not specified.
 
 ### Attributes
 * `<Path to image>` is a valid path to an image that will be used to generate all splashscreens.
-* `<background>` is a valid path to an image that will be used as a background of the splashscreen. Defaults to white in case it is not specified.
+* `<Color>` is a valid color. It can be represented with string, like `white`, `black`, `blue`, etc. or its HEX representation, for example `#FFFFFF`, `#000000`, `#0000FF`. NOTE: As the `#` is special symbol in some terminals, make sure to place the value in quotes, for example `$ tns resources generate splashes ../myImage.png --background "#FF00FF"`.
 
 <% if(isHtml) { %>
 ### Related Commands


### PR DESCRIPTION
Fix the help of `tns generate splashes` command as the content for `--background` option is incorrect.