### PR TITLE
feat(API): Expose androidProcessService - getAppProcessId

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -48,6 +48,8 @@ const tns = require("nativescript");
 * [assetsGenerationService](#assetsgenerationservice)
 	* [generateIcons](#generateicons)
 	* [generateSplashScreens](#generatesplashscreens)
+* [androidProcessService](#androidprocessservice)
+	* [getAppProcessId](#getappprocessid)
 
 ## Module projectService
 
@@ -1125,6 +1127,29 @@ tns.assetsGenerationService.generateSplashScreens({ projectDir: "/Users/username
 	});
 ```
 
+## androidProcessService
+The `androidProcessService` exposes methods for getting information about the applications working on Android devices.
+
+### getAppProcessId
+The `getAppProcessId` returns the PID of the specified application. If the app is not running on device, the method will return null.
+
+* Definition
+```TypeScript
+/**
+ * Gets the PID of a running application.
+ * @param deviceIdentifier {string} The identifier of the device.
+ * @param appIdentifier The identifier of the application.
+ * @return {string} Returns the process id matching the application identifier in the device process list.
+ */
+getAppProcessId(deviceIdentifier: string, appIdentifier: string): Promise<string>;
+```
+
+* Usage
+```JavaScript
+tns.androidProcessService.getAppProcessId("4df18f307d8a8f1b", "org.nativescript.demoapp")
+	.then(pid => console.log(`The PID is ${pid}`))
+	.catch(err => console.error(`Error while checking for PID: ${err}`));
+```
 
 
 ## How to add a new method to Public API

--- a/test/nativescript-cli-lib.ts
+++ b/test/nativescript-cli-lib.ts
@@ -47,7 +47,10 @@ describe("nativescript-cli-lib", () => {
 		],
 		assetsGenerationService: [
 			"generateIcons",
-			"generateSplashScreens"
+			"generateSplashScreens",
+		],
+		androidProcessService: [
+			"getAppProcessId"
 		]
 	};
 


### PR DESCRIPTION
Expose the `getAppProcessId` method from `androidProcessService`, so it can be called when using CLI as a library.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

> NOTE: Merge after https://github.com/telerik/mobile-cli-lib/pull/1086