### PR TITLE
fix: stop showing the command help on native build error

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -701,11 +701,17 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			const childProcessOpts = opts.childProcessOpts || {};
 			childProcessOpts.cwd = childProcessOpts.cwd || projectRoot;
 			childProcessOpts.stdio = childProcessOpts.stdio || "inherit";
+			let commandResult;
+			try {
+				commandResult = await this.spawn(gradlew,
+					gradleArgs,
+					childProcessOpts,
+					spawnFromEventOptions);
+			} catch (err) {
+				this.$errors.failWithoutHelp(err.message);
+			}
 
-			return await this.spawn(gradlew,
-				gradleArgs,
-				childProcessOpts,
-				spawnFromEventOptions);
+			return commandResult;
 		}
 	}
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -57,7 +57,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		private $plistParser: IPlistParser,
 		private $sysInfo: ISysInfo,
 		private $xCConfigService: XCConfigService) {
-			super($fs, $projectDataService);
+		super($fs, $projectDataService);
 	}
 
 	private _platformsDirCache: string = null;
@@ -442,11 +442,19 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			localArgs.push("-quiet");
 			this.$logger.info("Xcode build...");
 		}
-		return this.$childProcess.spawnFromEvent("xcodebuild",
-			localArgs,
-			"exit",
-			{ stdio: stdio || "inherit", cwd },
-			{ emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: true });
+
+		let commandResult;
+		try {
+			commandResult = await this.$childProcess.spawnFromEvent("xcodebuild",
+				localArgs,
+				"exit",
+				{ stdio: stdio || "inherit", cwd },
+				{ emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: true });
+		} catch (err) {
+			this.$errors.failWithoutHelp(err.message);
+		}
+
+		return commandResult;
 	}
 
 	private async setupSigningFromTeam(projectRoot: string, projectData: IProjectData, teamId: string) {
@@ -1112,7 +1120,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 	private async prepareNativeSourceCode(pluginName: string, pluginPlatformsFolderPath: string, projectData: IProjectData): Promise<void> {
 		const project = this.createPbxProj(projectData);
 		const group = this.getRootGroup(pluginName, pluginPlatformsFolderPath);
-		project.addPbxGroup(group.files, group.name, group.path, null, {isMain:true});
+		project.addPbxGroup(group.files, group.name, group.path, null, { isMain: true });
 		project.addToHeaderSearchPaths(group.path);
 		this.savePbxProj(project, projectData);
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The command help is shown on native build error.

## What is the new behavior?
The command help is not shown on native build error.
