### PR TITLE
Touch app.gradle file only if __PACKAGE__ placeholder exists

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -205,3 +205,5 @@ export class ProjectTemplateErrors {
 export class Hooks {
 	public static createProject = "createProject";
 }
+
+export const PACKAGE_PLACEHOLDER_NAME = "__PACKAGE__";

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -256,7 +256,10 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 		try {
 			// will replace applicationId in app/App_Resources/Android/app.gradle if it has not been edited by the user
-			shell.sed('-i', /__PACKAGE__/, projectData.projectId, projectData.appGradlePath);
+			const appGradleContent = this.$fs.readText(projectData.appGradlePath);
+			if (appGradleContent.indexOf(constants.PACKAGE_PLACEHOLDER_NAME) !== -1) {
+				shell.sed('-i', new RegExp(constants.PACKAGE_PLACEHOLDER_NAME), projectData.projectId, projectData.appGradlePath);
+			}
 		} catch (e) {
 			this.$logger.warn(`\n${e}.\nCheck if you're using an outdated template and update it.`);
 		}


### PR DESCRIPTION
In case when `tns run android` command is executed, the app is restarted twice on device. The first restart is when the fullSync is executed and the second one is when `app.gradle` file is interpolated. Actually once the `__PACKAGE__` placeholder is replaced inside `app.gradle`, there is no need to replace it again. This PR skips the interpolation of `app.gradle` file when there is no placeholder inside it.

Steps to reproduce: 
1. `tns create myApp`
2. `tns run android`

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The application is restarted twice on device.

## What is the new behavior?
The application is restarted only once on device.

