### PR TITLE
chore: reset filesToSync and filesToRemove when syncing on preview app

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -597,6 +597,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 									env: liveSyncData.env,
 									projectDir: projectData.projectDir
 								}, filesToSync);
+								filesToSync = [];
+								filesToRemove = [];
 							}
 						});
 					} else {


### PR DESCRIPTION
In case when `.js` file is changed and after that `.html` file is changed, preview app is restarted on device. Actually {N} CLI needs to reset filesToSync after syncing on preview app.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Preview app is restarted on `.html` change

## What is the new behavior?
Preview app is not restarted on `.html` change

