### PR TITLE
fix-next(hmr): set --env.hmr to true if the --hmr flag is raised

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -53,6 +53,8 @@ export class Options extends commonOptionsLibPath.OptionsBase {
 
 		if (that.hmr) {
 			that.bundle = "webpack";
+            that.env = that.env || {};
+            that.env.hmr = true;
 		}
 	}
 }


### PR DESCRIPTION
That way we won't have to inject $options in the webpack plugin and manually
set --env.hmr to true in every hook there.