### PR TITLE
feat: Speed up device detection

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -35,8 +35,6 @@ export class DebugPlatformCommand implements ICommand {
 			return;
 		}
 
-		await this.$devicesService.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: this.platform });
-
 		await this.$liveSyncCommandHelper.executeLiveSyncOperation([selectedDeviceForDebug], this.platform, {
 			deviceDebugMap: {
 				[selectedDeviceForDebug.deviceInfo.identifier]: true
@@ -51,8 +49,6 @@ export class DebugPlatformCommand implements ICommand {
 		if (this.$options.forDevice && this.$options.emulator) {
 			this.$errors.fail(DebugCommandErrors.UNABLE_TO_USE_FOR_DEVICE_AND_EMULATOR);
 		}
-
-		await this.$devicesService.detectCurrentlyAttachedDevices({ platform: this.platform, shouldReturnImmediateResult: false });
 
 		if (this.$options.device) {
 			const device = await this.$devicesService.getDevice(this.$options.device);

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -405,9 +405,6 @@ interface IPlatformTemplate {
 	platformTemplate: string;
 }
 
-interface IEmulator {
-	emulator: boolean;
-}
 
 interface IClean {
 	clean: boolean;
@@ -449,7 +446,7 @@ interface IPort {
 	port: Number;
 }
 
-interface IOptions extends ICommonOptions, IBundleString, IPlatformTemplate, IEmulator, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, INpmInstallConfigurationOptions, IPort, IEnvOptions {
+interface IOptions extends ICommonOptions, IBundleString, IPlatformTemplate, IHasEmulatorOption, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, INpmInstallConfigurationOptions, IPort, IEnvOptions {
 	all: boolean;
 	client: boolean;
 	compileSdk: number;
@@ -482,7 +479,7 @@ interface IAppFilesUpdaterOptions extends IBundle, IRelease, IOptionalWatchAllFi
 
 interface IPlatformBuildData extends IAppFilesUpdaterOptions, IBuildConfig, IEnvOptions { }
 
-interface IDeviceEmulator extends IEmulator, IDeviceIdentifier { }
+interface IDeviceEmulator extends IHasEmulatorOption, IDeviceIdentifier { }
 
 interface IRunPlatformOptions extends IJustLaunch, IDeviceEmulator { }
 

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -21,15 +21,15 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 	}
 
 	public async executeCommandLiveSync(platform?: string, additionalOptions?: ILiveSyncCommandHelperAdditionalOptions) {
+		const emulator = this.$options.emulator;
 		await this.$devicesService.initialize({
 			deviceId: this.$options.device,
-			platform: platform,
-			emulator: this.$options.emulator,
+			platform,
+			emulator,
 			skipDeviceDetectionInterval: true,
 			skipInferPlatform: !platform
 		});
 
-		await this.$devicesService.detectCurrentlyAttachedDevices({ shouldReturnImmediateResult: false, platform: platform });
 		const devices = this.$devicesService.getDeviceInstances()
 			.filter(d => !platform || d.deviceInfo.platform.toLowerCase() === platform.toLowerCase());
 

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -44,7 +44,6 @@ class TestExecutionService implements ITestExecutionService {
 						deviceId: this.$options.device,
 						emulator: this.$options.emulator
 					});
-					await this.$devicesService.detectCurrentlyAttachedDevices();
 					const projectFilesPath = path.join(platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME);
 
 					const configOptions: IKarmaConfigOptions = JSON.parse(launcherConfig);

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -36,7 +36,6 @@ function createTestInjector(): IInjector {
 	});
 	testInjector.register('devicesService', {
 		initialize: async () => { /* Intentionally left blank */ },
-		detectCurrentlyAttachedDevices: async () => { /* Intentionally left blank */ },
 		getDeviceInstances: (): any[] => { return []; },
 		execute: async (): Promise<any> => ({})
 	});


### PR DESCRIPTION
Speed up device detection by:
* removing duplicate calls to all device detection services
* cache the Promise of initialize method - this way even when multiple calls are executed simultaneously, the result of the first one will be used. This allows Sidekick to call the method asynchronously.
* do not execute iOS device detection in case `--emulator` is passed

Remove several public methods from the service - make them protected as we already have tests for them.
Remove all calls to detectCurrentlyAttachedDevices method outside of the service - the initialize method will do it anyway, so no need to call it externally.
Remove duplicate calls in the startLookingForDevices method - previously it had to filter which device detection services to call. As now each device detection service checks its platform, we can safely call all of them and rely on their filters to skip the execution.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
`$ tns run ios --emulator` tries to find attached iOS devices. When there's no such, it takes 6 seconds to complete.

## What is the new behavior?
`$ tns run ios --emulator` does not search for connected iOS devices, so when you do not have iOS devices attached, the command is with 6 seconds faster than before.

> NOTE: Merge after https://github.com/telerik/mobile-cli-lib/pull/1099