### PR TITLE
Fix android livesync with sockets

### DIFF
--- a/lib/definitions/livesync-global.d.ts
+++ b/lib/definitions/livesync-global.d.ts
@@ -1,7 +1,7 @@
-import * as stream from "stream";
+import { Socket } from "net";
 
 declare global {
-	interface IDuplexSocket extends stream.Duplex {
+	interface INetSocket extends Socket {
 		uid?: string;
 	}
 }

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -394,7 +394,7 @@ interface IAndroidNativeScriptDeviceLiveSyncService extends INativeScriptDeviceL
 	 * @param  {ILiveSyncResultInfo} liveSyncInfo Describes the LiveSync operation - for which project directory is the operation and other settings.
 	 * @return {Promise<IAndroidLiveSyncResultInfo>}
 	 */
-	finalizeSync(liveSyncInfo: ILiveSyncResultInfo): Promise<IAndroidLiveSyncResultInfo>;
+	finalizeSync(liveSyncInfo: ILiveSyncResultInfo, projectData: IProjectData): Promise<IAndroidLivesyncSyncOperationResult>;
 }
 
 interface IAndroidLivesyncTool {

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -332,6 +332,8 @@ interface ILiveSyncResultInfo {
 	useLiveEdit?: boolean;
 }
 
+interface IAndroidLiveSyncResultInfo extends ILiveSyncResultInfo, IAndroidLivesyncSyncOperationResult { }
+
 interface IFullSyncInfo extends IProjectDataComposition {
 	device: Mobile.IDevice;
 	watch: boolean;
@@ -377,22 +379,22 @@ interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase 
 	 * @return {Promise<Mobile.ILocalToDevicePathData[]>} Returns the ILocalToDevicePathData of all transfered files
 	 */
 	transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean): Promise<Mobile.ILocalToDevicePathData[]>;
-
-	/**
-	 * Guarantees all remove/update operations have finished
-	 * @param  {ILiveSyncResultInfo} liveSyncInfo Describes the LiveSync operation - for which project directory is the operation and other settings.
-	 * @return {Promise<void>}
-	 */
-	finalizeSync(liveSyncInfo: ILiveSyncResultInfo): Promise<void>;
 }
 
