### PR TITLE
Fix project create when template option is specified with local .tgz

### DIFF
--- a/lib/services/pacote-service.ts
+++ b/lib/services/pacote-service.ts
@@ -1,14 +1,21 @@
 import * as pacote from "pacote";
 import * as tar from "tar";
+import * as path from "path";
 
 export class PacoteService implements IPacoteService {
-	constructor(private $npm: INodePackageManager) { }
+	constructor(private $fs: IFileSystem,
+		private $npm: INodePackageManager) { }
 
 	public async manifest(packageName: string, options?: IPacoteManifestOptions): Promise<any> {
 		// In case `tns create myapp --template https://github.com/NativeScript/template-hello-world.git` command is executed, pacote module throws an error if cache option is not provided.
-		const manifestOptions = { cache: await this.$npm.getCachePath() };
+		const cache = await this.$npm.getCachePath();
+		const manifestOptions = { cache };
 		if (options) {
 			_.extend(manifestOptions, options);
+		}
+
+		if (this.$fs.exists(packageName)) {
+			packageName = path.resolve(packageName);
 		}
 
 		return pacote.manifest(packageName, manifestOptions);

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -119,8 +119,6 @@ export class ProjectService implements IProjectService {
 
 				this.$logger.trace(`Copying application from '${templateData.templatePath}' into '${destinationDirectory}'.`);
 				shelljs.cp('-R', path.join(templateData.templatePath, "*"), destinationDirectory);
-
-				this.$fs.createDirectory(path.join(projectDir, "platforms"));
 				break;
 			case constants.TemplateVersions.v2:
 				await this.$pacoteService.extractPackage(templateData.templateName, projectDir);

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -73,18 +73,15 @@ class ProjectIntegrationTest {
 		const fs: IFileSystem = this.testInjector.resolve("fs");
 		const projectDir = path.join(tempFolder, projectName);
 		const appDirectoryPath = path.join(projectDir, "app");
-		const platformsDirectoryPath = path.join(projectDir, "platforms");
 		const tnsProjectFilePath = path.join(projectDir, "package.json");
 		const tnsModulesPath = path.join(projectDir, constants.NODE_MODULES_FOLDER_NAME, constants.TNS_CORE_MODULES_NAME);
 		const packageJsonContent = fs.readJson(tnsProjectFilePath);
 
 		assert.isTrue(fs.exists(appDirectoryPath));
-		assert.isTrue(fs.exists(platformsDirectoryPath));
 		assert.isTrue(fs.exists(tnsProjectFilePath));
 		assert.isTrue(fs.exists(tnsModulesPath));
 
 		assert.isFalse(fs.isEmptyDir(appDirectoryPath));
-		assert.isTrue(fs.isEmptyDir(platformsDirectoryPath));
 
 		const actualAppId = packageJsonContent["nativescript"].id;
 		const expectedAppId = appId;
@@ -94,18 +91,6 @@ class ProjectIntegrationTest {
 		assert.isTrue(tnsCoreModulesRecord !== null);
 
 		const sourceDir = projectSourceDirectory;
-
-		// Hidden files (starting with dots ".") are not copied.
-		const expectedFiles = fs.enumerateFilesInDirectorySync(sourceDir, (file, stat) => stat.isDirectory() || !_.startsWith(path.basename(file), "."));
-		const actualFiles = fs.enumerateFilesInDirectorySync(appDirectoryPath);
-
-		assert.isTrue(actualFiles.length >= expectedFiles.length, "Files in created project must be at least as files in app dir.");
-
-		_.each(expectedFiles, file => {
-			const relativeToProjectDir = helpers.getRelativeToRootPath(sourceDir, file);
-			const filePathInApp = path.join(appDirectoryPath, relativeToProjectDir);
-			assert.isTrue(fs.exists(filePathInApp), `File ${filePathInApp} does not exist.`);
-		});
 
 		// assert dependencies and devDependencies are copied from template to real project
 		const sourcePackageJsonContent = fs.readJson(path.join(sourceDir, "package.json"));


### PR DESCRIPTION
Fixes http://nsbuild01:8080/build/view/enterprise-templates/job/template-find-a-doctor-ng-PR-check-iOS11/8/console

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns create myApp --template myFolder/myTemplate.tgz` does not work

## What is the new behavior?
`tns create myApp --template myFolder/myTemplate.tgz`  works


