### PR TITLE
fix: clear the socket timer on timeout

### DIFF
--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -313,6 +313,10 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 			const connectionTimer = setTimeout(() => {
 				if (!isConnected) {
 					isConnected = true;
+					if (this.pendingConnectionData && this.pendingConnectionData.socketTimer) {
+						clearTimeout(this.pendingConnectionData.socketTimer);
+					}
+
 					reject(lastKnownError || new Error("Socket connection timeouted."));
 					this.pendingConnectionData = null;
 				}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
A `Cannot set property 'socket' of null` exception is shown on each socket connection timeout.

## What is the new behavior?
The socket timer is cleared on timeout and the exception is not thrown.

related to #3818 