### PR TITLE
feat: Validate Java compiler version based on runtime version

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -381,5 +381,5 @@ interface IUpdateAppOptions extends IOptionalFilesToSync, IOptionalFilesToRemove
 }
 
 interface IPlatformEnvironmentRequirements {
-	checkEnvironmentRequirements(platform?: string): Promise<boolean>;
+	checkEnvironmentRequirements(platform?: string, projectDir?: string): Promise<boolean>;
 }

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -133,7 +133,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		this.validatePackageName(projectData.projectId);
 		this.validateProjectName(projectData.projectName);
 
-		await this.$platformEnvironmentRequirements.checkEnvironmentRequirements(this.getPlatformData(projectData).normalizedPlatformName);
+		await this.$platformEnvironmentRequirements.checkEnvironmentRequirements(this.getPlatformData(projectData).normalizedPlatformName, projectData.projectDir);
 		this.$androidToolsInfo.validateTargetSdk({ showWarningsAsErrors: true });
 	}
 

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -17,10 +17,10 @@ class DoctorService implements IDoctorService {
 		private $terminalSpinnerService: ITerminalSpinnerService,
 		private $versionsService: IVersionsService) { }
 
-	public async printWarnings(configOptions?: { trackResult: boolean }): Promise<void> {
+	public async printWarnings(configOptions?: { trackResult: boolean , projectDir?: string }): Promise<void> {
 		const infos = await this.$terminalSpinnerService.execute<NativeScriptDoctor.IInfo[]>({
 			text: `Getting environment information ${EOL}`
-		}, () => doctor.getInfos());
+		}, () => doctor.getInfos({ projectDir: configOptions && configOptions.projectDir }));
 
 		const warnings = infos.filter(info => info.type === constants.WARNING_TYPE_NAME);
 		const hasWarnings = warnings.length > 0;
@@ -48,7 +48,7 @@ class DoctorService implements IDoctorService {
 			this.$logger.error("Cannot get the latest versions information from npm. Please try again later.");
 		}
 
-		await this.$injector.resolve("platformEnvironmentRequirements").checkEnvironmentRequirements(null);
+		await this.$injector.resolve("platformEnvironmentRequirements").checkEnvironmentRequirements(null, configOptions && configOptions.projectDir);
 	}
 
 	public async runSetupScript(): Promise<ISpawnResult> {
@@ -81,12 +81,12 @@ class DoctorService implements IDoctorService {
 		});
 	}
 
-	public async canExecuteLocalBuild(platform?: string): Promise<boolean> {
+	public async canExecuteLocalBuild(platform?: string, projectDir?: string): Promise<boolean> {
 		await this.$analyticsService.trackEventActionInGoogleAnalytics({
 			action: TrackActionNames.CheckLocalBuildSetup,
 			additionalData: "Starting",
 		});
-		const infos = await doctor.getInfos({ platform });
+		const infos = await doctor.getInfos({ platform, projectDir });
 
 		const warnings = this.filterInfosByType(infos, constants.WARNING_TYPE_NAME);
 		const hasWarnings = warnings.length > 0;

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -139,7 +139,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			return;
 		}
 
-		await this.$platformEnvironmentRequirements.checkEnvironmentRequirements(this.getPlatformData(projectData).normalizedPlatformName);
+		await this.$platformEnvironmentRequirements.checkEnvironmentRequirements(this.getPlatformData(projectData).normalizedPlatformName, projectData.projectDir);
 
 		const xcodeBuildVersion = await this.getXcodeVersion();
 		if (helpers.versionCompare(xcodeBuildVersion, IOSProjectService.XCODEBUILD_MIN_VERSION) < 0) {

--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -30,7 +30,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 		"deploy": "tns cloud deploy"
 	};
 
-	public async checkEnvironmentRequirements(platform?: string): Promise<boolean> {
+	public async checkEnvironmentRequirements(platform?: string, projectDir?: string): Promise<boolean> {
 		if (process.env.NS_SKIP_ENV_CHECK) {
 			await this.$analyticsService.trackEventActionInGoogleAnalytics({
 				action: TrackActionNames.CheckEnvironmentRequirements,
@@ -39,7 +39,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 			return true;
 		}
 
-		const canExecute = await this.$doctorService.canExecuteLocalBuild(platform);
+		const canExecute = await this.$doctorService.canExecuteLocalBuild(platform, projectDir);
 		if (!canExecute) {
 			if (!isInteractive()) {
 				await this.$analyticsService.trackEventActionInGoogleAnalytics({
@@ -71,7 +71,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 			if (selectedOption === PlatformEnvironmentRequirements.LOCAL_SETUP_OPTION_NAME) {
 				await this.$doctorService.runSetupScript();
 
-				if (await this.$doctorService.canExecuteLocalBuild(platform)) {
+				if (await this.$doctorService.canExecuteLocalBuild(platform, projectDir)) {
 					return true;
 				}
 
@@ -102,7 +102,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 
 			if (selectedOption === PlatformEnvironmentRequirements.BOTH_CLOUD_SETUP_AND_LOCAL_SETUP_OPTION_NAME) {
 				await this.processBothCloudBuildsAndSetupScript();
-				if (await this.$doctorService.canExecuteLocalBuild(platform)) {
+				if (await this.$doctorService.canExecuteLocalBuild(platform, projectDir)) {
 					return true;
 				}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3812,9 +3812,9 @@
       "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
     },
     "nativescript-doctor": {
-      "version": "1.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.1.0-rc.0.tgz",
-      "integrity": "sha1-2ABOL5lGgTHqE8+U8IhzS9j/XBU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.1.0.tgz",
+      "integrity": "sha512-XmZO+6tLbiOGr/gLYuhmVhec0UPOSsShK/dG7LlEkiLOE7ew7LB/j/gPFAzS5I54jjudJ/qDK/cMvcZWS0TvBg==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.3.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3812,9 +3812,9 @@
       "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
     },
     "nativescript-doctor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.0.0.tgz",
-      "integrity": "sha512-QZ/hhDCeenIyVM3e9ly4xqldvsQwpQUv9R6Eqq7EXujysDrOyhRb2o59SbJ14uWRBYVKFILEvls+tqSWdc/wSw==",
+      "version": "1.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.1.0-rc.0.tgz",
+      "integrity": "sha1-2ABOL5lGgTHqE8+U8IhzS9j/XBU=",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "1.1.0-rc.0",
+    "nativescript-doctor": "1.1.0",
     "open": "0.0.5",
     "ora": "2.0.0",
     "osenv": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "1.0.0",
+    "nativescript-doctor": "1.1.0-rc.0",
     "open": "0.0.5",
     "ora": "2.0.0",
     "osenv": "0.1.3",


### PR DESCRIPTION

Update calls to `nativescript-doctor` package to pass projectDir where applicable. This allows the package to verify installed Java Compiler version against the project's Android runtime.
This is required in case the installed Java version is 10 or above and the Androud runtime in the project is older than 4.1.0. In this case the user cannot build this application for Android, but have to update the Android runtime version or downgrade the Java version.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.
