### PR TITLE
fix: status of iOS Sim images and Android Emulator images are different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 NativeScript CLI Changelog
 ================
 
+4.2.1 (2018, August 10)
+==
+
+### Fixed
+* [Fixed #3763](https://github.com/NativeScript/nativescript-cli/issues/3763): Duplicated entries in `tns run` log while livesyncing
+* [Fixed #3802](https://github.com/NativeScript/nativescript-cli/issues/3802): Unable to use templates without `App_Resources`
+* [Fixed #3803](https://github.com/NativeScript/nativescript-cli/issues/3803): `tns run ios` command fails if tns-ios version is a tag
+* [Fixed #3805](https://github.com/NativeScript/nativescript-cli/issues/3805): `tns run android` fails in case you do not have Android emulator images
+
+
 4.2.0 (2018, August 7)
 ==
 


### PR DESCRIPTION
### fix: status of iOS Sim images and Android Emulator images are different
Whenever CLI returns information for available emulators/simulators, the returned object for each of the image has a status property.
For Android the status is "Running" or "Not running", for iOS it is "Connected" or "Disconnected".
Unify the status properties - use "Running" and "Not running" for both of the images.

Also, for iOS images, the imageIdentifier property has not been populated - fill it with the value of the identifier property, so the API will be consistent for both Android and iOS.
As the property has not been populated for iOS Simulators, the events "emulatorImageFound" and "emulatorImageLost" were never triggered in case you add new iOS Simulator images. Now this should work correctly.

Fix unit tests on Windows - the split by EOL when parsing the output of avdmanager executable is not working on Windows, as the EOL is `\r\n`, while the avdmanager prints results with `\n` only.
Also the tests were failing on Windows due to the same reason - test case has `\n`, while split is by `\r\n`.

Use some constants in the tests instead of strings for status property.

### docs: update changelog for 4.2.1
Update the CHANGELOG for 4.2.1

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
When using CLI as a library and call `tns.devicesService.getEmulatorImages` on macOS, the status properties of iOS and Android images are not consistent.

## What is the new behavior?
Status are the same for iOS and Android