### PR TITLE
fix: platform update/clean commands may fail with Java 10

### DIFF
--- a/lib/commands/platform-clean.ts
+++ b/lib/commands/platform-clean.ts
@@ -5,7 +5,7 @@ export class CleanCommand implements ICommand {
 		private $projectData: IProjectData,
 		private $platformService: IPlatformService,
 		private $errors: IErrors,
-		private $platformsData: IPlatformsData) {
+		private $platformEnvironmentRequirements: IPlatformEnvironmentRequirements) {
 		this.$projectData.initializeProjectData();
 	}
 
@@ -18,12 +18,15 @@ export class CleanCommand implements ICommand {
 			this.$errors.fail("No platform specified. Please specify a platform to clean");
 		}
 
+		_.each(args, platform => {
+			this.$platformService.validatePlatform(platform, this.$projectData);
+		});
+
 		for (const platform of args) {
 			this.$platformService.validatePlatformInstalled(platform, this.$projectData);
 
-			const platformData = this.$platformsData.getPlatformData(platform, this.$projectData);
-			const platformProjectService = platformData.platformProjectService;
-			await platformProjectService.validate(this.$projectData);
+			const currentRuntimeVersion = this.$platformService.getCurrentPlatformVersion(platform, this.$projectData);
+			await this.$platformEnvironmentRequirements.checkEnvironmentRequirements(platform, this.$projectData.projectDir, currentRuntimeVersion);
 		}
 
 		return true;

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -214,6 +214,14 @@ interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
 	 * @returns {void}
 	 */
 	saveBuildInfoFile(platform: string, projectDir: string, buildInfoFileDirname: string): void;
+
+	/**
+	 * Gives information for the current version of the runtime.
+	 * @param {string} platform The platform to be checked.
+	 * @param {IProjectData} projectData The data describing the project
+	 * @returns {string} Runtime version
+	 */
+	getCurrentPlatformVersion(platform: string, projectData: IProjectData): string;
 }
 
 interface IPlatformOptions extends IPlatformSpecificData, ICreateProjectOptions { }
@@ -381,5 +389,5 @@ interface IUpdateAppOptions extends IOptionalFilesToSync, IOptionalFilesToRemove
 }
 
 interface IPlatformEnvironmentRequirements {
-	checkEnvironmentRequirements(platform?: string, projectDir?: string): Promise<boolean>;
+	checkEnvironmentRequirements(platform?: string, projectDir?: string, runtimeVersion?: string): Promise<boolean>;
 }

--- a/lib/services/doctor-service.ts
+++ b/lib/services/doctor-service.ts
@@ -17,10 +17,10 @@ class DoctorService implements IDoctorService {
 		private $terminalSpinnerService: ITerminalSpinnerService,
 		private $versionsService: IVersionsService) { }
 
-	public async printWarnings(configOptions?: { trackResult: boolean , projectDir?: string }): Promise<void> {
+	public async printWarnings(configOptions?: { trackResult: boolean , projectDir?: string, runtimeVersion?: string }): Promise<void> {
 		const infos = await this.$terminalSpinnerService.execute<NativeScriptDoctor.IInfo[]>({
 			text: `Getting environment information ${EOL}`
-		}, () => doctor.getInfos({ projectDir: configOptions && configOptions.projectDir }));
+		}, () => doctor.getInfos({ projectDir: configOptions && configOptions.projectDir, androidRuntimeVersion: configOptions && configOptions.runtimeVersion }));
 
 		const warnings = infos.filter(info => info.type === constants.WARNING_TYPE_NAME);
 		const hasWarnings = warnings.length > 0;
@@ -80,12 +80,12 @@ class DoctorService implements IDoctorService {
 		});
 	}
 
