### PR TITLE
fix: do not use adb push directory on Android 9 or later as its throwing an exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "proxy-lib": "0.4.0",
     "qr-image": "3.2.0",
     "request": "2.85.0",
-    "semver": "5.3.0",
+    "semver": "5.5.0",
     "shelljs": "0.7.6",
     "simple-plist": "0.2.1",
     "source-map": "0.5.6",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
If you are using an older version of the Android Runtime (4.1.2 or lower), adb push dir is throwing an exception during the initial sync on Android P.

## What is the new behavior?
If you are using an older version of the Android Runtime (4.1.2 or lower), we will transfer the project dir file by file during the initial sync on Android P. In this way it will be slower but stable for users who do not want to update their Android Runtime to the latest version.

related to issue #3602

