### PR TITLE
fix: iOS debug issues 

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -643,7 +643,7 @@ interface ISocketProxyFactory extends NodeJS.EventEmitter {
 	createWebSocketProxy(factory: () => Promise<any>, deviceIdentifier: string): Promise<any>;
 }
 
-interface IiOSNotification {
+interface IiOSNotification extends NodeJS.EventEmitter {
 	getWaitForDebug(projectId: string): string;
 	getAttachRequest(projectId: string, deviceId: string): string;
 	getAppLaunching(projectId: string): string;

--- a/lib/device-sockets/ios/notification.ts
+++ b/lib/device-sockets/ios/notification.ts
@@ -15,6 +15,8 @@ export class IOSNotification extends EventEmitter implements IiOSNotification {
 	}
 
 	public getAttachRequest(appId: string, deviceId: string): string {
+		// It could be too early to emit this event, but we rely that if you construct attach request,
+		// you will execute it immediately.
 		this.emit(ATTACH_REQUEST_EVENT_NAME, { deviceId, appId });
 		return this.formatNotification(IOSNotification.ATTACH_REQUEST_NOTIFICATION_NAME, appId);
 	}

--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -95,7 +95,7 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 					err.deviceIdentifier = deviceIdentifier;
 					this.$logger.trace(err);
 					this.emit(CONNECTION_ERROR_EVENT_NAME, err);
-					this.$errors.failWithoutHelp("Cannot connect to device socket.");
+					this.$errors.failWithoutHelp(`Cannot connect to device socket. The error message is ${err.message}`);
 				}
 
 				this.$logger.info("Backend socket created.");

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -127,6 +127,8 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 	}
 
 	private async emulatorStart(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
+		const device = await this.$devicesService.getDevice(debugData.deviceIdentifier);
+		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
 		const result = await this.wireDebuggerClient(debugData, debugOptions);
 
 		const attachRequestMessage = this.$iOSNotification.getAttachRequest(debugData.applicationIdentifier, debugData.deviceIdentifier);
@@ -175,6 +177,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 	}
 
 	private async deviceStartCore(device: Mobile.IiOSDevice, debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
+		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
 		await this.$iOSSocketRequestExecutor.executeAttachRequest(device, AWAIT_NOTIFICATION_TIMEOUT_SECONDS, debugData.applicationIdentifier);
 		return this.wireDebuggerClient(debugData, debugOptions, device);
 	}

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -39,7 +39,9 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 		return "ios";
 	}
 
-	public debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
+	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
+		await this.device.openDeviceLogStream();
+
 		if (debugOptions.debugBrk && debugOptions.start) {
 			this.$errors.failWithoutHelp("Expected exactly one of the --debug-brk or --start options.");
 		}

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -106,12 +106,13 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 
 	private async emulatorDebugBrk(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
 		const args = debugOptions.debugBrk ? "--nativescript-debug-brk" : "--nativescript-debug-start";
-		const launchResult = await this.$iOSEmulatorServices.runApplicationOnEmulator(debugData.pathToAppPackage, {
+			const launchResult = await this.$iOSEmulatorServices.runApplicationOnEmulator(debugData.pathToAppPackage, {
 			waitForDebugger: true,
 			captureStdin: true,
 			args: args,
 			appId: debugData.applicationIdentifier,
-			skipInstall: true
+			skipInstall: true,
+			device: debugData.deviceIdentifier
 		});
 
 		const pid = getPidFromiOSSimulatorLogs(debugData.applicationIdentifier, launchResult);

--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -9,6 +9,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 
 	constructor(private $iOSLogParserService: IIOSLogParserService,
 		private $iOSProjectService: IPlatformProjectService,
+		private $iOSNotification: IiOSNotification,
 		private $logger: ILogger,
 		private $projectData: IProjectData) { }
 
@@ -62,7 +63,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 
 	@cache()
 	private attachToAttachRequestEvent(device: Mobile.IDevice): void {
-		device.applicationManager.on(ATTACH_REQUEST_EVENT_NAME, (data: IIOSDebuggerPortData) => {
+		this.$iOSNotification.on(ATTACH_REQUEST_EVENT_NAME, (data: IIOSDebuggerPortData) => {
 			this.$logger.trace(ATTACH_REQUEST_EVENT_NAME, data);
 			const timer = setTimeout(() => {
 				this.clearTimeout(data);

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -13,6 +13,7 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		$devicePathProvider: IDevicePathProvider,
 		$logger: ILogger,
 		$projectFilesProvider: IProjectFilesProvider,
+		private $iOSDebuggerPortService: IIOSDebuggerPortService,
 	) {
 		super($fs, $logger, $platformsData, $projectFilesManager, $devicePathProvider, $projectFilesProvider);
 	}
@@ -22,6 +23,8 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 
 		if (device.isEmulator) {
 			return super.fullSync(syncInfo);
+		} else {
+			this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
 		}
 
 		const projectData = syncInfo.projectData;

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -23,9 +23,9 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 
 		if (device.isEmulator) {
 			return super.fullSync(syncInfo);
-		} else {
-			this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
 		}
+
+		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
 
 		const projectData = syncInfo.projectData;
 		const platformData = this.$platformsData.getPlatformData(device.deviceInfo.platform, projectData);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2868,9 +2868,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.4.1.tgz",
-      "integrity": "sha512-5zouPe8hjN6tLCwoxYXT4S1l2lY0aMZAXOGK9L8pPF8nXtanNKbVxpCrEszKcCbGzNQ/WyY/diJXTNL1ZO6HZg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-3.4.3.tgz",
+      "integrity": "sha512-Ail75Gfk9FkEEeTbgoQwXOFR/+DJFGXWNbekZDpdd4zmyzYEMfp8ZG2J0KefKlDeYJ2H3lA/Y7OtDMcT3oF9ug==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.12",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "3.4.1",
+    "ios-sim-portable": "3.4.3",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",
     "lodash": "4.13.1",


### PR DESCRIPTION
### fix: Unable to debug on iOS Simulator when multiple sims are running 
In case multiple iOS Simulators are running and `tns debug ios` is called, CLI prompts you to select you on which device/simulator to debug.
Selecting the device and trying to debug your application leads to error as CLI does not pass correctly the device identifier.
Fix this by passing the correct device identifier.
Also update ios-sim-portable to latest version, where several fixes for this case are applied


### fix: `tns debug ios --start` fails
The `tns debug ios --start` command fails as we do not get the port from iOS Application on device in this case. In order to fix this, start the log parsing in case --start option is passed.
Also fix the attaching to ATTACH_REQUEST_EVENT_NAME - we've incorrectly attached to device's application manager, which does not emit such event. Fix it by attaching to `iOSNotification`, which is the correct one.
Also remove incorrect cache decorator and ensure we do not start logging for iOS devices more than once.