### PR TITLE
fix: fix failing test for creating a project from local directory template on MAC

### DIFF
--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -75,16 +75,16 @@ export class ProjectService implements IProjectService {
 				this.removeMergedDependencies(projectDir, templatePackageJsonContent);
 			}
 
+			if (templateVersion === constants.TemplateVersions.v1) {
+				await this.$npm.uninstall(templatePackageJsonContent.name, { save: true }, projectDir);
+			}
+
 			// Install devDependencies and execute all scripts:
 			await this.$npm.install(projectDir, projectDir, {
 				disableNpmInstall: false,
 				frameworkPath: null,
 				ignoreScripts
 			});
-
-			if (templateVersion === constants.TemplateVersions.v1) {
-				await this.$npm.uninstall(templatePackageJsonContent.name, { save: true }, projectDir);
-			}
 		} catch (err) {
 			this.$fs.deleteDirectory(projectDir);
 			throw err;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
The `Project Service Tests project service integration tests creates valid project from local directory template` test was failing on MAC. (the `npm i` in the project was also making `npm i` in the template because of the symlink).

## What is the new behavior?
All tests are passing on MAC
