### PR TITLE
feat: Allow using JAVA 8+

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3812,9 +3812,9 @@
       "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g=="
     },
     "nativescript-doctor": {
-      "version": "0.13.0-rc.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-0.13.0-rc.0.tgz",
-      "integrity": "sha512-IAQzfxYo1S18TxI0cjh96raV8/1f1cjvX6OIePi9HVKUhL9Oh/GHro33lSkifSpV+jYeFUqk+JODRZZRFukyVA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.0.0.tgz",
+      "integrity": "sha512-QZ/hhDCeenIyVM3e9ly4xqldvsQwpQUv9R6Eqq7EXujysDrOyhRb2o59SbJ14uWRBYVKFILEvls+tqSWdc/wSw==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.3.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3812,9 +3812,9 @@
       "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g=="
     },
     "nativescript-doctor": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-0.12.0.tgz",
-      "integrity": "sha512-eGEx9MFagJ7i2mtFZv5Jbsg6YQqQsVLxLhmg2uOOjLC253daAkGUBFbPnpEajrqhPZX3PBmoYIh+oHfc9/trjA==",
+      "version": "0.13.0-rc.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-0.13.0-rc.0.tgz",
+      "integrity": "sha512-IAQzfxYo1S18TxI0cjh96raV8/1f1cjvX6OIePi9HVKUhL9Oh/GHro33lSkifSpV+jYeFUqk+JODRZZRFukyVA==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "0.13.0-rc.0",
+    "nativescript-doctor": "1.0.0",
     "open": "0.0.5",
     "ora": "2.0.0",
     "osenv": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "0.12.0",
+    "nativescript-doctor": "0.13.0-rc.0",
     "open": "0.0.5",
     "ora": "2.0.0",
     "osenv": "0.1.3",

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -28,7 +28,7 @@ apply plugin: 'com.android.library'
 
 def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 24 }
 def computeBuildToolsVersion = { ->
-    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "27.0.1"
+    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "27.0.3"
 }
 
 android {

--- a/vendor/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/vendor/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 21 13:58:00 EET 2017
+#Fri May 11 16:45:47 EEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip


### PR DESCRIPTION
Currently in case you have JAVA 9 or 10, CLI does not allow you to build your application. Remove the check for max JAVA version from nativescript-doctor and use the rc version of the package in CLI.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
in case you have JAVA 9 or 10, CLI does not allow you to build your application.

## What is the new behavior?
CLI allows building apps with JAVA 9 or 10.

Implements https://github.com/NativeScript/nativescript-cli/issues/3605