-	public async canExecuteLocalBuild(platform?: string, projectDir?: string): Promise<boolean> {
+	public async canExecuteLocalBuild(platform?: string, projectDir?: string, runtimeVersion?: string): Promise<boolean> {
 		await this.$analyticsService.trackEventActionInGoogleAnalytics({
 			action: TrackActionNames.CheckLocalBuildSetup,
 			additionalData: "Starting",
 		});
-		const infos = await doctor.getInfos({ platform, projectDir });
+		const infos = await doctor.getInfos({ platform, projectDir, androidRuntimeVersion: runtimeVersion });
 
 		const warnings = this.filterInfosByType(infos, constants.WARNING_TYPE_NAME);
 		const hasWarnings = warnings.length > 0;

--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -30,7 +30,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 		"deploy": "tns cloud deploy"
 	};
 
-	public async checkEnvironmentRequirements(platform?: string, projectDir?: string): Promise<boolean> {
+	public async checkEnvironmentRequirements(platform?: string, projectDir?: string, runtimeVersion?: string): Promise<boolean> {
 		if (process.env.NS_SKIP_ENV_CHECK) {
 			await this.$analyticsService.trackEventActionInGoogleAnalytics({
 				action: TrackActionNames.CheckEnvironmentRequirements,
@@ -39,7 +39,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 			return true;
 		}
 
-		const canExecute = await this.$doctorService.canExecuteLocalBuild(platform, projectDir);
+		const canExecute = await this.$doctorService.canExecuteLocalBuild(platform, projectDir, runtimeVersion);
 		if (!canExecute) {
 			if (!isInteractive()) {
 				await this.$analyticsService.trackEventActionInGoogleAnalytics({
@@ -71,7 +71,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 			if (selectedOption === PlatformEnvironmentRequirements.LOCAL_SETUP_OPTION_NAME) {
 				await this.$doctorService.runSetupScript();
 
-				if (await this.$doctorService.canExecuteLocalBuild(platform, projectDir)) {
+				if (await this.$doctorService.canExecuteLocalBuild(platform, projectDir, runtimeVersion)) {
 					return true;
 				}
 
@@ -102,7 +102,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 
 			if (selectedOption === PlatformEnvironmentRequirements.BOTH_CLOUD_SETUP_AND_LOCAL_SETUP_OPTION_NAME) {
 				await this.processBothCloudBuildsAndSetupScript();
-				if (await this.$doctorService.canExecuteLocalBuild(platform, projectDir)) {
+				if (await this.$doctorService.canExecuteLocalBuild(platform, projectDir, runtimeVersion)) {
 					return true;
 				}
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -74,7 +74,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	private getCurrentPlatformVersion(platform: string, projectData: IProjectData): string {
+	public getCurrentPlatformVersion(platform: string, projectData: IProjectData): string {
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const currentPlatformData: any = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
 		let version: string;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -16,13 +16,13 @@
     "@types/chai": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.1.tgz",
-      "integrity": "sha512-DWrdkraJO+KvBB7+Jc6AuDd2+fwV6Z9iK8cqEEoYpcurYrH7GiUZmwjFuQIIWj5HhFz6NsSxdN72YMIHT7Fy2Q==",
+      "integrity": "sha1-N/6neWF8/sP9KxmgJH6LvdUTO/Y=",
       "dev": true
     },
     "@types/chai-as-promised": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-0.0.31.tgz",
-      "integrity": "sha512-DWT96QeM5AeASIkChnFtEOy6O45WvKmaw27MPhAKLkx06TaFNqrzJuWVurKjCEo3PqVV89YLR2iVON8PhTRaLg==",
+      "integrity": "sha1-4ekF6m2XHa/K02VgyPH3p9aQxeU=",
       "dev": true,
       "requires": {
         "@types/chai": "4.0.1"
@@ -79,7 +79,7 @@
     "@types/lockfile": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/lockfile/-/lockfile-1.0.0.tgz",
-      "integrity": "sha512-pD6JuijPmrfi84qF3/TzGQ7zi0QIX+d7ZdetD6jUA6cp+IsCzAquXZfi5viesew+pfpOTIdAVKuh1SHA7KeKzg==",
+      "integrity": "sha1-dqfBnFD+juKxZm1lP/XVV8MP4P8=",
       "dev": true
     },
     "@types/node": {
@@ -109,7 +109,7 @@
     "@types/request": {
       "version": "0.0.45",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-0.0.45.tgz",
-      "integrity": "sha512-OIIREjT58pnpfJjEY5PeBEuRtRR2ED4DF1Ez3Dj9474kCqEKfE+iNAYyM/P3RxxDjNxBhipo+peNBW0S/7Wrzg==",
+      "integrity": "sha1-xuUr6LEI6wNcNaqa9Wo4omDD5+Y=",
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.1",
@@ -137,7 +137,7 @@
     "@types/universal-analytics": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/universal-analytics/-/universal-analytics-0.4.1.tgz",
-      "integrity": "sha512-AZSPpDUEZ4mAgO9geHc62dp/xCLmBJ1yIpbgTq5W/cWcVQsxmU/FyKwYKHXk2hnT9TAmYVFFdAijMrCdYjuHsA==",
+      "integrity": "sha1-7mESGwqJiwvqXuskcgCJjg+o8Jw=",
       "dev": true
     },
     "@types/ws": {
@@ -638,7 +638,7 @@
     "chai-as-promised": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.0.0.tgz",
-      "integrity": "sha512-7YYdnXPq2pV9nvRBb36Wi/MXfT8j2iL/H76GtenlOMatXbMoQLb+PonuVHGFsw5wE2M6R/VFciq8AnSSAix0GA==",
+      "integrity": "sha1-yH7mE+qhlnZjk9pvu0BS8RKs9nU=",
       "dev": true,
       "requires": {
         "check-error": "1.0.2",
@@ -2217,7 +2217,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2230,7 +2230,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -2266,7 +2266,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -3812,9 +3812,9 @@
       "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
     },
     "nativescript-doctor": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.1.0.tgz",
-      "integrity": "sha512-XmZO+6tLbiOGr/gLYuhmVhec0UPOSsShK/dG7LlEkiLOE7ew7LB/j/gPFAzS5I54jjudJ/qDK/cMvcZWS0TvBg==",
+      "version": "1.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.2.0-rc.0.tgz",
+      "integrity": "sha512-tqWLXzYmFjlWOh+XoNkmbS1knYU5U13AhBQjZtZdhecwC3Snyp43nmHQEIrjq1gmgOgTEFDSa0gsK826FiyYwg==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.3.0",
@@ -3886,7 +3886,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "requires": {
         "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
@@ -4731,7 +4731,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "semver": {
       "version": "5.3.0",
@@ -4776,7 +4776,7 @@
     },
     "should-equal": {
       "version": "0.5.0",
-      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.5.0.tgz",
       "integrity": "sha1-x5fxNfMGf+tp6+zbMGscP+IbPm8=",
       "dev": true,
       "requires": {
@@ -5327,7 +5327,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -5476,7 +5476,7 @@
     "universal-analytics": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.15.tgz",
-      "integrity": "sha512-9Dt6WBWsHsmv74G+N/rmEgi6KFZxVvQXkVhr0disegeUryybQAUQwMD1l5EtqaOu+hSOGbhL/hPPQYisZIqPRw==",
+      "integrity": "sha1-SrxhsVn/52W+FE4Ht7c54O57iKs=",
       "requires": {
         "async": "1.2.1",
         "request": "2.85.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3812,9 +3812,9 @@
       "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
     },
     "nativescript-doctor": {
-      "version": "1.2.0-rc.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.2.0-rc.0.tgz",
-      "integrity": "sha512-tqWLXzYmFjlWOh+XoNkmbS1knYU5U13AhBQjZtZdhecwC3Snyp43nmHQEIrjq1gmgOgTEFDSa0gsK826FiyYwg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.2.0.tgz",
+      "integrity": "sha512-huJB71CxCcbBQDCt9F1CkfsGDN2YHVJHGQyQYhnCCX6OJFOOjSr/HMqNpUUIGlhqVQfUR1SYeCFfaKa+1/eDvg==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "1.2.0-rc.0",
+    "nativescript-doctor": "1.2.0",
     "open": "0.0.5",
     "ora": "2.0.0",
     "osenv": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "1.1.0",
+    "nativescript-doctor": "1.2.0-rc.0",
     "open": "0.0.5",
     "ora": "2.0.0",
     "osenv": "0.1.3",

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -165,6 +165,9 @@ function createTestInjector() {
 		getPlaygroundInfo: () => Promise.resolve(null)
 	});
 	testInjector.register("filesHashService", {});
+	testInjector.register("platformEnvironmentRequirements", {
+		checkEnvironmentRequirements: async (platform?: string, projectDir?: string, runtimeVersion?: string): Promise<boolean> => true
+	});
 
 	return testInjector;
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -812,6 +812,10 @@ export class PlatformServiceStub extends EventEmitter implements IPlatformServic
 	public async trackActionForPlatform(actionData: ITrackPlatformAction): Promise<void> {
 		return null;
 	}
+
+	public getCurrentPlatformVersion(platform: string, projectData: IProjectData): string {
+		return null;
+	}
 }
 
 export class EmulatorPlatformService implements IEmulatorPlatformService {


### PR DESCRIPTION
Add logic to validate environment based on the specified runtime version. This is required for the cases where the runtime version is not specified in the project's package.json but we need to verify if a runtime version can be used
For `tns platform update <platform>` command validate the runtime version that will be installed based on the passed argument. This has two cases:
1. In case version is specified: `tns platform update android@4.0.1` - we'll get the 4.0.1 version and validate if it can be used with currently installed Java compiler version.
2. In case version is not specified: `tns platform update android` - we'll not validate the java version here as we know we'll install at least 4.1.0 runtime, which is compatible with all Java versions

For `tns platform clean <platform>` command we need to validate the current platform immediately as the command removes it and adds the same version after that.

Depends on: https://github.com/NativeScript/nativescript-doctor/pull/37 and https://github.com/telerik/mobile-cli-lib/pull/1096