### PR TITLE
Fix  `tns run ios --justlaunch`

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -337,6 +337,7 @@ interface IPlatformLiveSyncService {
 	fullSync(syncInfo: IFullSyncInfo): Promise<ILiveSyncResultInfo>;
 	liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<ILiveSyncResultInfo>;
 	refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void>;
+	prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo): void;
 }
 
 interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase {

--- a/lib/services/debug-service.ts
+++ b/lib/services/debug-service.ts
@@ -51,7 +51,7 @@ export class DebugService extends EventEmitter implements IDebugService {
 			this.$errors.failWithoutHelp(`Unsupported device OS: ${device.deviceInfo.platform}. You can debug your applications only on iOS or Android.`);
 		}
 
-		if (this.$mobileHelper.isiOSPlatform(device.deviceInfo.platform)) {
+		if (this.$mobileHelper.isiOSPlatform(device.deviceInfo.platform)) { // TODO: Consider to move this code to ios-debug-service
 			if (device.isEmulator && !debugData.pathToAppPackage && debugOptions.debugBrk) {
 				this.$errors.failWithoutHelp("To debug on iOS simulator you need to provide path to the app package.");
 			}
@@ -61,11 +61,9 @@ export class DebugService extends EventEmitter implements IDebugService {
 			} else if (!this.$hostInfo.isDarwin) {
 				this.$errors.failWithoutHelp(`Debugging on iOS devices is not supported for ${platform()} yet.`);
 			}
-
-			result = await debugService.debug(debugData, debugOptions);
-		} else if (this.$mobileHelper.isAndroidPlatform(device.deviceInfo.platform)) {
-			result = await debugService.debug(debugData, debugOptions);
 		}
+
+		result = await debugService.debug(debugData, debugOptions);
 
 		return this.getDebugInformation(result, device.deviceInfo.identifier);
 	}

--- a/lib/services/debug-service.ts
+++ b/lib/services/debug-service.ts
@@ -51,7 +51,8 @@ export class DebugService extends EventEmitter implements IDebugService {
 			this.$errors.failWithoutHelp(`Unsupported device OS: ${device.deviceInfo.platform}. You can debug your applications only on iOS or Android.`);
 		}
 
-		if (this.$mobileHelper.isiOSPlatform(device.deviceInfo.platform)) { // TODO: Consider to move this code to ios-debug-service
+		// TODO: Consider to move this code to ios-debug-service
+		if (this.$mobileHelper.isiOSPlatform(device.deviceInfo.platform)) {
 			if (device.isEmulator && !debugData.pathToAppPackage && debugOptions.debugBrk) {
 				this.$errors.failWithoutHelp("To debug on iOS simulator you need to provide path to the app package.");
 			}

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -63,6 +63,8 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 			await this.device.openDeviceLogStream();
 		}
 
+		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(this.device, debugData);
+
 		if (debugOptions.emulator) {
 			if (debugOptions.start) {
 				return this.emulatorStart(debugData, debugOptions);
@@ -142,12 +144,8 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 	}
 
 	private async emulatorStart(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
-		const device = await this.$devicesService.getDevice(debugData.deviceIdentifier);
-		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, debugData);
 		const result = await this.wireDebuggerClient(debugData, debugOptions);
-
 		const attachRequestMessage = this.$iOSNotification.getAttachRequest(debugData.applicationIdentifier, debugData.deviceIdentifier);
-
 		const iOSEmulatorService = <Mobile.IiOSSimulatorService>this.$iOSEmulatorServices;
 		await iOSEmulatorService.postDarwinNotification(attachRequestMessage, debugData.deviceIdentifier);
 		return result;
@@ -192,7 +190,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 	}
 
 	private async deviceStartCore(device: Mobile.IiOSDevice, debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
-		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, debugData);
+
 		await this.$iOSSocketRequestExecutor.executeAttachRequest(device, AWAIT_NOTIFICATION_TIMEOUT_SECONDS, debugData.applicationIdentifier);
 		return this.wireDebuggerClient(debugData, debugOptions, device);
 	}

--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -8,14 +8,15 @@ export class AndroidLiveSyncService extends PlatformLiveSyncServiceBase implemen
 		$devicePathProvider: IDevicePathProvider,
 		$fs: IFileSystem,
 		$logger: ILogger,
-		$projectFilesProvider: IProjectFilesProvider,
-	) {
-		super($fs, $logger, $platformsData, $projectFilesManager, $devicePathProvider, $projectFilesProvider);
+		$projectFilesProvider: IProjectFilesProvider) {
+			super($fs, $logger, $platformsData, $projectFilesManager, $devicePathProvider, $projectFilesProvider);
 	}
 
 	protected _getDeviceLiveSyncService(device: Mobile.IDevice, data: IProjectDir): INativeScriptDeviceLiveSyncService {
 		const service = this.$injector.resolve<INativeScriptDeviceLiveSyncService>(AndroidDeviceLiveSyncService, { _device: device, data });
 		return service;
 	}
