### PR TITLE
Update ios sim lib to 4.0.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3157,9 +3157,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.0.tgz",
-      "integrity": "sha512-89oTyigxgdLVvCcR9vN6CxqzFNulWF42Nivnrf1P8k0L+Wqojsdht0XiXHrvVY0MdkPeKTLGsmZ5OjKM58Xmdw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.1.tgz",
+      "integrity": "sha512-HVWFgRMgnzSzjAyBz6LNPy3wF8sdlBy2LPciDVUSYIa04m2Y2Gn8rwCblwJs0pHE4OBCKZ2bbiODA0zwswcfEg==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "inquirer": "0.9.0",
     "ios-device-lib": "0.4.14",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "4.0.0",
+    "ios-sim-portable": "4.0.1",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",
     "lodash": "4.13.1",


### PR DESCRIPTION
Fixes the behaviour of `tns run ios --device fakeId`

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns run ios --device fakeId` throws unhandled error

## What is the new behavior?
`tns run ios --device fakeId` shows correct error


