### PR TITLE
fix: read npm registry from npm config

### DIFF
--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -120,7 +120,8 @@ export class NodePackageManager implements INodePackageManager {
 	}
 
 	public async getRegistryPackageData(packageName: string): Promise<any> {
-		const url = `https://registry.npmjs.org/${packageName}`;
+		const registry = await this.$childProcess.exec(`npm config get registry`);
+		const url = registry.trim() + packageName;
 		this.$logger.trace(`Trying to get data from npm registry for package ${packageName}, url is: ${url}`);
 		const responseData = (await this.$httpClient.httpRequest(url)).body;
 		this.$logger.trace(`Successfully received data from npm registry for package ${packageName}. Response data is: ${responseData}`);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

nativescript-cli assumes that npmjs.org is used. If another (local) repo like artifactory is used, `tns add platform` (and probably other steps) fails as it hard-wired tries to pull packages from npmjs.org

## What is the new behavior?
<!-- Describe the changes. -->

read npm registry from npm config instead of hard-wiring it to npmjs.org, fixes #3866


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

