### PR TITLE
Get debugger port from device logs

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -167,3 +167,5 @@ $injector.requireCommand("resources|generate|splashes", "./commands/generate-ass
 $injector.requirePublic("assetsGenerationService", "./services/assets-generation/assets-generation-service");
 
 $injector.require("filesHashService", "./services/files-hash-service");
+$injector.require("iOSLogParserService", "./services/ios-log-parser-service");
+$injector.require("iOSDebuggerPortService", "./services/ios-debugger-port-service");

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -143,13 +143,15 @@ export class DebugIOSCommand implements ICommand {
 		private $injector: IInjector,
 		private $projectData: IProjectData,
 		private $platformsData: IPlatformsData,
-		$iosDeviceOperations: IIOSDeviceOperations) {
+		$iosDeviceOperations: IIOSDeviceOperations,
+		$iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider) {
 		this.$projectData.initializeProjectData();
 		// Do not dispose ios-device-lib, so the process will remain alive and the debug application (NativeScript Inspector or Chrome DevTools) will be able to connect to the socket.
 		// In case we dispose ios-device-lib, the socket will be closed and the code will fail when the debug application tries to read/send data to device socket.
 		// That's why the `$ tns debug ios --justlaunch` command will not release the terminal.
 		// In case we do not set it to false, the dispose will be called once the command finishes its execution, which will prevent the debugging.
 		$iosDeviceOperations.setShouldDispose(false);
+		$iOSSimulatorLogProvider.setShouldDispose(false);
 	}
 
 	public execute(args: string[]): Promise<void> {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -645,7 +645,7 @@ interface ISocketProxyFactory extends NodeJS.EventEmitter {
 
 interface IiOSNotification {
 	getWaitForDebug(projectId: string): string;
-	getAttachRequest(projectId: string): string;
+	getAttachRequest(projectId: string, deviceId: string): string;
 	getAppLaunching(projectId: string): string;
 	getReadyForAttach(projectId: string): string;
 	getAttachAvailabilityQuery(projectId: string): string;

--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -87,6 +87,10 @@ interface IDebugOptions {
 	 * Defines if the iOS App Inspector should be used instead of providing URL to debug the application with Chrome DevTools
 	 */
 	inspector?: boolean;
+	/**
+	 * Defines if should print all availableDevices
+	 */
+	availableDevices?: boolean;
 }
 
 /**

--- a/lib/definitions/ios-debugger-port-service.d.ts
+++ b/lib/definitions/ios-debugger-port-service.d.ts
@@ -1,0 +1,28 @@
+interface IIOSDebuggerPortInputData {
+	deviceId: string;
+	appId: string;
+}
+
+interface IIOSDebuggerPortData extends IIOSDebuggerPortInputData {
+	port: number;
+}
+
+interface IIOSDebuggerPortStoredData {
+	port: number;
+	timer?: NodeJS.Timer;
+}
+
+interface IIOSDebuggerPortService {
+	/**
+	 * Gets iOS debugger port for specified deviceId and appId
+	 * @param {IIOSDebuggerPortInputData} data - Describes deviceId and appId
+	 */
+	getPort(data: IIOSDebuggerPortInputData): Promise<number>;
+	/**
+	 * Attaches on DEBUGGER_PORT_FOUND event and STARTING_IOS_APPLICATION events
+	 * In case when DEBUGGER_PORT_FOUND event is emitted, stores the port and clears the timeout if such.
+	 * In case when STARTING_IOS_APPLICATION event is emiited, sets the port to null and add timeout for 5000 miliseconds which checks if port is null and prints a warning.
+	 * @param {Mobile.IDevice} device - Describes the device which logs should be parsed. 
+	 */
+	attachToDebuggerPortFoundEvent(device: Mobile.IDevice): void;
+}

--- a/lib/definitions/ios-log-parser-service.d.ts
+++ b/lib/definitions/ios-log-parser-service.d.ts
@@ -3,5 +3,5 @@ interface IIOSLogParserService extends NodeJS.EventEmitter {
 	 * Starts looking for debugger port. Attaches on device logs and processes them. In case when port is found, DEBUGGER_PORT_FOUND event is emitted.
 	 * @param {Mobile.IDevice} device - Describes the device which logs will be processed.
 	 */
-	startLookingForDebuggerPort(device: Mobile.IDevice): void;
+	startParsingLog(device: Mobile.IDevice): void;
 }

--- a/lib/definitions/ios-log-parser-service.d.ts
+++ b/lib/definitions/ios-log-parser-service.d.ts
@@ -1,0 +1,7 @@
+interface IIOSLogParserService extends NodeJS.EventEmitter {
+	/**
+	 * Starts looking for debugger port. Attaches on device logs and processes them. In case when port is found, DEBUGGER_PORT_FOUND event is emitted.
+	 * @param {Mobile.IDevice} device - Describes the device which logs will be processed.
+	 */
+	startLookingForDebuggerPort(device: Mobile.IDevice): void;
+}

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -218,6 +218,7 @@ interface IProjectTemplatesService {
 
 interface IPlatformProjectServiceBase {
 	getPluginPlatformsFolderPath(pluginData: IPluginData, platform: string): string;
+	getFrameworkVersion(projectData: IProjectData): string;
 }
 
 interface IBuildForDevice {
@@ -270,7 +271,7 @@ interface ILocalBuildService {
 
 interface ICleanNativeAppData extends IProjectDir, IPlatform { }
 
-interface IPlatformProjectService extends NodeJS.EventEmitter {
+interface IPlatformProjectService extends NodeJS.EventEmitter, IPlatformProjectServiceBase {
 	getPlatformData(projectData: IProjectData): IPlatformData;
 	validate(projectData: IProjectData): Promise<void>;
 	createProject(frameworkDir: string, frameworkVersion: string, projectData: IProjectData, config: ICreateProjectOptions): Promise<void>;

--- a/lib/device-sockets/ios/notification.ts
+++ b/lib/device-sockets/ios/notification.ts
@@ -1,4 +1,7 @@
-export class IOSNotification implements IiOSNotification {
+import { EventEmitter } from "events";
+import { ATTACH_REQUEST_EVENT_NAME } from "../../common/constants";
+
+export class IOSNotification extends EventEmitter implements IiOSNotification {
 	private static WAIT_FOR_DEBUG_NOTIFICATION_NAME = "WaitForDebugger";
 	private static ATTACH_REQUEST_NOTIFICATION_NAME = "AttachRequest";
 	private static APP_LAUNCHING_NOTIFICATION_NAME = "AppLaunching";
@@ -11,8 +14,9 @@ export class IOSNotification implements IiOSNotification {
 		return this.formatNotification(IOSNotification.WAIT_FOR_DEBUG_NOTIFICATION_NAME, projectId);
 	}
 
-	public getAttachRequest(projectId: string): string {
-		return this.formatNotification(IOSNotification.ATTACH_REQUEST_NOTIFICATION_NAME, projectId);
+	public getAttachRequest(appId: string, deviceId: string): string {
+		this.emit(ATTACH_REQUEST_EVENT_NAME, { deviceId, appId });
+		return this.formatNotification(IOSNotification.ATTACH_REQUEST_NOTIFICATION_NAME, appId);
 	}
 
 	public getAppLaunching(projectId: string): string {

--- a/lib/device-sockets/ios/socket-request-executor.ts
+++ b/lib/device-sockets/ios/socket-request-executor.ts
@@ -61,7 +61,7 @@ export class IOSSocketRequestExecutor implements IiOSSocketRequestExecutor {
 			const readyForAttachSocket = await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getReadyForAttach(projectId), constants.IOS_OBSERVE_NOTIFICATION_COMMAND_TYPE);
 			const readyForAttachPromise = this.$iOSNotificationService.awaitNotification(deviceIdentifier, +readyForAttachSocket, readyForAttachTimeout);
 
-			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAttachRequest(projectId));
+			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAttachRequest(projectId, deviceIdentifier));
 			await readyForAttachPromise;
 		} catch (e) {
 			this.$logger.trace("Launch request error:");
@@ -76,7 +76,7 @@ export class IOSSocketRequestExecutor implements IiOSSocketRequestExecutor {
 			// before we send the PostNotification.
 			const readyForAttachSocket = await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getReadyForAttach(projectId), constants.IOS_OBSERVE_NOTIFICATION_COMMAND_TYPE);
 			const readyForAttachPromise = this.$iOSNotificationService.awaitNotification(deviceIdentifier, +readyForAttachSocket, timeout);
-			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAttachRequest(projectId));
+			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAttachRequest(projectId, deviceIdentifier));
 			await readyForAttachPromise;
 		} catch (e) {
 			this.$errors.failWithoutHelp(`The application ${projectId} timed out when performing the socket handshake.`);

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -10,7 +10,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 		private $platformsData: IPlatformsData,
 		private $analyticsService: IAnalyticsService,
 		private $bundleValidatorHelper: IBundleValidatorHelper,
-		private $errors: IErrors) {
+		private $errors: IErrors,
+		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider) {
 		this.$analyticsService.setShouldDispose(this.$options.justlaunch || !this.$options.watch);
 	}
 
@@ -53,6 +54,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 		const shouldKeepProcessAlive = this.$options.watch || !this.$options.justlaunch;
 		if (workingWithiOSDevices && shouldKeepProcessAlive) {
 			this.$iosDeviceOperations.setShouldDispose(false);
+			this.$iOSSimulatorLogProvider.setShouldDispose(false);
 		}
 
 		if (this.$options.release) {

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -128,7 +128,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 	private async emulatorStart(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
 		const result = await this.wireDebuggerClient(debugData, debugOptions);
 
-		const attachRequestMessage = this.$iOSNotification.getAttachRequest(debugData.applicationIdentifier);
+		const attachRequestMessage = this.$iOSNotification.getAttachRequest(debugData.applicationIdentifier, debugData.deviceIdentifier);
 
 		const iOSEmulatorService = <Mobile.IiOSSimulatorService>this.$iOSEmulatorServices;
 		await iOSEmulatorService.postDarwinNotification(attachRequestMessage, debugData.deviceIdentifier);

--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -1,0 +1,103 @@
+import { DEBUGGER_PORT_FOUND_EVENT_NAME, STARTING_IOS_APPLICATION_EVENT_NAME } from "../common/constants";
+import { cache } from "../common/decorators";
+import * as semver from "semver";
+
+export class IOSDebuggerPortService implements IIOSDebuggerPortService {
+	private mapDebuggerPortData: IDictionary<IIOSDebuggerPortStoredData> = {};
+	private static DEFAULT_PORT = 18181;
+	private static MIN_REQUIRED_FRAMEWORK_VERSION = "4.0.0";
+
+	constructor(private $iOSLogParserService: IIOSLogParserService,
+		private $iOSProjectService: IPlatformProjectService,
+		private $logger: ILogger,
+		private $projectData: IProjectData) { }
+
+	public getPort(data: IIOSDebuggerPortInputData): Promise<number> {
+		return new Promise((resolve, reject) => {
+			if (!this.canStartLookingForDebuggerPort()) {
+				return IOSDebuggerPortService.DEFAULT_PORT;
+			}
+
+			const key = `${data.deviceId}${data.appId}`;
+			let retryCount: number = 10;
+
+			const interval = setInterval(() => {
+				let port = this.getPortByKey(key);
+				if (port || retryCount === 0) {
+					clearInterval(interval);
+					resolve(port);
+				} else {
+					port = this.getPortByKey(key);
+					retryCount--;
+				}
+			}, 500);
+		});
+	}
+
+	public attachToDebuggerPortFoundEvent(device: Mobile.IDevice): void {
+		if (!this.canStartLookingForDebuggerPort()) {
+			return;
+		}
+
+		this.attachToDebuggerPortFoundEventCore();
+		this.attachToStartingApplicationEvent(device);
+
+		this.$iOSLogParserService.startLookingForDebuggerPort(device);
+	}
+
+	private canStartLookingForDebuggerPort(): boolean {
+		const frameworkVersion = this.$iOSProjectService.getFrameworkVersion(this.$projectData);
+		return semver.gte(frameworkVersion, IOSDebuggerPortService.MIN_REQUIRED_FRAMEWORK_VERSION);
+	}
+
+	@cache()
+	private attachToDebuggerPortFoundEventCore(): void {
+		this.$iOSLogParserService.on(DEBUGGER_PORT_FOUND_EVENT_NAME, (data: IIOSDebuggerPortData) => {
+			this.$logger.trace(DEBUGGER_PORT_FOUND_EVENT_NAME, data);
+			this.setData(data, { port: data.port });
+			this.clearTimeout(data);
+		});
+	}
+
+	@cache()
+	private attachToStartingApplicationEvent(device: Mobile.IDevice): void {
+		device.applicationManager.on(STARTING_IOS_APPLICATION_EVENT_NAME, (data: IIOSDebuggerPortData) => {
+			this.$logger.trace(STARTING_IOS_APPLICATION_EVENT_NAME, data);
+			const timer = setTimeout(() => {
+				this.clearTimeout(data);
+				if (!this.getPortByKey(`${data.deviceId}${data.appId}`)) {
+					this.$logger.warn("NativeScript debugger was not able to get inspector socket port.");
+				}
+			}, 5000);
+
+			this.setData(data, { port: null, timer });
+		});
+	}
+
+	private getPortByKey(key: string): number {
+		if (this.mapDebuggerPortData[key]) {
+			return this.mapDebuggerPortData[key].port;
+		}
+
+		return null;
+	}
+
+	private setData(data: IIOSDebuggerPortData, storedData: IIOSDebuggerPortStoredData): void {
+		const key = `${data.deviceId}${data.appId}`;
+
+		if (!this.mapDebuggerPortData[key]) {
+			this.mapDebuggerPortData[key] = <any>{};
+		}
+
+		this.mapDebuggerPortData[key].port = storedData.port;
+		this.mapDebuggerPortData[key].timer = storedData.timer;
+	}
+
+	private clearTimeout(data: IIOSDebuggerPortData): void {
+		const storedData = this.mapDebuggerPortData[`${data.deviceId}${data.appId}`];
+		if (storedData && storedData.timer) {
+			clearTimeout(storedData.timer);
+		}
+	}
+}
+$injector.register("iOSDebuggerPortService", IOSDebuggerPortService);

--- a/lib/services/ios-log-parser-service.ts
+++ b/lib/services/ios-log-parser-service.ts
@@ -13,15 +13,15 @@ export class IOSLogParserService extends EventEmitter implements IIOSLogParserSe
 			super();
 		}
 
-	public startLookingForDebuggerPort(device: Mobile.IDevice): void {
+	public startParsingLog(device: Mobile.IDevice): void {
 		this.$deviceLogProvider.setProjectNameForDevice(device.deviceInfo.identifier, this.$projectData.projectName);
 
-		this.startLookingForDebuggerPortCore(device);
+		this.startParsingLogCore(device);
 		this.startLogProcess(device);
 	}
 
 	@cache()
-	private startLookingForDebuggerPortCore(device: Mobile.IDevice): void {
+	private startParsingLogCore(device: Mobile.IDevice): void {
 		const logProvider = device.isEmulator ? this.$iOSSimulatorLogProvider : this.$iosDeviceOperations;
 		logProvider.on(DEVICE_LOG_EVENT_NAME, (response: IOSDeviceLib.IDeviceLogData) => this.processDeviceLogResponse(response));
 	}

--- a/lib/services/ios-log-parser-service.ts
+++ b/lib/services/ios-log-parser-service.ts
@@ -1,0 +1,50 @@
+import { DEBUGGER_PORT_FOUND_EVENT_NAME, DEVICE_LOG_EVENT_NAME } from "../common/constants";
+import { cache } from "../common/decorators";
+import { EventEmitter } from "events";
+
+export class IOSLogParserService extends EventEmitter implements IIOSLogParserService {
+	private static MESSAGE_REGEX = /NativeScript debugger has opened inspector socket on port (\d+?) for (.*)[.]/;
+
+	constructor(private $deviceLogProvider: Mobile.IDeviceLogProvider,
+		private $iosDeviceOperations: IIOSDeviceOperations,
+		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider,
+		private $logger: ILogger,
+		private $projectData: IProjectData) {
+			super();
+		}
+
+	public startLookingForDebuggerPort(device: Mobile.IDevice): void {
+		this.$deviceLogProvider.setProjectNameForDevice(device.deviceInfo.identifier, this.$projectData.projectName);
+
+		this.startLookingForDebuggerPortCore(device);
+		this.startLogProcess(device);
+	}
+
+	@cache()
+	private startLookingForDebuggerPortCore(device: Mobile.IDevice): void {
+		const logProvider = device.isEmulator ? this.$iOSSimulatorLogProvider : this.$iosDeviceOperations;
+		logProvider.on(DEVICE_LOG_EVENT_NAME, (response: IOSDeviceLib.IDeviceLogData) => this.processDeviceLogResponse(response));
+	}
+
+	private processDeviceLogResponse(response: IOSDeviceLib.IDeviceLogData) {
+		const matches = IOSLogParserService.MESSAGE_REGEX.exec(response.message);
+		if (matches) {
+			const data = {
+				port: parseInt(matches[1]),
+				appId: matches[2],
+				deviceId: response.deviceId
+			};
+			this.$logger.trace(`Emitting ${DEBUGGER_PORT_FOUND_EVENT_NAME} event`, data);
+			this.emit(DEBUGGER_PORT_FOUND_EVENT_NAME, data);
+		}
+	}
+
+	private startLogProcess(device: Mobile.IDevice): void {
+		if (device.isEmulator) {
+			return this.$iOSSimulatorLogProvider.startNewMutedLogProcess(device.deviceInfo.identifier);
+		}
+
+		return this.$iosDeviceOperations.startDeviceLog(device.deviceInfo.identifier);
+	}
+}
+$injector.register("iOSLogParserService", IOSLogParserService);

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -125,7 +125,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	public getAppResourcesDestinationDirectoryPath(projectData: IProjectData): string {
-		const frameworkVersion = this.getFrameworkVersion(this.getPlatformData(projectData).frameworkPackageName, projectData.projectDir);
+		const frameworkVersion = this.getFrameworkVersion(projectData);
 
 		if (semver.lt(frameworkVersion, "1.3.0")) {
 			return path.join(this.getPlatformData(projectData).projectRoot, projectData.projectName, "Resources", "icons");
@@ -337,7 +337,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		];
 
 		// Starting from tns-ios 1.4 the xcconfig file is referenced in the project template
-		const frameworkVersion = this.getFrameworkVersion(this.getPlatformData(projectData).frameworkPackageName, projectData.projectDir);
+		const frameworkVersion = this.getFrameworkVersion(projectData);
 		if (semver.lt(frameworkVersion, "1.4.0")) {
 			basicArgs.push("-xcconfig", path.join(projectRoot, projectData.projectName, BUILD_XCCONFIG_FILE_NAME));
 		}

--- a/lib/services/livesync/ios-device-livesync-service.ts
+++ b/lib/services/livesync/ios-device-livesync-service.ts
@@ -29,7 +29,7 @@ export class IOSDeviceLiveSyncService extends DeviceLiveSyncServiceBase implemen
 		}
 
 		if (this.device.isEmulator) {
-			await this.$iOSEmulatorServices.postDarwinNotification(this.$iOSNotification.getAttachRequest(appId), this.device.deviceInfo.identifier);
+			await this.$iOSEmulatorServices.postDarwinNotification(this.$iOSNotification.getAttachRequest(appId, this.device.deviceInfo.identifier), this.device.deviceInfo.identifier);
 			const port = await this.$iOSDebuggerPortService.getPort({ deviceId: this.device.deviceInfo.identifier, appId });
 			this.socket = await this.$iOSEmulatorServices.connectToPort({ port });
 			if (!this.socket) {

--- a/lib/services/platform-project-service-base.ts
+++ b/lib/services/platform-project-service-base.ts
@@ -1,13 +1,19 @@
 import { EventEmitter } from "events";
 
-export class PlatformProjectServiceBase extends EventEmitter implements IPlatformProjectServiceBase {
+export abstract class PlatformProjectServiceBase extends EventEmitter implements IPlatformProjectServiceBase {
 	constructor(protected $fs: IFileSystem,
 		protected $projectDataService: IProjectDataService) {
 			super();
 	}
 
+	protected abstract getPlatformData(projectData: IProjectData): IPlatformData;
+
 	public getPluginPlatformsFolderPath(pluginData: IPluginData, platform: string): string {
 		return pluginData.pluginPlatformsFolderPath(platform);
+	}
+
+	public getFrameworkVersion(projectData: IProjectData): string {
+		return this.$projectDataService.getNSValue(projectData.projectDir, this.getPlatformData(projectData).frameworkPackageName).version;
 	}
 
 	protected getAllNativeLibrariesForPlugin(pluginData: IPluginData, platform: string, filter: (fileName: string, _pluginPlatformsFolderPath: string) => boolean): string[] {
@@ -22,9 +28,5 @@ export class PlatformProjectServiceBase extends EventEmitter implements IPlatfor
 		}
 
 		return nativeLibraries;
-	}
-
-	protected getFrameworkVersion(runtimePackageName: string, projectDir: string): string {
-		return this.$projectDataService.getNSValue(projectDir, runtimePackageName).version;
 	}
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2868,9 +2868,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.4.0.tgz",
-      "integrity": "sha512-EDSgmMYFeKZD5Akw7jQJFa8zouPpDS/xm0VLp4fWOUhiiPh8mpSOi99dGHCGZ/6UHguhJkWHMbGqESIzJITlIQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.4.1.tgz",
+      "integrity": "sha512-5zouPe8hjN6tLCwoxYXT4S1l2lY0aMZAXOGK9L8pPF8nXtanNKbVxpCrEszKcCbGzNQ/WyY/diJXTNL1ZO6HZg==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -40,7 +40,7 @@
     "@types/color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.0.tgz",
-      "integrity": "sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==",
+      "integrity": "sha1-QPimvy/YbpaYdrM5qDfY/xsKbjA=",
       "dev": true,
       "requires": {
         "@types/color-convert": "1.9.0"
@@ -49,7 +49,7 @@
     "@types/color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
+      "integrity": "sha1-v6ggPkHnxlRx6YQdfjBqfNi1Fy0=",
       "dev": true,
       "requires": {
         "@types/color-name": "1.1.0"
@@ -58,7 +58,7 @@
     "@types/color-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.0.tgz",
-      "integrity": "sha512-gZ/Rb+MFXF0pXSEQxdRoPMm5jeO3TycjOdvbpbcpHX/B+n9AqaHFe5q6Ga9CsZ7ir/UgIWPfrBzUzn3F19VH/w==",
+      "integrity": "sha1-km929+ZvScxZrYgLsVsDCrvwtm0=",
       "dev": true
     },
     "@types/events": {
@@ -91,7 +91,7 @@
     "@types/ora": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/ora/-/ora-1.3.3.tgz",
-      "integrity": "sha512-XaSVRyCfnGq1xGlb6iuoxnomMXPIlZnvIIkKiGNMTCeVOg7G1Si+FA9N1lPrykPEfiRHwbuZXuTCSoYcHyjcdg==",
+      "integrity": "sha1-0xhkGMPPN6gxeZs3a+ykqOG/yi0=",
       "dev": true,
       "requires": {
         "@types/node": "6.0.61"
@@ -153,7 +153,7 @@
     "@types/xml2js": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
-      "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
+      "integrity": "sha1-pLhLOHn/1HEJU/2Syr/emopOhFY=",
       "dev": true,
       "requires": {
         "@types/node": "6.0.61"
@@ -272,7 +272,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -766,7 +766,7 @@
     "color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
       "requires": {
         "color-convert": "1.9.1",
         "color-string": "1.5.2"
@@ -2868,9 +2868,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "3.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.3.3-rc.0.tgz",
-      "integrity": "sha512-w0bddSdFk/xBFxAhky7GkVoHyaqbGOwPpwN/2iNxajwJOk/DtiRuCkf/98nwIa4iMrMKB9TykfZLDuvrr0SdkQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.4.0.tgz",
+      "integrity": "sha512-EDSgmMYFeKZD5Akw7jQJFa8zouPpDS/xm0VLp4fWOUhiiPh8mpSOi99dGHCGZ/6UHguhJkWHMbGqESIzJITlIQ==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",
@@ -3676,7 +3676,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
     },
     "mime-db": {
       "version": "1.33.0",
@@ -5668,7 +5668,7 @@
     "xhr": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
-      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
+      "integrity": "sha1-upgsztIFrl7sOHFprJ3HfKSFPTg=",
       "requires": {
         "global": "4.3.2",
         "is-function": "1.0.1",
@@ -5684,7 +5684,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
       "requires": {
         "sax": "1.2.4",
         "xmlbuilder": "9.0.7"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2868,9 +2868,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.3.3.tgz",
-      "integrity": "sha512-2RJMB865NQbes1tcGxbjMVfEZhXb9ACaGyDindYUcBVWGDz6bep/Z00HbBC+6VpRmnce6hMvmL/EyUnFdml7mg==",
+      "version": "3.3.3-rc.0",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.3.3-rc.0.tgz",
+      "integrity": "sha512-w0bddSdFk/xBFxAhky7GkVoHyaqbGOwPpwN/2iNxajwJOk/DtiRuCkf/98nwIa4iMrMKB9TykfZLDuvrr0SdkQ==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -407,15 +407,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.4.0.tgz",
       "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg="
     },
-    "binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "requires": {
-        "buffers": "0.1.1",
-        "chainsaw": "0.1.0"
-      }
-    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -537,11 +528,6 @@
       "resolved": "https://registry.npmjs.org/bufferpack/-/bufferpack-0.0.6.tgz",
       "integrity": "sha1-+z2HOKDh5OA7z/mfmnX57Bip1z4="
     },
-    "buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -643,14 +629,6 @@
       "requires": {
         "check-error": "1.0.2",
         "eslint": "3.19.0"
-      }
-    },
-    "chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "requires": {
-        "traverse": "0.3.9"
       }
     },
     "chalk": {
@@ -2139,27 +2117,6 @@
         }
       }
     },
-    "fstream": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-      "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
-      "requires": {
-        "graceful-fs": "3.0.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.2.8"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "requires": {
-            "natives": "1.1.3"
-          }
-        }
-      }
-    },
     "gaze": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.0.tgz",
@@ -3584,38 +3541,6 @@
         }
       }
     },
-    "match-stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
-      "requires": {
-        "buffers": "0.1.1",
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -4078,11 +4003,6 @@
         "os-tmpdir": "1.0.2"
       }
     },
-    "over": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
-      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
-    },
     "parse-bmfont-ascii": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
@@ -4362,40 +4282,6 @@
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
           }
-        }
-      }
-    },
-    "pullstream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
-      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
-      "requires": {
-        "over": "0.0.5",
-        "readable-stream": "1.0.34",
-        "setimmediate": "1.0.5",
-        "slice-stream": "1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -4748,11 +4634,6 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
     "shelljs": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
@@ -4889,37 +4770,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
-    },
-    "slice-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
-      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
-      "requires": {
-        "readable-stream": "1.0.34"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
     },
     "sntp": {
       "version": "2.1.0",
@@ -5278,11 +5128,6 @@
         "punycode": "1.4.1"
       }
     },
