### PR TITLE
chore: check network connectivity when `tns preview` command is executed

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -181,3 +181,5 @@ $injector.require("iOSDebuggerPortService", "./services/ios-debugger-port-servic
 
 $injector.require("pacoteService", "./services/pacote-service");
 $injector.require("qrCodeTerminalService", "./services/qr-code-terminal-service");
+
+$injector.require("networkConnectivityValidator", "./helpers/network-connectivity-validator");

--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -3,6 +3,7 @@ export class PreviewCommand implements ICommand {
 
 	constructor(private $bundleValidatorHelper: IBundleValidatorHelper,
 		private $liveSyncService: ILiveSyncService,
+		private $networkConnectivityValidator: INetworkConnectivityValidator,
 		private $projectData: IProjectData,
 		private $options: IOptions,
 		private $playgroundQrCodeGenerator: IPlaygroundQrCodeGenerator,
@@ -27,6 +28,7 @@ export class PreviewCommand implements ICommand {
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
+		await this.$networkConnectivityValidator.validate();
 		this.$bundleValidatorHelper.validate();
 		return true;
 	}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -866,3 +866,7 @@ interface IRuntimeGradleVersions {
 	gradleVersion?: string;
 	gradleAndroidPluginVersion?: string;
 }
+
+interface INetworkConnectivityValidator {
+	validate(): Promise<void>;
+}

--- a/lib/helpers/network-connectivity-validator.ts
+++ b/lib/helpers/network-connectivity-validator.ts
@@ -1,0 +1,31 @@
+import * as dns from "dns";
+
+export class NetworkConnectivityValidator implements INetworkConnectivityValidator {
+	private static DNS_LOOKUP_URL = "play.nativescript.org";
+	private static NO_INTERNET_ERROR_CODE = "ENOTFOUND";
+	private static NO_INTERNET_ERROR_MESSAGE = "No internet connection. Check your internet settings and try again.";
+
+	constructor(private $errors: IErrors,
+		private $logger: ILogger) { }
+
+	public async validate(): Promise<void> {
+		const isConnected = await this.isConnected();
+		if (!isConnected) {
+			this.$errors.failWithoutHelp(NetworkConnectivityValidator.NO_INTERNET_ERROR_MESSAGE);
+		}
+	}
+
+	private isConnected(): Promise<boolean> {
+		return new Promise((resolve, reject) => {
+			dns.lookup(NetworkConnectivityValidator.DNS_LOOKUP_URL, err => {
+				this.$logger.trace(`Error from dns.lookup is ${err}.`);
+				if (err && err.code === NetworkConnectivityValidator.NO_INTERNET_ERROR_CODE) {
+					resolve(false);
+				} else {
+					resolve(true);
+				}
+			});
+		});
+	}
+}
+$injector.register("networkConnectivityValidator", NetworkConnectivityValidator);


### PR DESCRIPTION
Rel to: https://github.com/NativeScript/nativescript-cli/issues/3813

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
No error message is shown when no internet connection and `tns preview` command is executed

## What is the new behavior?
An error message is shown when no internet connection and `tns preview` command is executed