### PR TITLE
Fix tns update command when no platform is added

### DIFF
--- a/lib/commands/update-platform.ts
+++ b/lib/commands/update-platform.ts
@@ -25,7 +25,6 @@ export class UpdatePlatformCommand implements ICommand {
 
 		for (const arg of args) {
 			const [ platform, versionToBeInstalled ] = arg.split("@");
-			this.$platformService.validatePlatformInstalled(platform, this.$projectData);
 			const argsToCheckEnvironmentRequirements: string[] = [ platform ];
 			// If version is not specified, we know the command will install the latest compatible Android runtime.
 			// The latest compatible Android runtime supports Java version, so we do not need to pass it here.


### PR DESCRIPTION
In case when no platform is added and `tns update android` command is executed, `The platform android is not added to this project` error is thrown.

Steps to reproduce:
1. `tns create TestApp`
2. `tns platform update android` (now installs 4.0.1)

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