-    "traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
-    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -5489,42 +5334,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
-    },
-    "unzip": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
-      "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
-      "requires": {
-        "binary": "0.3.0",
-        "fstream": "0.1.31",
-        "match-stream": "0.0.2",
-        "pullstream": "0.4.1",
-        "readable-stream": "1.0.34",
-        "setimmediate": "1.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
     },
     "url-regex": {
       "version": "3.2.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -407,6 +407,15 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.4.0.tgz",
       "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg="
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "requires": {
+        "buffers": "0.1.1",
+        "chainsaw": "0.1.0"
+      }
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -528,6 +537,11 @@
       "resolved": "https://registry.npmjs.org/bufferpack/-/bufferpack-0.0.6.tgz",
       "integrity": "sha1-+z2HOKDh5OA7z/mfmnX57Bip1z4="
     },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -629,6 +643,14 @@
       "requires": {
         "check-error": "1.0.2",
         "eslint": "3.19.0"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "requires": {
+        "traverse": "0.3.9"
       }
     },
     "chalk": {
@@ -2117,6 +2139,27 @@
         }
       }
     },
+    "fstream": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+      "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+      "requires": {
+        "graceful-fs": "3.0.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "requires": {
+            "natives": "1.1.4"
+          }
+        }
+      }
+    },
     "gaze": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.0.tgz",
