### PR TITLE
fix: TypeError is thrown when iOS device is detached during LiveSync

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2798,9 +2798,9 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ios-device-lib": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.12.tgz",
-      "integrity": "sha512-S0XPH5NTbWVibEOvExHrbGWxJvrHEqRumWB1N1ZyIjgFsqMgaS9o8bCgPmc0kev3xxYTtmZ+REEceTV5qI0yfg==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.13.tgz",
+      "integrity": "sha512-2vJpXctCy+ZluPBz9wxzIQ3W8LxxYBXlT5QHL3bV5TR+ClhpZbdHDajt0bmfPR92JAUufejHVRk5jCG6uGfUAA==",
       "requires": {
         "bufferpack": "0.0.6",
         "node-uuid": "1.4.7"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gaze": "1.1.0",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-device-lib": "0.4.12",
+    "ios-device-lib": "0.4.13",
     "ios-mobileprovision-finder": "1.0.10",
     "ios-sim-portable": "3.4.3",
     "jimp": "0.2.28",


### PR DESCRIPTION
In some cases, when iOS device is detached during LiveSync, an error will be shown - `TypeError: Assignment to constant variable`. The issue is in `ios-device-lib`, so update to its latest version, where it is fixed.

