### PR TITLE
fix(livesync): stop forcing native prepare when using --bundle

### DIFF
--- a/lib/services/prepare-platform-native-service.ts
+++ b/lib/services/prepare-platform-native-service.ts
@@ -26,12 +26,12 @@ export class PreparePlatformNativeService extends PreparePlatformService impleme
 			await this.cleanProject(config.platform, config.appFilesUpdaterOptions, config.platformData, config.projectData);
 		}
 
-		if (!config.changesInfo || config.changesInfo.changesRequirePrepare || config.appFilesUpdaterOptions.bundle) {
+		if (!config.changesInfo || config.changesInfo.changesRequirePrepare) {
 			this.prepareAppResources(config.platformData, config.projectData);
 			await config.platformData.platformProjectService.prepareProject(config.projectData, config.platformSpecificData);
 		}
 
-		if (!config.changesInfo || config.changesInfo.modulesChanged || config.appFilesUpdaterOptions.bundle) {
+		if (!config.changesInfo || config.changesInfo.modulesChanged) {
 			await this.$pluginsService.validate(config.platformData, config.projectData);
 
 			const appDestinationDirectoryPath = path.join(config.platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);

--- a/lib/services/prepare-platform-native-service.ts
+++ b/lib/services/prepare-platform-native-service.ts
@@ -26,8 +26,14 @@ export class PreparePlatformNativeService extends PreparePlatformService impleme
 			await this.cleanProject(config.platform, config.appFilesUpdaterOptions, config.platformData, config.projectData);
 		}
 
-		if (!config.changesInfo || config.changesInfo.changesRequirePrepare) {
+		// Move the native application resources from platforms/.../app/App_Resources
+		// to the right places in the native project,
+		// because webpack copies them on every build (not every change).
+		if (!config.changesInfo || config.changesInfo.changesRequirePrepare || config.appFilesUpdaterOptions.bundle) {
 			this.prepareAppResources(config.platformData, config.projectData);
+		}
+
+		if (!config.changesInfo || config.changesInfo.changesRequirePrepare) {
 			await config.platformData.platformProjectService.prepareProject(config.projectData, config.platformSpecificData);
 		}
 


### PR DESCRIPTION
These checks are no longer needed. They also cause the CLI to rebuild the .aar files on every change when using `tns run android --bundle`.

- The first check:
The CLI watches the `App_Resources` folder and will execute the logic
for preparing them whenever there's a change.

- The second check:
The CLI will try to detect changes in node_modules by comparing the
timestamps of every file there on every change. When there's a change,
it will set the `modulesChanged` flag to true. Therefore, the `bundle` flag is not needed.

fixes #3707 