### PR TITLE
fix: run ios fails if tns-ios version contains tags

### DIFF
--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -52,7 +52,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 	private canStartLookingForDebuggerPort(data: IProjectDir): boolean {
 		const projectData = this.$projectDataService.getProjectData(data && data.projectDir);
 		const frameworkVersion = this.$iOSProjectService.getFrameworkVersion(projectData);
-		return !frameworkVersion || semver.gt(frameworkVersion, IOSDebuggerPortService.MIN_REQUIRED_FRAMEWORK_VERSION);
+		return !frameworkVersion || !semver.valid(frameworkVersion) || semver.gt(frameworkVersion, IOSDebuggerPortService.MIN_REQUIRED_FRAMEWORK_VERSION);
 	}
 
 	@cache()

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -459,8 +459,6 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				const platformLiveSyncService = this.getLiveSyncService(platform);
 				const deviceBuildInfoDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
 
-				await platformLiveSyncService.prepareForLiveSync(device, projectData, liveSyncData, deviceBuildInfoDescriptor.debugOptions);
-
 				await this.ensureLatestAppPackageIsInstalledOnDevice({
 					device,
 					preparedPlatforms,
@@ -473,6 +471,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					release: liveSyncData.release,
 					env: liveSyncData.env
 				}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
+
+				await platformLiveSyncService.prepareForLiveSync(device, projectData, liveSyncData, deviceBuildInfoDescriptor.debugOptions);
 
 				const liveSyncResultInfo = await platformLiveSyncService.fullSync({
 					projectData, device,


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`tns run ios` command will fail with:
`Unable to apply changes on device: xxxxxx. Error is: Invalid Version: rc`.

## What is the new behavior?
<!-- Describe the changes. -->
The application will be build and deployed

Fixes/Implements/Closes #[3803](https://github.com/NativeScript/nativescript-cli/issues/3803).


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

