### PR TITLE
fix: remove keys from package.json after project is created

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -54,6 +54,7 @@ export class LiveSyncTrackActionNames {
 }
 
 export const PackageJsonKeysToKeep: Array<String> = ["name", "main", "android", "version", "pluginsData"];
+export const TemplatesV2PackageJsonKeysToRemove: Array<String> = ["name", "version", "displayName", "templateType", "author", "keywords", "homepage", "bugs"];
 
 export class SaveOptions {
 	static PRODUCTION = "save";

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as shelljs from "shelljs";
 import { format } from "util";
 import { exported } from "../common/decorators";
-import { Hooks } from "../constants";
+import { Hooks, TemplatesV2PackageJsonKeysToRemove } from "../constants";
 
 export class ProjectService implements IProjectService {
 
@@ -212,7 +212,7 @@ export class ProjectService implements IProjectService {
 		const packageJsonData = this.$fs.readJson(projectFilePath);
 
 		// Remove the metadata keys from the package.json
-		let updatedPackageJsonData = _.omitBy<any, any>(packageJsonData, (value: any, key: string) => _.startsWith(key, "_"));
+		let updatedPackageJsonData = _.omitBy<any, any>(packageJsonData, (value: any, key: string) => _.startsWith(key, "_") || TemplatesV2PackageJsonKeysToRemove.indexOf(key) !== -1);
 		updatedPackageJsonData = _.merge(updatedPackageJsonData, this.packageJsonDefaultData);
 
 		if (updatedPackageJsonData.nativescript && updatedPackageJsonData.nativescript.templateVersion) {


### PR DESCRIPTION
Remove confusing keys from project's package.json when Template v2 is used. Remove `name` and `version` as the users may decide we will use the values to set project name and version of the application.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
After project is created and template v2 is used, the package.json contains a lot of confusing and unneeded keys:
```JSON
{
  "nativescript": {
    "id": "org.nativescript.app7",
    "tns-android": {
      "version": "4.1.3"
    },
    "tns-ios": {
      "version": "4.1.1"
    }
  },
  "name": "tns-template-master-detail-ng",
  "displayName": "Master-Detail with Firebase",
  "templateType": "App template",
  "version": "4.1.2",
  "description": "NativeScript Application",
  "author": "Telerik <support@telerik.com>",
  "license": "SEE LICENSE IN <your-license-filename>",
  "keywords": [
    "telerik",
    "mobile",
    "nativescript",
    "{N}",
    "tns",
    "appbuilder",
    "template",
    "master-details",
    "detail",
    "category-general"
  ],
  "repository": "<fill-your-repository-here>",
  "homepage": "https://github.com/NativeScript/template-master-detail-ng",
  "bugs": {
    "url": "https://github.com/NativeScript/NativeScript/issues"
  },
  "scripts": {
    "lint": "tslint \"app/**/*.ts\""
  },
  "dependencies": {
    "@angular/animations": "~6.0.6",
    "@angular/common": "~6.0.6",
    "@angular/compiler": "~6.0.6",
    "@angular/core": "~6.0.6",
    "@angular/forms": "~6.0.6",
    "@angular/http": "~6.0.6",
    "@angular/platform-browser": "~6.0.6",
    "@angular/platform-browser-dynamic": "~6.0.6",
    "@angular/router": "~6.0.6",
    "nativescript-angular": "~6.0.6",
    "nativescript-imagepicker": "~6.0.0",
    "nativescript-plugin-firebase": "~6.0.0",
    "nativescript-theme-core": "~1.0.4",
    "nativescript-ui-listview": "~3.5.0",
    "tns-core-modules": "~4.1.0",
    "reflect-metadata": "~0.1.10",
    "rxjs": "~6.1.0",
    "zone.js": "~0.8.18"
  },
  "devDependencies": {
    "codelyzer": "~4.3.0",
    "nativescript-dev-sass": "~1.6.0",
    "nativescript-dev-typescript": "~0.7.0",
    "nativescript-dev-webpack": "~0.14.0",
    "tslint": "~5.10.0",
    "typescript": "~2.7.2",
    "@angular/compiler-cli": "~6.1.0-beta.3",
    "@ngtools/webpack": "6.1.0-rc.0"
  },
  "readme": "NativeScript Application"
}
```
## What is the new behavior?
The package.json contains only required keys:
```JSON
{
  "nativescript": {
    "id": "org.nativescript.app8",
    "tns-android": {
      "version": "4.1.3"
    },
    "tns-ios": {
      "version": "4.1.1"
    }
  },
  "description": "NativeScript Application",
  "license": "SEE LICENSE IN <your-license-filename>",
  "repository": "<fill-your-repository-here>",
  "scripts": {
    "lint": "tslint \"app/**/*.ts\""
  },
  "dependencies": {
    "@angular/animations": "~6.0.6",
    "@angular/common": "~6.0.6",
    "@angular/compiler": "~6.0.6",
    "@angular/core": "~6.0.6",
    "@angular/forms": "~6.0.6",
    "@angular/http": "~6.0.6",
    "@angular/platform-browser": "~6.0.6",
    "@angular/platform-browser-dynamic": "~6.0.6",
    "@angular/router": "~6.0.6",
    "nativescript-angular": "~6.0.6",
    "nativescript-imagepicker": "~6.0.0",
    "nativescript-plugin-firebase": "~6.0.0",
    "nativescript-theme-core": "~1.0.4",
    "nativescript-ui-listview": "~3.5.0",
    "tns-core-modules": "~4.1.0",
    "reflect-metadata": "~0.1.10",
    "rxjs": "~6.1.0",
    "zone.js": "~0.8.18"
  },
  "devDependencies": {
    "codelyzer": "~4.3.0",
    "nativescript-dev-sass": "~1.6.0",
    "nativescript-dev-typescript": "~0.7.0",
    "nativescript-dev-webpack": "~0.14.0",
    "tslint": "~5.10.0",
    "typescript": "~2.7.2",
    "@angular/compiler-cli": "~6.1.0-beta.3",
    "@ngtools/webpack": "6.1.0-rc.0"
  },
  "readme": "NativeScript Application"
}
```
