### PR TITLE
replacing forum references with stack overflow

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ questions regarding the behavior/reproduction for more than 20 days "dead". All
 
 ## Please, provide the details below:
 
-### Did you verify this is a real problem by searching the [NativeScript Forum](http://forum.nativescript.org) and the [other open issues in this repo](https://github.com/NativeScript/nativescript/issues)?
+### Did you verify this is a real problem by searching [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript), the [NativeScript Forum](https://discourse.nativescript.org/), and the [other open issues in this repo](https://github.com/NativeScript/nativescript/issues)?
 
 ### Tell us about the problem
 Please, ensure your title is less than 63 characters long and starts with a capital

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ questions regarding the behavior/reproduction for more than 20 days "dead". All
 
 ## Please, provide the details below:
 
-### Did you verify this is a real problem by searching [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript), the [NativeScript Forum](https://discourse.nativescript.org/), and the [other open issues in this repo](https://github.com/NativeScript/nativescript/issues)?
+### Did you verify this is a real problem by searching [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript) and the [other open issues in this repo](https://github.com/NativeScript/nativescript/issues)?
 
 ### Tell us about the problem
 Please, ensure your title is less than 63 characters long and starts with a capital

--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ To use the locally built CLI instead `tns` you can call `PATH_TO_CLI_FOLDER/bin/
 Get Help
 ===
 
-Please, use [github issues](https://github.com/NativeScript/nativescript-cli/issues) strictly for [reporting bugs](CONTRIBUTING.md#report-an-issue) or [requesting features](CONTRIBUTING.md#request-a-feature). For general NativeScript questions and support, check out the [NativeScript community forum](https://discourse.nativescript.org/) or ask our experts in [NativeScript community Slack channel](http://developer.telerik.com/wp-login.php?action=slack-invitation).
+Please, use [github issues](https://github.com/NativeScript/nativescript-cli/issues) strictly for [reporting bugs](CONTRIBUTING.md#report-an-issue) or [requesting features](CONTRIBUTING.md#request-a-feature). For general NativeScript questions and support, check out [Stack Overflow](https://stackoverflow.com/questions/tagged/nativescript) or ask our experts in the [NativeScript community Slack channel](http://developer.telerik.com/wp-login.php?action=slack-invitation).
 
 [Back to Top][1]
 

--- a/lib/commands/post-install.ts
+++ b/lib/commands/post-install.ts
@@ -20,10 +20,10 @@ export class PostInstallCliCommand extends PostInstallCommand {
 	}
 
 	public async postCommandAction(args: string[]): Promise<void> {
-		this.$logger.info("You have successfully installed NativeScript CLI.");
-		this.$logger.info("In order to create a new project, you can use:".green);
+		this.$logger.info("You have successfully installed the NativeScript CLI!");
+		this.$logger.info("To create a new project, you use:".green);
 		this.$logger.printMarkdown("`tns create <app name>`");
-		this.$logger.info("To build your project locally you can use:".green);
+		this.$logger.info("To build your project locally you use:".green);
 		this.$logger.printMarkdown("`tns build <platform>`");
 		this.$logger.printMarkdown("NOTE: Local builds require additional setup of your environment. You can find more information here: `https://docs.nativescript.org/start/quick-setup`");
 
@@ -34,10 +34,10 @@ export class PostInstallCliCommand extends PostInstallCommand {
 		this.$logger.printMarkdown("NOTE: Cloud builds require Telerik account. You can find more information here: `https://docs.nativescript.org/sidekick/intro/requirements`");
 
 		this.$logger.info("");
-		this.$logger.printMarkdown("In case you want to experiment quickly with NativeScript, you can try the Playground: `https://play.nativescript.org`");
+		this.$logger.printMarkdown("If you want to experiment with NativeScript in your browser, try the Playground: `https://play.nativescript.org`");
 
 		this.$logger.info("");
-		this.$logger.printMarkdown("In case you have any questions, you can check our forum: `https://forum.nativescript.org` and our public Slack channel: `https://nativescriptcommunity.slack.com/`");
+		this.$logger.printMarkdown("If you have any questions, check Stack Overflow: `https://stackoverflow.com/questions/tagged/nativescript` and our public Slack channel: `https://nativescriptcommunity.slack.com/`");
 	}
 }
 

--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -18,7 +18,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 	public static MANUALLY_SETUP_OPTION_NAME = "Skip Step and Configure Manually";
 	private static BOTH_CLOUD_SETUP_AND_LOCAL_SETUP_OPTION_NAME = "Configure for Both Local and Cloud Builds";
 	private static CHOOSE_OPTIONS_MESSAGE = "To continue, choose one of the following options: ";
-	private static NOT_CONFIGURED_ENV_AFTER_SETUP_SCRIPT_MESSAGE = `The setup script was not able to configure your environment for local builds. To execute local builds, you have to set up your environment manually. In case you have any questions, you can check our forum: 'http://forum.nativescript.org' and our public Slack channel: 'https://nativescriptcommunity.slack.com/'.`;
+	private static NOT_CONFIGURED_ENV_AFTER_SETUP_SCRIPT_MESSAGE = `The setup script was not able to configure your environment for local builds. To execute local builds, you have to set up your environment manually. Please consult our setup instructions here 'https://docs.nativescript.org/start/quick-setup'.`;
 	private static MISSING_LOCAL_SETUP_MESSAGE = "Your environment is not configured properly and you will not be able to execute local builds.";
 	private static MISSING_LOCAL_AND_CLOUD_SETUP_MESSAGE = `You are missing the ${NATIVESCRIPT_CLOUD_EXTENSION_NAME} extension and you will not be able to execute cloud builds. ${PlatformEnvironmentRequirements.MISSING_LOCAL_SETUP_MESSAGE} ${PlatformEnvironmentRequirements.CHOOSE_OPTIONS_MESSAGE} `;
 	private static MISSING_LOCAL_BUT_CLOUD_SETUP_MESSAGE = `You have ${NATIVESCRIPT_CLOUD_EXTENSION_NAME} extension installed, so you can execute cloud builds, but ${_.lowerFirst(PlatformEnvironmentRequirements.MISSING_LOCAL_SETUP_MESSAGE)}`;
@@ -156,7 +156,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 	}
 
 	private processManuallySetup(platform?: string): void {
-		this.fail(`To be able to ${platform ? `build for ${platform}` : 'build'}, verify that your environment is configured according to the system requirements described at ${this.$staticConfig.SYS_REQUIREMENTS_LINK}. In case you have any questions, you can check our forum: 'http://forum.nativescript.org' and our public Slack channel: 'https://nativescriptcommunity.slack.com/'.`);
+		this.fail(`To be able to ${platform ? `build for ${platform}` : 'build'}, verify that your environment is configured according to the system requirements described at ${this.$staticConfig.SYS_REQUIREMENTS_LINK}. If you have any questions, check Stack Overflow: 'https://stackoverflow.com/questions/tagged/nativescript' and our public Slack channel: 'https://nativescriptcommunity.slack.com/'`);
 	}
 
 	private async processBothCloudBuildsAndSetupScript(): Promise<void> {


### PR DESCRIPTION
As we are looking to deprecate usage of the community forum by the end of September, this PR replaces most references of the forum with appropriate Stack Overflow links.

Replaces https://github.com/NativeScript/nativescript-cli/pull/3872