### PR TITLE
fix: Unable to run app on iOS in Sidekick

### DIFF
--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -51,7 +51,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 	private canStartLookingForDebuggerPort(data: IProjectDir): boolean {
 		const projectData = this.$projectDataService.getProjectData(data && data.projectDir);
 		const frameworkVersion = this.$iOSProjectService.getFrameworkVersion(projectData);
-		return semver.gt(frameworkVersion, IOSDebuggerPortService.MIN_REQUIRED_FRAMEWORK_VERSION);
+		return !frameworkVersion || semver.gt(frameworkVersion, IOSDebuggerPortService.MIN_REQUIRED_FRAMEWORK_VERSION);
 	}
 
 	@cache()

--- a/lib/services/platform-project-service-base.ts
+++ b/lib/services/platform-project-service-base.ts
@@ -13,7 +13,8 @@ export abstract class PlatformProjectServiceBase extends EventEmitter implements
 	}
 
 	public getFrameworkVersion(projectData: IProjectData): string {
-		return this.$projectDataService.getNSValue(projectData.projectDir, this.getPlatformData(projectData).frameworkPackageName).version;
+		const frameworkData = this.$projectDataService.getNSValue(projectData.projectDir, this.getPlatformData(projectData).frameworkPackageName);
+		return frameworkData && frameworkData.version;
 	}
 
 	protected getAllNativeLibrariesForPlugin(pluginData: IPluginData, platform: string, filter: (fileName: string, _pluginPlatformsFolderPath: string) => boolean): string[] {


### PR DESCRIPTION
When trying to run application on iOS in Sidekick for the first time (when the iOS platform is not added yet to the project), the run fails with error "Cannot read property version of undefined".
The problem is in the call to `platformLiveSyncService.prepareForLiveSync` which tries to start parsing device logs before starting the liveSync action. However, at this point, the application does not have the platform added yet and the code that tries to get the version of `tns-ios` from project's package.json fails. In order to resolve this, ensure the code for getting framework version from package.json will return undefined instead of failing.
When undefined is returned, we know CLI will add the latest compatible iOS runtime version. We know that this version will print the port for debugging in the logs, so we can safely start parsing the logs.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
