### PR TITLE
fix: Run and debug fail for iOS in Sidekick

### DIFF
--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -1,7 +1,7 @@
 /**
  * Describes information for starting debug process.
  */
-interface IDebugData extends Mobile.IDeviceIdentifier {
+interface IDebugData extends Mobile.IDeviceIdentifier, IProjectDir {
 	/**
 	 * Application identifier of the app that it will be debugged.
 	 */
@@ -16,11 +16,6 @@ interface IDebugData extends Mobile.IDeviceIdentifier {
 	 * The name of the application, for example `MyProject`.
 	 */
 	projectName?: string;
-
-	/**
-	 * Path to project.
-	 */
-	projectDir?: string;
 }
 
 /**

--- a/lib/definitions/ios-debugger-port-service.d.ts
+++ b/lib/definitions/ios-debugger-port-service.d.ts
@@ -1,4 +1,4 @@
-interface IIOSDebuggerPortInputData {
+interface IIOSDebuggerPortInputData extends IProjectDir {
 	deviceId: string;
 	appId: string;
 }
@@ -21,8 +21,10 @@ interface IIOSDebuggerPortService {
 	/**
 	 * Attaches on DEBUGGER_PORT_FOUND event and STARTING_IOS_APPLICATION events
 	 * In case when DEBUGGER_PORT_FOUND event is emitted, stores the port and clears the timeout if such.
-	 * In case when STARTING_IOS_APPLICATION event is emiited, sets the port to null and add timeout for 5000 miliseconds which checks if port is null and prints a warning.
-	 * @param {Mobile.IDevice} device - Describes the device which logs should be parsed. 
+	 * In case when STARTING_IOS_APPLICATION event is emitted, sets the port to null and add timeout for 5000 miliseconds which checks if port is null and prints a warning.
+	 * @param {Mobile.IDevice} device - Describes the device which logs should be parsed.
+	 * @param {IProjectDir} data - Object that has a projectDir property.
+	 * @returns {void}
 	 */
-	attachToDebuggerPortFoundEvent(device: Mobile.IDevice): void;
+	attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir): void;
 }

