### PR TITLE
fix: platform remove command fails with old Android runtime

### DIFF
--- a/lib/commands/remove-platform.ts
+++ b/lib/commands/remove-platform.ts
@@ -3,8 +3,7 @@ export class RemovePlatformCommand implements ICommand {
 
 	constructor(private $platformService: IPlatformService,
 		private $projectData: IProjectData,
-		private $errors: IErrors,
-		private $platformsData: IPlatformsData) {
+		private $errors: IErrors) {
 		this.$projectData.initializeProjectData();
 	}
 
@@ -17,12 +16,9 @@ export class RemovePlatformCommand implements ICommand {
 			this.$errors.fail("No platform specified. Please specify a platform to remove");
 		}
 
-		for (const platform of args) {
-			this.$platformService.validatePlatformInstalled(platform, this.$projectData);
-			const platformData = this.$platformsData.getPlatformData(platform, this.$projectData);
-			const platformProjectService = platformData.platformProjectService;
-			await platformProjectService.validate(this.$projectData);
-		}
+		_.each(args, platform => {
+			this.$platformService.validatePlatform(platform, this.$projectData);
+		});
 
 		return true;
 	}


### PR DESCRIPTION
After upgrading `nativescript-doctor`, the version of the Java is
validated against the current Android runtime version. In case the
runtime version cannot work with Java 10, `nativescript-doctor` does not
allow the operation to continue. This breaks the `platform remove`
command, as it checks the system requirements first, before executing
the actual removal. However, this is no longer required as the code for
removing the platform is `try-catched` and in case the current
environment is not setup correctly, it will try to remove the
platforms/<platform> dir and the respective key in package.json.
So remove the environment validation from this command. Also remove the
`validatePlatformInstalled` call from the `canExecute` method of the
command, as it is actually called in the `removePlatforms` method.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Trying to execute `tns platform remove android` on an older project, when Java version on local machine is 10, fails with error that you need to update your Android runtime version.
## What is the new behavior?
You can successfully remove older platforms with `tns platform remove android` even when Java version is 10.
