### PR TITLE
fix(GDPR): Do not track local project paths

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,5 @@
+require("colors");
+
 export const APP_FOLDER_NAME = "app";
 export const APP_RESOURCES_FOLDER_NAME = "App_Resources";
 export const PROJECT_FRAMEWORK_FOLDER_NAME = "framework";
@@ -77,6 +79,8 @@ export const RESERVED_TEMPLATE_NAMES: IStringDictionary = {
 	"ng": "tns-template-hello-world-ng",
 	"angular": "tns-template-hello-world-ng"
 };
+
+export const ANALYTICS_LOCAL_TEMPLATE_PREFIX = "localTemplate_";
 
 export class ITMSConstants {
 	static ApplicationMetadataFile = "metadata.xml";
@@ -169,4 +173,12 @@ export class AssetConstants {
 
 	public static defaultScale = 1;
 	public static defaultOverlayImageScale = 0.8;
+}
+
+export const PROGRESS_PRIVACY_POLICY_URL = "https://www.progress.com/legal/privacy-policy";
+export class SubscribeForNewsletterMessages {
+	public static AgreeToReceiveEmailMsg = "I agree to receive email communications from Progress Software or its Partners (`https://www.progress.com/partners/partner-directory`)," +
+		"containing information about Progress Software's products. Consent may be withdrawn at any time.";
+	public static ReviewPrivacyPolicyMsg = `You can review the Progress Software Privacy Policy at \`${PROGRESS_PRIVACY_POLICY_URL}\``;
+	public static PromptMsg = "Input your e-mail address to agree".green + " or " + "leave empty to decline".red.bold + ":";
 }

--- a/lib/services/subscription-service.ts
+++ b/lib/services/subscription-service.ts
@@ -1,6 +1,7 @@
 import * as emailValidator from "email-validator";
 import * as queryString from "querystring";
 import * as helpers from "../common/helpers";
+import { SubscribeForNewsletterMessages } from "../constants";
 
 export class SubscriptionService implements ISubscriptionService {
 	constructor(private $httpClient: Server.IHttpClient,
@@ -11,8 +12,10 @@ export class SubscriptionService implements ISubscriptionService {
 
 	public async subscribeForNewsletter(): Promise<void> {
 		if (await this.shouldAskForEmail()) {
-			this.$logger.out("Enter your e-mail address to subscribe to the NativeScript Newsletter and hear about product updates, tips & tricks, and community happenings:");
-			const email = await this.getEmail("(press Enter for blank)");
+			this.$logger.printMarkdown(SubscribeForNewsletterMessages.AgreeToReceiveEmailMsg);
+			this.$logger.printMarkdown(SubscribeForNewsletterMessages.ReviewPrivacyPolicyMsg);
+
+			const email = await this.getEmail(SubscribeForNewsletterMessages.PromptMsg);
 			await this.$userSettingsService.saveSetting("EMAIL_REGISTERED", true);
 			await this.sendEmail(email);
 		}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "4.0.1",
+  "version": "4.0.2",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -151,6 +151,20 @@ describe("project-templates-service", () => {
 					additionalData: `${constants.ANALYTICS_LOCAL_TEMPLATE_PREFIX}${templateName}`
 				});
 			});
+
+			it("does not send anything when trying to get template name fails", async () => {
+				const templateName = "localtemplate";
+				const localTemplatePath = `/Users/username/${templateName}`;
+				const fs = testInjector.resolve<IFileSystem>("fs");
+				fs.exists = (localPath: string): boolean => true;
+				fs.readJson = (filename: string, encoding?: string): any => {
+					throw new Error("Unable to read json");
+				};
+
+				await projectTemplatesService.prepareTemplate(localTemplatePath, "tempFolder");
+
+				assert.deepEqual(dataSentToGoogleAnalytics, null);
+			});
 		});
 	});
 });

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -3,7 +3,6 @@ import * as stubs from "./stubs";
 import { ProjectTemplatesService } from "../lib/services/project-templates-service";
 import { assert } from "chai";
 import * as path from "path";
-import temp = require("temp");
 import * as constants from "../lib/constants";
 
 let isDeleteDirectoryCalledForNodeModulesDir = false;
