### PR TITLE
feat: Improve rebuild of native plugins and node_modules checks

### DIFF
--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -60,7 +60,6 @@ export class PublishIOS implements ICommand {
 			const platformInfo: IPreparePlatformInfo = {
 				platform,
 				appFilesUpdaterOptions,
-				skipModulesNativeCheck: !this.$options.syncAllFiles,
 				platformTemplate: this.$options.platformTemplate,
 				projectData: this.$projectData,
 				config: this.$options,

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -17,7 +17,6 @@ export class BuildCommandBase {
 		const platformInfo: IPreparePlatformInfo = {
 			platform,
 			appFilesUpdaterOptions,
-			skipModulesNativeCheck: !this.$options.syncAllFiles,
 			platformTemplate: this.$options.platformTemplate,
 			projectData: this.$projectData,
 			config: this.$options,

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -14,7 +14,6 @@ export class PrepareCommand implements ICommand {
 		const platformInfo: IPreparePlatformInfo = {
 			platform: args[0],
 			appFilesUpdaterOptions,
-			skipModulesNativeCheck: !this.$options.syncAllFiles,
 			platformTemplate: this.$options.platformTemplate,
 			projectData: this.$projectData,
 			config: this.$options,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -217,3 +217,5 @@ export const PACKAGE_PLACEHOLDER_NAME = "__PACKAGE__";
 export class AddPlaformErrors {
 	public static InvalidFrameworkPathStringFormat = "Invalid frameworkPath: %s. Please ensure the specified frameworkPath exists.";
 }
+
+export const PLUGIN_BUILD_DATA_FILENAME = "plugin-data.json";

--- a/lib/definitions/files-hash-service.d.ts
+++ b/lib/definitions/files-hash-service.d.ts
@@ -1,4 +1,5 @@
 interface IFilesHashService {
 	generateHashes(files: string[]): Promise<IStringDictionary>;
 	getChanges(files: string[], oldHashes: IStringDictionary): Promise<IStringDictionary>;
+	hasChangesInShasums(oldHashes: IStringDictionary, newHashes: IStringDictionary): boolean;
 }

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -42,7 +42,7 @@ interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision, IT
 }
 
 interface ICheckForChangesOptions extends IPlatform, IProjectDataComposition {
-	projectChangesOptions: IProjectChangesOptions
+	projectChangesOptions: IProjectChangesOptions;
 }
 
 interface IProjectChangesService {

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -41,8 +41,12 @@ interface IProjectChangesOptions extends IAppFilesUpdaterOptions, IProvision, IT
 	nativePlatformStatus?: "1" | "2" | "3";
 }
 
+interface ICheckForChangesOptions extends IPlatform, IProjectDataComposition {
+	projectChangesOptions: IProjectChangesOptions
+}
+
 interface IProjectChangesService {
-	checkForChanges(platform: string, projectData: IProjectData, buildOptions: IProjectChangesOptions): Promise<IProjectChangesInfo>;
+	checkForChanges(checkForChangesOpts: ICheckForChangesOptions): Promise<IProjectChangesInfo>;
 	getPrepareInfo(platform: string, projectData: IProjectData): IPrepareInfo;
 	savePrepareInfo(platform: string, projectData: IProjectData): void;
 	getPrepareInfoFilePath(platform: string, projectData: IProjectData): string;

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { MANIFEST_FILE_NAME, INCLUDE_GRADLE_NAME, ASSETS_DIR, RESOURCES_DIR, TNS_ANDROID_RUNTIME_NAME, AndroidBuildDefaults } from "../constants";
+import { MANIFEST_FILE_NAME, INCLUDE_GRADLE_NAME, ASSETS_DIR, RESOURCES_DIR, TNS_ANDROID_RUNTIME_NAME, AndroidBuildDefaults, PLUGIN_BUILD_DATA_FILENAME } from "../constants";
 import { getShortPluginName, hook } from "../common/helpers";
 import { Builder, parseString } from "xml2js";
 import { ILogger } from "log4js";
@@ -25,7 +25,8 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		private $npm: INodePackageManager,
 		private $projectDataService: IProjectDataService,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
-		private $errors: IErrors) { }
+		private $errors: IErrors,
+		private $filesHashService: IFilesHashService) { }
 
 	private static MANIFEST_ROOT = {
 		$: {
@@ -172,21 +173,77 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		this.validateOptions(options);
 		const manifestFilePath = this.getManifest(options.platformsAndroidDirPath);
 		const androidSourceDirectories = this.getAndroidSourceDirectories(options.platformsAndroidDirPath);
-		const shouldBuildAar = !!manifestFilePath || androidSourceDirectories.length > 0;
+		const shortPluginName = getShortPluginName(options.pluginName);
+		const pluginTempDir = path.join(options.tempPluginDirPath, shortPluginName);
+		const pluginSourceFileHashesInfo = await this.getSourceFilesHashes(options.platformsAndroidDirPath, shortPluginName);
+
+		const shouldBuildAar = await this.shouldBuildAar({
+			manifestFilePath,
+			androidSourceDirectories,
+			pluginTempDir,
+			pluginSourceDir: options.platformsAndroidDirPath,
+			shortPluginName,
+			fileHashesInfo: pluginSourceFileHashesInfo
+		});
 
 		if (shouldBuildAar) {
-			const shortPluginName = getShortPluginName(options.pluginName);
-			const pluginTempDir = path.join(options.tempPluginDirPath, shortPluginName);
-			const pluginTempMainSrcDir = path.join(pluginTempDir, "src", "main");
+			// In case plugin was already built in the current process, we need to clean the old sources as they may break the new build.
+			this.$fs.deleteDirectory(pluginTempDir);
+			this.$fs.ensureDirectoryExists(pluginTempDir);
 
+			const pluginTempMainSrcDir = path.join(pluginTempDir, "src", "main");
 			await this.updateManifest(manifestFilePath, pluginTempMainSrcDir, shortPluginName);
 			this.copySourceSetDirectories(androidSourceDirectories, pluginTempMainSrcDir);
 			await this.setupGradle(pluginTempDir, options.platformsAndroidDirPath, options.projectDir);
 			await this.buildPlugin({ pluginDir: pluginTempDir, pluginName: options.pluginName });
 			this.copyAar(shortPluginName, pluginTempDir, options.aarOutputDir);
+			this.writePluginHashInfo(pluginSourceFileHashesInfo, pluginTempDir);
 		}
 
 		return shouldBuildAar;
+	}
+
+	private getSourceFilesHashes(pluginTempPlatformsAndroidDir: string, shortPluginName: string): Promise<IStringDictionary> {
+		const pathToAar = path.join(pluginTempPlatformsAndroidDir, `${shortPluginName}.aar`);
+		const pluginNativeDataFiles = this.$fs.enumerateFilesInDirectorySync(pluginTempPlatformsAndroidDir, (file: string, stat: IFsStats) => {
+			return file !== pathToAar;
+		});
+
+		return this.$filesHashService.generateHashes(pluginNativeDataFiles);
+	}
+
+	private async writePluginHashInfo(fileHashesInfo: IStringDictionary, pluginTempDir: string): Promise<void> {
+		const buildDataFile = this.getPathToPluginBuildDataFile(pluginTempDir);
+		this.$fs.writeJson(buildDataFile, fileHashesInfo);
+	}
+
+	private async shouldBuildAar(opts: {
+		manifestFilePath: string,
+		androidSourceDirectories: string[],
+		pluginTempDir: string,
+		pluginSourceDir: string,
+		shortPluginName: string,
+		fileHashesInfo: IStringDictionary
+	}): Promise<boolean> {
+
+		let shouldBuildAar = !!opts.manifestFilePath || opts.androidSourceDirectories.length > 0;
+
+		if (shouldBuildAar &&
+			this.$fs.exists(opts.pluginTempDir) &&
+			this.$fs.exists(path.join(opts.pluginSourceDir, `${opts.shortPluginName}.aar`))) {
+
+			const buildDataFile = this.getPathToPluginBuildDataFile(opts.pluginTempDir);
+			if (this.$fs.exists(buildDataFile)) {
+				const oldHashes = this.$fs.readJson(buildDataFile);
+				shouldBuildAar = this.$filesHashService.hasChangesInShasums(oldHashes, opts.fileHashesInfo);
+			}
+		}
+
+		return shouldBuildAar;
+	}
+
+	private getPathToPluginBuildDataFile(pluginDir: string): string {
+		return path.join(pluginDir, PLUGIN_BUILD_DATA_FILENAME);
 	}
 
 	private async updateManifest(manifestFilePath: string, pluginTempMainSrcDir: string, shortPluginName: string): Promise<void> {
@@ -256,7 +313,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		return runtimeGradleVersions || {};
 	}
 
-	private getGradleVersions(packageData: { gradle: { version: string, android: string }}): IRuntimeGradleVersions {
+	private getGradleVersions(packageData: { gradle: { version: string, android: string } }): IRuntimeGradleVersions {
 		const packageJsonGradle = packageData && packageData.gradle;
 		let runtimeVersions: IRuntimeGradleVersions = null;
 		if (packageJsonGradle && (packageJsonGradle.version || packageJsonGradle.android)) {

--- a/lib/services/files-hash-service.ts
+++ b/lib/services/files-hash-service.ts
@@ -26,6 +26,14 @@ export class FilesHashService implements IFilesHashService {
 
 	public async getChanges(files: string[], oldHashes: IStringDictionary): Promise<IStringDictionary> {
 		const newHashes = await this.generateHashes(files);
+		return this.getChangesInShasums(oldHashes, newHashes);
+	}
+
+	public hasChangesInShasums(oldHashes: IStringDictionary, newHashes: IStringDictionary): boolean {
+		return !!_.keys(this.getChangesInShasums(oldHashes, newHashes)).length;
+	}
+
+	private getChangesInShasums(oldHashes: IStringDictionary, newHashes: IStringDictionary): IStringDictionary {
 		return _.omitBy(newHashes, (hash: string, pathToFile: string) => !!_.find(oldHashes, (oldHash: string, oldPath: string) => pathToFile === oldPath && hash === oldHash));
 	}
 }

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -469,7 +469,6 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					deviceBuildInfoDescriptor,
 					liveSyncData,
 					settings,
-					skipModulesNativeCheck: !liveSyncData.watchAllFiles,
 					bundle: liveSyncData.bundle,
 					release: liveSyncData.release,
 					env: liveSyncData.env

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -269,13 +269,17 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 		const bundle = appFilesUpdaterOptions.bundle;
 		const nativePlatformStatus = (nativePrepare && nativePrepare.skipNativePrepare) ? constants.NativePlatformStatus.requiresPlatformAdd : constants.NativePlatformStatus.requiresPrepare;
-		const changesInfo = await this.$projectChangesService.checkForChanges(platform, projectData, {
-			bundle,
-			release: appFilesUpdaterOptions.release,
-			provision: config.provision,
-			teamId: config.teamId,
-			nativePlatformStatus,
-			skipModulesNativeCheck: skipNativeCheckOptions.skipModulesNativeCheck
+		const changesInfo = await this.$projectChangesService.checkForChanges({
+			platform,
+			projectData,
+			projectChangesOptions: {
+				bundle,
+				release: appFilesUpdaterOptions.release,
+				provision: config.provision,
+				teamId: config.teamId,
+				nativePlatformStatus,
+				skipModulesNativeCheck: skipNativeCheckOptions.skipModulesNativeCheck
+			}
 		});
 
 		this.$logger.trace("Changes info in prepare platform:", changesInfo);

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -59,7 +59,6 @@ class TestExecutionService implements ITestExecutionService {
 					const preparePlatformInfo: IPreparePlatformInfo = {
 						platform,
 						appFilesUpdaterOptions,
-						skipModulesNativeCheck: !this.$options.syncAllFiles,
 						platformTemplate: this.$options.platformTemplate,
 						projectData,
 						config: this.$options,
@@ -187,7 +186,6 @@ class TestExecutionService implements ITestExecutionService {
 				const preparePlatformInfo: IPreparePlatformInfo = {
 					platform,
 					appFilesUpdaterOptions,
-					skipModulesNativeCheck: !this.$options.syncAllFiles,
 					platformTemplate: this.$options.platformTemplate,
 					projectData,
 					config: this.$options,

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -6,6 +6,7 @@ import { PlatformsData } from "../lib/platforms-data";
 import { ProjectChangesService } from "../lib/services/project-changes-service";
 import * as Constants from "../lib/constants";
 import { FileSystem } from "../lib/common/file-system";
+import { HooksServiceStub } from "./stubs";
 
 // start tracking temporary folders/files
 temp.track();
@@ -36,6 +37,7 @@ class ProjectChangesServiceTest extends BaseServiceTest {
 		this.injector.register("logger", {
 			warn: () => ({})
 		});
+		this.injector.register("hooksService", HooksServiceStub);
 
 		const fs = this.injector.resolve<IFileSystem>("fs");
 		fs.writeJson(path.join(this.projectDir, Constants.PACKAGE_JSON_FILE_NAME), {
@@ -149,9 +151,28 @@ describe("Project Changes Service Tests", () => {
 
 	describe("Accumulates Changes From Project Services", () => {
 		it("accumulates changes from the project service", async () => {
-			const iOSChanges = await serviceTest.projectChangesService.checkForChanges("ios", serviceTest.projectData, { bundle: false, release: false, provision: undefined, teamId: undefined });
+			const iOSChanges = await serviceTest.projectChangesService.checkForChanges({
+				platform: "ios",
+				projectData: serviceTest.projectData,
+				projectChangesOptions: {
+					bundle: false,
+					release: false,
+					provision: undefined,
+					teamId: undefined
+				}
+			});
 			assert.isTrue(!!iOSChanges.signingChanged, "iOS signingChanged expected to be true");
-			const androidChanges = await serviceTest.projectChangesService.checkForChanges("android", serviceTest.projectData, { bundle: false, release: false, provision: undefined, teamId: undefined });
+
+			const androidChanges = await serviceTest.projectChangesService.checkForChanges({
+				platform: "android",
+				projectData: serviceTest.projectData,
+				projectChangesOptions: {
+					bundle: false,
+					release: false,
+					provision: undefined,
+					teamId: undefined
+				}
+			});
 			assert.isFalse(!!androidChanges.signingChanged, "Android signingChanged expected to be false");
 		});
 	});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -651,7 +651,7 @@ export class ChildProcessStub {
 }
 
 export class ProjectChangesService implements IProjectChangesService {
-	public async checkForChanges(platform: string): Promise<IProjectChangesInfo> {
+	public async checkForChanges(checkForChangesOpts: ICheckForChangesOptions): Promise<IProjectChangesInfo> {
 		return <IProjectChangesInfo>{};
 	}
 


### PR DESCRIPTION
### fix: Changes in node_modules are always skipped
Currently all changes in `node_modules` are skipped as we do not check for changes in case `--syncAllFiles` is not passed.
In fact the meaning of this option is for LiveSync operations and by default CLI does not watch for changes in node_modules. However, the separate commands like prepare, build, test and even the initial LiveSync must check the node_modules and prepare the correct files.
In latest versions (4.1.x) we were always checking all `node_modules` even during change of a single file during LiveSync. After that we've applied a change in the current master branch to skip node_modules check in case specific option is passed to the projectChangesService. The problem with latest approach is that we've missed this option is always passed based on syncAllFiles.
This led to the problem that once you have node_modules setup, CLI from master branch never checks for changes in these files and does not move them to platforms dir.

With the current changes, node_modules will be checked on all commands. Once LiveSync starts, all consecutive changes in project files will not check node_modules unless `syncAllFiles` option is passed to CLI.

### feat: Rebuild plugins for Android only when necessary 
In case CLI builds `.aar` file for the Android part of a plugin during project preparation, consecutive prepares should not build the `.aar` file. Add logic to keep the hashes of the files that have been used for building the plugin and persist them in the `<project dir>/platforms/tempPlugin/<plugin-name>/plugin-data.json`.
Before building a new `.aar` file, CLI will check if the mentioned file exists and compare its content with the shasums of the current source files of the plugin. This way we ensure the `.aar` will be built only when the sources are changed.

### feat: Add hook for checkForChanges

In case a plugin needs to apply some modifications over its own source, based on the project files, currently it cannot do it. The earliest possible hooks are before-shouldPrepare and beforePrepare, but they are both run after CLI had check the project for changes. In case the plugin uses any of these hooks and apply changes to its source code, CLI will not move the changes to platforms dir of the project as it will not recheck the project state.
In order to resolve this issue, add a hook to checkForChanges method. This way a plugin can apply the changes in before-checkForChanges hook and CLI will detect them correctly.
Change the method parameters to be a single object, which will allow easier modifications in the future without breaking the plugins that are already using the hook.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
### CLI 4.1.x:
Whenever CLI checks for changes, it always lists all node_modules and checks for changes there. This happens on all commands and on every change during LiveSync. In case a change in `node_modules` is detected, CLI checks if it is in `platforms/android` directory of the plugin. In case yes, CLI rebuilds all plugins which do not have their own `.aar`. CLI rebuilds the `.aar` files even for plugins, for which it has already built `.aar` and there's no change in their source code that requires rebuild of this `.aar`.
### master branch
CLI skips all checks for changes in `node_modules`. The only chance to get your changes applied is to pass `--syncAllFiles`. Whenever a change in `platforms/android` dir of any plugin is detected and `--syncAllFiles` is passed, CLI will rebuild all `.aar` files.

## What is the new behavior?
CLI checks `node_modules` for changes during all commands. During LiveSync, CLI will check `node_modules` for changes only during the initial sync (i.e. the first operation of the started command). When a change is detected, CLI will not check `node_modules` for changes unless `--syncAllFiles` is passed.
When a change in any `platforms/android` directory of a plugin is detected, CLI will check all plugins and their source files. In case the source files that are used for building the `.aar` have not been changed since last build, CLI will not rebuild the `.aar`.

Fixes/Implements/Closes #[Issue Number].
