### PR TITLE
Do not show "Skipping node_modules folder!..." message from Sidekick

### DIFF
--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -11,7 +11,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 		private $analyticsService: IAnalyticsService,
 		private $bundleValidatorHelper: IBundleValidatorHelper,
 		private $errors: IErrors,
-		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider) {
+		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider,
+		private $logger: ILogger) {
 		this.$analyticsService.setShouldDispose(this.$options.justlaunch || !this.$options.watch);
 	}
 
@@ -21,6 +22,10 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 	}
 
 	public async executeCommandLiveSync(platform?: string, additionalOptions?: ILiveSyncCommandHelperAdditionalOptions) {
+		if (!this.$options.syncAllFiles) {
+			this.$logger.info("Skipping node_modules folder! Use the syncAllFiles option to sync files from this folder.");
+		}
+
 		const emulator = this.$options.emulator;
 		await this.$devicesService.initialize({
 			deviceId: this.$options.device,

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -35,7 +35,6 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		this.$fs.copyFile(path.join(path.dirname(projectFilesPath), `${APP_FOLDER_NAME}/*`), tempApp);
 
 		if (!syncInfo.syncAllFiles) {
-			this.$logger.info("Skipping node_modules folder! Use the syncAllFiles option to sync files from this folder.");
 			this.$fs.deleteDirectory(path.join(tempApp, TNS_MODULES_FOLDER_NAME));
 		}
 


### PR DESCRIPTION
Move the message from `ios-livesync-service` to `livesync-command-helper`.
This way the message will not be displayed from sidekick.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The message `Skipping node modules folder!...` is displayed from sidekick

## What is the new behavior?
The message `Skipping node modules folder!...` will not be displayed from sidekick