@@ -3541,6 +3584,38 @@
         }
       }
     },
+    "match-stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+      "requires": {
+        "buffers": "0.1.1",
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
@@ -3732,9 +3807,9 @@
       "optional": true
     },
     "natives": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
-      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
+      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
     },
     "nativescript-doctor": {
       "version": "1.0.0",
@@ -4002,6 +4077,11 @@
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
       }
+    },
+    "over": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
+      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
     },
     "parse-bmfont-ascii": {
       "version": "1.0.6",
@@ -4282,6 +4362,40 @@
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
           }
+        }
+      }
+    },
+    "pullstream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
+      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
+      "requires": {
+        "over": "0.0.5",
+        "readable-stream": "1.0.34",
+        "setimmediate": "1.0.5",
+        "slice-stream": "1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -4634,6 +4748,11 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
     "shelljs": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
@@ -4770,6 +4889,37 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
+    },
+    "slice-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
+      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "sntp": {
       "version": "2.1.0",
@@ -5128,6 +5278,11 @@
         "punycode": "1.4.1"
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -5334,6 +5489,42 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "unzip": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
+      "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
+      "requires": {
+        "binary": "0.3.0",
+        "fstream": "0.1.31",
+        "match-stream": "0.0.2",
+        "pullstream": "0.4.1",
+        "readable-stream": "1.0.34",
+        "setimmediate": "1.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "url-regex": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.11",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "3.4.0",
+    "ios-sim-portable": "3.4.1",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",
     "lodash": "4.13.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.11",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "3.3.3-rc.0",
+    "ios-sim-portable": "3.4.0",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",
     "lodash": "4.13.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.11",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "3.3.3",
+    "ios-sim-portable": "3.3.3-rc.0",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",
     "lodash": "4.13.1",

--- a/test/services/ios-debug-service.ts
+++ b/test/services/ios-debug-service.ts
@@ -14,6 +14,7 @@ class IOSDebugServiceInheritor extends IOSDebugService {
 		$logger: ILogger,
 		$errors: IErrors,
 		$npmInstallationManager: INpmInstallationManager,
+		$iOSDebuggerPortService: IIOSDebuggerPortService,
 		$iOSNotification: IiOSNotification,
 		$iOSSocketRequestExecutor: IiOSSocketRequestExecutor,
 		$processService: IProcessService,
@@ -21,7 +22,7 @@ class IOSDebugServiceInheritor extends IOSDebugService {
 		$net: INet,
 		$projectDataService: IProjectDataService) {
 		super(<any>{}, $devicesService, $platformService, $iOSEmulatorServices, $childProcess, $hostInfo, $logger, $errors,
-			$npmInstallationManager, $iOSNotification, $iOSSocketRequestExecutor, $processService, $socketProxyFactory, $net, $projectDataService);
+			$npmInstallationManager, $iOSDebuggerPortService, $iOSNotification, $iOSSocketRequestExecutor, $processService, $socketProxyFactory, $projectDataService);
 	}
 
 	public getChromeDebugUrl(debugOptions: IDebugOptions, port: number): string {
@@ -56,6 +57,7 @@ const createTestInjector = (): IInjector => {
 	});
 
 	testInjector.register("projectDataService", {});
+	testInjector.register("iOSDebuggerPortService", {});
 
 	return testInjector;
 };

--- a/test/services/ios-debugger-port-service.ts
+++ b/test/services/ios-debugger-port-service.ts
@@ -1,0 +1,162 @@
+import { assert } from "chai";
+import { CONNECTED_STATUS, DEBUGGER_PORT_FOUND_EVENT_NAME, DEVICE_LOG_EVENT_NAME } from "../../lib/common/constants";
+import { ErrorsStub, LoggerStub } from "../stubs";
+import { IOSDebuggerPortService } from "../../lib/services/ios-debugger-port-service";
+import { IOSLogParserService } from "../../lib/services/ios-log-parser-service";
+import { IOSSimulatorLogProvider } from "../../lib/common/mobile/ios/simulator/ios-simulator-log-provider";
+import { Yok } from "../../lib/common/yok";
+import { EventEmitter } from "events";
+
+class DeviceApplicationManagerMock extends EventEmitter { }
+
+class IOSDeviceOperationsMock extends EventEmitter {
+	public startDeviceLog(deviceId: string): void {
+		// need this to be empty
+	}
+}
+
+const appId = "org.nativescript.test";
+const deviceId = "fbece8e562ac63749a1018a9f1ea57614c5c953a";
+const device = <Mobile.IDevice>{
+	deviceInfo: {
+		identifier: deviceId,
+		status: CONNECTED_STATUS
+	},
+	applicationManager: new DeviceApplicationManagerMock()
+};
+
+function createTestInjector() {
+	const injector = new Yok();
+
+	injector.register("deviceLogProvider", {
+		setProjectNameForDevice: () => ({})
+	});
+	injector.register("errors", ErrorsStub);
+	injector.register("iOSDebuggerPortService", IOSDebuggerPortService);
+	injector.register("iosDeviceOperations", IOSDeviceOperationsMock);
+	injector.register("iOSLogParserService", IOSLogParserService);
+	injector.register("iOSProjectService", {
+		getFrameworkVersion: () => "4.1.0"
+	});
+	injector.register("iOSSimResolver", {
+		iOSSim: () => ({})
+	});
+	injector.register("iOSSimulatorLogProvider", IOSSimulatorLogProvider);
+	injector.register("logger", LoggerStub);
+	injector.register("processService", {
+		attachToProcessExitSignals: () => ({})
+	});
+	injector.register("projectData", {
+		projectName: "test",
+		projectId: appId
+	});
+
+	return injector;
+}
+
+function getDebuggerPortMessage(port: number) {
+	return `NativeScript debugger has opened inspector socket on port ${port} for ${appId}.`;
+}
+
+function getMultilineDebuggerPortMessage(port: number) {
+	return `2018-04-20 09:45:48.645149+0300  localhost locationd[1040]: Created Activity ID: 0x7b46b, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:48.645199+0300  localhost locationd[1040]: Created Activity ID: 0x7b46c, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:48.645234+0300  localhost locationd[1040]: Created Activity ID: 0x7b46d, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:48.645278+0300  localhost locationd[1040]: Created Activity ID: 0x7b46e, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:49.645448+0300  localhost locationd[1040]: Created Activity ID: 0x7b46f, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:49.645518+0300  localhost locationd[1040]: Created Activity ID: 0x7b490, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:49.645554+0300  localhost locationd[1040]: Created Activity ID: 0x7b491, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:49.645592+0300  localhost locationd[1040]: Created Activity ID: 0x7b492, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:49.645623+0300  localhost locationd[1040]: Created Activity ID: 0x7b493, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:49.645641+0300  localhost locationd[1040]: Created Activity ID: 0x7b494, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:50.647222+0300  localhost locationd[1040]: Created Activity ID: 0x7b495, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:50.647294+0300  localhost locationd[1040]: Created Activity ID: 0x7b496, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:50.647331+0300  localhost locationd[1040]: Created Activity ID: 0x7b497, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:50.647369+0300  localhost locationd[1040]: Created Activity ID: 0x7b498, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:50.647400+0300  localhost locationd[1040]: Created Activity ID: 0x7b499, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:50.647417+0300  localhost locationd[1040]: Created Activity ID: 0x7b49a, Description: CL: notifyClientsWithData (Fallback)
+		2018-04-20 09:45:51.071718+0300  localhost securityuploadd[17963]: [com.apple.securityd:lifecycle] will exit when clean
+		2018-04-20 09:45:51.256053+0300  localhost CoreSimulatorBridge[1046]: Pasteboard change listener callback port <NSMachPort: 0x7ff1b1802390> registered
+		2018-04-20 09:45:51.260951+0300  localhost nglog[17917]: NativeScript debugger has opened inspector socket on port ${port} for ${appId}.`;
+}
+
+describe("iOSDebuggerPortService", () => {
+	let injector: IInjector, iOSDebuggerPortService: IIOSDebuggerPortService, iosDeviceOperations: IIOSDeviceOperations;
+
+	beforeEach(() => {
+		injector = createTestInjector();
+		iOSDebuggerPortService = injector.resolve("iOSDebuggerPortService");
+		iosDeviceOperations = injector.resolve("iosDeviceOperations");
+	});
+
+	function emitDeviceLog(message: string) {
+		iosDeviceOperations.emit(DEVICE_LOG_EVENT_NAME, {
+			deviceId: device.deviceInfo.identifier,
+			message: message
+		});
+	}
+
+	function emitStartingIOSApplicationEvent() {
+		device.applicationManager.emit("STARTING_IOS_APPLICATION", {
+			appId: appId,
+			deviceId: device.deviceInfo.identifier
+		});
+	}
+
+	describe("getPort", () => {
+		const testCases = [
+			{
+				name: `should return null when ${DEBUGGER_PORT_FOUND_EVENT_NAME} event is not emitted`,
+				emittedPort: null,
+				emitStartingIOSApplicationEvent: false
+			},
+			{
+				name: `should return default port when ${DEBUGGER_PORT_FOUND_EVENT_NAME} event is emitted`,
+				emittedPort: 18181,
+				emitStartingIOSApplicationEvent: false
+			},
+			{
+				name: `should return random port when ${DEBUGGER_PORT_FOUND_EVENT_NAME} event is emitted`,
+				emittedPort: 65432,
+				emitStartingIOSApplicationEvent: false
+			},
+			{
+				name: `should return default port when ${DEBUGGER_PORT_FOUND_EVENT_NAME} and STARTING_IOS_APPLICATION events are emitted`,
+				emittedPort: 18181,
+				emitStartingIOSApplicationEvent: true
+			},
+			{
+				name: `should return random port when ${DEBUGGER_PORT_FOUND_EVENT_NAME} and STARTING_IOS_APPLICATION events are emitted`,
+				emittedPort: 12345,
+				emitStartingIOSApplicationEvent: true
+			}
+		];
+
+		_.each(testCases, testCase => {
+			it(testCase.name, async () => {
+				iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
+				if (testCase.emitStartingIOSApplicationEvent) {
+					emitStartingIOSApplicationEvent();
+				}
+				if (testCase.emittedPort) {
+					emitDeviceLog(getDebuggerPortMessage(testCase.emittedPort));
+				}
+
+				const port = await iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId });
+				assert.deepEqual(port, testCase.emittedPort);
+			});
+			it(`${testCase.name} for multiline debugger port message.`, async () => {
+				iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
+				if (testCase.emitStartingIOSApplicationEvent) {
+					emitStartingIOSApplicationEvent();
+				}
+				if (testCase.emittedPort) {
+					emitDeviceLog(getMultilineDebuggerPortMessage(testCase.emittedPort));
+				}
+
+				const port = await iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId });
+				assert.deepEqual(port, testCase.emittedPort);
+			});
+		});
+	});
+});

