### PR TITLE
Speed up android livesync

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -39,6 +39,7 @@ export const CONFIG_NS_APP_RESOURCES_ENTRY = "appResourcesPath";
 export const CONFIG_NS_APP_ENTRY = "appPath";
 export const DEPENDENCIES_JSON_NAME = "dependencies.json";
 export const APK_EXTENSION_NAME = ".apk";
+export const HASHES_FILE_NAME = ".nshashes";
 
 export class PackageVersion {
 	static NEXT = "next";

--- a/lib/definitions/files-hash-service.d.ts
+++ b/lib/definitions/files-hash-service.d.ts
@@ -1,5 +1,27 @@
 interface IFilesHashService {
 	generateHashes(files: string[]): Promise<IStringDictionary>;
+	/**
+	 * Generate hashes for all prepared files (all files from app folder under platforms folder).
+	 * @param platformData - Current platform's data
+	 * @returns {Promise<IStringDictionary>}
+	 * A map with key file's path and value - file's hash
+	 */
+	generateHashesForProject(platformData: IPlatformData): Promise<IStringDictionary>;
+	/**
+	 * @param hashesFileDirectory - Path to directory containing the hash file.
+	 * @returns {IStringDictionary}
+	 * In case .nshashes file exists (under `hashesFileDirectory` directory), returns its content
+	 * In case .nshashes file does not exist (under `hashesFileDirectory` directory), returns {}
+	 */
+	getGeneratedHashes(hashesFileDirectory: string): IStringDictionary;
+	/**
+	 * Generates hashes for all prepared files (all files from app folder under platforms folder)
+	 * and saves them in .nshashes file under `hashFileDirectory` directory.
+	 * @param platformData - Current platform's data
+	 * @param hashesFileDirectory - Path to directory containing the hash file.
+	 * @returns {Promise<void>}
+	 */
+	saveHashesForProject(platformData: IPlatformData, hashesFileDirectory: string): Promise<void>;
 	getChanges(files: string[], oldHashes: IStringDictionary): Promise<IStringDictionary>;
 	hasChangesInShasums(oldHashes: IStringDictionary, newHashes: IStringDictionary): boolean;
 }

--- a/lib/definitions/files-hash-service.d.ts
+++ b/lib/definitions/files-hash-service.d.ts
@@ -8,20 +8,14 @@ interface IFilesHashService {
 	 */
 	generateHashesForProject(platformData: IPlatformData): Promise<IStringDictionary>;
 	/**
-	 * @param hashesFileDirectory - Path to directory containing the hash file.
-	 * @returns {IStringDictionary}
-	 * In case .nshashes file exists (under `hashesFileDirectory` directory), returns its content
-	 * In case .nshashes file does not exist (under `hashesFileDirectory` directory), returns {}
-	 */
-	getGeneratedHashes(hashesFileDirectory: string): IStringDictionary;
-	/**
 	 * Generates hashes for all prepared files (all files from app folder under platforms folder)
 	 * and saves them in .nshashes file under `hashFileDirectory` directory.
 	 * @param platformData - Current platform's data
 	 * @param hashesFileDirectory - Path to directory containing the hash file.
 	 * @returns {Promise<void>}
 	 */
-	saveHashesForProject(platformData: IPlatformData, hashesFileDirectory: string): Promise<void>;
+	saveHashesForProject(platformData: IPlatformData, hashesFileDirectory: string): Promise<IStringDictionary>;
+	saveHashes(hashes: IStringDictionary, hashesFileDirectory: string): void;
 	getChanges(files: string[], oldHashes: IStringDictionary): Promise<IStringDictionary>;
 	hasChangesInShasums(oldHashes: IStringDictionary, newHashes: IStringDictionary): boolean;
 }

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -155,6 +155,13 @@ interface ILiveSyncInfo extends IProjectDir, IEnvOptions, IBundle, IRelease, IOp
 	clean?: boolean;
 
 	/**
+	 * Defines if initial sync will be forced.
+	 * In case it is true, transfers all project's directory on device
+	 * In case it is false, transfers only changed files.
+	 */
+	force?: boolean;
+
+	/**
 	 * Defines the timeout in seconds {N} CLI will wait to find the inspector socket port from device's logs.
 	 * If not provided, defaults to 10seconds.
 	 */
@@ -330,6 +337,8 @@ interface ILiveSyncWatchInfo extends IProjectDataComposition, IHasUseHotModuleRe
 	filesToSync: string[];
 	isReinstalled: boolean;
 	syncAllFiles: boolean;
+	liveSyncDeviceInfo: ILiveSyncDeviceInfo;
+	force?: boolean;
 }
 
 interface ILiveSyncResultInfo extends IHasUseHotModuleReloadOption {
@@ -344,6 +353,13 @@ interface IFullSyncInfo extends IProjectDataComposition, IHasUseHotModuleReloadO
 	device: Mobile.IDevice;
 	watch: boolean;
 	syncAllFiles: boolean;
+	liveSyncDeviceInfo: ILiveSyncDeviceInfo;
+	force?: boolean;
+}
+
+interface ITransferFilesOptions {
+	isFullSync: boolean;
+	force?: boolean;
 }
 
 interface IPlatformLiveSyncService {
@@ -383,7 +399,7 @@ interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase 
 	 * @param  {boolean} isFullSync Indicates if the operation is part of a fullSync
 	 * @return {Promise<Mobile.ILocalToDevicePathData[]>} Returns the ILocalToDevicePathData of all transfered files
 	 */
-	transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean): Promise<Mobile.ILocalToDevicePathData[]>;
+	transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, projectData: IProjectData, liveSyncDeviceInfo: ILiveSyncDeviceInfo, options: ITransferFilesOptions): Promise<Mobile.ILocalToDevicePathData[]>;
 }
 
 interface IAndroidNativeScriptDeviceLiveSyncService extends INativeScriptDeviceLiveSyncService {

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -115,7 +115,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			release: this.$options.release,
 			env: this.$options.env,
 			timeout: this.$options.timeout,
-			useHotModuleReload: this.$options.hmr
+			useHotModuleReload: this.$options.hmr,
+			force: this.$options.force
 		};
 
 		await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -30,7 +30,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		private $npm: INodePackageManager,
 		private $androidPluginBuildService: IAndroidPluginBuildService,
 		private $platformEnvironmentRequirements: IPlatformEnvironmentRequirements,
