### PR TITLE
fix: Platform add hangs when invalid frameworkPath is passed

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -208,3 +208,7 @@ export class Hooks {
 }
 
 export const PACKAGE_PLACEHOLDER_NAME = "__PACKAGE__";
+
+export class AddPlaformErrors {
+	public static InvalidFrameworkPathStringFormat = "Invalid frameworkPath: %s. Please ensure the specified frameworkPath exists.";
+}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -4,6 +4,7 @@ import * as constants from "../constants";
 import { Configurations } from "../common/constants";
 import * as helpers from "../common/helpers";
 import * as semver from "semver";
+import { format } from "util";
 import { EventEmitter } from "events";
 import { AppFilesUpdater } from "./app-files-updater";
 import { attachAwaitDetach } from "../common/helpers";
@@ -104,6 +105,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		let packageToInstall = "";
 		if (frameworkPath) {
 			packageToInstall = path.resolve(frameworkPath);
+			if (!this.$fs.exists(packageToInstall)) {
+				const errorMessage = format(constants.AddPlaformErrors.InvalidFrameworkPathStringFormat, frameworkPath);
+				this.$errors.fail(errorMessage);
+			}
 		} else {
 			if (!version) {
 				version = this.getCurrentPlatformVersion(platform, projectData) ||

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -2,12 +2,13 @@ import * as yok from "../lib/common/yok";
 import * as stubs from "./stubs";
 import * as PlatformServiceLib from "../lib/services/platform-service";
 import * as StaticConfigLib from "../lib/config";
-import { VERSION_STRING, PACKAGE_JSON_FILE_NAME } from "../lib/constants";
+import { VERSION_STRING, PACKAGE_JSON_FILE_NAME, AddPlaformErrors } from "../lib/constants";
 import * as fsLib from "../lib/common/file-system";
 import * as optionsLib from "../lib/options";
 import * as hostInfoLib from "../lib/common/host-info";
 import * as ProjectFilesManagerLib from "../lib/common/services/project-files-manager";
 import * as path from "path";
+import { format } from "util";
 import { assert } from "chai";
 import { DeviceAppDataFactory } from "../lib/common/mobile/device-app-data/device-app-data-factory";
 import { LocalToDevicePathDataFactory } from "../lib/common/mobile/local-to-device-path-data-factory";
@@ -230,6 +231,16 @@ describe('Platform Service Tests', () => {
 
 				const projectData: IProjectData = testInjector.resolve("projectData");
 				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, config), errorMessage);
+			});
+
+			it("fails when path passed to frameworkPath does not exist", async () => {
+				const fs = testInjector.resolve("fs");
+				fs.exists = () => false;
+
+				const projectData: IProjectData = testInjector.resolve("projectData");
+				const frameworkPath = "invalidPath";
+				const errorMessage = format(AddPlaformErrors.InvalidFrameworkPathStringFormat, frameworkPath);
+				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, config, frameworkPath), errorMessage);
 			});
 
 			const assertCorrectDataIsPassedToPacoteService = async (versionString: string): Promise<void> => {


### PR DESCRIPTION
In case non-existent file is passed to `--frameworkPath` the `tns platform add ...` command hangs. Fix this by checking if the passed value is correct.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
`tns platform add android --frameworkPath invalid.tgz` hangs.

## What is the new behavior?
`tns platform add android --frameworkPath invalid.tgz` fails with error: `Invalid frameworkPath: invalid.tgz. Please ensure the specified frameworkPath exists.`


