### PR TITLE
feat: remove requirement for Android Support Repository local installation

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -31,7 +31,6 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 			infoData.compileSdkVersion = this.getCompileSdkVersion();
 			infoData.buildToolsVersion = this.getBuildToolsVersion();
 			infoData.targetSdkVersion = this.getTargetSdk();
-			infoData.supportRepositoryVersion = this.getAndroidSupportRepositoryVersion();
 			infoData.generateTypings = this.shouldGenerateTypings();
 
 			this.toolsInfo = infoData;
@@ -201,32 +200,6 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		}
 
 		return buildToolsVersion;
-	}
-
-	private getAppCompatRange(): string {
-		const compileSdkVersion = this.getCompileSdkVersion();
-		let requiredAppCompatRange: string;
-		if (compileSdkVersion) {
-			requiredAppCompatRange = `>=${compileSdkVersion} <${compileSdkVersion + 1}`;
-		}
-
-		return requiredAppCompatRange;
-	}
-
-	private getAndroidSupportRepositoryVersion(): string {
-		let selectedAppCompatVersion: string;
-		const requiredAppCompatRange = this.getAppCompatRange();
-		if (this.androidHome && requiredAppCompatRange) {
-			const pathToAppCompat = path.join(this.androidHome, "extras", "android", "m2repository", "com", "android", "support", "appcompat-v7");
-			selectedAppCompatVersion = this.getMatchingDir(pathToAppCompat, requiredAppCompatRange);
-			if (!selectedAppCompatVersion) {
-				// get latest matching version, as there's no available appcompat versions for latest SDK versions.
-				selectedAppCompatVersion = this.getMatchingDir(pathToAppCompat, "*");
-			}
-		}
-
-		this.$logger.trace(`Selected AppCompat version is: ${selectedAppCompatVersion}`);
-		return selectedAppCompatVersion;
 	}
 
 	private getLatestValidAndroidTarget(): string {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -619,11 +619,6 @@ interface IAndroidToolsInfoData {
 	compileSdkVersion: number;
 
 	/**
-	 * The latest installed version of Android Support Repository that satisfies CLI's requirements.
-	 */
-	supportRepositoryVersion: string;
-
-	/**
 	 * The Android targetSdkVersion specified by the user.
 	 * In case it is not specified, compileSdkVersion will be used for targetSdkVersion.
 	 */

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -425,8 +425,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			pluginBuildSettings.pluginDir,
 			"assembleRelease",
 			`-PcompileSdk=android-${pluginBuildSettings.androidToolsInfo.compileSdkVersion}`,
-			`-PbuildToolsVersion=${pluginBuildSettings.androidToolsInfo.buildToolsVersion}`,
-			`-PsupportVersion=${pluginBuildSettings.androidToolsInfo.supportRepositoryVersion}`
+			`-PbuildToolsVersion=${pluginBuildSettings.androidToolsInfo.buildToolsVersion}`
 		];
 
 		try {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -369,13 +369,11 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		const compileSdk = androidToolsInfo.compileSdkVersion;
 		const targetSdk = this.getTargetFromAndroidManifest(configurationFilePath) || compileSdk;
 		const buildToolsVersion = androidToolsInfo.buildToolsVersion;
-		const appCompatVersion = androidToolsInfo.supportRepositoryVersion;
 		const generateTypings = androidToolsInfo.generateTypings;
 		const buildOptions = [
 			`-PcompileSdk=android-${compileSdk}`,
 			`-PtargetSdk=${targetSdk}`,
 			`-PbuildToolsVersion=${buildToolsVersion}`,
-			`-PsupportVersion=${appCompatVersion}`,
 			`-PgenerateTypings=${generateTypings}`
 		];
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -45,7 +45,7 @@
     "@types/color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.0.tgz",
-      "integrity": "sha1-QPimvy/YbpaYdrM5qDfY/xsKbjA=",
+      "integrity": "sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==",
       "dev": true,
       "requires": {
         "@types/color-convert": "*"
@@ -54,7 +54,7 @@
     "@types/color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-v6ggPkHnxlRx6YQdfjBqfNi1Fy0=",
+      "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
       "dev": true,
       "requires": {
         "@types/color-name": "*"
@@ -63,7 +63,7 @@
     "@types/color-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.0.tgz",
-      "integrity": "sha1-km929+ZvScxZrYgLsVsDCrvwtm0=",
+      "integrity": "sha512-gZ/Rb+MFXF0pXSEQxdRoPMm5jeO3TycjOdvbpbcpHX/B+n9AqaHFe5q6Ga9CsZ7ir/UgIWPfrBzUzn3F19VH/w==",
       "dev": true
     },
     "@types/events": {
@@ -102,7 +102,7 @@
     "@types/ora": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/ora/-/ora-1.3.3.tgz",
-      "integrity": "sha1-0xhkGMPPN6gxeZs3a+ykqOG/yi0=",
+      "integrity": "sha512-XaSVRyCfnGq1xGlb6iuoxnomMXPIlZnvIIkKiGNMTCeVOg7G1Si+FA9N1lPrykPEfiRHwbuZXuTCSoYcHyjcdg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -324,7 +324,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -920,7 +920,7 @@
     "color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-      "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -4237,7 +4237,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.36.0",
@@ -4437,14 +4437,14 @@
       "integrity": "sha512-BAnxAdaihzMoszwhqRy8FPOX+dijs7esUEUYTIQ1KsOSKmCVNYnitAMmBDFxYzA6VQYvuUKw7o2K1AcMBTGzIg=="
     },
     "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.5.tgz",
+      "integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A=="
     },
     "nativescript-doctor": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.2.0.tgz",
-      "integrity": "sha512-huJB71CxCcbBQDCt9F1CkfsGDN2YHVJHGQyQYhnCCX6OJFOOjSr/HMqNpUUIGlhqVQfUR1SYeCFfaKa+1/eDvg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.3.0.tgz",
+      "integrity": "sha512-0d8WQcAnaRxOW+nqlkJbXbhozxd/dLnPoCfRMvSt0hKc3cdGQBXya1vTAQIBCmLlEcV/sydqA50nx3wW51QqTg==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.3.0",
@@ -6799,7 +6799,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "1.2.0",
+    "nativescript-doctor": "1.3.0",
     "nativescript-preview-sdk": "0.2.9",
     "open": "0.0.5",
     "ora": "2.0.0",

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -603,7 +603,6 @@ export class AndroidToolsInfoStub implements IAndroidToolsInfo {
 		infoData.compileSdkVersion = 23;
 		infoData.buildToolsVersion = "23";
 		infoData.targetSdkVersion = 23;
-		infoData.supportRepositoryVersion = "23";
 		return infoData;
 	}
 


### PR DESCRIPTION
In the past there was a requirement to have a local installation of the Android Support Repository in order to use libraries from there. However, since some time, the new versions are not downloaded locally and they must be used from the Google repository.
Currently this is not possible in NativeScript as {N} CLI always passes the Support Library version to gradle based on the local installation.
Remove the requirement for local installation and never pass the version to gradle. This way the apps will use the value specified in the `build.gradle` and they can overwrite it in `app.gradle`.
Update nativescript-doctor to latest version, which allows building project without local Androud Support Repository

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
You cannot use new versions of Android Support Library. Defining it in `app.gradle` still does not allow you to use newer version, as CLI overwrites the value. Also you cannot build NativeScript projects in case you do not have local version of the Android Support Repository.

## What is the new behavior?
1. You can specify your own version of the Android Support Library in your `app.gradle`. In case you do not specify it, a default value will be used (set in `build.gradle`).
2. You can build projects without installing local version of Android Support Repository.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/3773 


BREAKING CHANGES:
Existing applications that are using older runtime (not 5.0.0 one), but are built with CLI 5.0.0, may experience some changes - until now CLI was always passing parameter to gradle `-PsupportVersion=26.0.0-alpha1`. As CLI no longer passes this version, the default one from `build.gradle` will be used (for example 27.0.1). In case you want to use the old version in your application, add the following in your `app.gradle`:
```Groovy
project.ext.supportVersion = "26.0.0-alpha1"
```

