### PR TITLE
chore: don't show warnings for {N} plugins without native code  when bundle option is provided

### DIFF
--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -15,6 +15,7 @@ interface IPluginsService {
 	validate(platformData: IPlatformData, projectData: IProjectData): Promise<void>;
 	preparePluginNativeCode(pluginData: IPluginData, platform: string, projectData: IProjectData): Promise<void>;
 	convertToPluginData(cacheData: any, projectDir: string): IPluginData;
+	isNativeScriptPlugin(pluginName: string, projectData: IProjectData): boolean;
 }
 
 interface IPackageJsonDepedenciesResult {

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -18,7 +18,7 @@ declare global {
 	}
 
 	interface IPreviewAppPluginsService {
-		comparePluginsOnDevice(device: Device): Promise<void>;
+		comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void>;
 		getExternalPlugins(device: Device): string[];
 	}
 

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -49,7 +49,7 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 					startSyncFilesTimeout: startSyncFilesTimeout.bind(this)
 				}
 			});
-			await this.$previewAppPluginsService.comparePluginsOnDevice(device);
+			await this.$previewAppPluginsService.comparePluginsOnDevice(data, device);
 			const payloads = await this.syncFilesForPlatformSafe(data, device.platform);
 
 			return payloads;
@@ -60,7 +60,7 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 		this.showWarningsForNativeFiles(files);
 
 		for (const device of this.$previewSdkService.connectedDevices) {
-			await this.$previewAppPluginsService.comparePluginsOnDevice(device);
+			await this.$previewAppPluginsService.comparePluginsOnDevice(data, device);
 		}
 
 		const platforms = _(this.$previewSdkService.connectedDevices)

--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -4,12 +4,14 @@ import * as util from "util";
 import { Device } from "nativescript-preview-sdk";
 import { PluginComparisonMessages } from "./preview-app-constants";
 import { NODE_MODULES_DIR_NAME } from "../../../common/constants";
+import { PLATFORMS_DIR_NAME } from "../../../constants";
 
 export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 	private previewAppVersionWarnings: IDictionary<string[]> = {};
 
 	constructor(private $fs: IFileSystem,
 		private $logger: ILogger,
+		private $pluginsService: IPluginsService,
 		private $projectData: IProjectData) { }
 
 	public async comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void> {
@@ -91,17 +93,11 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 	}
 
 	private isNativeScriptPluginWithoutNativeCode(localPlugin: string, platform: string): boolean {
-		return this.isNativeScriptPlugin(localPlugin) && !this.hasNativeCode(localPlugin, platform);
-	}
-
-	private isNativeScriptPlugin(localPlugin: string): boolean {
-		const pluginPackageJsonPath = path.join(this.$projectData.projectDir, NODE_MODULES_DIR_NAME, localPlugin, "package.json");
-		const pluginPackageJsonContent = this.$fs.readJson(pluginPackageJsonPath);
-		return pluginPackageJsonContent && pluginPackageJsonContent.nativescript;
+		return this.$pluginsService.isNativeScriptPlugin(localPlugin, this.$projectData) && !this.hasNativeCode(localPlugin, platform);
 	}
 
 	private hasNativeCode(localPlugin: string, platform: string): boolean {
-		const nativeFolderPath = path.join(this.$projectData.projectDir, NODE_MODULES_DIR_NAME, localPlugin, "platforms", platform.toLowerCase());
+		const nativeFolderPath = path.join(this.$projectData.projectDir, NODE_MODULES_DIR_NAME, localPlugin, PLATFORMS_DIR_NAME, platform.toLowerCase());
 		return this.$fs.exists(nativeFolderPath) && !this.$fs.isEmptyDir(nativeFolderPath);
 	}
 }

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as shelljs from "shelljs";
 import * as semver from "semver";
 import * as constants from "../constants";
+import { NODE_MODULES_DIR_NAME } from "../common/constants";
 
 export class PluginsService implements IPluginsService {
 	private static INSTALL_COMMAND_NAME = "install";
@@ -205,6 +206,12 @@ export class PluginsService implements IPluginsService {
 			dependencies,
 			devDependencies
 		};
+	}
+
+	public isNativeScriptPlugin(pluginName: string, projectData: IProjectData): boolean {
+		const pluginPackageJsonPath = path.join(projectData.projectDir, NODE_MODULES_DIR_NAME, pluginName, "package.json");
+		const pluginPackageJsonContent = this.$fs.readJson(pluginPackageJsonPath);
+		return pluginPackageJsonContent && pluginPackageJsonContent.nativescript;
 	}
 
 	private getBasicPluginInformation(dependencies: any): IBasePluginData[] {

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -34,6 +34,11 @@ function createTestInjector(localPlugins: IStringDictionary, options?: { isNativ
 			return !options.hasPluginNativeCode;
 		}
 	});
+	injector.register("pluginsService", {
+		isNativeScriptPlugin: () => {
+			return options.isNativeScriptPlugin;
+		}
+	});
 	injector.register("logger", {
 		trace: () => ({}),
 		warn: (message: string) =>  warnParams.push(message)


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
A warning is shown for plugin with only .js files when `tns preview --bundle` command is executed

## What is the new behavior?
A warning is not shown for plugin with only .js files when `tns preview --bundle` command is executed
