### PR TITLE
chore: fix the template name that will be send to google analytics

### DIFF
--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -92,7 +92,7 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 	private getTemplateNameToBeTracked(templateName: string, packageJsonContent: any): string {
 		try {
 			if (this.$fs.exists(templateName)) {
-				const templateNameToBeTracked = this.$fs.exists(path.join(templateName, constants.PACKAGE_JSON_FILE_NAME)) ? packageJsonContent.name : path.basename(templateName);
+				const templateNameToBeTracked = (packageJsonContent && packageJsonContent.name) || path.basename(templateName);
 				return `${constants.ANALYTICS_LOCAL_TEMPLATE_PREFIX}${templateNameToBeTracked}`;
 			}
 

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -163,6 +163,8 @@ describe("project-templates-service", () => {
 				const localTemplatePath = `/Users/username/${templateName}`;
 				const fs = testInjector.resolve<IFileSystem>("fs");
 				fs.exists = (localPath: string): boolean => path.basename(localPath) !== constants.PACKAGE_JSON_FILE_NAME;
+				const pacoteService = testInjector.resolve<IPacoteService>("pacoteService");
+				pacoteService.manifest = () => Promise.resolve({ });
 				await projectTemplatesService.prepareTemplate(localTemplatePath, "tempFolder");
 				assert.deepEqual(dataSentToGoogleAnalytics, [
 					{


### PR DESCRIPTION
Fix data send to google analytics when `tns create --template <localTemplatePath>` command is executed.
Expected: `localTemplate_tns-template-hello-world`
Current: `localTemplate_livesync-hello-world.tgz`

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns create myApp --template <localTemplatePath>` sends wrong data to google analytics 

## What is the new behavior?
`tns create myApp --template <localTemplatePath>` sends correct data to google analytics 
