### PR TITLE
fix: Device logs are not properly shown with debug command

### DIFF
--- a/test/services/android-debug-service.ts
+++ b/test/services/android-debug-service.ts
@@ -12,8 +12,9 @@ class AndroidDebugServiceInheritor extends AndroidDebugService {
 		$androidDeviceDiscovery: Mobile.IDeviceDiscovery,
 		$androidProcessService: Mobile.IAndroidProcessService,
 		$net: INet,
-		$projectDataService: IProjectDataService) {
-		super(<any>{}, $devicesService, $errors, $logger, $androidDeviceDiscovery, $androidProcessService, $net, $projectDataService);
+		$projectDataService: IProjectDataService,
+		$deviceLogProvider: Mobile.IDeviceLogProvider) {
+		super(<any>{}, $devicesService, $errors, $logger, $androidDeviceDiscovery, $androidProcessService, $net, $projectDataService, $deviceLogProvider);
 	}
 
 	public getChromeDebugUrl(debugOptions: IDebugOptions, port: number): string {
@@ -30,6 +31,7 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("androidProcessService", {});
 	testInjector.register("net", {});
 	testInjector.register("projectDataService", {});
+	testInjector.register("deviceLogProvider", {});
 
 	return testInjector;
 };

--- a/test/services/ios-debug-service.ts
+++ b/test/services/ios-debug-service.ts
@@ -20,9 +20,11 @@ class IOSDebugServiceInheritor extends IOSDebugService {
 		$processService: IProcessService,
 		$socketProxyFactory: ISocketProxyFactory,
 		$net: INet,
-		$projectDataService: IProjectDataService) {
+		$projectDataService: IProjectDataService,
+		$deviceLogProvider: Mobile.IDeviceLogProvider) {
 		super(<any>{}, $devicesService, $platformService, $iOSEmulatorServices, $childProcess, $hostInfo, $logger, $errors,
-			$npmInstallationManager, $iOSDebuggerPortService, $iOSNotification, $iOSSocketRequestExecutor, $processService, $socketProxyFactory, $projectDataService);
+			$npmInstallationManager, $iOSDebuggerPortService, $iOSNotification, $iOSSocketRequestExecutor, $processService,
+			$socketProxyFactory, $projectDataService, $deviceLogProvider);
 	}
 
 	public getChromeDebugUrl(debugOptions: IDebugOptions, port: number): string {
@@ -58,6 +60,7 @@ const createTestInjector = (): IInjector => {
 
 	testInjector.register("projectDataService", {});
 	testInjector.register("iOSDebuggerPortService", {});
+	testInjector.register("deviceLogProvider", {});
 
 	return testInjector;
 };


### PR DESCRIPTION
The console.log from application should be shown in the terminal when `tns debug <platform>` command is executed.
When `tns debug android --start` is used, the console.log messages are not visible as noone has started reading them. Add logic to read and filter them based on the PID of the application.
When `tns debug ios [--start]` is used with older runtime (4.0.1 for example) with iOS Simulator, the device logs are not shown as the filtering is based on the projectName, but noone has set this projectName to the filter. So we filter everything. Fix this by setting the projectName to the filter instance.

Fix the `tns debug ios --justlaunch` and `tns debug ios --start --justlaunch` which are always printing console.logs, while in fact they shouldn't.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Missing console.logs when `tns debug android --start` or `tns debug ios` is used.

## What is the new behavior?
Console.logs are visible.

Fixes: 
* https://github.com/NativeScript/nativescript-cli/issues/2831
* https://github.com/NativeScript/nativescript-cli/issues/3629
