### PR TITLE
chore: stop webpack compiler when ctrl+c is pressed while executing `tns preview --bundle` command

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -66,6 +66,7 @@ interface ILiveSyncProcessInfo {
 	isStopped: boolean;
 	deviceDescriptors: ILiveSyncDeviceInfo[];
 	currentSyncAction: Promise<any>;
+	syncToPreviewApp: boolean;
 }
 
 interface IOptionalOutputPath {

--- a/test/services/livesync-service.ts
+++ b/test/services/livesync-service.ts
@@ -105,7 +105,8 @@ describe("liveSyncService", () => {
 				},
 				patterns: ["pattern"]
 			},
-			deviceDescriptors: []
+			deviceDescriptors: [],
+			syncToPreviewApp: false
 		});
 
 		const getDeviceDescriptor = (identifier: string): ILiveSyncDeviceInfo => ({


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Webpack process does not stop when ctrl+c is pressed while executing `tns preview --bundle` command

## What is the new behavior?
Webpack process stops when ctrl+c is pressed while executing `tns preview --bundle` command

Should be merged with this: https://github.com/NativeScript/nativescript-dev-webpack/pull/661