### PR TITLE
fix(unit-testing): Fix tests executed with jasmine

### DIFF
--- a/lib/commands/test-init.ts
+++ b/lib/commands/test-init.ts
@@ -101,12 +101,11 @@ class TestInitCommand implements ICommand {
 
 		this.$fs.ensureDirectoryExists(testsDir);
 
+		const frameworks = [frameworkToInstall].concat(this.karmaConfigAdditionalFrameworks[frameworkToInstall] || [])
+			.map(fw => `'${fw}'`)
+			.join(', ');
 		const karmaConfTemplate = this.$resources.readText('test/karma.conf.js');
-		const karmaConf = _.template(karmaConfTemplate)({
-			frameworks: [frameworkToInstall].concat(this.karmaConfigAdditionalFrameworks[frameworkToInstall])
-				.map(fw => `'${fw}'`)
-				.join(', ')
-		});
+		const karmaConf = _.template(karmaConfTemplate)({ frameworks });
 
 		this.$fs.writeFile(path.join(projectDir, 'karma.conf.js'), karmaConf);
 


### PR DESCRIPTION
Trying to execute execute tests with jasmine fails, as during initialization we have written incorrect data in karma.config.js file.
The error is: `Error: No provider for “framework:undefined”! (Resolving: framework:undefined)`
The problem is that during initalization we set undefined for framework value. Fix the initalization code to enter correct data in karma.config.js

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

