### PR TITLE
chore: fix console.log regression after introducing ios-sim async api

### DIFF
--- a/lib/definitions/ios-debugger-port-service.d.ts
+++ b/lib/definitions/ios-debugger-port-service.d.ts
@@ -24,7 +24,7 @@ interface IIOSDebuggerPortService {
 	 * In case when STARTING_IOS_APPLICATION event is emitted, sets the port to null and add timeout for 5000 miliseconds which checks if port is null and prints a warning.
 	 * @param {Mobile.IDevice} device - Describes the device which logs should be parsed.
 	 * @param {IProjectDir} data - Object that has a projectDir property.
-	 * @returns {void}
+	 * @returns {Promise<void>}
 	 */
-	attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir): void;
+	attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir): Promise<void>;
 }

--- a/lib/definitions/ios-log-parser-service.d.ts
+++ b/lib/definitions/ios-log-parser-service.d.ts
@@ -3,5 +3,5 @@ interface IIOSLogParserService extends NodeJS.EventEmitter {
 	 * Starts looking for debugger port. Attaches on device logs and processes them. In case when port is found, DEBUGGER_PORT_FOUND event is emitted.
 	 * @param {Mobile.IDevice} device - Describes the device which logs will be processed.
 	 */
-	startParsingLog(device: Mobile.IDevice, data: IProjectName): void;
+	startParsingLog(device: Mobile.IDevice, data: IProjectName): Promise<void>;
 }

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -337,7 +337,7 @@ interface IPlatformLiveSyncService {
 	fullSync(syncInfo: IFullSyncInfo): Promise<ILiveSyncResultInfo>;
 	liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<ILiveSyncResultInfo>;
 	refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void>;
-	prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo): void;
+	prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo): Promise<void>;
 }
 
 interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase {

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -63,7 +63,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 			await this.device.openDeviceLogStream();
 		}
 
-		this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(this.device, debugData);
+		await this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(this.device, debugData);
 
 		if (debugOptions.emulator) {
 			if (debugOptions.start) {

--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -36,7 +36,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 		});
 	}
 
-	public attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir): void {
+	public async attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir): Promise<void> {
 		const projectData = this.$projectDataService.getProjectData(data && data.projectDir);
 		if (!this.canStartLookingForDebuggerPort(projectData)) {
 			return;
@@ -45,7 +45,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 		this.attachToDebuggerPortFoundEventCore();
 		this.attachToAttachRequestEvent(device);
 
-		this.$iOSLogParserService.startParsingLog(device, projectData);
+		await this.$iOSLogParserService.startParsingLog(device, projectData);
 	}
 
 	private canStartLookingForDebuggerPort(data: IProjectDir): boolean {

--- a/lib/services/ios-log-parser-service.ts
+++ b/lib/services/ios-log-parser-service.ts
@@ -13,12 +13,12 @@ export class IOSLogParserService extends EventEmitter implements IIOSLogParserSe
 		super();
 	}
 
-	public startParsingLog(device: Mobile.IDevice, data: IProjectName): void {
+	public async startParsingLog(device: Mobile.IDevice, data: IProjectName): Promise<void> {
 		this.$deviceLogProvider.setProjectNameForDevice(device.deviceInfo.identifier, data.projectName);
 
 		if (!this.startedDeviceLogInstances[device.deviceInfo.identifier]) {
 			this.startParsingLogCore(device);
-			this.startLogProcess(device);
+			await this.startLogProcess(device);
 			this.startedDeviceLogInstances[device.deviceInfo.identifier] = true;
 		}
 	}
@@ -41,7 +41,7 @@ export class IOSLogParserService extends EventEmitter implements IIOSLogParserSe
 		}
 	}
 
-	private startLogProcess(device: Mobile.IDevice): void {
+	private async startLogProcess(device: Mobile.IDevice): Promise<void> {
 		if (device.isEmulator) {
 			return this.$iOSSimulatorLogProvider.startNewMutedLogProcess(device.deviceInfo.identifier);
 		}

--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -17,6 +17,6 @@ export class AndroidLiveSyncService extends PlatformLiveSyncServiceBase implemen
 		return service;
 	}
 
-	public prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir): void { /* */ }
+	public async prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir): Promise<void> { /* */ }
 }
 $injector.register("androidLiveSyncService", AndroidLiveSyncService);

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -66,9 +66,9 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		}
 	}
 
-	public prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo): void {
+	public async prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo): Promise<void> {
 		if (!liveSyncInfo.skipWatcher) {
-			this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, data);
+			return this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, data);
 		}
 	}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -459,7 +459,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				const platformLiveSyncService = this.getLiveSyncService(platform);
 				const deviceBuildInfoDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
 
-				platformLiveSyncService.prepareForLiveSync(device, projectData, liveSyncData);
+				await platformLiveSyncService.prepareForLiveSync(device, projectData, liveSyncData);
 
 				await this.ensureLatestAppPackageIsInstalledOnDevice({
 					device,

--- a/test/services/ios-debugger-port-service.ts
+++ b/test/services/ios-debugger-port-service.ts
@@ -148,7 +148,7 @@ describe("iOSDebuggerPortService", () => {
 
 		_.each(testCases, testCase => {
 			it(testCase.name, async () => {
-				iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj);
+				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj);
 				if (testCase.emitStartingIOSApplicationEvent) {
 					emitStartingIOSApplicationEvent();
 				}
@@ -162,7 +162,7 @@ describe("iOSDebuggerPortService", () => {
 				assert.deepEqual(port, testCase.emittedPort);
 			});
 			it(`${testCase.name} for multiline debugger port message.`, async () => {
-				iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj);
+				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj);
 				if (testCase.emitStartingIOSApplicationEvent) {
 					emitStartingIOSApplicationEvent();
 				}


### PR DESCRIPTION

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns run ios` does not print the logs from iOS simulator

## What is the new behavior?
`tns run ios` prints the logs from iOS simulator

