### PR TITLE
feat: use long living socket connection for sync

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -399,6 +399,11 @@ interface IAndroidNativeScriptDeviceLiveSyncService extends INativeScriptDeviceL
 
 interface IAndroidLivesyncTool {
 	/**
+	 * The protocol version the current app(adnroid runtime) is using.
+	 */
+	protocolVersion: string;
+
+	/**
 	 * Creates new socket connection.
 	 * @param configuration - The configuration to the socket connection.
 	 * @returns {Promise<void>}
@@ -457,6 +462,11 @@ interface IAndroidLivesyncTool {
 	 * @param error - Optional error for rejecting pending sync operations
 	 */
 	end(error?: Error): void;
+
+	/**
+	 * Returns true if a connection has been already established
+	 */
+	hasConnection(): boolean;
 }
 
 interface IAndroidLivesyncToolConfiguration {

--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -20,6 +20,7 @@ const TRY_CONNECT_TIMEOUT = 30000;
 const DEFAULT_LOCAL_HOST_ADDRESS = "127.0.0.1";
 
 export class AndroidLivesyncTool implements IAndroidLivesyncTool {
+	public protocolVersion: string;
 	private operationPromises: IDictionary<any>;
 	private socketError: string | Error;
 	private socketConnection: INetSocket;
@@ -179,6 +180,10 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 		}
 	}
 
+	public hasConnection(): boolean {
+		return !!this.socketConnection;
+	}
+
 	private sendFileHeader(filePath: string): Promise<void> {
 		return new Promise((resolve, reject) => {
 			let error;
@@ -292,6 +297,7 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 		const protocolVersion = versionBuffer.toString();
 		const appIdentifier = appIdentifierBuffer.toString();
 		this.$logger.trace(`Handle socket connection for app identifier: ${appIdentifier} with protocol version: ${protocolVersion}.`);
+		this.protocolVersion = protocolVersion;
 
 		this.socketConnection.on("data", (connectionData: NodeBuffer) => this.handleData(socket.uid, connectionData));
 		this.socketConnection.on("close", (hasError: boolean) => this.handleSocketClose(socket.uid, hasError));


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Every time a new LS operation is started a new socket connection is established with the application

## What is the new behavior?
<!-- Describe the changes. -->
A connection is reused if possible for sync operations. And a connection is established in advance when the application is restarted.

Fixes/Implements/Closes #3843

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

