### PR TITLE
fix(ios-debugging): Close frontend socket unconditionally

### DIFF
--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -132,9 +132,7 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 
 			deviceSocket.on("close", () => {
 				this.$logger.info("Backend socket closed!");
-				if (!this.$options.watch) {
-					webSocket.close();
-				}
+				webSocket.close();
 			});
 
 			webSocket.on("close", () => {


### PR DESCRIPTION
There's no need to keep the frontend socket open after its corresponding
backend socket disconnects. This misleads the Inspector UI that it
is still connected with a backend.

A part of the fix to https://github.com/NativeScript/ios-runtime/issues/927

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When the backend socket disconnects, the frontend socket is closed only if `tns debug --no-watch` is used.
## What is the new behavior?
When the backend socket disconnects, the frontend socket is closed unconditionally.

<!-- Fixes/Implements/Closes #[Issue Number]. -->

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

