### PR TITLE
fix: Unable to fast sync changes with iOS runtime 4.0.1 and earlier

### DIFF
--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -15,7 +15,8 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 	public getPort(data: IIOSDebuggerPortInputData): Promise<number> {
 		return new Promise((resolve, reject) => {
 			if (!this.canStartLookingForDebuggerPort()) {
-				return IOSDebuggerPortService.DEFAULT_PORT;
+				resolve(IOSDebuggerPortService.DEFAULT_PORT);
+				return;
 			}
 
 			const key = `${data.deviceId}${data.appId}`;


### PR DESCRIPTION
CLI should be able to execute fast sync on devices and iOS Simulator (single instance) when using older runtime version (4.0.1 and prior).
However, currently it just hangs as the promise that should return the port for fast sync, is never resolved. Fix this by resolving the promise in this case.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
LiveSync of .css files on iOS devices and Simulators when iOS Runtime is 4.0.1 or earlier, just hangs.

## What is the new behavior?
LiveSync of .css files is executed successfully.