### PR TITLE
fix: fix a deprecation warning that is shown when debug command is executed using node v10

### DIFF
--- a/lib/device-sockets/ios/packet-stream.ts
+++ b/lib/device-sockets/ios/packet-stream.ts
@@ -13,7 +13,7 @@ export class PacketStream extends stream.Transform {
 			if (!this.buffer) {
 				// read length
 				const length = packet.readInt32BE(0);
-				this.buffer = new Buffer(length);
+				this.buffer = Buffer.allocUnsafe(length);
 				this.offset = 0;
 				packet = packet.slice(4);
 			}

--- a/lib/device-sockets/ios/socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/socket-proxy-factory.ts
@@ -124,7 +124,7 @@ export class SocketProxyFactory extends EventEmitter implements ISocketProxyFact
 
 			webSocket.on("message", (message: string) => {
 				const length = Buffer.byteLength(message, encoding);
-				const payload = new Buffer(length + 4);
+				const payload = Buffer.allocUnsafe(length + 4);
 				payload.writeInt32BE(length, 0);
 				payload.write(message, 4, length, encoding);
 				deviceSocket.write(payload);

--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -129,7 +129,7 @@ export class AndroidDeviceLiveSyncService extends DeviceLiveSyncServiceBase impl
 			const socket = new net.Socket();
 
 			socket.connect(this.port, '127.0.0.1', () => {
-				socket.write(new Buffer([0, 0, 0, 1, 1]));
+				socket.write(Buffer.from([0, 0, 0, 1, 1]));
 			});
 			socket.on("data", (data: any) => {
 				isResolved = true;

--- a/lib/services/livesync/ios-device-livesync-service.ts
+++ b/lib/services/livesync/ios-device-livesync-service.ts
@@ -134,7 +134,7 @@ export class IOSDeviceLiveSyncService extends DeviceLiveSyncServiceBase implemen
 			await new Promise<void>((resolve, reject) => {
 				let isResolved = false;
 				const length = Buffer.byteLength(message, "utf16le");
-				const payload = new Buffer(length + 4);
+				const payload = Buffer.allocUnsafe(length + 4);
 				payload.writeInt32BE(length, 0);
 				payload.write(message, 4, length, "utf16le");
 


### PR DESCRIPTION
When `tns debug ios` command is executed with node10, a deprecation warning is shown
```
(node:93714) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Deprecation warning is shown when `tns debug ios` command is executed using node v10

## What is the new behavior?
No deprecation warning is shown using node v10

