### PR TITLE
fix: Shrinkwrap is incorrect which prevents CLI from installing

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5659,7 +5659,7 @@
     },
     "xcode": {
       "version": "https://github.com/NativeScript/node-xcode/archive/NativeScript-1.5.1.tar.gz",
-      "integrity": "sha512-YIj7RSd4onuBYp2CAxFaO5zm+q59AyqRbng+fKb0Schwj+23xKM2AmtuVzg/XrC5eFUEBnIznVDT+pRMzUy5RQ==",
+      "integrity": "sha512-MM7xAUBkS0yP3l6nwDDv//PjkrNBvar6aq0ErTpeiZRKapnfye3265H7pYb6OvQVw5P/FB9N288WrsUoX2wIGA==",
       "requires": {
         "node-uuid": "1.3.3",
         "pegjs": "0.6.2"


### PR DESCRIPTION
The `integrity` value of the `xcode` package is not corect, which prevents npm of installing the package and CLI respectively. Can be reproduced with npm 5 or 6 by wiping the npm cache and trying to install current rc version.


