### PR TITLE
fix(API): isValidNativeScriptProject returns incorrect result

### DIFF
--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -80,8 +80,9 @@ export class ProjectService implements IProjectService {
 	@exported("projectService")
 	public isValidNativeScriptProject(pathToProject?: string): boolean {
 		try {
-			this.$projectData.initializeProjectData(pathToProject);
-			return !!this.$projectData.projectDir && !!this.$projectData.projectId;
+			const projectData = this.$projectDataService.getProjectData(pathToProject);
+
+			return !!projectData && !!projectData.projectDir && !!projectData.projectId;
 		} catch (e) {
 			return false;
 		}


### PR DESCRIPTION
In case CLI is used as a library and `isValidNativeScriptProject` is called multiple times, it does not return correct results after the first time.
The problem is that it uses the singleton object - projectData. Change the implementation to use projectDataService, this way the method will always return correc results.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
In case CLI is used as a library and `isValidNativeScriptProject` is called multiple times, it does not return correct results after the first time.

## What is the new behavior?
In case CLI is used as a library and `isValidNativeScriptProject` is called multiple times, it returns correct results.
