### PR TITLE
fix: skip platform add on every change when `tns preview --bundle` command is executed

### DIFF
--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -106,6 +106,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("pacoteService", {
 		extractPackage: async (packageName: string, destinationDirectory: string, options?: IPacoteExtractOptions): Promise<void> => undefined
 	});
+	testInjector.register("usbLiveSyncService", () => ({}));
 
 	return testInjector;
 }

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -179,6 +179,7 @@ function createTestInjector() {
 	testInjector.register("pacoteService", {
 		extractPackage: async (packageName: string, destinationDirectory: string, options?: IPacoteExtractOptions): Promise<void> => undefined
 	});
+	testInjector.register("usbLiveSyncService", ({}));
 
 	return testInjector;
 }


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
"Platform android successfully added. V4.2.0" message is shown on every change when `tns preview --bundle` command is executed.

## What is the new behavior?
"Platform android successfully added. V4.2.0" message is not shown on every change.
