### PR TITLE
Update the Gradle script to put JCenter at bottom of search list.

### DIFF
--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -14,13 +14,13 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         mavenLocal()
         mavenCentral()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
     }
 }
 


### PR DESCRIPTION

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. 
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Using certain plugins that request newer versions of Google Support will fail out during gradle building of the plugin because apparently jcenter being first quits out after that search.  Which then causes the application to fail to build

## What is the new behavior?
Those plugins will now build correctly, letting the application then build properly.

Fixes/Implements/Closes 
#1081 & #3751 

