### PR TITLE
chore: sync correctly deleted files on android devices

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -465,7 +465,7 @@ interface IAndroidLivesyncTool {
 	 * @param filePaths - Array of files that will be removed.
 	 * @returns {Promise<boolean[]>}
 	 */
-	removeFiles(filePaths: string[]): Promise<void[]>;
+	removeFiles(filePaths: string[]): Promise<void>;
 	/**
 	 * Sends doSyncOperation that will be handled by the runtime.
 	 * @param options

--- a/lib/services/livesync/android-device-livesync-sockets-service.ts
+++ b/lib/services/livesync/android-device-livesync-sockets-service.ts
@@ -48,6 +48,7 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 			return result;
 		} catch (e) {
 			this.livesyncTool.end();
+			throw e;
 		}
 	}
 

--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -104,26 +104,27 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 	}
 
 	public async removeFile(filePath: string): Promise<void> {
-			this.verifyActiveConnection();
-			const filePathData = this.getFilePathData(filePath);
-			const headerBuffer = Buffer.alloc(PROTOCOL_OPERATION_LENGTH_SIZE +
-				SIZE_BYTE_LENGTH +
-				filePathData.filePathLengthSize +
-				filePathData.filePathLengthBytes);
+		this.verifyActiveConnection();
+		const filePathData = this.getFilePathData(filePath);
+		const headerBuffer = Buffer.alloc(PROTOCOL_OPERATION_LENGTH_SIZE +
+			SIZE_BYTE_LENGTH +
+			filePathData.filePathLengthSize +
+			filePathData.filePathLengthBytes);
 
-			let offset = 0;
-			offset += headerBuffer.write(AndroidLivesyncTool.DELETE_FILE_OPERATION.toString(), offset, PROTOCOL_OPERATION_LENGTH_SIZE);
-			offset = headerBuffer.writeInt8(filePathData.filePathLengthSize, offset);
-			offset += headerBuffer.write(filePathData.filePathLengthString, offset, filePathData.filePathLengthSize);
-			headerBuffer.write(filePathData.relativeFilePath, offset, filePathData.filePathLengthBytes);
-			const hash = crypto.createHash("md5").update(headerBuffer).digest();
+		let offset = 0;
+		offset += headerBuffer.write(AndroidLivesyncTool.DELETE_FILE_OPERATION.toString(), offset, PROTOCOL_OPERATION_LENGTH_SIZE);
+		offset = headerBuffer.writeInt8(filePathData.filePathLengthSize, offset);
+		offset += headerBuffer.write(filePathData.filePathLengthString, offset, filePathData.filePathLengthSize);
+		headerBuffer.write(filePathData.relativeFilePath, offset, filePathData.filePathLengthBytes);
+		const hash = crypto.createHash("md5").update(headerBuffer).digest();
 
-			await this.writeToSocket(headerBuffer);
-			await this.writeToSocket(hash);
+		await this.writeToSocket(headerBuffer);
+		await this.writeToSocket(hash);
 	}
-
-	public removeFiles(files: string[]) {
-		return Promise.all(files.map(file => this.removeFile(file)));
+	public async removeFiles(files: string[]): Promise<void> {
+		for (const file of files) {
+			await this.removeFile(file);
+		}
 	}
 
 	public generateOperationIdentifier(): string {

--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -266,6 +266,7 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 		const error = this.checkConnectionStatus();
 		if (error && rejectHandler) {
 			rejectHandler(error);
+			return false;
 		}
 
 		if (error && !rejectHandler) {


### PR DESCRIPTION
Remove files synchronously (not in parallel) in order to ensure header and content of files are sent in correct order.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When something unexpected happens, the error from runtime is not propagated to the client.

## What is the new behavior?
When something unexpected happens, the error from runtime is propagated to the client.

Steps to reproduce:
1. Create new project
2. Execute `tns run android`
3. Add new folder and file inside it to the`app` folder
4. Ensure the folder is successfully transferred to device
5. Remove the folder
6. The command is successfully executed but actually the folder is not removed from device