-		private $androidResourcesMigrationService: IAndroidResourcesMigrationService) {
+		private $androidResourcesMigrationService: IAndroidResourcesMigrationService,
+		private $filesHashService: IFilesHashService) {
 		super($fs, $projectDataService);
 		this.isAndroidStudioTemplate = false;
 	}
@@ -340,6 +341,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				message: "Gradle build..."
 			})
 		);
+
+		await this.$filesHashService.saveHashesForProject(this._platformData, this._platformData.deviceBuildOutputPath);
 	}
 
 	private getGradleBuildOptions(settings: IAndroidBuildOptionsSettings, projectData: IProjectData): Array<string> {

--- a/lib/services/files-hash-service.ts
+++ b/lib/services/files-hash-service.ts
@@ -33,20 +33,10 @@ export class FilesHashService implements IFilesHashService {
 		return hashes;
 	}
 
-	public async saveHashesForProject(platformData: IPlatformData, hashesFileDirectory: string): Promise<void> {
+	public async saveHashesForProject(platformData: IPlatformData, hashesFileDirectory: string): Promise<IStringDictionary> {
 		const hashes = await this.generateHashesForProject(platformData);
-		const hashesFilePath = path.join(hashesFileDirectory, HASHES_FILE_NAME);
-		this.$fs.writeJson(hashesFilePath, hashes);
-	}
-
-	public getGeneratedHashes(hashesFileDirectory: string): IStringDictionary {
-		let result = {};
-		const hashesFilePath = path.join(hashesFileDirectory, HASHES_FILE_NAME);
-		if (this.$fs.exists(hashesFilePath)) {
-			result = this.$fs.readJson(hashesFilePath);
-		}
-
-		return result;
+		this.saveHashes(hashes, hashesFileDirectory);
+		return hashes;
 	}
 
 	public async getChanges(files: string[], oldHashes: IStringDictionary): Promise<IStringDictionary> {
@@ -56,6 +46,11 @@ export class FilesHashService implements IFilesHashService {
 
 	public hasChangesInShasums(oldHashes: IStringDictionary, newHashes: IStringDictionary): boolean {
 		return !!_.keys(this.getChangesInShasums(oldHashes, newHashes)).length;
+	}
+
+	public saveHashes(hashes: IStringDictionary, hashesFileDirectory: string): void {
+		const hashesFilePath = path.join(hashesFileDirectory, HASHES_FILE_NAME);
+		this.$fs.writeJson(hashesFilePath, hashes);
 	}
 
 	private getChangesInShasums(oldHashes: IStringDictionary, newHashes: IStringDictionary): IStringDictionary {

--- a/lib/services/livesync/android-device-livesync-service-base.ts
+++ b/lib/services/livesync/android-device-livesync-service-base.ts
@@ -1,0 +1,85 @@
+import { DeviceLiveSyncServiceBase } from './device-livesync-service-base';
+import { AndroidDeviceHashService } from "../../common/mobile/android/android-device-hash-service";
+
+export abstract class AndroidDeviceLiveSyncServiceBase extends DeviceLiveSyncServiceBase {
+	private deviceHashServices: IDictionary<Mobile.IAndroidDeviceHashService>;
+
+	constructor(protected $injector: IInjector,
+		protected $platformsData: IPlatformsData,
+		protected $filesHashService: IFilesHashService,
+		protected $logger: ILogger,
+		protected device: Mobile.IAndroidDevice) {
+			super($platformsData, device);
+			this.deviceHashServices = {};
+	}
+
+	public abstract async transferFilesOnDevice(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void>;
+	public abstract async transferDirectoryOnDevice(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<void>;
+
+	public getDeviceHashService(appIdentifier: string): Mobile.IAndroidDeviceHashService {
+		const key = `${this.device.deviceInfo.identifier}${appIdentifier}`;
+		if (!this.deviceHashServices[key]) {
+			const deviceHashService = this.$injector.resolve(AndroidDeviceHashService, { adb: this.device.adb, appIdentifier });
+			this.deviceHashServices[key] = deviceHashService;
+		}
+
+		return this.deviceHashServices[key];
+	}
+
+	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, projectData: IProjectData, liveSyncDeviceInfo: ILiveSyncDeviceInfo, options: ITransferFilesOptions): Promise<Mobile.ILocalToDevicePathData[]> {
+		const transferredFiles = await this.transferFilesCore(deviceAppData, localToDevicePaths, projectFilesPath, options);
+		await this.updateHashes(deviceAppData, localToDevicePaths, projectData, liveSyncDeviceInfo);
+		return transferredFiles;
+	}
+
+	private async transferFilesCore(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, options: ITransferFilesOptions): Promise<Mobile.ILocalToDevicePathData[]> {
+		if (options.force && options.isFullSync) {
+			const hashFileDevicePath = this.getDeviceHashService(deviceAppData.appIdentifier).hashFileDevicePath;
+			await this.device.fileSystem.deleteFile(hashFileDevicePath, deviceAppData.appIdentifier);
+			this.$logger.trace("Before transfer directory on device ", localToDevicePaths);
+			await this.transferDirectoryOnDevice(deviceAppData, localToDevicePaths, projectFilesPath);
+			return localToDevicePaths;
+		}
+
+		const localToDevicePathsToTransfer = await this.getLocalToDevicePathsToTransfer(deviceAppData, localToDevicePaths, options);
+		this.$logger.trace("Files to transfer: ", localToDevicePathsToTransfer);
+		await this.transferFilesOnDevice(deviceAppData, localToDevicePathsToTransfer);
+		return localToDevicePathsToTransfer;
+	}
+
+	private async getLocalToDevicePathsToTransfer(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], options: ITransferFilesOptions): Promise<Mobile.ILocalToDevicePathData[]> {
+		if (options.force || !options.isFullSync) {
+			return localToDevicePaths;
+		}
+
+		const changedLocalToDevicePaths = await this.getChangedLocalToDevicePaths(deviceAppData.appIdentifier, localToDevicePaths);
+		return changedLocalToDevicePaths;
+	}
+
+	private async getChangedLocalToDevicePaths(appIdentifier: string, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<Mobile.ILocalToDevicePathData[]> {
+		const deviceHashService = this.getDeviceHashService(appIdentifier);
+		const currentHashes = await deviceHashService.generateHashesFromLocalToDevicePaths(localToDevicePaths);
+		const oldHashes = (await deviceHashService.getShasumsFromDevice()) || {};
+		const changedHashes = deviceHashService.getChangedShasums(oldHashes, currentHashes);
+		const changedFiles = _.keys(changedHashes);
+		const changedLocalToDevicePaths = localToDevicePaths.filter(localToDevicePathData => changedFiles.indexOf(localToDevicePathData.getLocalPath()) >= 0);
+		return changedLocalToDevicePaths;
+	}
+
+	private async updateHashes(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectData: IProjectData, liveSyncDeviceInfo: ILiveSyncDeviceInfo): Promise<void> {
+		const hashes = await this.updateHashesOnDevice(deviceAppData, localToDevicePaths, projectData, liveSyncDeviceInfo);
+		this.updateLocalHashes(hashes, deviceAppData, projectData, liveSyncDeviceInfo);
+	}
+
+	private async updateHashesOnDevice(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectData: IProjectData, liveSyncDeviceInfo: ILiveSyncDeviceInfo): Promise<IStringDictionary> {
+		const deviceHashService = this.getDeviceHashService(deviceAppData.appIdentifier);
+		const currentHashes = await deviceHashService.generateHashesFromLocalToDevicePaths(localToDevicePaths);
+		await deviceHashService.uploadHashFileToDevice(currentHashes);
+		return currentHashes;
+	}
+
+	private updateLocalHashes(hashes: IStringDictionary, deviceAppData: Mobile.IDeviceAppData, projectData: IProjectData, liveSyncDeviceInfo: ILiveSyncDeviceInfo): void {
+		const hashFilePath = liveSyncDeviceInfo.outputPath || this.$platformsData.getPlatformData(deviceAppData.platform, projectData).deviceBuildOutputPath;
+		this.$filesHashService.saveHashes(hashes, hashFilePath);
+	}
+}

--- a/lib/services/livesync/device-livesync-service-base.ts
+++ b/lib/services/livesync/device-livesync-service-base.ts
@@ -27,10 +27,10 @@ export abstract class DeviceLiveSyncServiceBase {
 		return fastSyncFileExtensions;
 	}
 
-	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean): Promise<Mobile.ILocalToDevicePathData[]> {
+	public async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, projectData: IProjectData, liveSyncDeviceInfo: ILiveSyncDeviceInfo, options: ITransferFilesOptions): Promise<Mobile.ILocalToDevicePathData[]> {
 		let transferredFiles: Mobile.ILocalToDevicePathData[] = [];
 
-		if (isFullSync) {
+		if (options.isFullSync) {
 			transferredFiles = await this.device.fileSystem.transferDirectory(deviceAppData, localToDevicePaths, projectFilesPath);
 		} else {
 			transferredFiles = await this.device.fileSystem.transferFiles(deviceAppData, localToDevicePaths);

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -60,7 +60,7 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 	public liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<ILiveSyncResultInfo> {
 		if (liveSyncInfo.isReinstalled) {
 			// In this case we should execute fullsync because iOS Runtime requires the full content of app dir to be extracted in the root of sync dir.
-			return this.fullSync({ projectData: liveSyncInfo.projectData, device, syncAllFiles: liveSyncInfo.syncAllFiles, watch: true });
+			return this.fullSync({ projectData: liveSyncInfo.projectData, device, syncAllFiles: liveSyncInfo.syncAllFiles, liveSyncDeviceInfo: liveSyncInfo.liveSyncDeviceInfo, watch: true });
 		} else {
 			return super.liveSyncWatchAction(device, liveSyncInfo);
 		}

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -505,10 +505,13 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				await platformLiveSyncService.prepareForLiveSync(device, projectData, liveSyncData, deviceBuildInfoDescriptor.debugOptions);
 
 				const liveSyncResultInfo = await platformLiveSyncService.fullSync({
-					projectData, device,
+					projectData,
+					device,
 					syncAllFiles: liveSyncData.watchAllFiles,
 					useHotModuleReload: liveSyncData.useHotModuleReload,
-					watch: !liveSyncData.skipWatcher
+					watch: !liveSyncData.skipWatcher,
+					force: liveSyncData.force,
+					liveSyncDeviceInfo: deviceBuildInfoDescriptor
 				});
 
 				await this.$platformService.trackActionForPlatform({ action: "LiveSync", platform: device.deviceInfo.platform, isForDevice: !device.isEmulator, deviceOsVersion: device.deviceInfo.version });
@@ -637,12 +640,14 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 										const service = this.getLiveSyncService(device.deviceInfo.platform);
 										const settings: ILiveSyncWatchInfo = {
+											liveSyncDeviceInfo: deviceBuildInfoDescriptor,
 											projectData,
 											filesToRemove: currentFilesToRemove,
 											filesToSync: currentFilesToSync,
 											isReinstalled: appInstalledOnDeviceResult.appInstalled,
 											syncAllFiles: liveSyncData.watchAllFiles,
-											useHotModuleReload: liveSyncData.useHotModuleReload
+											useHotModuleReload: liveSyncData.useHotModuleReload,
+											force: liveSyncData.force
 										};
 
 										const liveSyncResultInfo = await service.liveSyncWatchAction(device, settings);

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -47,7 +47,7 @@ export abstract class PlatformLiveSyncServiceBase {
 
 		const projectFilesPath = path.join(platformData.appDestinationDirectoryPath, APP_FOLDER_NAME);
 		const localToDevicePaths = await this.$projectFilesManager.createLocalToDevicePaths(deviceAppData, projectFilesPath, null, []);
-		const modifiedFilesData = await this.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, true, projectData);
+		const modifiedFilesData = await this.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, projectData, syncInfo.liveSyncDeviceInfo, { isFullSync: true, force: syncInfo.force });
 
 		return {
 			modifiedFilesData,
@@ -86,7 +86,7 @@ export abstract class PlatformLiveSyncServiceBase {
 				const localToDevicePaths = await this.$projectFilesManager.createLocalToDevicePaths(deviceAppData,
 					projectFilesPath, existingFiles, []);
 				modifiedLocalToDevicePaths.push(...localToDevicePaths);
-				modifiedLocalToDevicePaths = await this.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, false, projectData);
+				modifiedLocalToDevicePaths = await this.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, projectData, liveSyncInfo.liveSyncDeviceInfo, { isFullSync: false, force: liveSyncInfo.force});
 			}
 		}
 
@@ -113,11 +113,11 @@ export abstract class PlatformLiveSyncServiceBase {
 		};
 	}
 
-	protected async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean, projectData: IProjectData): Promise<Mobile.ILocalToDevicePathData[]> {
+	protected async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, projectData: IProjectData, liveSyncDeviceInfo: ILiveSyncDeviceInfo, options: ITransferFilesOptions): Promise<Mobile.ILocalToDevicePathData[]> {
 		let transferredFiles: Mobile.ILocalToDevicePathData[] = [];
 		const deviceLiveSyncService = this.getDeviceLiveSyncService(deviceAppData.device, projectData);
 
-		transferredFiles = await deviceLiveSyncService.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, isFullSync);
+		transferredFiles = await deviceLiveSyncService.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, projectData, liveSyncDeviceInfo, options);
 
 		this.logFilesSyncInformation(transferredFiles, "Successfully transferred %s.", this.$logger.info);
 

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -78,6 +78,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("androidPluginBuildService", stubs.AndroidPluginBuildServiceStub);
 	testInjector.register("platformEnvironmentRequirements", {});
 	testInjector.register("androidResourcesMigrationService", stubs.AndroidResourcesMigrationServiceStub);
+	testInjector.register("filesHashService", {});
 
 	return testInjector;
 }

--- a/test/services/livesync/android-device-livesync-service-base.ts
+++ b/test/services/livesync/android-device-livesync-service-base.ts
@@ -1,0 +1,381 @@
+import { Yok } from "../../../lib/common/yok";
+import { AndroidDeviceLiveSyncServiceBase } from "../../../lib/services/livesync/android-device-livesync-service-base";
+import { LiveSyncPaths } from "../../../lib/common/constants";
+import { assert } from "chai";
+import * as path from "path";
+
+interface ITestSetupInput {
+	existsHashesFile?: boolean;
+	addChangedFile?: boolean;
+	addUnchangedFile?: boolean;
+	changedFileLocalName?: string;
+	unchangedFileLocalName?: string;
+}
+
+interface ITestSetupOutput {
+	deviceAppData: Mobile.IDeviceAppData;
+	localToDevicePaths: Mobile.ILocalToDevicePathData[];
+	androidDeviceLiveSyncServiceBase: any;
+	projectRoot: string;
+	changedFileLocalPath: string;
+	unchangedFileLocalPath: string;
+}
+
+const transferFilesOnDeviceParams: any[] = [];
+let transferDirectoryOnDeviceParams: any[] = [];
+let resolveParams: any[] = [];
+const deleteFileParams: any[] = [];
+const writeJsonParams: any[] = [];
+const pushFileParams: any[] = [];
+
+class AndroidDeviceLiveSyncServiceBaseMock extends AndroidDeviceLiveSyncServiceBase {
+	constructor($injector: IInjector,
+		$platformsData: any,
+		$filesHashService: any,
+		$logger: ILogger,
+		device: Mobile.IAndroidDevice) {
+		super($injector, $platformsData, $filesHashService, $logger, device);
+	}
+
+	public async transferFilesOnDevice(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
+		transferFilesOnDeviceParams.push({ deviceAppData, localToDevicePaths });
+	}
+
+	public async transferDirectoryOnDevice(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<void> {
+		transferDirectoryOnDeviceParams.push({ deviceAppData, localToDevicePaths, projectFilesPath });
+	}
+}
+
+class LocalToDevicePathDataMock {
+	constructor(private filePath: string) { }
+
+	public getLocalPath(): string {
+		return this.filePath;
+	}
+
+	public getDevicePath(): string {
+		return `${LiveSyncPaths.ANDROID_TMP_DIR_NAME}/${path.basename(this.filePath)}`;
+	}
+}
+
+function mockPlatformsData() {
+	return {
+		getPlatformData: () => {
+			return {
+				deviceBuildOutputPath: "testDeviceBuildOutputPath"
+			};
+		}
+	};
+}
+
+function createTestInjector() {
+	const injector = new Yok();
+	injector.register("fs", {});
+	injector.register("mobileHelper", {
+		buildDevicePath: (filePath: string) => filePath
+	});
+	return injector;
+}
+
+const device: Mobile.IAndroidDevice = {
+	deviceInfo: mockDeviceInfo(),
+	adb: mockAdb(),
+	applicationManager: mockDeviceApplicationManager(),
+	fileSystem: mockDeviceFileSystem(),
+	isEmulator: true,
+	openDeviceLogStream: () => Promise.resolve(),
+	getApplicationInfo: () => Promise.resolve(null),
+	init: () => Promise.resolve()
+};
+
+function mockDeviceInfo(): Mobile.IDeviceInfo {
+	return {
+		identifier: "testIdentifier",
+		displayName: "testDisplayName",
+		model: "testModel",
+		version: "8.0.0",
+		vendor: "Google",
+		status: "",
+		errorHelp: null,
+		isTablet: true,
+		type: "Device",
+		platform: "Android"
+	};
+}
+
+function createDeviceAppData(androidVersion?: string): Mobile.IDeviceAppData {
+	return {
+		getDeviceProjectRootPath: async () => `${LiveSyncPaths.ANDROID_TMP_DIR_NAME}/${LiveSyncPaths.SYNC_DIR_NAME}`,
+		appIdentifier,
+		device: <Mobile.IDevice>{
+			deviceInfo: {
+				version: androidVersion || "8.1.2"
+			}
+		},
+		isLiveSyncSupported: async () => true,
+		platform: "Android"
+	};
+}
+
+function mockAdb(): Mobile.IDeviceAndroidDebugBridge {
+	return <Mobile.IDeviceAndroidDebugBridge> {
+		pushFile: async (filePath: string) => {
+			pushFileParams.push({ filePath });
+		},
+		sendBroadcastToDevice: async (action: string, extras?: IStringDictionary) => 1,
+		executeCommand: () => Promise.resolve(),
+		executeShellCommand: () => Promise.resolve(),
+		removeFile: () => Promise.resolve(),
+		getPropertyValue: async () => "testProperty",
+		getDevicesSafe: async () => [],
+		getDevices: async () => []
+	};
+}
+
+function mockDeviceApplicationManager(): Mobile.IDeviceApplicationManager {
+	return <Mobile.IDeviceApplicationManager>{};
+}
+
+function mockDeviceFileSystem(): Mobile.IDeviceFileSystem {
+	return <Mobile.IDeviceFileSystem> {
+		deleteFile: async (deviceFilePath, appIdentifier) => {
+			deleteFileParams.push({ deviceFilePath, appIdentifier });
+		}
+	};
+}
+
+function mockFsStats(options: { isDirectory: boolean, isFile: boolean }): (filePath: string) => { isDirectory: () => boolean, isFile: () => boolean } {
+	return (filePath: string) => ({
+		isDirectory: (): boolean => options.isDirectory,
+		isFile: (): boolean => options.isFile
+	});
+}
+
+function mockFilesHashService() {
+	return {
+		saveHashes: () => ({})
+	};
+}
+
+function mockLogger(): any {
+	return {
+		trace: () => ({})
+	};
+}
+
+function createAndroidDeviceLiveSyncServiceBase() {
+	const injector = new Yok();
+	injector.resolve = (service, args) => resolveParams.push({ service, args });
+	const androidDeviceLiveSyncServiceBase = new AndroidDeviceLiveSyncServiceBaseMock(injector, mockPlatformsData(), mockFilesHashService(), mockLogger(), device);
+	return androidDeviceLiveSyncServiceBase;
+}
+
+function setup(options?: ITestSetupInput): ITestSetupOutput {
+	options = options || {};
+	const projectRoot = "~/TestApp/app";
+	const changedFileName = "test.js";
+	const unchangedFileName = "notChangedFile.js";
+	const changedFileLocalPath = `${projectRoot}/${options.changedFileLocalName || changedFileName}`;
+	const unchangedFileLocalPath = `${projectRoot}/${options.unchangedFileLocalName || unchangedFileName}`;
+	const filesToShasums: IStringDictionary = {};
+	if (options.addChangedFile) {
+		filesToShasums[changedFileLocalPath] = "1";
+	}
+	if (options.addUnchangedFile) {
+		filesToShasums[unchangedFileLocalPath] = "2";
+	}
+
+	const injector = createTestInjector();
+	const localToDevicePaths = _.keys(filesToShasums).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
+	const deviceAppData = createDeviceAppData();
+	const androidDeviceLiveSyncServiceBase = new AndroidDeviceLiveSyncServiceBaseMock(injector, mockPlatformsData(), mockFilesHashService(), mockLogger(), device);
+
+	const fs = injector.resolve("fs");
+	fs.exists = () => options.existsHashesFile;
+	fs.getFsStats = mockFsStats({ isDirectory: false, isFile: true });
+	fs.getFileShasum = async (filePath: string) => filesToShasums[filePath];
+	fs.writeJson = (filename: string, data: any) => writeJsonParams.push({ filename, data });
+	fs.readJson = (filePath: string) => {
+		const deviceHashesFileContent: IStringDictionary = {};
+		deviceHashesFileContent[`${projectRoot}/${changedFileName}`] = "11";
+		if (options.addUnchangedFile) {
+			deviceHashesFileContent[`${projectRoot}/${unchangedFileName}`] = "2";
+		}
+
+		return deviceHashesFileContent;
+	};
+
+	return {
+		localToDevicePaths,
+		deviceAppData,
+		androidDeviceLiveSyncServiceBase,
+		projectRoot,
+		changedFileLocalPath,
+		unchangedFileLocalPath
+	};
+}
+
+const appIdentifier = "testAppIdentifier";
+
+async function transferFiles(testSetup: ITestSetupOutput, options: { force: boolean, isFullSync: boolean}): Promise<Mobile.ILocalToDevicePathData[]> {
+	const androidDeviceLiveSyncServiceBase = testSetup.androidDeviceLiveSyncServiceBase;
+	const transferredFiles = await androidDeviceLiveSyncServiceBase.transferFiles(
+		testSetup.deviceAppData,
+		testSetup.localToDevicePaths,
+		testSetup.projectRoot,
+		{},
+		{},
+		options
+	);
+	return transferredFiles;
+}
+
+describe("AndroidDeviceLiveSyncServiceBase", () => {
+	describe("getDeviceHashService", () => {
+		beforeEach(() => {
+			resolveParams = [];
+		});
+		it("should resolve AndroidDeviceHashService when the key is not stored in dictionary", () => {
+			const androidDeviceLiveSyncServiceBase = createAndroidDeviceLiveSyncServiceBase();
+			androidDeviceLiveSyncServiceBase.getDeviceHashService(appIdentifier);
+			assert.equal(resolveParams.length, 1);
+			assert.isFunction(resolveParams[0].service);
+			assert.isDefined(resolveParams[0].args.adb);
+			assert.equal(resolveParams[0].args.appIdentifier, appIdentifier);
+		});
+		it("should return already stored value when the method is called for second time with the same deviceIdentifier and appIdentifier", () => {
+			const androidDeviceLiveSyncServiceBase = createAndroidDeviceLiveSyncServiceBase();
+			androidDeviceLiveSyncServiceBase.getDeviceHashService(appIdentifier);
+			assert.equal(resolveParams.length, 1);
+			assert.isFunction(resolveParams[0].service);
+			assert.isDefined(resolveParams[0].args.adb);
+			assert.equal(resolveParams[0].args.appIdentifier, appIdentifier);
+
+			androidDeviceLiveSyncServiceBase.getDeviceHashService(appIdentifier);
+			assert.equal(resolveParams.length, 1);
+			assert.isFunction(resolveParams[0].service);
+			assert.isDefined(resolveParams[0].args.adb);
+			assert.equal(resolveParams[0].args.appIdentifier, appIdentifier);
+		});
+		it("should return AndroidDeviceHashService when the method is called for second time with different appIdentifier and same deviceIdentifier", () => {
+			const androidDeviceLiveSyncServiceBase = createAndroidDeviceLiveSyncServiceBase();
+			androidDeviceLiveSyncServiceBase.getDeviceHashService(appIdentifier);
+			assert.equal(resolveParams.length, 1);
+			assert.isFunction(resolveParams[0].service);
+			assert.isDefined(resolveParams[0].args.adb);
+			assert.equal(resolveParams[0].args.appIdentifier, appIdentifier);
+
+			androidDeviceLiveSyncServiceBase.getDeviceHashService(appIdentifier);
+			assert.equal(resolveParams.length, 1);
+			assert.isFunction(resolveParams[0].service);
+			assert.isDefined(resolveParams[0].args.adb);
+			assert.equal(resolveParams[0].args.appIdentifier, appIdentifier);
+
+			const newAppIdentifier = "myNewAppIdentifier";
+			androidDeviceLiveSyncServiceBase.getDeviceHashService(newAppIdentifier);
+			assert.equal(resolveParams.length, 2);
+			assert.isFunction(resolveParams[1].service);
+			assert.isDefined(resolveParams[1].args.adb);
+			assert.equal(resolveParams[1].args.appIdentifier, newAppIdentifier);
+		});
+	});
+
+	describe("transferFiles", () => {
+		beforeEach(() => {
+			transferDirectoryOnDeviceParams = [];
+		});
+
+		describe("when is full sync", () => {
+			it("transfers the whole directory when force option is specified", async () => {
+				const testSetup = setup({
+					addChangedFile: true
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: true, isFullSync: true });
+				assert.equal(transferredFiles.length, 1);
+				assert.equal(transferredFiles[0].getLocalPath(), testSetup.changedFileLocalPath);
+				assert.equal(transferDirectoryOnDeviceParams.length, 1);
+				assert.equal(transferDirectoryOnDeviceParams[0].localToDevicePaths.length, 1);
+			});
+			it("transfers only changed files when there are file changes", async () => {
+				const testSetup = setup({
+					existsHashesFile: true,
+					addChangedFile: true,
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: false, isFullSync: true });
+				assert.equal(transferredFiles.length, 1);
+				assert.equal(transferredFiles[0].getLocalPath(), testSetup.changedFileLocalPath);
+			});
+			it("transfers only changed files when there are both changed and not changed files", async () => {
+				const testSetup = setup({
+					existsHashesFile: true,
+					addChangedFile: true,
+					addUnchangedFile: true
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: false, isFullSync: true });
+				assert.equal(transferredFiles.length, 1);
+				assert.equal(transferredFiles[0].getLocalPath(), testSetup.changedFileLocalPath);
+			});
+			it("does not transfer files when no file changes", async () => {
+				const testSetup = setup({
+					existsHashesFile: true,
+					addChangedFile: false
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: false, isFullSync: true });
+				assert.equal(transferredFiles.length, 0);
+			});
+			it("transfers files which has different location and there are changed files", async () => {
+				const testSetup = setup({
+					existsHashesFile: true,
+					addChangedFile: true,
+					addUnchangedFile: true,
+					unchangedFileLocalName: "newLocation/notChangedFile.js"
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: false, isFullSync: true });
+				assert.equal(transferredFiles.length, 2);
+				assert.deepEqual(transferredFiles[0].getLocalPath(), testSetup.changedFileLocalPath);
+				assert.deepEqual(transferredFiles[1].getLocalPath(), testSetup.unchangedFileLocalPath);
+			});
+			it("transfers files which has different location and no changed files", async () => {
+				const testSetup = setup({
+					existsHashesFile: true,
+					addChangedFile: false,
+					addUnchangedFile: true,
+					unchangedFileLocalName: "newLocation/notChangedFile.js"
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: false, isFullSync: true });
+				assert.equal(transferredFiles.length, 1);
+				assert.deepEqual(transferredFiles[0].getLocalPath(), testSetup.unchangedFileLocalPath);
+			});
+			it("transfers changed files with different location", async () => {
+				const testSetup = setup({
+					existsHashesFile: true,
+					addChangedFile: true,
+					changedFileLocalName: "newLocation/test.js"
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: false, isFullSync: true });
+				assert.equal(transferredFiles.length, 1);
+				assert.equal(transferredFiles[0].getLocalPath(), testSetup.changedFileLocalPath);
+			});
+		});
+
+		describe("when is not full sync", () => {
+			it("does not transfer the whole directory when force option is specified", async () => {
+				const testSetup = setup({
+					addChangedFile: true
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: true, isFullSync: false });
+				assert.equal(transferredFiles.length, 1);
+				assert.equal(transferredFiles[0].getLocalPath(), testSetup.changedFileLocalPath);
+				assert.equal(transferDirectoryOnDeviceParams.length, 0);
+			});
+			it("transfers all provided files", async () => {
+				const testSetup = setup({
+					addChangedFile: true
+				});
+				const transferredFiles = await transferFiles(testSetup, { force: false, isFullSync: false });
+				assert.equal(transferredFiles.length, 1);
+				assert.equal(transferredFiles[0].getLocalPath(), testSetup.changedFileLocalPath);
+			});
+		});
+	});
+});


### PR DESCRIPTION
`tns run android` command transfers all files on initial sync. Actually there is no need to transfer all files on device because the installed `.apk` contains them. So after the application is installed on device, calculate the hashes for files inside `\plaforms\android\app\*` and upload the hash file on device. When the initial sync is executed {N} CLI compares the hashes and no file is transferred on device because all files are the same (no change is occurred). This PR speeds up the initial livesync with around 15seconds for angular application.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
LiveSync for android always transfer all project files on device but actually no need to do it.

## What is the new behavior?
LiveSync for android is faster.

