### PR TITLE
fix: Skip preparation of plugins native files in case they are not changed

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -219,3 +219,4 @@ export class AddPlaformErrors {
 }
 
 export const PLUGIN_BUILD_DATA_FILENAME = "plugin-data.json";
+export const PLUGINS_BUILD_DATA_FILENAME = ".ns-plugins-build-data.json";

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -126,6 +126,10 @@ function createTestInjector(projectPath: string, projectName: string, xcode?: IX
 		on: () => ({})
 	});
 	testInjector.register("emulatorHelper", {});
+	testInjector.register("filesHashService", {
+		hasChangesInShasums: (oldPluginNativeHashes: IStringDictionary, currentPluginNativeHashes: IStringDictionary) => true,
+		generateHashes: async (files: string[]): Promise<IStringDictionary> => ({})
+	});
 
 	return testInjector;
 }

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -6,7 +6,7 @@ import { PlatformsData } from "../lib/platforms-data";
 import { ProjectChangesService } from "../lib/services/project-changes-service";
 import * as Constants from "../lib/constants";
 import { FileSystem } from "../lib/common/file-system";
-import { HooksServiceStub } from "./stubs";
+import { HooksServiceStub, LoggerStub } from "./stubs";
 
 // start tracking temporary folders/files
 temp.track();
@@ -34,9 +34,7 @@ class ProjectChangesServiceTest extends BaseServiceTest {
 		this.injector.register("filesHashService", {
 			generateHashes: () => Promise.resolve({})
 		});
-		this.injector.register("logger", {
-			warn: () => ({})
-		});
+		this.injector.register("logger", LoggerStub);
 		this.injector.register("hooksService", HooksServiceStub);
 
 		const fs = this.injector.resolve<IFileSystem>("fs");


### PR DESCRIPTION
Skip the preparation of plugins' native files in case there's no change of the files since last operation when the files have been prepared.
Do this by using hash sums of files in each plugin's `platforms/<platform>` dir in case such exists. This way, in case you apply a change outside of the `<plugin dir>/platforms/<platform>` dir, the plugin's native files will not be prepared again. This way application will not be rebuilt as there's no need to do this.

### chore: Add logging in projectChangesService
Add logging in projectChangesService's checkForChanges method in order to know which files are changed. This will help us to understand why prepare is triggered.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Whenever a change in `node_modules` is detected, CLI prepares the native resources. For example this leads to regeneration of Podfile whenever a change in `.js` or even `.css` inside `node_modules` is detected.

## What is the new behavior?
CLI persists shasums for each plugin's native part. In case the plugin's native part is not changed, CLI will not prepare the native resources of the plugin itself.

Partial fix for #3549 
