### PR TITLE
chore: persist warnings per preview app's version when comparing plugins from preview app with local plugins

### DIFF
--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -5,35 +5,27 @@ import { Device } from "nativescript-preview-sdk";
 import { PluginComparisonMessages } from "./preview-app-constants";
 
 export class PreviewAppPluginsService implements IPreviewAppPluginsService {
+	private previewAppVersionWarnings: IDictionary<string[]> = {};
+
 	constructor(private $fs: IFileSystem,
 		private $logger: ILogger,
 		private $projectData: IProjectData) { }
 
 	public async comparePluginsOnDevice(device: Device): Promise<void> {
-		const devicePlugins = this.getDevicePlugins(device);
-		const localPlugins = this.getLocalPlugins();
+		if (!this.previewAppVersionWarnings[device.previewAppVersion]) {
+			const devicePlugins = this.getDevicePlugins(device);
+			const localPlugins = this.getLocalPlugins();
+			const warnings = _.keys(localPlugins)
+				.map(localPlugin => {
+					const localPluginVersion = localPlugins[localPlugin];
+					const devicePluginVersion = devicePlugins[localPlugin];
+					return this.getWarningForPlugin(localPlugin, localPluginVersion, devicePluginVersion, device.id);
+				})
+				.filter(item => !!item);
+			this.previewAppVersionWarnings[device.previewAppVersion] = warnings;
+		}
 
-		_.keys(localPlugins).forEach(localPlugin => {
-			const localPluginVersion = localPlugins[localPlugin];
-			const devicePluginVersion = devicePlugins[localPlugin];
-
-			this.$logger.trace(`Comparing plugin ${localPlugin} with localPluginVersion ${localPluginVersion} and devicePluginVersion ${devicePluginVersion}`);
-
-			if (devicePluginVersion) {
-				const localPluginVersionData = semver.coerce(localPluginVersion);
-				const devicePluginVersionData = semver.coerce(devicePluginVersion);
-
-				if (localPluginVersionData.major !== devicePluginVersionData.major) {
-					this.$logger.warn(util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_DIFFERENCE_IN_MAJOR_VERSION, localPlugin, localPluginVersion, devicePluginVersion));
-				}
-
-				if (localPluginVersionData.major === devicePluginVersionData.major && localPluginVersionData.minor > devicePluginVersionData.minor) {
-					this.$logger.warn(util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_GREATHER_MINOR_VERSION, localPlugin, localPluginVersion, devicePluginVersion));
-				}
-			} else {
-				this.$logger.warn(util.format(PluginComparisonMessages.PLUGIN_NOT_INCLUDED_IN_PREVIEW_APP, localPlugin, device.id));
-			}
-		});
+		this.previewAppVersionWarnings[device.previewAppVersion].map(warning => this.$logger.warn(warning));
 	}
 
 	private getDevicePlugins(device: Device): IStringDictionary {
@@ -53,6 +45,25 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 			this.$logger.trace(`Error while parsing ${projectFilePath}. Error is ${err.message}`);
 			return {};
 		}
+	}
+
+	private getWarningForPlugin(localPlugin: string, localPluginVersion: string, devicePluginVersion: string, deviceId: string): string {
+		this.$logger.trace(`Comparing plugin ${localPlugin} with localPluginVersion ${localPluginVersion} and devicePluginVersion ${devicePluginVersion}`);
+
+		if (devicePluginVersion) {
+			const localPluginVersionData = semver.coerce(localPluginVersion);
+			const devicePluginVersionData = semver.coerce(devicePluginVersion);
+
+			if (localPluginVersionData.major !== devicePluginVersionData.major) {
+				return util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_DIFFERENCE_IN_MAJOR_VERSION, localPlugin, localPluginVersion, devicePluginVersion);
+			} else if (localPluginVersionData.minor > devicePluginVersionData.minor) {
+				return util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_GREATHER_MINOR_VERSION, localPlugin, localPluginVersion, devicePluginVersion);
+			}
+
+			return null;
+		}
+
+		return util.format(PluginComparisonMessages.PLUGIN_NOT_INCLUDED_IN_PREVIEW_APP, localPlugin, deviceId);
 	}
 }
 $injector.register("previewAppPluginsService", PreviewAppPluginsService);

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -38,7 +38,7 @@ function createDevice(plugins: string): Device {
 		model: "myTestDeviceModel",
 		name: "myTestDeviceName",
 		osVersion: "10.0",
-		previewAppVersion: "28.0",
+		previewAppVersion: "28.0.0",
 		runtimeVersion: "4.3.0",
 		plugins,
 		pluginsExpanded: false
@@ -58,6 +58,53 @@ function setup(localPlugins: IStringDictionary, previewAppPlugins: IStringDictio
 
 describe("previewAppPluginsService", () => {
 	describe("comparePluginsOnDevice", () => {
+		it("should persist warnings per preview app's version", async () => {
+			const localPlugins = {
+				"nativescript-facebook": "2.2.3",
+				"nativescript-theme-core": "1.0.4",
+				"tns-core-modules": "4.2.0"
+			};
+			const previewAppPlugins = {
+				"nativescript-theme-core": "2.0.4",
+				"tns-core-modules": "4.2.0"
+			};
+			const injector = createTestInjector(localPlugins);
+			const previewAppPluginsService = injector.resolve("previewAppPluginsService");
+
+			let isGetDevicePluginsCalled = false;
+			const originalGetDevicePlugins = (<any>previewAppPluginsService).getDevicePlugins;
+			(<any>previewAppPluginsService).getDevicePlugins = (device: Device) => {
+				isGetDevicePluginsCalled = true;
+				return originalGetDevicePlugins(device);
+			};
+			let isGetLocalPluginsCalled = false;
+			const originalGetLocalPlugins = (<any>previewAppPluginsService).getLocalPlugins;
+			(<any>previewAppPluginsService).getLocalPlugins = () => {
+				isGetLocalPluginsCalled = true;
+				return originalGetLocalPlugins.apply(previewAppPluginsService);
+			};
+
+			await previewAppPluginsService.comparePluginsOnDevice(createDevice(JSON.stringify(previewAppPlugins)));
+
+			const expectedWarnings = [
+				util.format(PluginComparisonMessages.PLUGIN_NOT_INCLUDED_IN_PREVIEW_APP, "nativescript-facebook", deviceId),
+				util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_DIFFERENCE_IN_MAJOR_VERSION, "nativescript-theme-core", "1.0.4", "2.0.4")
+			];
+			assert.isTrue(isGetDevicePluginsCalled);
+			assert.isTrue(isGetLocalPluginsCalled);
+			assert.deepEqual(warnParams, expectedWarnings);
+
+			isGetDevicePluginsCalled = false;
+			isGetLocalPluginsCalled = false;
+			warnParams = [];
+
+			await previewAppPluginsService.comparePluginsOnDevice(createDevice(JSON.stringify(previewAppPlugins)));
+
+			assert.isFalse(isGetDevicePluginsCalled);
+			assert.isFalse(isGetLocalPluginsCalled);
+			assert.deepEqual(warnParams, expectedWarnings);
+		});
+
 		const testCases = [
 			{
 				name: "should show warning for plugin not included in preview app",


### PR DESCRIPTION
In case when QR code is scanned with 2 different devices with the same version of preview app, {N} CLI will compares 2 times plugins from preview app with local plugins.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
{N} CLI compares **2 times** plugins from preview app with local plugins when QR code is scanned with 2 different devices with the same version of preview app.

## What is the new behavior?
{N} CLI compares **only once** plugins from preview app with local plugins when QR code is scanned with 2 different devices with the same version of preview app.

