### PR TITLE
fix: add changed file name in logs when `tns preview` command is executed

### DIFF
--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -90,11 +90,11 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 			let result: FilesPayload = null;
 			if (files && files.length) {
 				result = await this.applyChanges(platformData, projectData, files);
+				this.$logger.info(`Successfully synced ${result.files.map(filePayload => filePayload.file.yellow)} for platform ${platform}.`);
 			} else {
 				result = await this.getFilesPayload(platformData, projectData);
+				this.$logger.info(`Successfully synced changes for platform ${platform}.`);
 			}
-
-			this.$logger.info(`Successfully synced changes for platform ${platform}.`);
 
 			return result;
 		} catch (err) {


### PR DESCRIPTION
‘tns preview’ + scan QR  

Change something in *.js file and missing name of the changed file in console. 

‘Project successfully prepared (ios) 

Successfully synced changes for platform ios. 

Start syncing changes for platform ios. 

Preparing project... 

Project successfully prepared (ios) 

Successfully synced changes for platform ios. 
’ 

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The changed file's name is not shown in logs when `tns preview` command is executed

## What is the new behavior?
The changed file's name is shown in logs when `tns preview` command is executed

