### PR TITLE
fix: During all gradle operations "Gradle build" message is printed

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -436,16 +436,6 @@ interface IPlatformProjectService extends NodeJS.EventEmitter, IPlatformProjectS
 	 * Traverse through the production dependencies and find plugins that need build/rebuild
 	 */
 	checkIfPluginsNeedBuild(projectData: IProjectData): Promise<Array<any>>;
-
-	/**
-	 * Get gradle options the CLI generates when building project
-	 */
-	getBuildOptions(configurationFilePath?: string): Array<string>;
-
-	/**
-	 * Get gradle options the CLI generates when building project
-	 */
-	executeCommand(projectRoot: string, args: any, childProcessOpts?: any, spawnFromEventOptions?: ISpawnFromEventOptions): Promise<ISpawnResult>;
 }
 
 interface ITestExecutionService {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -14,7 +14,6 @@ import { IOSProvisionService } from "./ios-provision-service";
 import { IOSEntitlementsService } from "./ios-entitlements-service";
 import { XCConfigService } from "./xcconfig-service";
 import * as mobileprovision from "ios-mobileprovision-finder";
-import { SpawnOptions } from "child_process";
 import { BUILD_XCCONFIG_FILE_NAME } from "../constants";
 
 interface INativeSourceCodeGroup {
@@ -124,10 +123,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		}
 
 		return true;
-	}
-
-	public async executeCommand(projectRoot: string, args: any, childProcessOpts?: SpawnOptions, spawnFromEventOptions?: ISpawnFromEventOptions): Promise<ISpawnResult> {
-		return { stderr: "", stdout: "", exitCode: 0 };
 	}
 
 	public getAppResourcesDestinationDirectoryPath(projectData: IProjectData): string {
@@ -1036,10 +1031,6 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 	}
 
 	public async checkIfPluginsNeedBuild(projectData: IProjectData): Promise<Array<any>> {
-		return [];
-	}
-
-	public getBuildOptions(configurationFilePath: string): Array<string> {
 		return [];
 	}
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -3,7 +3,6 @@
 import * as util from "util";
 import * as chai from "chai";
 import { EventEmitter } from "events";
-import { SpawnOptions } from "child_process";
 import * as path from "path";
 import * as constants from "./../lib/constants";
 import { Yok } from "./../lib/common/yok";
@@ -355,10 +354,6 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 		return Promise.resolve();
 	}
 
-	public async executeCommand(projectRoot: string, gradleArgs: string[], childProcessOpts?: SpawnOptions, spawnFromEventOptions?: ISpawnFromEventOptions): Promise<ISpawnResult> {
-		return { stderr: "", stdout: "", exitCode: 0 };
-	}
-
 	async buildProject(projectRoot: string): Promise<void> {
 		return Promise.resolve();
 	}
@@ -378,10 +373,6 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 
 	async preparePluginNativeCode(pluginData: IPluginData): Promise<void> {
 		return Promise.resolve();
-	}
-
-	getBuildOptions(configurationFilePath?: string): Array<string> {
-		return [];
 	}
 
 	async removePluginNativeCode(pluginData: IPluginData): Promise<void> { }


### PR DESCRIPTION
In case CLI executes any Gradle operation, it always prints `Gradle build...` message. Fix this by printing specific message for each operation, for example "Gradle clean..." when clean is executed.
Also make some methods private as they are used only in AndroidProjectService and they were incorrectly added to the IPlatformProjectService interface.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When CLI calls gradle clean (for example if you call `tns build android --bundle && tns build android`), `Gradle build...` is printed, while executing clean operation.

## What is the new behavior?
CLI prints correct information for the gradle task.