### PR TITLE
fix(project): fix project creation when template v2 is used

### DIFF
--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -79,7 +79,8 @@ export class ProjectService implements IProjectService {
 				ignoreScripts
 			});
 
-			const templatePackageJson = this.$fs.readJson(path.join(templatePath, constants.PACKAGE_JSON_FILE_NAME));
+			const templatePackageJsonPath = templateVersion === constants.TemplateVersions.v2 ? path.join(projectDir, constants.PACKAGE_JSON_FILE_NAME) : path.join(templatePath, constants.PACKAGE_JSON_FILE_NAME);
+			const templatePackageJson = this.$fs.readJson(templatePackageJsonPath);
 
 			await this.$npm.uninstall(templatePackageJson.name, { save: true }, projectDir);
 			if (templateVersion === constants.TemplateVersions.v2) {


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
An error is thrown when the user tries to create project with template v2.

## What is the new behavior?
The user is able to create project with template v2.

Steps to reproduce: 
1. `tns create --template https://github.com/rosen-vladimirov/test-tns-template-v2/tarball/master`

