### PR TITLE
fix: comparing shasums takes a lot of time

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "4.2.3",
+  "version": "4.2.4",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {


### PR DESCRIPTION
Comparing the old shasums and new shasums takes a lot of time as we use find for searching in a map. Instead, just check if we have the entry we are looking for.
In bigger projects (for example with more than 20 000 files including node_modules), the comparison may take more than 100 seconds, which breaks the LiveSync for Android as the socket is closed after 70 seconds without action.
So, in case you have a huge project and try `tns run android`, you'll probably receive:
```
Unable to apply changes on device: 192.168.3.101:5555. Error is: Socket Error:
Error: write ECONNABORTED.
```

After the change, the time for comparing 24 000 shasums is 25 ms instead of more than 100 seconds
