### PR TITLE
Fix assets generation

### DIFF
--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -143,16 +143,16 @@ export class ProjectDataService implements IProjectDataService {
 					assetElement.filename === image.filename && path.basename(assetElement.directory) === path.basename(dirPath)
 				);
 
-				if (assetItem) {
-					if (image.size) {
-						// size is basically <width>x<height>
-						const [width, height] = image.size.toString().split(AssetConstants.sizeDelimiter);
-						if (width && height) {
-							image.width = +width;
-							image.height = +height;
-						}
+				if (image.size) {
+					// size is basically <width>x<height>
+					const [width, height] = image.size.toString().split(AssetConstants.sizeDelimiter);
+					if (width && height) {
+						image.width = +width;
+						image.height = +height;
 					}
+				}
 
+				if (assetItem) {
 					if (!image.width || !image.height) {
 						image.width = assetItem.width;
 						image.height = assetItem.height;


### PR DESCRIPTION
## What is the current behavior?
When we don't find an asset in the default image definitions(image-definitions.json) we skip width and height parsing. Then the image generation fails because width and height are undefined.

## What is the new behavior?
Now we set the correct size even we don't find default asset properties.

Fixes  https://github.com/NativeScript/sidekick-feedback/issues/199.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.