### PR TITLE
fix: Detect iOS devices connected by USB only

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2798,9 +2798,9 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ios-device-lib": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.10.tgz",
-      "integrity": "sha1-1wENLPSJ0y4zSMKrZd9tILaJ8xA=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.11.tgz",
+      "integrity": "sha512-hqrdyJ8kUnInx1ba454xdIgP9FGSKvwHYUycc7zgAyGauZyUJIyv03+KXNJtoiYA+cGynztjiqbBbM86XlQK8g==",
       "requires": {
         "bufferpack": "0.0.6",
         "node-uuid": "1.4.7"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gaze": "1.1.0",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-device-lib": "0.4.10",
+    "ios-device-lib": "0.4.11",
     "ios-mobileprovision-finder": "1.0.10",
     "ios-sim-portable": "3.3.3",
     "jimp": "0.2.28",


### PR DESCRIPTION
Currently CLI detects iOS Devices with Wi-Fi sync enabled. However, we can only detect them, but we are not able to deploy and livesync applications on them. This also breaks the workflow with devices connected by USB, but with Wi-Fi sync enabled.
So detect only the USB connected devices and disregard the ones connected with Wi-Fi sync enabled. This is handled in the 0.4.11 version of ios-device-lib, so just update the version: https://github.com/telerik/ios-device-lib/releases/tag/v0.4.11

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Devices with Wi-Fi sync enabled are detected by CLI, but it cannot work with them. Also devices connected with USB cable and Wi-Fi sync enabled are not usable as CLI fails to deploy/livesync the applications.

## What is the new behavior?
Devices with Wi-Fi sync enabled are not detected anymore.
Devices connected with USB cable and Wi-Fi sync enabled can be used without interruption.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1398