-interface IAndroidNativeScriptDeviceLiveSyncService {
+interface IAndroidNativeScriptDeviceLiveSyncService extends INativeScriptDeviceLiveSyncService {
 	/**
 	 * Retrieves the android device's hash service.
 	 * @param  {string} appIdentifier Application identifier.
 	 * @return {Promise<Mobile.IAndroidDeviceHashService>} The hash service
 	 */
 	getDeviceHashService(appIdentifier: string): Mobile.IAndroidDeviceHashService;
+
+	/**
+	 * Guarantees all remove/update operations have finished
+	 * @param  {ILiveSyncResultInfo} liveSyncInfo Describes the LiveSync operation - for which project directory is the operation and other settings.
+	 * @return {Promise<IAndroidLiveSyncResultInfo>}
+	 */
+	finalizeSync(liveSyncInfo: ILiveSyncResultInfo): Promise<IAndroidLiveSyncResultInfo>;
 }
 
 interface IAndroidLivesyncTool {

--- a/lib/services/livesync/android-device-livesync-sockets-service.ts
+++ b/lib/services/livesync/android-device-livesync-sockets-service.ts
@@ -39,23 +39,23 @@ export class AndroidDeviceSocketsLiveSyncService extends DeviceLiveSyncServiceBa
 		return `${LiveSyncPaths.ANDROID_TMP_DIR_NAME}/${appIdentifier}-livesync-in-progress`;
 	}
 
-	public async finalizeSync(liveSyncInfo: ILiveSyncResultInfo): Promise<any> {
+	public async finalizeSync(liveSyncInfo: ILiveSyncResultInfo, projectData: IProjectData): Promise<IAndroidLivesyncSyncOperationResult> {
 		try {
-			const result = await this.doSync(liveSyncInfo);
+			const result = await this.doSync(liveSyncInfo, projectData);
 			return result;
 		} finally {
 			this.livesyncTool.end();
 		}
 	}
 
-	private async doSync(liveSyncInfo: ILiveSyncResultInfo): Promise<IAndroidLivesyncSyncOperationResult> {
+	private async doSync(liveSyncInfo: ILiveSyncResultInfo, projectData: IProjectData): Promise<IAndroidLivesyncSyncOperationResult> {
 		const operationId = this.livesyncTool.generateOperationIdentifier();
 
 		let result = { operationId, didRefresh: true };
 
 		if (liveSyncInfo.modifiedFilesData.length) {
-
-			const doSyncPromise = this.livesyncTool.sendDoSyncOperation(true, null, operationId);
+			const canExecuteFastSync = !liveSyncInfo.isFullSync && this.canExecuteFastSyncForPaths(liveSyncInfo.modifiedFilesData, projectData, this.device.deviceInfo.platform);
+			const doSyncPromise = this.livesyncTool.sendDoSyncOperation(canExecuteFastSync, null, operationId);
 
 			const syncInterval: NodeJS.Timer = setInterval(() => {
 				if (this.livesyncTool.isOperationInProgress(operationId)) {

--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -23,6 +23,25 @@ export class AndroidLiveSyncService extends PlatformLiveSyncServiceBase implemen
 		return this.$injector.resolve<INativeScriptDeviceLiveSyncService>(AndroidDeviceLiveSyncService, { device, data });
 	}
 
+	public async liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<IAndroidLiveSyncResultInfo> {
+		const liveSyncResult = await super.liveSyncWatchAction(device, liveSyncInfo);
+		const result = await this.finalizeSync(device, liveSyncInfo.projectData, liveSyncResult);
+		return result;
+	}
+
+	public async fullSync(syncInfo: IFullSyncInfo): Promise<IAndroidLiveSyncResultInfo> {
+		const liveSyncResult = await super.fullSync(syncInfo);
+		const result = await this.finalizeSync(syncInfo.device, syncInfo.projectData, liveSyncResult);
+		return result;
+	}
+
 	public async prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir): Promise<void> { /* */ }
+
+	private async finalizeSync(device: Mobile.IDevice, projectData: IProjectData, liveSyncResult: ILiveSyncResultInfo): Promise<IAndroidLiveSyncResultInfo> {
+		const liveSyncService = <IAndroidNativeScriptDeviceLiveSyncService>this.getDeviceLiveSyncService(device, projectData);
+		const finalizeResult = await liveSyncService.finalizeSync(liveSyncResult);
+		const result = _.extend(liveSyncResult, finalizeResult);
+		return result;
+	}
 }
 $injector.register("androidLiveSyncService", AndroidLiveSyncService);

--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -39,7 +39,7 @@ export class AndroidLiveSyncService extends PlatformLiveSyncServiceBase implemen
 
 	private async finalizeSync(device: Mobile.IDevice, projectData: IProjectData, liveSyncResult: ILiveSyncResultInfo): Promise<IAndroidLiveSyncResultInfo> {
 		const liveSyncService = <IAndroidNativeScriptDeviceLiveSyncService>this.getDeviceLiveSyncService(device, projectData);
-		const finalizeResult = await liveSyncService.finalizeSync(liveSyncResult);
+		const finalizeResult = await liveSyncService.finalizeSync(liveSyncResult, projectData);
 		const result = _.extend(liveSyncResult, finalizeResult);
 		return result;
 	}

--- a/lib/services/livesync/device-livesync-service-base.ts
+++ b/lib/services/livesync/device-livesync-service-base.ts
@@ -39,7 +39,11 @@ export abstract class DeviceLiveSyncServiceBase {
 		return transferredFiles;
 	}
 
-	public async finalizeSync(liveSyncInfo: ILiveSyncResultInfo): Promise<any> {
+	public async finalizeSync(liveSyncInfo: ILiveSyncResultInfo, projectData: IProjectData): Promise<IAndroidLivesyncSyncOperationResult> {
 		//implement in case a sync point for all remove/create operation is needed
+		return {
+			didRefresh:true,
+			operationId: ""
+		};
 	}
 }

--- a/lib/services/livesync/device-livesync-service-base.ts
+++ b/lib/services/livesync/device-livesync-service-base.ts
@@ -39,7 +39,7 @@ export abstract class DeviceLiveSyncServiceBase {
 		return transferredFiles;
 	}
 
-	public async finalizeSync(liveSyncInfo: ILiveSyncResultInfo): Promise<void> {
+	public async finalizeSync(liveSyncInfo: ILiveSyncResultInfo): Promise<any> {
 		//implement in case a sync point for all remove/create operation is needed
 	}
 }

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -164,9 +164,6 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		};
 
 		try {
-			const platformLiveSyncService = this.getLiveSyncService(liveSyncResultInfo.deviceAppData.platform);
-			const deviceLivesyncService = platformLiveSyncService.getDeviceLiveSyncService(deviceAppData.device, projectData);
-			await deviceLivesyncService.finalizeSync(liveSyncResultInfo);
 			await deviceAppData.device.applicationManager.stopApplication({ appId: applicationId, projectName: projectData.projectName });
 			// Now that we've stopped the application we know it isn't started, so set debugOptions.start to false
 			// so that it doesn't default to true in attachDebugger method


### PR DESCRIPTION
Fixes the following problems with android livesync with sockets:
1. Ensure .end is always called.
2. Don't use doSync in refreshApplication - in case doSync fails and is called inside `refreshApplication` method, {N} CLI will not stop livesync.
3. Call `await doSyncPromise.then(...)`
4. Call `socket.destroy()` in order to fix ctrl +c problem with node version < 10

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.


