### PR TITLE
fix: after-createProject hook may not be executed

### DIFF
--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -90,7 +90,7 @@ export class ProjectService implements IProjectService {
 			throw err;
 		}
 
-		this.$hooksService.executeAfterHooks(Hooks.createProject, {
+		await this.$hooksService.executeAfterHooks(Hooks.createProject, {
 			hookArgs: projectCreationSettings
 		});
 


### PR DESCRIPTION
In some cases the `after-createProject` may not be executed as we have missed the `await` of the promise.
