### PR TITLE
chrore: don't prepare the platform when webpack emits changed files on preview command - just send a message to pubnub.

### DIFF
--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -31,7 +31,8 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 			const startSyncFilesTimeout = async (platform: string) => {
 				await promise
 					.then(async () => {
-						promise = this.syncFilesForPlatformSafe(data, platform, filesToSyncMap[platform]);
+						const projectData = this.$projectDataService.getProjectData(data.projectDir);
+						promise = this.applyChanges(this.$platformsData.getPlatformData(platform, projectData), projectData, filesToSyncMap[platform]);
 						await promise;
 					});
 				filesToSyncMap[platform] = [];


### PR DESCRIPTION
Skip platform prepare when `tns preview --bundle` command is executed and some  changed files are reported by webpack. In this case we just need to send a message to pubnub.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
