### PR TITLE
Respect timeout option when getting debugger port

### DIFF
--- a/lib/definitions/ios-debugger-port-service.d.ts
+++ b/lib/definitions/ios-debugger-port-service.d.ts
@@ -17,7 +17,7 @@ interface IIOSDebuggerPortService {
 	 * Gets iOS debugger port for specified deviceId and appId
 	 * @param {IIOSDebuggerPortInputData} data - Describes deviceId and appId
 	 */
-	getPort(data: IIOSDebuggerPortInputData): Promise<number>;
+	getPort(data: IIOSDebuggerPortInputData, debugOptions?: IDebugOptions): Promise<number>;
 	/**
 	 * Attaches on DEBUGGER_PORT_FOUND event and STARTING_IOS_APPLICATION events
 	 * In case when DEBUGGER_PORT_FOUND event is emitted, stores the port and clears the timeout if such.

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -202,7 +202,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 		// the VSCode Ext starts `tns debug ios --no-client` to start/attach to debug sessions
 		// check if --no-client is passed - default to opening a tcp socket (versus Chrome DevTools (websocket))
 		if ((debugOptions.inspector || !debugOptions.client) && this.$hostInfo.isDarwin) {
-			this._socketProxy = await this.$socketProxyFactory.createTCPSocketProxy(this.getSocketFactory(debugData, device));
+			this._socketProxy = await this.$socketProxyFactory.createTCPSocketProxy(this.getSocketFactory(device, debugData, debugOptions));
 			await this.openAppInspector(this._socketProxy.address(), debugData, debugOptions);
 			return null;
 		} else {
@@ -211,7 +211,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 			}
 
 			const deviceIdentifier = device ? device.deviceInfo.identifier : debugData.deviceIdentifier;
-			this._socketProxy = await this.$socketProxyFactory.createWebSocketProxy(this.getSocketFactory(debugData, device), deviceIdentifier);
+			this._socketProxy = await this.$socketProxyFactory.createWebSocketProxy(this.getSocketFactory(device, debugData, debugOptions), deviceIdentifier);
 			return this.getChromeDebugUrl(debugOptions, this._socketProxy.options.port);
 		}
 	}
@@ -230,9 +230,9 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 		}
 	}
 
-	private getSocketFactory(debugData: IDebugData, device?: Mobile.IiOSDevice): () => Promise<net.Socket> {
+	private getSocketFactory(device: Mobile.IiOSDevice, debugData: IDebugData, debugOptions: IDebugOptions): () => Promise<net.Socket> {
 		const factory = async () => {
-			const port = await this.$iOSDebuggerPortService.getPort({ projectDir: debugData.projectDir, deviceId: debugData.deviceIdentifier, appId: debugData.applicationIdentifier });
+			const port = await this.$iOSDebuggerPortService.getPort({ projectDir: debugData.projectDir, deviceId: debugData.deviceIdentifier, appId: debugData.applicationIdentifier }, debugOptions);
 			if (!port) {
 				this.$errors.fail("NativeScript debugger was not able to get inspector socket port.");
 			}

--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -14,7 +14,7 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 		private $projectDataService: IProjectDataService,
 		private $logger: ILogger) { }
 
-	public getPort(data: IIOSDebuggerPortInputData): Promise<number> {
+	public getPort(data: IIOSDebuggerPortInputData, debugOptions?: IDebugOptions): Promise<number> {
 		return new Promise((resolve, reject) => {
 			if (!this.canStartLookingForDebuggerPort(data)) {
 				resolve(IOSDebuggerPortService.DEFAULT_PORT);
@@ -22,7 +22,8 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 			}
 
 			const key = `${data.deviceId}${data.appId}`;
-			let retryCount: number = 10;
+			const timeout = this.getTimeout(debugOptions);
+			let retryCount = Math.max(timeout * 1000 / 500, 10);
 
 			const interval = setInterval(() => {
 				let port = this.getPortByKey(key);

--- a/test/services/ios-debugger-port-service.ts
+++ b/test/services/ios-debugger-port-service.ts
@@ -157,7 +157,7 @@ describe("iOSDebuggerPortService", () => {
 				}
 
 				const promise = iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId, projectDir: mockProjectDirObj.projectDir });
-				clock.tick(10000);
+				clock.tick(20000);
 				const port = await promise;
 				assert.deepEqual(port, testCase.emittedPort);
 			});
@@ -171,7 +171,7 @@ describe("iOSDebuggerPortService", () => {
 				}
 
 				const promise = iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId, projectDir: mockProjectDirObj.projectDir });
-				clock.tick(10000);
+				clock.tick(20000);
 				const port = await promise;
 				assert.deepEqual(port, testCase.emittedPort);
 			});


### PR DESCRIPTION
Sometimes when debug command is executed, an error is thrown because {N} CLI is not able to get debugger's port from device's logs. Currently {N} CLI tries 10 times (the retryCount) to get the  port every 500 miliseconds. If the port is not found, an error is thrown. This PR calculates the retry count based on timeout option.
In case no timeout option is specified {N} CLI will try 20 times to get the port (this is the difference with the current behaviour).
In case when calculated retry count is lower then 10, {N} CLI will try 10 times to get the port. 

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.