### PR TITLE
fix: unable to work with devices with numeric identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 NativeScript CLI Changelog
 ================
 
-4.2.4 (2018, September 17)
+4.2.4 (2018, September 19)
 ==
 
 ### Fixed
+* [Fixed #3832](https://github.com/NativeScript/nativescript-cli/issues/3832): Unable to work with devices with numeric identifiers
 * [Fixed #3881](https://github.com/NativeScript/nativescript-cli/pull/3881): Replace forum references with stack overflow.
 * [Fixed #3883](https://github.com/NativeScript/nativescript-cli/issues/3883): CLI installs the app on every change
 * [Fixed #3893](https://github.com/NativeScript/nativescript-cli/pull/3893): [API] Errors are raised when emulator lost/found event is raised.


### PR DESCRIPTION
In case the device identifier contains only numeric symbols or in case it looks like a number (16089e09 for example), CLI fails to work with it.
The problem is that CLI thinks an index is passed to it, so it removes "one" from the passed number and tries to find the device on the new index.
The other issue is with the `isNumber` helper method which works incorrectly when the string looks like number. Improve the logic in the method and rename it. We cannot parse safely values with exponent (`1e6` for example), but we do not need such functionality.
The new method name and tests reflects the described behavior.
Before using the identifier as an index, check if we'll find device with the specified identifier.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
When device with numeric identifier is attached, CLI fails to work with it.

## What is the new behavior?
CLI can work with devices with numeric identifiers.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3832 