### PR TITLE
fix: build with Xcode 10 may fail for missing plugins...xcconfig file

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -1301,6 +1301,13 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 			await this.mergeXcconfigFiles(appResourcesXcconfigPath, pluginsXcconfigFilePath);
 		}
 
+		if (!this.$fs.exists(pluginsXcconfigFilePath)) {
+			// We need the pluginsXcconfig file to exist in platforms dir as it is required in the native template:
+			// https://github.com/NativeScript/ios-runtime/blob/9c2b7b5f70b9bee8452b7a24aa6b646214c7d2be/build/project-template/__PROJECT_NAME__/build-debug.xcconfig#L3
+			// From Xcode 10 in case the file is missing, this include fails and the build itself fails (was a warning in previous Xcode versions).
+			this.$fs.writeFile(pluginsXcconfigFilePath, "");
+		}
+
 		// Set Entitlements Property to point to default file if not set explicitly by the user.
 		const entitlementsPropertyValue = this.$xCConfigService.readPropertyValue(pluginsXcconfigFilePath, constants.CODE_SIGN_ENTITLEMENTS);
 		if (entitlementsPropertyValue === null && this.$fs.exists(this.$iOSEntitlementsService.getPlatformsEntitlementsPath(projectData))) {

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -1029,4 +1029,18 @@ describe("Merge Project XCConfig files", () => {
 			assertPropertyValues(expected, destinationFilePath, testInjector);
 		}
 	});
+
+	it("creates empty plugins-<config>.xcconfig in case there are no build.xcconfig in App_Resources and in plugins", async () => {
+		// run merge for all release: debug|release
+		for (const release in [true, false]) {
+			await (<any>iOSProjectService).mergeProjectXcconfigFiles(release, projectData);
+
+			const destinationFilePath = release ? (<any>iOSProjectService).getPluginsReleaseXcconfigFilePath(projectData)
+				: (<any>iOSProjectService).getPluginsDebugXcconfigFilePath(projectData);
+
+			assert.isTrue(fs.exists(destinationFilePath), 'Target build xcconfig is missing for release: ' + release);
+			const content = fs.readFile(destinationFilePath).toString();
+			assert.equal(content, "");
+		}
+	});
 });


### PR DESCRIPTION
In the iOS Project template we have include for plugins-debug.xcconfig (or plugins-release.xcconfig when building in release mode). CLI should produce such file, but it does not do it when the project does not have build.xcconfig in its App_Resources and neither of the plugins have such file. With previous Xcode versions, this case was leading to warnings in the output, however they are errors now and the build fails.
Fix this by adding an empty file in such case.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Build fails for iOS in case the following circumstances are fulfilled:
* Xcode 10 is used
* application does not have build.xcconfig file in `App_Resources/iOS/build.xcconfig`
* none of the plugins have build.xcconfig file in `<plugin dir>/platforms/ios/build.xcconfig`

## What is the new behavior?
The application can be build in case the mentioned circumstances are fulfilled.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3912
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

