### PR TITLE
Fix connect to port

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -236,7 +236,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 			if (!port) {
 				this.$errors.fail("NativeScript debugger was not able to get inspector socket port.");
 			}
-			const socket = device ? await device.connectToPort(port) : net.connect(port);
+			const socket = device ? await device.connectToPort(port) : await this.$iOSEmulatorServices.connectToPort({ port });
 			this._sockets.push(socket);
 			return socket;
 		};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "4.2.2",
+  "version": "4.2.3",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Reconnect to dev tools dialog is shown when livesyncing to iOS simulator when debug command is executed.

## What is the new behavior?
Reconnect to dev tools dialog is not shown when livesyncing to iOS simulator when debug command is executed.

Steps to reproduce:
1. Open new project from Sidekick
2. Click run on device with debugger
3. Make change in some `.js` file
4. Reconnect to dev tools dialog is shown