--- a/test/services/ios-log-parser-service.ts
+++ b/test/services/ios-log-parser-service.ts
@@ -1,0 +1,146 @@
+import { assert } from "chai";
+import { CONNECTED_STATUS, DEBUGGER_PORT_FOUND_EVENT_NAME, DEVICE_LOG_EVENT_NAME } from "../../lib/common/constants";
+import { IOSDeviceOperations } from "../../lib/common/mobile/ios/device/ios-device-operations";
+import { IOSLogParserService } from "../../lib/services/ios-log-parser-service";
+import { IOSSimulatorLogProvider } from "../../lib/common/mobile/ios/simulator/ios-simulator-log-provider";
+import { Yok } from "../../lib/common/yok";
+
+const appId = "org.nativescript.test";
+const deviceId = "fbece8e562ac63749a1018a9f1ea57614c5c953a";
+const device = <Mobile.IDevice>{
+	deviceInfo: {
+		identifier: deviceId,
+		status: CONNECTED_STATUS
+	}
+};
+
+function createTestInjector() {
+	const injector = new Yok();
+	injector.register("deviceLogProvider", {
+		setProjectNameForDevice: () => ({})
+	});
+
+	injector.register("iosDeviceOperations", IOSDeviceOperations);
+	injector.register("iOSLogParserService", IOSLogParserService);
+	injector.register("iOSProjectService", {
+		getFrameworkVersion: () => "4.1.0"
+	});
+	injector.register("iOSSimResolver", () => ({}));
+	injector.register("iOSSimulatorLogProvider", IOSSimulatorLogProvider);
+
+	injector.register("logger", {
+		trace: () => ({})
+	});
+
+	injector.register("processService", {
+		attachToProcessExitSignals: () => ({})
+	});
+	injector.register("projectData", {
+		projectName: "test",
+		projectId: appId
+	});
+
+	return injector;
+}
+
+function getDebuggerPortMessage(port: number) {
+	return `NativeScript debugger has opened inspector socket on port ${port} for ${appId}.`;
+}
+
+describe("iOSLogParserService", () => {
+	let injector: IInjector, iOSLogParserService: IIOSLogParserService, iosDeviceOperations: IIOSDeviceOperations;
+
+	beforeEach(() => {
+		injector = createTestInjector();
+		iOSLogParserService = injector.resolve("iOSLogParserService");
+		iosDeviceOperations = injector.resolve("iosDeviceOperations");
+		iosDeviceOperations.startDeviceLog = () => ({});
+	});
+
+	function emitDeviceLog(message: string) {
+		iosDeviceOperations.emit(DEVICE_LOG_EVENT_NAME, {
+			deviceId: device.deviceInfo.identifier,
+			message: message
+		});
+	}
+
+	function attachOnDebuggerFoundEvent(emittedMessagesCount: number): Promise<IIOSDebuggerPortData[]> {
+		const receivedData: IIOSDebuggerPortData[] = [];
+
+		return new Promise((resolve, reject) => {
+			iOSLogParserService.on(DEBUGGER_PORT_FOUND_EVENT_NAME, (data: IIOSDebuggerPortData) => {
+				receivedData.push(data);
+				if (receivedData.length === emittedMessagesCount) {
+					resolve(receivedData);
+				}
+			});
+		});
+	}
+
+	describe("startLookingForDebuggerPort", () => {
+		it(`should emit ${DEBUGGER_PORT_FOUND_EVENT_NAME} event`, async () => {
+			const emittedMessagesCount = 1;
+			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
+
+			iOSLogParserService.startLookingForDebuggerPort(device);
+			emitDeviceLog("test message");
+			emitDeviceLog(getDebuggerPortMessage(18181));
+
+			const data = await promise;
+
+			assert.deepEqual(data.length, emittedMessagesCount);
+			assert.deepEqual(data[0], { port: 18181, deviceId: deviceId, appId: appId });
+		});
+		it("should receive all log data when cache logs are emitted in case when default port is not available", async () => {
+			const emittedMessagesCount = 5;
+			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
+
+			iOSLogParserService.startLookingForDebuggerPort(device);
+			emitDeviceLog(getDebuggerPortMessage(18181));
+			emitDeviceLog(getDebuggerPortMessage(18181));
+			emitDeviceLog(getDebuggerPortMessage(18181));
+			emitDeviceLog(getDebuggerPortMessage(18181));
+			emitDeviceLog(getDebuggerPortMessage(64087));
+
+			const data = await promise;
+
+			assert.deepEqual(data.length, emittedMessagesCount);
+			assert.deepEqual(data[0], { port: 18181, deviceId: deviceId, appId: appId });
+			assert.deepEqual(data[1], { port: 18181, deviceId: deviceId, appId: appId });
+			assert.deepEqual(data[2], { port: 18181, deviceId: deviceId, appId: appId });
+			assert.deepEqual(data[3], { port: 18181, deviceId: deviceId, appId: appId });
+			assert.deepEqual(data[4], { port: 64087, deviceId: deviceId, appId: appId });
+		});
+		it("should receive all log data when cache logs are emitted in case when default port is available", async () => {
+			const emittedMessagesCount = 5;
+			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
+
+			iOSLogParserService.startLookingForDebuggerPort(device);
+			emitDeviceLog(getDebuggerPortMessage(45898));
+			emitDeviceLog(getDebuggerPortMessage(1809));
+			emitDeviceLog(getDebuggerPortMessage(65072));
+			emitDeviceLog(getDebuggerPortMessage(12345));
+			emitDeviceLog(getDebuggerPortMessage(18181));
+
+			const data = await promise;
+
+			assert.deepEqual(data.length, emittedMessagesCount);
+			assert.deepEqual(data[0], { port: 45898, deviceId: deviceId, appId: appId });
+			assert.deepEqual(data[1], { port: 1809, deviceId: deviceId, appId: appId });
+			assert.deepEqual(data[2], { port: 65072, deviceId: deviceId, appId: appId });
+			assert.deepEqual(data[3], { port: 12345, deviceId: deviceId, appId: appId });
+			assert.deepEqual(data[4], { port: 18181, deviceId: deviceId, appId: appId });
+		});
+		it(`should not receive ${DEBUGGER_PORT_FOUND_EVENT_NAME} event when debugger port message is not emitted`, () => {
+			let isDebuggedPortFound = false;
+
+			iOSLogParserService.on(DEBUGGER_PORT_FOUND_EVENT_NAME, (data: IIOSDebuggerPortData) => isDebuggedPortFound = true);
+
+			iOSLogParserService.startLookingForDebuggerPort(device);
+			emitDeviceLog("some test message");
+			emitDeviceLog("another test message");
+
+			assert.isFalse(isDebuggedPortFound);
+		});
+	});
+});

