### PR TITLE
fix(assets-generation): Do not fail in case some App_Resources are missing

### DIFF
--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -125,7 +125,7 @@ export class ProjectDataService implements IProjectDataService {
 
 	private async getIOSAssetSubGroup(dirPath: string): Promise<IAssetSubGroup> {
 		const pathToContentJson = path.join(dirPath, AssetConstants.iOSResourcesFileName);
-		const content = <IAssetSubGroup>this.$fs.readJson(pathToContentJson);
+		const content = this.$fs.exists(pathToContentJson) && <IAssetSubGroup>this.$fs.readJson(pathToContentJson) || { images: [] };
 
 		const imageDefinitions = this.getImageDefinitions().ios;
 


### PR DESCRIPTION
In case you delete `App_Resources/iOS` directory, the `getAssetsStructure` method fails as it tries to read `Content.json` files from the deleted directory. Instead of failing, just return empty arrays for the images. This is already working this way for Android.
Add test for the case

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Trying to generate/get assets structure fails when App_Resources/iOS is deleted

## What is the new behavior?
The generation of assets will work for Android in this case.

Fixes https://github.com/NativeScript/sidekick-feedback/issues/168 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

