### PR TITLE
feat: Allow templates to be full applications

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -201,3 +201,7 @@ export class TemplateVersions {
 export class ProjectTemplateErrors {
 	public static InvalidTemplateVersionStringFormat = "The template '%s' has a NativeScript version '%s' that is not supported. Unable to create project from it.";
 }
+
+export class Hooks {
+	public static createProject = "createProject";
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -137,6 +137,7 @@ export const enum DebugTools {
 export const enum TrackActionNames {
 	Build = "Build",
 	CreateProject = "Create project",
+	UsingTemplate = "Using Template",
 	Debug = "Debug",
 	Deploy = "Deploy",
 	LiveSync = "LiveSync",
@@ -144,6 +145,8 @@ export const enum TrackActionNames {
 	CheckLocalBuildSetup = "Check Local Build Setup",
 	CheckEnvironmentRequirements = "Check Environment Requirements"
 }
+
+export const AnalyticsEventLabelDelimiter = "__";
 
 export const enum BuildStates {
 	Clean = "Clean",
@@ -188,4 +191,13 @@ export class SubscribeForNewsletterMessages {
 		"containing information about Progress Software's products. Consent may be withdrawn at any time.";
 	public static ReviewPrivacyPolicyMsg = `You can review the Progress Software Privacy Policy at \`${PROGRESS_PRIVACY_POLICY_URL}\``;
 	public static PromptMsg = "Input your e-mail address to agree".green + " or " + "leave empty to decline".red.bold + ":";
+}
+
+export class TemplateVersions {
+	public static v1 = "v1";
+	public static v2 = "v2";
+}
+
+export class ProjectTemplateErrors {
+	public static InvalidTemplateVersionStringFormat = "The template '%s' has a NativeScript version '%s' that is not supported. Unable to create project from it.";
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -201,6 +201,11 @@ interface IImageDefinitionsStructure {
 	android: IImageDefinitionGroup;
 }
 
+interface ITemplateData {
+	templatePath: string;
+	templateVersion: string;
+}
+
 /**
  * Describes working with templates.
  */
@@ -211,9 +216,9 @@ interface IProjectTemplatesService {
 	 * In case templateName is a special word, validated from us (for ex. typescript), resolve the real template name and add it to npm cache.
 	 * In any other cases try to `npm install` the specified templateName to temp directory.
 	 * @param {string} templateName The name of the template.
-	 * @return {string} Path to the directory where extracted template can be found.
+	 * @return {ITemplateData} Data describing the template - location where it is installed and its NativeScript version.
 	 */
-	prepareTemplate(templateName: string, projectDir: string): Promise<string>;
+	prepareTemplate(templateName: string, projectDir: string): Promise<ITemplateData>;
 }
 
 interface IPlatformProjectServiceBase {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -219,6 +219,14 @@ interface IProjectTemplatesService {
 	 * @return {ITemplateData} Data describing the template - location where it is installed and its NativeScript version.
 	 */
 	prepareTemplate(templateName: string, projectDir: string): Promise<ITemplateData>;
+
+	/**
+	 * Gives information for the nativescript specific version of the template, for example v1, v2, etc.
+	 * Defaults to v1 in case there's no version specified.
+	 * @param {string} templatePath Full path to the template.
+	 * @returns {string} The version, for example v1 or v2.
+	 */
+	getTemplateVersion(templatePath: string): string;
 }
 
 interface IPlatformProjectServiceBase {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -1,11 +1,18 @@
-/**
- * Describes available settings when creating new NativeScript application.
- */
-interface IProjectSettings {
+interface IProjectName {
+	projectName: string;
+}
+
+interface IProjectSettingsBase extends IProjectName {
 	/**
 	 * Name of the newly created application.
 	 */
 	projectName: string;
+
+	/**
+	 * Defines whether the `npm install` command should be executed with `--ignore-scripts` option.
+	 * When it is passed, all scripts (postinstall for example) will not be executed.
+	 */
+	ignoreScripts?: boolean;
 
 	/**
 	 * Selected template from which to create the project. If not specified, defaults to hello-world template.
@@ -19,7 +26,19 @@ interface IProjectSettings {
 	 * Application identifier for the newly created application. If not specified, defaults to org.nativescript.<projectName>.
 	 */
 	appId?: string;
+}
 
+/**
+ * Describes information passed to project creation hook (createProject).
+ */
+interface IProjectCreationSettings extends IProjectSettingsBase, IProjectDir {
+
+}
+
+/**
+ * Describes available settings when creating new NativeScript application.
+ */
+interface IProjectSettings extends IProjectSettingsBase {
 	/**
 	 * Path where the project will be created. If not specified, defaults to current working dir.
 	 */
@@ -29,17 +48,8 @@ interface IProjectSettings {
 	 * Defines if invalid application name can be used for project creation.
 	 */
 	force?: boolean;
-
-	/**
-	 * Defines whether the `npm install` command should be executed with `--ignore-scripts` option.
-	 * When it is passed, all scripts (postinstall for example) will not be executed.
-	 */
-	ignoreScripts?: boolean;
 }
 
-interface IProjectName {
-	projectName: string;
-}
 
 interface ICreateProjectData extends IProjectDir, IProjectName {
 

--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -45,7 +45,7 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 		return { templatePath, templateVersion };
 	}
 
-	private getTemplateVersion(templatePath: string): string {
+	public getTemplateVersion(templatePath: string): string {
 		this.$logger.trace(`Checking the NativeScript version of the template located at ${templatePath}.`);
 		const pathToPackageJson = path.join(templatePath, constants.PACKAGE_JSON_FILE_NAME);
 		if (this.$fs.exists(pathToPackageJson)) {

--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as temp from "temp";
 import * as constants from "../constants";
+import { format } from "util";
 temp.track();
 
 export class ProjectTemplatesService implements IProjectTemplatesService {
@@ -8,9 +9,10 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 	public constructor(private $analyticsService: IAnalyticsService,
 		private $fs: IFileSystem,
 		private $logger: ILogger,
-		private $npmInstallationManager: INpmInstallationManager) { }
+		private $npmInstallationManager: INpmInstallationManager,
+		private $errors: IErrors) { }
 
-	public async prepareTemplate(originalTemplateName: string, projectDir: string): Promise<string> {
+	public async prepareTemplate(originalTemplateName: string, projectDir: string): Promise<ITemplateData> {
 		// support <reserved_name>@<version> syntax
 		const data = originalTemplateName.split("@"),
 			name = data[0],
@@ -18,23 +20,52 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 
 		const templateName = constants.RESERVED_TEMPLATE_NAMES[name.toLowerCase()] || name;
 
-		const realTemplatePath = await this.prepareNativeScriptTemplate(templateName, version, projectDir);
+		const templatePath = await this.prepareNativeScriptTemplate(templateName, version, projectDir);
 
 		await this.$analyticsService.track("Template used for project creation", templateName);
 
-		const templateNameToBeTracked = this.getTemplateNameToBeTracked(templateName, realTemplatePath);
+		const templateNameToBeTracked = this.getTemplateNameToBeTracked(templateName, templatePath);
+		const templateVersion = this.getTemplateVersion(templatePath);
 		if (templateNameToBeTracked) {
 			await this.$analyticsService.trackEventActionInGoogleAnalytics({
 				action: constants.TrackActionNames.CreateProject,
 				isForDevice: null,
 				additionalData: templateNameToBeTracked
 			});
+
+			await this.$analyticsService.trackEventActionInGoogleAnalytics({
+				action: constants.TrackActionNames.UsingTemplate,
+				additionalData: `${templateNameToBeTracked}${constants.AnalyticsEventLabelDelimiter}${templateVersion}`
+			});
 		}
 
 		// this removes dependencies from templates so they are not copied to app folder
-		this.$fs.deleteDirectory(path.join(realTemplatePath, constants.NODE_MODULES_FOLDER_NAME));
+		this.$fs.deleteDirectory(path.join(templatePath, constants.NODE_MODULES_FOLDER_NAME));
 
-		return realTemplatePath;
+		return { templatePath, templateVersion };
+	}
+
+	private getTemplateVersion(templatePath: string): string {
+		this.$logger.trace(`Checking the NativeScript version of the template located at ${templatePath}.`);
+		const pathToPackageJson = path.join(templatePath, constants.PACKAGE_JSON_FILE_NAME);
+		if (this.$fs.exists(pathToPackageJson)) {
+			const packageJsonContent = this.$fs.readJson(pathToPackageJson);
+			const templateVersionFromPackageJson: string = packageJsonContent && packageJsonContent.nativescript && packageJsonContent.nativescript.templateVersion;
+
+			if (templateVersionFromPackageJson) {
+				this.$logger.trace(`The template ${templatePath} has version ${templateVersionFromPackageJson}.`);
+
+				if (_.values(constants.TemplateVersions).indexOf(templateVersionFromPackageJson) === -1) {
+					this.$errors.failWithoutHelp(format(constants.ProjectTemplateErrors.InvalidTemplateVersionStringFormat, templatePath, templateVersionFromPackageJson));
+				}
+
+				return templateVersionFromPackageJson;
+			}
+		}
+
+		const defaultVersion = constants.TemplateVersions.v1;
+		this.$logger.trace(`The template ${templatePath} does not specify version or we were unable to find out the version. Using default one ${defaultVersion}`);
+		return defaultVersion;
 	}
 
 	/**

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -18,6 +18,7 @@ import { Options } from "../lib/options";
 import { HostInfo } from "../lib/common/host-info";
 import { ProjectTemplatesService } from "../lib/services/project-templates-service";
 import { SettingsService } from "../lib/common/test/unit-tests/stubs";
+import { DevicePlatformsConstants } from "../lib/common/mobile/device-platforms-constants";
 
 const mockProjectNameValidator = {
 	validate: () => true
@@ -157,8 +158,13 @@ class ProjectIntegrationTest {
 		});
 		this.testInjector.register("npmInstallationManager", NpmInstallationManager);
 		this.testInjector.register("settingsService", SettingsService);
-		this.testInjector.register("devicePlatformsConstants", {});
-		this.testInjector.register("androidResourcesMigrationService", {});
+		this.testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
+		this.testInjector.register("androidResourcesMigrationService", {
+			hasMigrated: (appResourcesDir: string): boolean => true
+		});
+		this.testInjector.register("hooksService", {
+			executeAfterHooks: async (commandName: string, hookArguments?: IDictionary<any>): Promise<void> => undefined
+		});
 	}
 }
 
@@ -436,6 +442,9 @@ describe("Project Service Tests", () => {
 			testInjector.register("projectHelper", {});
 			testInjector.register("npmInstallationManager", {});
 			testInjector.register("settingsService", SettingsService);
+			testInjector.register("hooksService", {
+				executeAfterHooks: async (commandName: string, hookArguments?: IDictionary<any>): Promise<void> => undefined
+			});
 
 			return testInjector;
 		};

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -478,6 +478,10 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 	async prepareTemplate(templateName: string): Promise<ITemplateData> {
 		return Promise.resolve(<any>{});
 	}
+
+	getTemplateVersion(templatePath: string): string {
+		return constants.TemplateVersions.v1;
+	}
 }
 
 export class HooksServiceStub implements IHooksService {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -475,8 +475,8 @@ export class ProjectHelperStub implements IProjectHelper {
 }
 
 export class ProjectTemplatesService implements IProjectTemplatesService {
-	async prepareTemplate(templateName: string): Promise<string> {
-		return Promise.resolve("");
+	async prepareTemplate(templateName: string): Promise<ITemplateData> {
+		return Promise.resolve(<any>{});
 	}
 }
 


### PR DESCRIPTION
Currently when a project is created the content of the template is placed inside the `app` directory of the newly created project.
This leads to some issues when you want to support more complex scenarios, for example it is difficult to add configuration file (like nsconfig.json or webpack.config.js) in the root of the project.
The suggested solution to allow templates to be the full application is to check the template from which the application is created. In case the template contains a nativescript key and templateVersion property in it, check its value.
In case it is v1, use the old way, i.e. place the content of the template in the app directory of the created project.
In case it is v2 place the content of the template at the root of the application.
In case it is anything else - throw an error.
In case it is missing, use v1 as default.

The solution ensures backwards compatiblity with existing templates and allows creating new types of templates.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

Fixes/Implements/Closes #[Issue Number].
