### PR TITLE
Increase the default timeout for debug command from 5 to 10 seconds

### DIFF
--- a/docs/man_pages/project/testing/debug-ios.md
+++ b/docs/man_pages/project/testing/debug-ios.md
@@ -27,7 +27,7 @@ While debugging, prints the output from the application in the console and watch
 * `--debug-brk` - Prepares, builds and deploys the application package on a device or in a simulator, runs the app, launches the developer tools of your Safari browser and stops at the first code statement.
 * `--start` - Attaches the debug tools to a deployed and running app and launches the developer tools of your Safari browser.
 * `--no-client` - If set, the NativeScript CLI attaches the debug tools but does not launch the developer tools in Safari. Could be used on already started Safari Web Inspector.
-* `--timeout` - Sets the number of seconds that NativeScript CLI will wait for the simulator/device to boot. If not set, the default timeout is 90 seconds.
+* `--timeout` - Sets the number of seconds that NativeScript CLI will wait to find the inspector socket port from device's logs. If not set, the default timeout is 10 seconds.
 * `--no-watch` - If set, changes in your code will not be reflected during the execution of this command.
 * `--clean` - If set, forces rebuilding the native application.
 * `--chrome` - Deprecated - default behavior uses '--chrome' implicitly. Allows debugging in Chrome Developer Tools. If set, Safari Web Inspector is not started and debugging is attached to Chrome Developer Tools.

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -159,6 +159,10 @@ export class DebugIOSCommand implements ICommand {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.iOS} can not be built on this OS`);
 		}
 
+		if (this.$options.timeout && !parseInt(this.$options.timeout, 10)) {
+			this.$errors.fail(`Timeout option specifies the seconds NativeScript CLI will wait to find the inspector socket port from device's logs. Must be a number.`);
+		}
+
 		return await this.debugPlatformCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.iOS);
 	}
 

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -159,11 +159,29 @@ export class DebugIOSCommand implements ICommand {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.iOS} can not be built on this OS`);
 		}
 
-		if (this.$options.timeout && !parseInt(this.$options.timeout, 10)) {
+		const isValidTimeoutOption = this.isValidTimeoutOption();
+		if (!isValidTimeoutOption) {
 			this.$errors.fail(`Timeout option specifies the seconds NativeScript CLI will wait to find the inspector socket port from device's logs. Must be a number.`);
 		}
 
 		return await this.debugPlatformCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.iOS);
+	}
+
+	private isValidTimeoutOption() {
+		if (!this.$options.timeout) {
+			return true;
+		}
+
+		const timeout = parseInt(this.$options.timeout, 10);
+		if (timeout === 0) {
+			return true;
+		}
+
+		if (!timeout) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public platform = this.$devicePlatformsConstants.iOS;

--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -86,6 +86,11 @@ interface IDebugOptions {
 	 * Defines if should print all availableDevices
 	 */
 	availableDevices?: boolean;
+	/**
+	 * Defines the timeout in seconds {N} CLI will wait to find the inspector socket port from device's logs.
+	 * If not provided, defaults to 10 seconds.
+	 */
+	timeout?: string;
 }
 
 /**

--- a/lib/definitions/ios-debugger-port-service.d.ts
+++ b/lib/definitions/ios-debugger-port-service.d.ts
@@ -21,10 +21,11 @@ interface IIOSDebuggerPortService {
 	/**
 	 * Attaches on DEBUGGER_PORT_FOUND event and STARTING_IOS_APPLICATION events
 	 * In case when DEBUGGER_PORT_FOUND event is emitted, stores the port and clears the timeout if such.
-	 * In case when STARTING_IOS_APPLICATION event is emitted, sets the port to null and add timeout for 5000 miliseconds which checks if port is null and prints a warning.
+	 * In case when STARTING_IOS_APPLICATION event is emitted, sets the port to null and add timeout for 10000 miliseconds which checks if port is null and prints a warning.
 	 * @param {Mobile.IDevice} device - Describes the device which logs should be parsed.
 	 * @param {IProjectDir} data - Object that has a projectDir property.
+	 * @param {IDebugOptions} debugOptions
 	 * @returns {Promise<void>}
 	 */
-	attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir): Promise<void>;
+	attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir, debugOptions: IDebugOptions): Promise<void>;
 }

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -159,6 +159,12 @@ interface ILiveSyncInfo extends IProjectDir, IEnvOptions, IBundle, IRelease, IOp
 	 * Forces a build before the initial livesync.
 	 */
 	clean?: boolean;
+
+	/**
+	 * Defines the timeout in seconds {N} CLI will wait to find the inspector socket port from device's logs.
+	 * If not provided, defaults to 10seconds.
+	 */
+	timeout: string;
 }
 
 interface ILatestAppPackageInstalledSettings extends IDictionary<IDictionary<boolean>> { /* empty */ }
@@ -337,7 +343,7 @@ interface IPlatformLiveSyncService {
 	fullSync(syncInfo: IFullSyncInfo): Promise<ILiveSyncResultInfo>;
 	liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<ILiveSyncResultInfo>;
 	refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void>;
-	prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo): Promise<void>;
+	prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo, debugOptions: IDebugOptions): Promise<void>;
 }
 
 interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase {

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -109,7 +109,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			clean: this.$options.clean,
 			bundle: !!this.$options.bundle,
 			release: this.$options.release,
-			env: this.$options.env
+			env: this.$options.env,
+			timeout: this.$options.timeout
 		};
 
 		await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -63,7 +63,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 			await this.device.openDeviceLogStream();
 		}
 
