### PR TITLE
fix: handle invalid runtime versions and Android P livesync

### DIFF
--- a/lib/services/pacote-service.ts
+++ b/lib/services/pacote-service.ts
@@ -22,11 +22,16 @@ export class PacoteService implements IPacoteService {
 			_.extend(extractOptions, options);
 		}
 
-		const source = pacote.tarball.stream(packageName, { cache: await this.$npm.getCachePath() });
-		const destination = tar.x(extractOptions);
-		source.pipe(destination);
-
+		const cache = await this.$npm.getCachePath();
 		return new Promise<void>((resolve, reject) => {
+			const source = pacote.tarball.stream(packageName, { cache });
+			source.on("error", (err: Error) => {
+				reject(err);
+			});
+
+			const destination = tar.x(extractOptions);
+			source.pipe(destination);
+
 			destination.on("error", (err: Error) => reject(err));
 			destination.on("finish", () => resolve());
 		});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
The live sync is not working on Android P.
There is an infinite loader when a nonexisting runtime is specified in the package.json.

## What is the new behavior?
The live sync is working on Android P.
An error is shown when a nonexisting runtime is specified in the package.json.

Related to issue #3602 