--- a/lib/definitions/ios-log-parser-service.d.ts
+++ b/lib/definitions/ios-log-parser-service.d.ts
@@ -3,5 +3,5 @@ interface IIOSLogParserService extends NodeJS.EventEmitter {
 	 * Starts looking for debugger port. Attaches on device logs and processes them. In case when port is found, DEBUGGER_PORT_FOUND event is emitted.
 	 * @param {Mobile.IDevice} device - Describes the device which logs will be processed.
 	 */
-	startParsingLog(device: Mobile.IDevice): void;
+	startParsingLog(device: Mobile.IDevice, data: IProjectName): void;
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -1,13 +1,11 @@
 interface IProjectName {
-	projectName: string;
-}
-
-interface IProjectSettingsBase extends IProjectName {
 	/**
 	 * Name of the newly created application.
 	 */
 	projectName: string;
+}
 
+interface IProjectSettingsBase extends IProjectName {
 	/**
 	 * Defines whether the `npm install` command should be executed with `--ignore-scripts` option.
 	 * When it is passed, all scripts (postinstall for example) will not be executed.

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -143,7 +143,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 
 	private async emulatorStart(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
 		const device = await this.$devicesService.getDevice(debugData.deviceIdentifier);
-		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
+		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, debugData);
 		const result = await this.wireDebuggerClient(debugData, debugOptions);
 
 		const attachRequestMessage = this.$iOSNotification.getAttachRequest(debugData.applicationIdentifier, debugData.deviceIdentifier);
@@ -192,7 +192,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 	}
 
 	private async deviceStartCore(device: Mobile.IiOSDevice, debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
-		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
+		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, debugData);
 		await this.$iOSSocketRequestExecutor.executeAttachRequest(device, AWAIT_NOTIFICATION_TIMEOUT_SECONDS, debugData.applicationIdentifier);
 		return this.wireDebuggerClient(debugData, debugOptions, device);
 	}
@@ -231,7 +231,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 
 	private getSocketFactory(debugData: IDebugData, device?: Mobile.IiOSDevice): () => Promise<net.Socket> {
 		const factory = async () => {
-			const port = await this.$iOSDebuggerPortService.getPort({ deviceId: debugData.deviceIdentifier, appId: debugData.applicationIdentifier });
+			const port = await this.$iOSDebuggerPortService.getPort({ projectDir: debugData.projectDir, deviceId: debugData.deviceIdentifier, appId: debugData.applicationIdentifier });
 			if (!port) {
 				this.$errors.fail("NativeScript debugger was not able to get inspector socket port.");
 			}

--- a/lib/services/ios-log-parser-service.ts
+++ b/lib/services/ios-log-parser-service.ts
@@ -9,13 +9,12 @@ export class IOSLogParserService extends EventEmitter implements IIOSLogParserSe
 	constructor(private $deviceLogProvider: Mobile.IDeviceLogProvider,
 		private $iosDeviceOperations: IIOSDeviceOperations,
 		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider,
-		private $logger: ILogger,
-		private $projectData: IProjectData) {
+		private $logger: ILogger) {
 		super();
 	}
 
-	public startParsingLog(device: Mobile.IDevice): void {
-		this.$deviceLogProvider.setProjectNameForDevice(device.deviceInfo.identifier, this.$projectData.projectName);
+	public startParsingLog(device: Mobile.IDevice, data: IProjectName): void {
+		this.$deviceLogProvider.setProjectNameForDevice(device.deviceInfo.identifier, data.projectName);
 
 		if (!this.startedDeviceLogInstances[device.deviceInfo.identifier]) {
 			this.startParsingLogCore(device);

--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -12,7 +12,6 @@ export class AndroidDeviceLiveSyncService extends DeviceLiveSyncServiceBase impl
 	private port: number;
 
 	constructor(_device: Mobile.IDevice,
-		data: IProjectDir,
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $devicePathProvider: IDevicePathProvider,
 		private $injector: IInjector,

--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -12,6 +12,7 @@ export class AndroidDeviceLiveSyncService extends DeviceLiveSyncServiceBase impl
 	private port: number;
 
 	constructor(_device: Mobile.IDevice,
+		data: IProjectDir,
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $devicePathProvider: IDevicePathProvider,
 		private $injector: IInjector,

--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -13,8 +13,8 @@ export class AndroidLiveSyncService extends PlatformLiveSyncServiceBase implemen
 		super($fs, $logger, $platformsData, $projectFilesManager, $devicePathProvider, $projectFilesProvider);
 	}
 
-	protected _getDeviceLiveSyncService(device: Mobile.IDevice): INativeScriptDeviceLiveSyncService {
-		const service = this.$injector.resolve<INativeScriptDeviceLiveSyncService>(AndroidDeviceLiveSyncService, { _device: device });
+	protected _getDeviceLiveSyncService(device: Mobile.IDevice, data: IProjectDir): INativeScriptDeviceLiveSyncService {
+		const service = this.$injector.resolve<INativeScriptDeviceLiveSyncService>(AndroidDeviceLiveSyncService, { _device: device, data });
 		return service;
 	}
 }

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -25,7 +25,7 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 			return super.fullSync(syncInfo);
 		}
 
-		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
+		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, syncInfo.projectData);
 
 		const projectData = syncInfo.projectData;
 		const platformData = this.$platformsData.getPlatformData(device.deviceInfo.platform, projectData);
@@ -70,8 +70,8 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		}
 	}
 
-	protected _getDeviceLiveSyncService(device: Mobile.IDevice): INativeScriptDeviceLiveSyncService {
-		const service = this.$injector.resolve<INativeScriptDeviceLiveSyncService>(IOSDeviceLiveSyncService, { _device: device });
+	protected _getDeviceLiveSyncService(device: Mobile.IDevice, data: IProjectDir): INativeScriptDeviceLiveSyncService {
+		const service = this.$injector.resolve<INativeScriptDeviceLiveSyncService>(IOSDeviceLiveSyncService, { _device: device, data });
 		return service;
 	}
 }

--- a/test/services/ios-debugger-port-service.ts
+++ b/test/services/ios-debugger-port-service.ts
@@ -47,9 +47,11 @@ function createTestInjector() {
 	injector.register("processService", {
 		attachToProcessExitSignals: () => ({})
 	});
-	injector.register("projectData", {
-		projectName: "test",
-		projectId: appId
+	injector.register("projectDataService", {
+		getProjectData: (projectDir: string) => ({
+			projectName: "test",
+			projectId: appId
+		})
 	});
 	injector.register("iOSNotification", DeviceApplicationManagerMock);
 
@@ -140,9 +142,13 @@ describe("iOSDebuggerPortService", () => {
 			}
 		];
 
+		const mockProjectDirObj = {
+			projectDir: "/Users/username/projectdir"
+		};
+
 		_.each(testCases, testCase => {
 			it(testCase.name, async () => {
-				iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
+				iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj);
 				if (testCase.emitStartingIOSApplicationEvent) {
 					emitStartingIOSApplicationEvent();
 				}
@@ -150,13 +156,13 @@ describe("iOSDebuggerPortService", () => {
 					emitDeviceLog(getDebuggerPortMessage(testCase.emittedPort));
 				}
 
-				const promise = iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId });
+				const promise = iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId, projectDir: mockProjectDirObj.projectDir });
 				clock.tick(10000);
 				const port = await promise;
 				assert.deepEqual(port, testCase.emittedPort);
 			});
 			it(`${testCase.name} for multiline debugger port message.`, async () => {
-				iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device);
+				iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj);
 				if (testCase.emitStartingIOSApplicationEvent) {
 					emitStartingIOSApplicationEvent();
 				}
@@ -164,7 +170,7 @@ describe("iOSDebuggerPortService", () => {
 					emitDeviceLog(getMultilineDebuggerPortMessage(testCase.emittedPort));
 				}
 
-				const promise = iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId });
+				const promise = iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId, projectDir: mockProjectDirObj.projectDir });
 				clock.tick(10000);
 				const port = await promise;
 				assert.deepEqual(port, testCase.emittedPort);

--- a/test/services/ios-log-parser-service.ts
+++ b/test/services/ios-log-parser-service.ts
@@ -35,9 +35,11 @@ function createTestInjector() {
 	injector.register("processService", {
 		attachToProcessExitSignals: () => ({})
 	});
-	injector.register("projectData", {
-		projectName: "test",
-		projectId: appId
+	injector.register("projectDataService", {
+		getProjectData: (projectDir: string) => ({
+			projectName: "test",
+			projectId: appId
+		})
 	});
 
 	return injector;
@@ -77,12 +79,16 @@ describe("iOSLogParserService", () => {
 		});
 	}
 
+	const mockProjectNameObj: IProjectName = {
+		projectName: "projectName"
+	};
+
 	describe("startLookingForDebuggerPort", () => {
 		it(`should emit ${DEBUGGER_PORT_FOUND_EVENT_NAME} event`, async () => {
 			const emittedMessagesCount = 1;
 			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
 
-			iOSLogParserService.startParsingLog(device);
+			iOSLogParserService.startParsingLog(device, mockProjectNameObj);
 			emitDeviceLog("test message");
 			emitDeviceLog(getDebuggerPortMessage(18181));
 
@@ -95,7 +101,7 @@ describe("iOSLogParserService", () => {
 			const emittedMessagesCount = 5;
 			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
 
-			iOSLogParserService.startParsingLog(device);
+			iOSLogParserService.startParsingLog(device, mockProjectNameObj);
 			emitDeviceLog(getDebuggerPortMessage(18181));
 			emitDeviceLog(getDebuggerPortMessage(18181));
 			emitDeviceLog(getDebuggerPortMessage(18181));
@@ -115,7 +121,7 @@ describe("iOSLogParserService", () => {
 			const emittedMessagesCount = 5;
 			const promise = attachOnDebuggerFoundEvent(emittedMessagesCount);
 
-			iOSLogParserService.startParsingLog(device);
+			iOSLogParserService.startParsingLog(device, mockProjectNameObj);
 			emitDeviceLog(getDebuggerPortMessage(45898));
 			emitDeviceLog(getDebuggerPortMessage(1809));
 			emitDeviceLog(getDebuggerPortMessage(65072));
@@ -136,7 +142,7 @@ describe("iOSLogParserService", () => {
 
 			iOSLogParserService.on(DEBUGGER_PORT_FOUND_EVENT_NAME, (data: IIOSDebuggerPortData) => isDebuggedPortFound = true);
 
-			iOSLogParserService.startParsingLog(device);
+			iOSLogParserService.startParsingLog(device, mockProjectNameObj);
 			emitDeviceLog("some test message");
 			emitDeviceLog("another test message");
 


### PR DESCRIPTION
When CLI is used as a library (in NativeScript Sidekick for example), calling methods for run and debug currently fails. The problem is with the parsing of the iOS logs, which was introduced several days ago.
The logic uses `$projectData` from the `$injector`. However, when CLI is used as a library, the `$projectData` is never initialized. Instead of using `$projectData` pass the project directory and construct new project data (from `$projectDataService`) where required.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Trying to run application on iOS device/simulator fails in Sidekick.

## What is the new behavior?
You can successfully run application on iOS device/simulator with Sidekick.

