### PR TITLE
fix: Unable to create project from local path of template v2

### DIFF
--- a/lib/services/pacote-service.ts
+++ b/lib/services/pacote-service.ts
@@ -29,6 +29,10 @@ export class PacoteService implements IPacoteService {
 			_.extend(extractOptions, options);
 		}
 
+		if (this.$fs.exists(packageName)) {
+			packageName = path.resolve(packageName);
+		}
+
 		const cache = await this.$npm.getCachePath();
 		return new Promise<void>((resolve, reject) => {
 			const source = pacote.tarball.stream(packageName, { cache });


### PR DESCRIPTION
`pacote` package does not work very well with relative paths, so ensure we pass full path to the `extractPackage` method. When trying to pass `.tgz` with relative path for template and the `.tgz` is located next to `.git` dir, the `pacote` package tries to download the repository instead of using the local .tgz package. Once full path is passed, it works correctly.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Follow the steps below and you'll receive an error:
1. Clone any v2 template repo, for example https://github.com/rosen-vladimirov/test-tns-template-v2: `git clone https://github.com/rosen-vladimirov/test-tns-template-v2`
2. Pack the template: `cd test-tns-template-v2 && npm pack && cd ..` - this will produce a `test-tns-template-v2.tgz` in `test-tns-template-v2` dir.
3. From any outside dir (not the `test-tns-template-v2`) try to create a new project by passing relative path to the .tgz: `tns create myApp --template test-tns-template-v2/test-tns-template-v2.tgz`
The last operation will fail with error:
```
Error while executing:
/usr/local/bin/git ls-remote -h -t ssh://git@github.com/test-tns-template-v2/test-tns-template-v2-1.0.0.tgz.git

ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

exited with error code: 128
```

## What is the new behavior?
You can successfully create a project with the steps above