### PR TITLE
fix: log device identifier on success message when `tns run` command is executed

### DIFF
--- a/lib/common/services/livesync-service-base.ts
+++ b/lib/common/services/livesync-service-base.ts
@@ -221,7 +221,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 
 	private async transferFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string, isFullSync: boolean): Promise<void> {
 		this.$logger.info("Transferring project files...");
-		this.logFilesSyncInformation(localToDevicePaths, "Transferring %s.", this.$logger.trace);
+		this.logFilesSyncInformation(localToDevicePaths, "Transferring %s on device %s.", this.$logger.trace, deviceAppData.device.deviceInfo.identifier);
 
 		const canTransferDirectory = isFullSync && (this.$devicesService.isAndroidDevice(deviceAppData.device) || this.$devicesService.isiOSSimulator(deviceAppData.device));
 		if (canTransferDirectory) {
@@ -238,13 +238,13 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 			await this.$liveSyncProvider.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, isFullSync);
 		}
 
-		this.logFilesSyncInformation(localToDevicePaths, "Successfully transferred %s.", this.$logger.info);
+		this.logFilesSyncInformation(localToDevicePaths, "Successfully transferred %s on device %s.", this.$logger.info, deviceAppData.device.deviceInfo.identifier);
 	}
 
-	private logFilesSyncInformation(localToDevicePaths: Mobile.ILocalToDevicePathData[], message: string, action: Function): void {
+	private logFilesSyncInformation(localToDevicePaths: Mobile.ILocalToDevicePathData[], message: string, action: Function, deviceIdentifier: string): void {
 		if (this.showFullLiveSyncInformation) {
 			_.each(localToDevicePaths, (file: Mobile.ILocalToDevicePathData) => {
-				action.call(this.$logger, util.format(message, path.basename(file.getLocalPath()).yellow));
+				action.call(this.$logger, util.format(message, path.basename(file.getLocalPath()).yellow), deviceIdentifier);
 			});
 		} else {
 			action.call(this.$logger, util.format(message, "all files"));

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -120,7 +120,7 @@ export abstract class PlatformLiveSyncServiceBase {
 
 		transferredFiles = await deviceLiveSyncService.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, projectData, liveSyncDeviceInfo, options);
 
-		this.logFilesSyncInformation(transferredFiles, "Successfully transferred %s.", this.$logger.info);
+		this.logFilesSyncInformation(transferredFiles, "Successfully transferred %s on device %s.", this.$logger.info, deviceAppData.device.deviceInfo.identifier);
 
 		return transferredFiles;
 	}
@@ -139,10 +139,10 @@ export abstract class PlatformLiveSyncServiceBase {
 		};
 	}
 
-	private logFilesSyncInformation(localToDevicePaths: Mobile.ILocalToDevicePathData[], message: string, action: Function): void {
+	private logFilesSyncInformation(localToDevicePaths: Mobile.ILocalToDevicePathData[], message: string, action: Function, deviceIdentifier: string): void {
 		if (localToDevicePaths && localToDevicePaths.length < 10) {
 			_.each(localToDevicePaths, (file: Mobile.ILocalToDevicePathData) => {
-				action.call(this.$logger, util.format(message, path.basename(file.getLocalPath()).yellow));
+				action.call(this.$logger, util.format(message, path.basename(file.getLocalPath()).yellow), deviceIdentifier);
 			});
 		} else {
 			action.call(this.$logger, util.format(message, "all files"));


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
"Successfully transferred myfile.js." message is shown on success livesync.

## What is the new behavior?
"Successfully transferred myfile.js on device myDeivce" message is shown on success livesync.