@@ -25,9 +24,12 @@ function createTestInjector(configuration?: { shouldNpmInstallThrow: boolean, np
 			if (directory.indexOf("node_modules") !== -1) {
 				isDeleteDirectoryCalledForNodeModulesDir = true;
 			}
-		}
+		},
+
+		exists: (filePath: string): boolean => false
 
 	});
+
 	injector.register("npm", {
 		install: (packageName: string, pathToSave: string, config?: any) => {
 			if (configuration.shouldNpmInstallThrow) {
@@ -70,8 +72,7 @@ describe("project-templates-service", () => {
 			it("when npm install fails", async () => {
 				testInjector = createTestInjector({ shouldNpmInstallThrow: true, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: null });
 				projectTemplatesService = testInjector.resolve("projectTemplatesService");
-				const tempFolder = temp.mkdirSync("preparetemplate");
-				await assert.isRejected(projectTemplatesService.prepareTemplate("invalidName", tempFolder));
+				await assert.isRejected(projectTemplatesService.prepareTemplate("invalidName", "tempFolder"));
 			});
 		});
 
@@ -79,8 +80,7 @@ describe("project-templates-service", () => {
 			it("when reserved template name is used", async () => {
 				testInjector = createTestInjector({ shouldNpmInstallThrow: false, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: [] });
 				projectTemplatesService = testInjector.resolve("projectTemplatesService");
-				const tempFolder = temp.mkdirSync("preparetemplate");
-				const actualPathToTemplate = await projectTemplatesService.prepareTemplate("typescript", tempFolder);
+				const actualPathToTemplate = await projectTemplatesService.prepareTemplate("typescript", "tempFolder");
 				assert.strictEqual(path.basename(actualPathToTemplate), nativeScriptValidatedTemplatePath);
 				assert.strictEqual(isDeleteDirectoryCalledForNodeModulesDir, true, "When correct path is returned, template's node_modules directory should be deleted.");
 			});
@@ -88,8 +88,7 @@ describe("project-templates-service", () => {
 			it("when reserved template name is used (case-insensitive test)", async () => {
 				testInjector = createTestInjector({ shouldNpmInstallThrow: false, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: [] });
 				projectTemplatesService = testInjector.resolve("projectTemplatesService");
-				const tempFolder = temp.mkdirSync("preparetemplate");
-				const actualPathToTemplate = await projectTemplatesService.prepareTemplate("tYpEsCriPT", tempFolder);
+				const actualPathToTemplate = await projectTemplatesService.prepareTemplate("tYpEsCriPT", "tempFolder");
 				assert.strictEqual(path.basename(actualPathToTemplate), nativeScriptValidatedTemplatePath);
 				assert.strictEqual(isDeleteDirectoryCalledForNodeModulesDir, true, "When correct path is returned, template's node_modules directory should be deleted.");
 			});
@@ -97,10 +96,60 @@ describe("project-templates-service", () => {
 			it("uses defaultTemplate when undefined is passed as parameter", async () => {
 				testInjector = createTestInjector({ shouldNpmInstallThrow: false, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: [] });
 				projectTemplatesService = testInjector.resolve("projectTemplatesService");
-				const tempFolder = temp.mkdirSync("preparetemplate");
-				const actualPathToTemplate = await projectTemplatesService.prepareTemplate(constants.RESERVED_TEMPLATE_NAMES["default"], tempFolder);
+				const actualPathToTemplate = await projectTemplatesService.prepareTemplate(constants.RESERVED_TEMPLATE_NAMES["default"], "tempFolder");
 				assert.strictEqual(path.basename(actualPathToTemplate), nativeScriptValidatedTemplatePath);
 				assert.strictEqual(isDeleteDirectoryCalledForNodeModulesDir, true, "When correct path is returned, template's node_modules directory should be deleted.");
+			});
+		});
+
+		describe("sends correct information to Google Analytics", () => {
+			let analyticsService: IAnalyticsService;
+			let dataSentToGoogleAnalytics: IEventActionData;
+			beforeEach(() => {
+				testInjector = createTestInjector({ shouldNpmInstallThrow: false, npmInstallationDirContents: [], npmInstallationDirNodeModulesContents: [] });
+				analyticsService = testInjector.resolve<IAnalyticsService>("analyticsService");
+				dataSentToGoogleAnalytics = null;
+				analyticsService.trackEventActionInGoogleAnalytics = async (data: IEventActionData): Promise<void> => {
+					dataSentToGoogleAnalytics = data;
+				};
+				projectTemplatesService = testInjector.resolve("projectTemplatesService");
+			});
+
+			it("sends template name when the template is used from npm", async () => {
+				const templateName = "template-from-npm";
+				await projectTemplatesService.prepareTemplate(templateName, "tempFolder");
+				assert.deepEqual(dataSentToGoogleAnalytics, {
+					action: constants.TrackActionNames.CreateProject,
+					isForDevice: null,
+					additionalData: templateName
+				});
+			});
+
+			it("sends template name (from template's package.json) when the template is used from local path", async () => {
+				const templateName = "my-own-local-template";
+				const localTemplatePath = "/Users/username/localtemplate";
+				const fs = testInjector.resolve<IFileSystem>("fs");
+				fs.exists = (path: string): boolean => true;
+				fs.readJson = (filename: string, encoding?: string): any => ({ name: templateName });
+				await projectTemplatesService.prepareTemplate(localTemplatePath, "tempFolder");
+				assert.deepEqual(dataSentToGoogleAnalytics, {
+					action: constants.TrackActionNames.CreateProject,
+					isForDevice: null,
+					additionalData: `${constants.ANALYTICS_LOCAL_TEMPLATE_PREFIX}${templateName}`
+				});
+			});
+
+			it("sends the template name (path to dirname) when the template is used from local path but there's no package.json at the root", async () => {
+				const templateName = "localtemplate";
+				const localTemplatePath = `/Users/username/${templateName}`;
+				const fs = testInjector.resolve<IFileSystem>("fs");
+				fs.exists = (localPath: string): boolean => path.basename(localPath) !== constants.PACKAGE_JSON_FILE_NAME;
+				await projectTemplatesService.prepareTemplate(localTemplatePath, "tempFolder");
+				assert.deepEqual(dataSentToGoogleAnalytics, {
+					action: constants.TrackActionNames.CreateProject,
+					isForDevice: null,
+					additionalData: `${constants.ANALYTICS_LOCAL_TEMPLATE_PREFIX}${templateName}`
+				});
 			});
 		});
 	});

--- a/test/services/subscription-service.ts
+++ b/test/services/subscription-service.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 import { SubscriptionService } from "../../lib/services/subscription-service";
 import { LoggerStub } from "../stubs";
 import { stringify } from "querystring";
+import { SubscribeForNewsletterMessages } from "../../lib/constants";
 const helpers = require("../../lib/common/helpers");
 
 interface IValidateTestData {
@@ -153,12 +154,16 @@ describe("subscriptionService", () => {
 				loggerOutput += args.join(" ");
 			};
 
+			logger.printMarkdown = (message: string): void => {
+				loggerOutput += message;
+			};
+
 			await subscriptionService.subscribeForNewsletter();
 
-			assert.equal(loggerOutput, "Enter your e-mail address to subscribe to the NativeScript Newsletter and hear about product updates, tips & tricks, and community happenings:");
+			assert.equal(loggerOutput, `${SubscribeForNewsletterMessages.AgreeToReceiveEmailMsg}${SubscribeForNewsletterMessages.ReviewPrivacyPolicyMsg}`);
 		});
 
-		const expectedMessageInPrompter = "(press Enter for blank)";
+		const expectedMessageInPrompter = SubscribeForNewsletterMessages.PromptMsg;
 		it(`calls prompter with specific message - ${expectedMessageInPrompter}`, async () => {
 			const testInjector = createTestInjector();
 			const subscriptionService = testInjector.resolve<SubscriptionServiceTester>(SubscriptionServiceTester);


### PR DESCRIPTION
Do not track paths to projects when local template is used. Instead track `localTemplate_<name from template's package.json or dirname>`.
Also fix the prompter for emails as we need to show information how to unsubscribe from the newsletter.
Add tests for the behavior.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3595