### PR TITLE
fix: Prepare for iOS with cloud builds fails on non macOS

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -603,7 +603,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	@helpers.hook('cleanApp')
 	public async cleanDestinationApp(platformInfo: IPreparePlatformInfo): Promise<void> {
-		await this.ensurePlatformInstalled(platformInfo.platform, platformInfo.platformTemplate, platformInfo.projectData, platformInfo.config);
+		await this.ensurePlatformInstalled(platformInfo.platform, platformInfo.platformTemplate, platformInfo.projectData, platformInfo.config, platformInfo.nativePrepare);
 
 		const platformData = this.$platformsData.getPlatformData(platformInfo.platform, platformInfo.projectData);
 		const appDestinationDirectoryPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);


### PR DESCRIPTION
In cloud builds, when we try to prepare the project for iOS, sometimes we fail as the `cleanDestinationApp` does not pass correct arguments to `ensurePlatformInstalled` method.
When we have cloud builds, the last argument should declare that the native prepartion should be skipped. When we do not pass it, the logic determines that the platform is not fully added and tries to add it again.
The whole `platforms/ios` directory is deleted and then we try preparing the project again. At some point the code fails as there are missing files in the `platforms/ios` (we have deleted them).

Pass the correct arguments, so the prepare will skip the native part in the mentioned case.
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Trying to build application for iOS with webpack in Sidekick leads to error.

## What is the new behavior?
Correct arguments are passed and the application can be build with Sidekick.
