### PR TITLE
fix: Tracking for used Debug tool is incorrect

### DIFF
--- a/lib/services/debug-service.ts
+++ b/lib/services/debug-service.ts
@@ -31,7 +31,7 @@ export class DebugService extends EventEmitter implements IDebugService {
 		await this.$analyticsService.trackEventActionInGoogleAnalytics({
 			action: TrackActionNames.Debug,
 			device,
-			additionalData: this.$mobileHelper.isiOSPlatform(device.deviceInfo.platform) && (!options || !options.chrome) ? DebugTools.Inspector : DebugTools.Chrome,
+			additionalData: this.$mobileHelper.isiOSPlatform(device.deviceInfo.platform) && options && options.inspector ? DebugTools.Inspector : DebugTools.Chrome,
 			projectDir: debugData.projectDir
 		});
 


### PR DESCRIPTION
The tracking if Inspector or Chrome is used as a debug tool is incorrect - currently it sends "Inspector" when `--inspector` is not specified. `Chrome` is sent only when `--chrome` is passed.
Fix the tracking and add tests.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Tracking for used debug tools is not correct - "Chrome" is the default option, but it is tracked only when `--chrome` is passed.

## What is the new behavior?
Tracking sends correct information when Inspector is used and when Chrome is used.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3593
