### PR TITLE
feat: Speed up adding native platform

### DIFF
--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -6,7 +6,6 @@ export class NpmInstallationManager implements INpmInstallationManager {
 	constructor(private $npm: INodePackageManager,
 		private $childProcess: IChildProcess,
 		private $logger: ILogger,
-		private $options: IOptions,
 		private $settingsService: ISettingsService,
 		private $fs: IFileSystem,
 		private $staticConfig: IStaticConfig,
@@ -39,9 +38,8 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		return maxSatisfying || latestVersion;
 	}
 
-	public async install(packageName: string, projectDir: string, opts?: INpmInstallOptions): Promise<any> {
+	public async install(packageToInstall: string, projectDir: string, opts?: INpmInstallOptions): Promise<any> {
 		try {
-			const packageToInstall = this.$options.frameworkPath || packageName;
 			const pathToSave = projectDir;
 			const version = (opts && opts.version) || null;
 			const dependencyType = (opts && opts.dependencyType) || null;

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -144,7 +144,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		const targetSdkVersion = androidToolsInfo && androidToolsInfo.targetSdkVersion;
 		this.$logger.trace(`Using Android SDK '${targetSdkVersion}'.`);
 
-		this.isAndroidStudioTemplate = this.isAndroidStudioCompatibleTemplate(projectData);
+		this.isAndroidStudioTemplate = this.isAndroidStudioCompatibleTemplate(projectData, frameworkVersion);
 		if (this.isAndroidStudioTemplate) {
 			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "*", "-R");
 		} else {
@@ -703,20 +703,12 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		}
 	}
 
-	private isAndroidStudioCompatibleTemplate(projectData: IProjectData): boolean {
+	private isAndroidStudioCompatibleTemplate(projectData: IProjectData, frameworkVersion?: string): boolean {
 		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME);
-		let platformVersion = currentPlatformData && currentPlatformData[constants.VERSION_STRING];
+		const platformVersion = (currentPlatformData && currentPlatformData[constants.VERSION_STRING]) || frameworkVersion;
 
 		if (!platformVersion) {
-			const tnsAndroidPackageJsonPath = path.join(projectData.projectDir, constants.NODE_MODULES_FOLDER_NAME, constants.TNS_ANDROID_RUNTIME_NAME, constants.PACKAGE_JSON_FILE_NAME);
-			if (this.$fs.exists(tnsAndroidPackageJsonPath)) {
-				const projectPackageJson: any = this.$fs.readJson(tnsAndroidPackageJsonPath);
-				if (projectPackageJson && projectPackageJson.version) {
-					platformVersion = projectPackageJson.version;
-				}
-			} else {
-				return true;
-			}
+			return true;
 		}
 
 		if (platformVersion === constants.PackageVersion.NEXT || platformVersion === constants.PackageVersion.LATEST || platformVersion === constants.PackageVersion.RC) {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -132,7 +132,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 
 		this.$fs.ensureDirectoryExists(platformPath);
-		this.$logger.out("Project successfully created.");
+		this.$logger.out(`Platform ${platform} successfully added.`);
 	}
 
 	private async addPlatformCore(platformData: IPlatformData, frameworkDir: string, platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, nativePrepare?: INativePrepare): Promise<string> {

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -104,6 +104,9 @@ function createTestInjector(): IInjector {
 		getChanges: () => Promise.resolve({}),
 		generateHashes: () => Promise.resolve()
 	});
+	testInjector.register("pacoteService", {
+		extractPackage: async (packageName: string, destinationDirectory: string, options?: IPacoteExtractOptions): Promise<void> => undefined
+	});
 
 	return testInjector;
 }

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -168,6 +168,9 @@ function createTestInjector() {
 	testInjector.register("platformEnvironmentRequirements", {
 		checkEnvironmentRequirements: async (platform?: string, projectDir?: string, runtimeVersion?: string): Promise<boolean> => true
 	});
+	testInjector.register("pacoteService", {
+		extractPackage: async (packageName: string, destinationDirectory: string, options?: IPacoteExtractOptions): Promise<void> => undefined
+	});
 
 	return testInjector;
 }


### PR DESCRIPTION
The current logic for adding native platform is:
1. Install the runtime package (tns-ios or tns-android) as a dependency of the project
2. Copy all files from the `<project dir>/node_modules/<runtime package>/framework` to `<project dir>/plaforms/<platform>/...` (specific places there).
3. Uninstall the runtime package, so it is no longer dependency of the project.

This solution becomes really slow when the project has a lot of dependencies. For example, for `tns-template-master-detail-ng`, all these steps take around 2 mins and 5 seconds on Windows (without SSD) and around 40 seconds on macOS (with SSD).

In order to speed up this process, remove the installing and uninstalling of the runtime package. Instead of this, use the `pacote` package to extract the runtime to a directory in the `temp` and copy
files from there to `platforms` directory. As we do not execute `npm install` and `npm uninstall` with this solution, the operation is not dependent on the number of dependencies used in the project. It takes
around 5-9 second on both Windows and macOS.

Also remove the usage of `$options` from `npmInstallationManager` - its purpose was to work with `--frameworkPath` on `tns platform add <platform>` command, but we no longer call `npmInstallationManager` for this case.

Fix the tests for `platorm-service`'s addPlatform method as they were incorrectly passing.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
`tns platform add <platform>` takes around 40 seconds

## What is the new behavior?
`tns platform add <platform>` takes around 6 seconds.

Fixes/Implements/Closes #[Issue Number].