### PR TITLE
Skip local prepare when executing cloud build from sidekick and no project's file is changed

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -99,8 +99,10 @@ export class ProjectChangesService implements IProjectChangesService {
 			}
 		}
 
-		const projectService = platformData.platformProjectService;
-		await projectService.checkForChanges(this._changesInfo, projectChangesOptions, projectData);
+		if (checkForChangesOpts.projectChangesOptions.nativePlatformStatus !== NativePlatformStatus.requiresPlatformAdd) {
+			const projectService = platformData.platformProjectService;
+			await projectService.checkForChanges(this._changesInfo, projectChangesOptions, projectData);
+		}
 
 		if (projectChangesOptions.bundle !== this._prepareInfo.bundle || projectChangesOptions.release !== this._prepareInfo.release) {
 			this._changesInfo.appFilesChanged = true;


### PR DESCRIPTION
Platform prepare is never skipped when executing cloud build for iOS from sidekick. The reason for this is the `signingChanged` property from `changesInfo` is always true and thus `shouldPrepare` is always true. `signingChanged` property is set to true inside `ios-project-service` because `pbxproject` file  does not exist. Actually locally from sidekick `pbxproject` file is never created. So the file never exists. This PR speeds the the cloud build for iOS with around 2-3 sec.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Local prepare is not skipped when no project's file is changed.

## What is the new behavior?
Local prepare is skipped when no project's file is changed.


