### PR TITLE
fix: don't fail if some unhandled error occurs in application

### DIFF
--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -7,8 +7,7 @@ export class PreviewSdkService implements IPreviewSdkService {
 	private instanceId: string = null;
 	public connectedDevices: Device[] = [];
 
-	constructor(private $errors: IErrors,
-		private $logger: ILogger,
+	constructor(private $logger: ILogger,
 		private $httpClient: Server.IHttpClient,
 		private $config: IConfiguration) {
 	}
@@ -62,7 +61,7 @@ export class PreviewSdkService implements IPreviewSdkService {
 				this.$logger.trace("Received onRestartMessage event.");
 			},
 			onUncaughtErrorMessage: () => {
-				this.$errors.failWithoutHelp("Error while communicating with preview app.");
+				this.$logger.warn("The Preview app has terminated unexpectedly. Please run it again to get a detailed crash report.");
 			},
 			onDeviceConnectedMessage: (deviceConnectedMessage: DeviceConnectedMessage) => ({ }),
 			onDeviceConnected: (device: Device) => {

--- a/test/services/preview-sdk-service.ts
+++ b/test/services/preview-sdk-service.ts
@@ -1,12 +1,11 @@
 import { PreviewSdkService } from "../../lib/services/livesync/playground/preview-sdk-service";
 import { Yok } from "../../lib/common/yok";
 import { assert } from "chai";
-import { LoggerStub, ErrorsStub } from "../stubs";
+import { LoggerStub } from "../stubs";
 
 const getPreviewSdkService = (): IPreviewSdkService => {
 	const testInjector = new Yok();
 	testInjector.register("logger", LoggerStub);
-	testInjector.register("errors", ErrorsStub);
 	testInjector.register("config", {});
 	testInjector.register("previewSdkService", PreviewSdkService);
 


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
If some error is thrown from application, {N} CLI stops command execution

## What is the new behavior?
If some error is thrown from application, {N} CLI does not stop command execution

Steps to reproduce:
1. Run `tns preview` command
2. Scan QR code
3. Throw some error from application