--- a/test/services/ios-log-parser-service.ts
+++ b/test/services/ios-log-parser-service.ts
@@ -82,7 +82,7 @@ describe("iOSLogParserService", () => {
 			const emittedMessagesCount = 1;
 			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
 
-			iOSLogParserService.startLookingForDebuggerPort(device);
+			iOSLogParserService.startParsingLog(device);
 			emitDeviceLog("test message");
 			emitDeviceLog(getDebuggerPortMessage(18181));
 
@@ -95,7 +95,7 @@ describe("iOSLogParserService", () => {
 			const emittedMessagesCount = 5;
 			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
 
-			iOSLogParserService.startLookingForDebuggerPort(device);
+			iOSLogParserService.startParsingLog(device);
 			emitDeviceLog(getDebuggerPortMessage(18181));
 			emitDeviceLog(getDebuggerPortMessage(18181));
 			emitDeviceLog(getDebuggerPortMessage(18181));
@@ -115,7 +115,7 @@ describe("iOSLogParserService", () => {
 			const emittedMessagesCount = 5;
 			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
 
-			iOSLogParserService.startLookingForDebuggerPort(device);
+			iOSLogParserService.startParsingLog(device);
 			emitDeviceLog(getDebuggerPortMessage(45898));
 			emitDeviceLog(getDebuggerPortMessage(1809));
 			emitDeviceLog(getDebuggerPortMessage(65072));
@@ -136,7 +136,7 @@ describe("iOSLogParserService", () => {
 
 			iOSLogParserService.on(DEBUGGER_PORT_FOUND_EVENT_NAME, (data: IIOSDebuggerPortData) => isDebuggedPortFound = true);
 
-			iOSLogParserService.startLookingForDebuggerPort(device);
+			iOSLogParserService.startParsingLog(device);
 			emitDeviceLog("some test message");
 			emitDeviceLog("another test message");
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -408,6 +408,12 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	async checkForChanges(changesInfo: IProjectChangesInfo, options: IProjectChangesOptions, projectData: IProjectData): Promise<void> {
 		// Nothing yet.
 	}
+	getFrameworkVersion(projectData: IProjectData): string {
+		return "";
+	}
+	getPluginPlatformsFolderPath(pluginData: IPluginData, platform: string): string {
+		return "";
+	}
 }
 
 export class PlatformsDataStub extends EventEmitter implements IPlatformsData {


### PR DESCRIPTION
## What is the current behavior?
The inspector listening socket is being closed 30 sec. after the last activity on it (opening, disconnection, etc). It had to be closed in order to have the hardcoded port number 18181
available for other apps after finishing (or never starting) a
debugging session. Without this timeout the first app that opened
the port would take it as long as it's running and would prevent
any subsequent debugging attempts of another app on the same iOS device;
or even the same app on another iOS Simulator on the same Mac machine.
This leads to unavailability to run fast sync on multiples simulators.

## What is the new behavior?
From now on, the port is printed from `ios-runtime` in devices logs. {N} CLI parses the logs and searches for specified string. The string should be in following format:
```
NativeScript debugger has opened inspector socket on port ${port} for ${appId}.
```

This will allow to connect the frontend at any moment after starting a debug session, instead of failing after the 30 seconds have elapsed.
 
Should be merged after these:
https://github.com/telerik/mobile-cli-lib/pull/1087
https://github.com/telerik/ios-sim-portable/pull/103

Relying on this:
https://github.com/NativeScript/ios-runtime/pull/907

Implementing:
https://github.com/NativeScript/nativescript-cli/issues/3321