### PR TITLE
fix: prompter for mail on postinstall is very obligatory

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -182,7 +182,7 @@ export class MacOSVersions {
 export const MacOSDeprecationStringFormat = "Support for macOS %s is deprecated and will be removed in one of the next releases of NativeScript. Please, upgrade to the latest macOS version.";
 export const PROGRESS_PRIVACY_POLICY_URL = "https://www.progress.com/legal/privacy-policy";
 export class SubscribeForNewsletterMessages {
-	public static AgreeToReceiveEmailMsg = "I agree to receive email communications from Progress Software or its Partners (`https://www.progress.com/partners/partner-directory`)," +
+	public static AgreeToReceiveEmailMsg = "I agree".green.bold + " to receive email communications from Progress Software or its Partners (`https://www.progress.com/partners/partner-directory`)," +
 		"containing information about Progress Software's products. Consent may be withdrawn at any time.";
 	public static ReviewPrivacyPolicyMsg = `You can review the Progress Software Privacy Policy at \`${PROGRESS_PRIVACY_POLICY_URL}\``;
 	public static PromptMsg = "Input your e-mail address to agree".green + " or " + "leave empty to decline".red.bold + ":";

--- a/lib/services/subscription-service.ts
+++ b/lib/services/subscription-service.ts
@@ -12,8 +12,8 @@ export class SubscriptionService implements ISubscriptionService {
 
 	public async subscribeForNewsletter(): Promise<void> {
 		if (await this.shouldAskForEmail()) {
-			this.$logger.printMarkdown(SubscribeForNewsletterMessages.AgreeToReceiveEmailMsg);
 			this.$logger.printMarkdown(SubscribeForNewsletterMessages.ReviewPrivacyPolicyMsg);
+			this.$logger.printMarkdown(SubscribeForNewsletterMessages.AgreeToReceiveEmailMsg);
 
 			const email = await this.getEmail(SubscribeForNewsletterMessages.PromptMsg);
 			await this.$userSettingsService.saveSetting("EMAIL_REGISTERED", true);

--- a/test/services/subscription-service.ts
+++ b/test/services/subscription-service.ts
@@ -160,7 +160,7 @@ describe("subscriptionService", () => {
 
 			await subscriptionService.subscribeForNewsletter();
 
-			assert.equal(loggerOutput, `${SubscribeForNewsletterMessages.AgreeToReceiveEmailMsg}${SubscribeForNewsletterMessages.ReviewPrivacyPolicyMsg}`);
+			assert.equal(loggerOutput, `${SubscribeForNewsletterMessages.ReviewPrivacyPolicyMsg}${SubscribeForNewsletterMessages.AgreeToReceiveEmailMsg}`);
 		});
 
 		const expectedMessageInPrompter = SubscribeForNewsletterMessages.PromptMsg;


### PR DESCRIPTION
On postinstall CLI checks if the user had subscribed for NativeScript newsletter if not, prompts for email. However, the messages seems obligatory, while it is not.
Reformat it, so the users can easily skip it in case they do not want to subscribe for the newsletter.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The prompter on postinstall seems mandatory.

## What is the new behavior?
The prompter on postinstall does not seem so mandatory.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