-		await this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(this.device, debugData);
+		await this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(this.device, debugData, debugOptions);
 
 		if (debugOptions.emulator) {
 			if (debugOptions.start) {

--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -6,6 +6,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 	private mapDebuggerPortData: IDictionary<IIOSDebuggerPortStoredData> = {};
 	private static DEFAULT_PORT = 18181;
 	private static MIN_REQUIRED_FRAMEWORK_VERSION = "4.0.1";
+	private static DEFAULT_TIMEOUT_IN_SECONDS = 10;
 
 	constructor(private $iOSLogParserService: IIOSLogParserService,
 		private $iOSProjectService: IPlatformProjectService,
@@ -36,14 +37,14 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 		});
 	}
 
-	public async attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir): Promise<void> {
+	public async attachToDebuggerPortFoundEvent(device: Mobile.IDevice, data: IProjectDir, debugOptions: IDebugOptions): Promise<void> {
 		const projectData = this.$projectDataService.getProjectData(data && data.projectDir);
 		if (!this.canStartLookingForDebuggerPort(projectData)) {
 			return;
 		}
 
 		this.attachToDebuggerPortFoundEventCore();
-		this.attachToAttachRequestEvent(device);
+		this.attachToAttachRequestEvent(device, debugOptions);
 
 		await this.$iOSLogParserService.startParsingLog(device, projectData);
 	}
@@ -64,7 +65,9 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 	}
 
 	@cache()
-	private attachToAttachRequestEvent(device: Mobile.IDevice): void {
+	private attachToAttachRequestEvent(device: Mobile.IDevice, debugOptions: IDebugOptions): void {
+		const timeout = this.getTimeout(debugOptions);
+
 		this.$iOSNotification.on(ATTACH_REQUEST_EVENT_NAME, (data: IIOSDebuggerPortData) => {
 			this.$logger.trace(ATTACH_REQUEST_EVENT_NAME, data);
 			const timer = setTimeout(() => {
@@ -72,7 +75,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 				if (!this.getPortByKey(`${data.deviceId}${data.appId}`)) {
 					this.$logger.warn(`NativeScript debugger was not able to get inspector socket port on device ${data.deviceId} for application ${data.appId}.`);
 				}
-			}, 5000);
+			}, timeout * 1000);
 
 			this.setData(data, { port: null, timer });
 		});
@@ -102,6 +105,15 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 		if (storedData && storedData.timer) {
 			clearTimeout(storedData.timer);
 		}
+	}
+
+	private getTimeout(debugOptions: IDebugOptions): number {
+		let timeout = parseInt(debugOptions && debugOptions.timeout, 10);
+		if (!timeout) {
+			timeout = IOSDebuggerPortService.DEFAULT_TIMEOUT_IN_SECONDS;
+		}
+
+		return timeout;
 	}
 }
 $injector.register("iOSDebuggerPortService", IOSDebuggerPortService);

--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -109,6 +109,9 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 
 	private getTimeout(debugOptions: IDebugOptions): number {
 		let timeout = parseInt(debugOptions && debugOptions.timeout, 10);
+		if (timeout === 0) {
+			timeout = Number.MAX_SAFE_INTEGER;
+		}
 		if (!timeout) {
 			timeout = IOSDebuggerPortService.DEFAULT_TIMEOUT_IN_SECONDS;
 		}

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -66,9 +66,9 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		}
 	}
 
-	public async prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo): Promise<void> {
+	public async prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo, debugOptions: IDebugOptions): Promise<void> {
 		if (!liveSyncInfo.skipWatcher) {
-			return this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, data);
+			return this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, data, debugOptions);
 		}
 	}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -459,7 +459,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				const platformLiveSyncService = this.getLiveSyncService(platform);
 				const deviceBuildInfoDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
 
-				await platformLiveSyncService.prepareForLiveSync(device, projectData, liveSyncData);
+				await platformLiveSyncService.prepareForLiveSync(device, projectData, liveSyncData, deviceBuildInfoDescriptor.debugOptions);
 
 				await this.ensureLatestAppPackageIsInstalledOnDevice({
 					device,

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -125,7 +125,8 @@ class TestExecutionService implements ITestExecutionService {
 						watchAllFiles: this.$options.syncAllFiles,
 						bundle: !!this.$options.bundle,
 						release: this.$options.release,
-						env: this.$options.env
+						env: this.$options.env,
+						timeout: this.$options.timeout
 					};
 
 					await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);
@@ -253,7 +254,8 @@ class TestExecutionService implements ITestExecutionService {
 						watchAllFiles: this.$options.syncAllFiles,
 						bundle: !!this.$options.bundle,
 						release: this.$options.release,
-						env: this.$options.env
+						env: this.$options.env,
+						timeout: this.$options.timeout
 					};
 
 					await this.$liveSyncService.liveSync(deviceDescriptors, liveSyncInfo);

--- a/test/services/ios-debugger-port-service.ts
+++ b/test/services/ios-debugger-port-service.ts
@@ -148,7 +148,7 @@ describe("iOSDebuggerPortService", () => {
 
 		_.each(testCases, testCase => {
 			it(testCase.name, async () => {
-				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj);
+				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj, <any>{});
 				if (testCase.emitStartingIOSApplicationEvent) {
 					emitStartingIOSApplicationEvent();
 				}
@@ -162,7 +162,7 @@ describe("iOSDebuggerPortService", () => {
 				assert.deepEqual(port, testCase.emittedPort);
 			});
 			it(`${testCase.name} for multiline debugger port message.`, async () => {
-				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj);
+				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent(device, mockProjectDirObj, <any>{});
 				if (testCase.emitStartingIOSApplicationEvent) {
 					emitStartingIOSApplicationEvent();
 				}


### PR DESCRIPTION
Add support for --timeout option that can be passed to debug command.
Fix help of debug command.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The default timeout for `debug ios` command is 5 seconds.

## What is the new behavior?
The default timeout for `debug ios` command is 10 seconds. Also adds support for `--timeout` option.
