### PR TITLE
Make appResourcesChanged check to be executed per platform

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -66,7 +66,9 @@ export class ProjectChangesService implements IProjectChangesService {
 			this._changesInfo.appFilesChanged = await this.hasChangedAppFiles(projectData);
 
 			this._changesInfo.packageChanged = this.isProjectFileChanged(projectData, platform);
-			this._changesInfo.appResourcesChanged = this.containsNewerFiles(projectData.appResourcesDirectoryPath, null, projectData);
+
+			const platformResourcesDir = path.join(projectData.appResourcesDirectoryPath, platformData.normalizedPlatformName);
+			this._changesInfo.appResourcesChanged = this.containsNewerFiles(platformResourcesDir, null, projectData);
 			/*done because currently all node_modules are traversed, a possible improvement could be traversing only the production dependencies*/
 			this._changesInfo.nativeChanged = this.containsNewerFiles(
 				path.join(projectData.projectDir, NODE_MODULES_FOLDER_NAME),
@@ -77,7 +79,6 @@ export class ProjectChangesService implements IProjectChangesService {
 			if (this._newFiles > 0 || this._changesInfo.nativeChanged) {
 				this._changesInfo.modulesChanged = true;
 			}
-			const platformResourcesDir = path.join(projectData.appResourcesDirectoryPath, platformData.normalizedPlatformName);
 			if (platform === this.$devicePlatformsConstants.iOS.toLowerCase()) {
 				this._changesInfo.configChanged = this.filesChanged([path.join(platformResourcesDir, platformData.configurationFileName),
 				path.join(platformResourcesDir, "LaunchScreen.storyboard"),


### PR DESCRIPTION
In case when when something is changed in `app/App_Resources/iOS` folder, `tns run android` command executes full application build. Actually there is no need to rebuild the application in this case. Make the `appResourcesDirectoryChanged` to be checked per platform so no rebuild is triggered.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.


