### PR TITLE
fix: Unhandled rejection is thrown when disconnection iOS Device

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -40,7 +40,7 @@
     "@types/color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.0.tgz",
-      "integrity": "sha1-QPimvy/YbpaYdrM5qDfY/xsKbjA=",
+      "integrity": "sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==",
       "dev": true,
       "requires": {
         "@types/color-convert": "1.9.0"
@@ -49,7 +49,7 @@
     "@types/color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-v6ggPkHnxlRx6YQdfjBqfNi1Fy0=",
+      "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
       "dev": true,
       "requires": {
         "@types/color-name": "1.1.0"
@@ -58,7 +58,7 @@
     "@types/color-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.0.tgz",
-      "integrity": "sha1-km929+ZvScxZrYgLsVsDCrvwtm0=",
+      "integrity": "sha512-gZ/Rb+MFXF0pXSEQxdRoPMm5jeO3TycjOdvbpbcpHX/B+n9AqaHFe5q6Ga9CsZ7ir/UgIWPfrBzUzn3F19VH/w==",
       "dev": true
     },
     "@types/events": {
@@ -91,7 +91,7 @@
     "@types/ora": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/ora/-/ora-1.3.3.tgz",
-      "integrity": "sha1-0xhkGMPPN6gxeZs3a+ykqOG/yi0=",
+      "integrity": "sha512-XaSVRyCfnGq1xGlb6iuoxnomMXPIlZnvIIkKiGNMTCeVOg7G1Si+FA9N1lPrykPEfiRHwbuZXuTCSoYcHyjcdg==",
       "dev": true,
       "requires": {
         "@types/node": "6.0.61"
@@ -153,7 +153,7 @@
     "@types/xml2js": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
-      "integrity": "sha1-pLhLOHn/1HEJU/2Syr/emopOhFY=",
+      "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
       "dev": true,
       "requires": {
         "@types/node": "6.0.61"
@@ -272,7 +272,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -766,7 +766,7 @@
     "color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-      "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
         "color-convert": "1.9.1",
         "color-string": "1.5.2"
@@ -2798,9 +2798,9 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ios-device-lib": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.11.tgz",
-      "integrity": "sha512-hqrdyJ8kUnInx1ba454xdIgP9FGSKvwHYUycc7zgAyGauZyUJIyv03+KXNJtoiYA+cGynztjiqbBbM86XlQK8g==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.12.tgz",
+      "integrity": "sha512-S0XPH5NTbWVibEOvExHrbGWxJvrHEqRumWB1N1ZyIjgFsqMgaS9o8bCgPmc0kev3xxYTtmZ+REEceTV5qI0yfg==",
       "requires": {
         "bufferpack": "0.0.6",
         "node-uuid": "1.4.7"
@@ -3676,7 +3676,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.33.0",
@@ -5668,7 +5668,7 @@
     "xhr": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
-      "integrity": "sha1-upgsztIFrl7sOHFprJ3HfKSFPTg=",
+      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
       "requires": {
         "global": "4.3.2",
         "is-function": "1.0.1",
@@ -5684,7 +5684,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": "1.2.4",
         "xmlbuilder": "9.0.7"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gaze": "1.1.0",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-device-lib": "0.4.11",
+    "ios-device-lib": "0.4.12",
     "ios-mobileprovision-finder": "1.0.10",
     "ios-sim-portable": "3.4.1",
     "jimp": "0.2.28",


### PR DESCRIPTION
In case iOS device is disconnected during LiveSync an unhandled rejection is thrown. The problem is in ios-device-lib, so update it to latest version - 0.4.12, where the issue is fixed.
Changelog: https://github.com/telerik/ios-device-lib/releases/tag/v0.4.12

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
1. Start livesync on iOS device: `tns run ios`
2. Apply some changes
3. After they are applied, disconnect the device
4. Unhandled rejection is thrown

## What is the new behavior?
Disconnecting the device does not throw any error.