+
+	public prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir): void { /* */ }
 }
 $injector.register("androidLiveSyncService", AndroidLiveSyncService);

--- a/lib/services/livesync/ios-device-livesync-service.ts
+++ b/lib/services/livesync/ios-device-livesync-service.ts
@@ -20,7 +20,6 @@ export class IOSDeviceLiveSyncService extends DeviceLiveSyncServiceBase implemen
 		private $processService: IProcessService,
 		protected $platformsData: IPlatformsData) {
 			super($platformsData);
-			this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(_device, data);
 			this.device = _device;
 	}
 

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -13,10 +13,9 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		$devicePathProvider: IDevicePathProvider,
 		$logger: ILogger,
 		$projectFilesProvider: IProjectFilesProvider,
-		private $iOSDebuggerPortService: IIOSDebuggerPortService,
-	) {
-		super($fs, $logger, $platformsData, $projectFilesManager, $devicePathProvider, $projectFilesProvider);
-	}
+		private $iOSDebuggerPortService: IIOSDebuggerPortService) {
+			super($fs, $logger, $platformsData, $projectFilesManager, $devicePathProvider, $projectFilesProvider);
+		}
 
 	public async fullSync(syncInfo: IFullSyncInfo): Promise<ILiveSyncResultInfo> {
 		const device = syncInfo.device;
@@ -24,9 +23,6 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		if (device.isEmulator) {
 			return super.fullSync(syncInfo);
 		}
-
-		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, syncInfo.projectData);
-
 		const projectData = syncInfo.projectData;
 		const platformData = this.$platformsData.getPlatformData(device.deviceInfo.platform, projectData);
 		const deviceAppData = await this.getAppData(syncInfo);
@@ -67,6 +63,12 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 			return this.fullSync({ projectData: liveSyncInfo.projectData, device, syncAllFiles: liveSyncInfo.syncAllFiles, watch: true });
 		} else {
 			return super.liveSyncWatchAction(device, liveSyncInfo);
+		}
+	}
+
+	public prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo): void {
+		if (!liveSyncInfo.skipWatcher) {
+			this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, data);
 		}
 	}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -456,10 +456,10 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		const deviceAction = async (device: Mobile.IDevice): Promise<void> => {
 			try {
 				const platform = device.deviceInfo.platform;
-				const liveSyncService = this.getLiveSyncService(platform);
+				const platformLiveSyncService = this.getLiveSyncService(platform);
 				const deviceBuildInfoDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
 
-				liveSyncService.prepareForLiveSync(device, projectData, liveSyncData);
+				platformLiveSyncService.prepareForLiveSync(device, projectData, liveSyncData);
 
 				await this.ensureLatestAppPackageIsInstalledOnDevice({
 					device,
@@ -475,7 +475,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					env: liveSyncData.env
 				}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
-				const liveSyncResultInfo = await liveSyncService.fullSync({
+				const liveSyncResultInfo = await platformLiveSyncService.fullSync({
 					projectData, device,
 					syncAllFiles: liveSyncData.watchAllFiles,
 					useLiveEdit: liveSyncData.useLiveEdit,

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -456,7 +456,10 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		const deviceAction = async (device: Mobile.IDevice): Promise<void> => {
 			try {
 				const platform = device.deviceInfo.platform;
+				const liveSyncService = this.getLiveSyncService(platform);
 				const deviceBuildInfoDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
+
+				liveSyncService.prepareForLiveSync(device, projectData, liveSyncData);
 
 				await this.ensureLatestAppPackageIsInstalledOnDevice({
 					device,
@@ -472,7 +475,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					env: liveSyncData.env
 				}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
-				const liveSyncResultInfo = await this.getLiveSyncService(platform).fullSync({
+				const liveSyncResultInfo = await liveSyncService.fullSync({
 					projectData, device,
 					syncAllFiles: liveSyncData.watchAllFiles,
 					useLiveEdit: liveSyncData.useLiveEdit,

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -138,5 +138,4 @@ export abstract class PlatformLiveSyncServiceBase {
 			action.call(this.$logger, util.format(message, "all files"));
 		}
 	}
-
 }


### PR DESCRIPTION
In case when `tns run ios --justlaunch` command is executed on real iOS device, the console should be released and the process should exit. Actually the process does not exit because a device's log process is started and this prevents the console to be released. So this PR fixes this behaviour.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3644

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The console is not released when `tns run ios --justlaunch` command is executed.

## What is the new behavior?
The console is released when `tns run ios` command is executed.
