### PR TITLE
Fix doctor

### DIFF
--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -34,12 +34,11 @@ class DoctorService implements IDoctorService {
 			await this.$analyticsService.track("DoctorEnvironmentSetup", hasWarnings ? "incorrect" : "correct");
 		}
 
-		this.printInfosCore(infos);
-
 		if (hasWarnings) {
 			this.$logger.info("There seem to be issues with your configuration.");
 		} else {
 			this.$logger.out("No issues were detected.".bold);
+			this.printInfosCore(infos);
 		}
 
 		try {

--- a/lib/services/versions-service.ts
+++ b/lib/services/versions-service.ts
@@ -100,14 +100,15 @@ class VersionsService implements IVersionsService {
 			allComponents.push(nativescriptCliInformation);
 		}
 
-		const nativescriptCoreModulesInformation: IVersionInformation = await this.getTnsCoreModulesVersion();
-		if (nativescriptCoreModulesInformation) {
-			allComponents.push(nativescriptCoreModulesInformation);
+		if (this.projectData) {
+			const nativescriptCoreModulesInformation: IVersionInformation = await this.getTnsCoreModulesVersion();
+			if (nativescriptCoreModulesInformation) {
+				allComponents.push(nativescriptCoreModulesInformation);
+			}
+
+			const runtimesVersions: IVersionInformation[] = await this.getRuntimesVersions();
+			allComponents = allComponents.concat(runtimesVersions);
 		}
-
-		const runtimesVersions: IVersionInformation[] = await this.getRuntimesVersions();
-
-		allComponents = allComponents.concat(runtimesVersions);
 
 		return allComponents
 			.map(componentInformation => {


### PR DESCRIPTION
Don't show components info when `tns doctor` command is executed outside of project directory. Don't print warning twice when `tns doctor` command is executed and env is not properly configured.

In case when some issues are detected, `checkEnvironmentRequirements` prints the detected warnings. (actually canExecuteLocalBuilds print them). In case when no issues are found, we need to print them from `printWarnings` method.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.