### PR TITLE
add switch to set projectName from package.json

### DIFF
--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -106,7 +106,7 @@ export class ProjectData implements IProjectData {
 		if (nsData) {
 			this.projectDir = projectDir;
 			this.projectName = this.$projectHelper.sanitizeName(path.basename(projectDir));
-			this.platformsDir = path.join(projectDir, constants.PLATFORMS_DIR_NAME);
+			this.platformsDir = nsData.projectName || path.join(projectDir, constants.PLATFORMS_DIR_NAME);
 			this.projectFilePath = projectFilePath;
 			this.projectId = nsData.id;
 			this.dependencies = packageJsonData.dependencies;


### PR DESCRIPTION
As projekt_name is used in quite a lot places throuout the project and one might have the need to adjust it aber a while in the project, I propose to provide a setting for that.
I realized that when I had the need to adjust the BuildableName and BlueprintName for IOS: https://github.com/NativeScript/ios-runtime/search?q=__PROJECT_NAME__&unscoped_q=__PROJECT_NAME__

Please let me know what you think about the proposal. If it's wanted, I'll extend the PR to meet the requirements.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

