### PR TITLE
fix: File connections to iOS device work for a single app only

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2798,9 +2798,9 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ios-device-lib": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.13.tgz",
-      "integrity": "sha512-2vJpXctCy+ZluPBz9wxzIQ3W8LxxYBXlT5QHL3bV5TR+ClhpZbdHDajt0bmfPR92JAUufejHVRk5jCG6uGfUAA==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.4.14.tgz",
+      "integrity": "sha512-e0srWzIoMqaHyLOjYQSlLzYF8uVE8oYOvWBaBMons6OcCNg8rTQaGuu5368x8dKKqTUtLkNkU4Husa7qAD1DXQ==",
       "requires": {
         "bufferpack": "0.0.6",
         "node-uuid": "1.4.7"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gaze": "1.1.0",
     "iconv-lite": "0.4.11",
     "inquirer": "0.9.0",
-    "ios-device-lib": "0.4.13",
+    "ios-device-lib": "0.4.14",
     "ios-mobileprovision-finder": "1.0.10",
     "ios-sim-portable": "3.4.5",
     "jimp": "0.2.28",


### PR DESCRIPTION
In case you have a long living process, the CLI should be able to access files to different applications. However, file connections on iOS device require to be closed after finishing operation. Currently this fails, but it is fixed in the latest version of ios-device-lib

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
