### PR TITLE
fix(analytics): Message for tracking in GA is always printed

### DIFF
--- a/lib/services/analytics/analytics-service.ts
+++ b/lib/services/analytics/analytics-service.ts
@@ -58,6 +58,7 @@ export class AnalyticsService extends AnalyticsServiceBase {
 			gaSettings.customDimensions[GoogleAnalyticsCustomDimensions.client] = this.$options.analyticsClient || (isInteractive() ? AnalyticsClients.Cli : AnalyticsClients.Unknown);
 
 			const googleAnalyticsData: IGoogleAnalyticsTrackingInformation = _.merge({ type: TrackingTypes.GoogleAnalyticsData, category: AnalyticsClients.Cli }, gaSettings);
+			this.$logger.trace("Will send the following information to Google Analytics:", googleAnalyticsData);
 			return this.sendMessageToBroker(googleAnalyticsData);
 		}
 	}
@@ -98,8 +99,6 @@ export class AnalyticsService extends AnalyticsServiceBase {
 			label,
 			customDimensions
 		};
-
-		this.$logger.trace("Will send the following information to Google Analytics:", googleAnalyticsEventData);
 
 		await this.trackInGoogleAnalytics(googleAnalyticsEventData);
 	}


### PR DESCRIPTION
In case the usage reporting is disabled, the verbose log of CLI still prints that will send information to Google Analytics. In fact it does not do it. The problem is that the message is printed before checking the state of the usage reporting.
Fix this by placing the printing in the correct method.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3536
