### PR TITLE
fix: unable to create project from scoped package template

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -238,6 +238,11 @@ interface ITemplateData {
 	 * The whole content of package.json file
 	 */
 	templatePackageJsonContent: ITemplatePackageJsonContent;
+
+	/**
+	 * The version of the package used for creating the application.
+	 */
+	version: string;
 }
 
 interface ITemplatePackageJsonContent extends IBasePluginData {

--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -19,8 +19,16 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 			originalTemplateName = constants.RESERVED_TEMPLATE_NAMES["default"];
 		}
 
-		// support <reserved_name>@<version> syntax
-		const [name, version] = originalTemplateName.split("@");
+		// support <reserved_name>@<version> syntax, for example typescript@1.0.0
+		// support <scoped_package_name>@<version> syntax, for example @nativescript/vue-template@1.0.0
+		const lastIndexOfAtSign = originalTemplateName.lastIndexOf("@");
+		let name = originalTemplateName;
+		let version = "";
+		if (lastIndexOfAtSign > 0) {
+			name = originalTemplateName.substr(0, lastIndexOfAtSign);
+			version = originalTemplateName.substr(lastIndexOfAtSign + 1);
+		}
+
 		const templateName = constants.RESERVED_TEMPLATE_NAMES[name.toLowerCase()] || name;
 		const fullTemplateName = version ? `${templateName}@${version}` : templateName;
 		const templatePackageJsonContent = await this.getTemplatePackageJsonContent(fullTemplateName);
@@ -49,7 +57,7 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 			});
 		}
 
-		return { templateName, templatePath, templateVersion, templatePackageJsonContent };
+		return { templateName, templatePath, templateVersion, templatePackageJsonContent, version };
 	}
 
 	private async getTemplateVersion(templateName: string): Promise<string> {

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -220,5 +220,42 @@ describe("project-templates-service", () => {
 			});
 
 		});
+
+		describe("uses correct version", () => {
+			[
+				{
+					name: "is correct when package version is passed",
+					templateName: "some-template@1.0.0",
+					expectedVersion: "1.0.0",
+					expectedTemplateName: "some-template"
+				},
+				{
+					name: "is correct when reserved package name with version is passed",
+					templateName: "typescript@1.0.0",
+					expectedVersion: "1.0.0",
+					expectedTemplateName: "tns-template-hello-world-ts"
+				},
+				{
+					name: "is correct when scoped package name without version is passed",
+					templateName: "@nativescript/vue-template",
+					expectedVersion: "",
+					expectedTemplateName: "@nativescript/vue-template"
+				},
+				{
+					name: "is correct when scoped package name with version is passed",
+					templateName: "@nativescript/vue-template@1.0.0",
+					expectedVersion: "1.0.0",
+					expectedTemplateName: "@nativescript/vue-template"
+				}
+			].forEach(testCase => {
+				it(testCase.name, async () => {
+					const testInjector = createTestInjector();
+					const projectTemplatesService = testInjector.resolve<IProjectTemplatesService>("projectTemplatesService");
+					const { version, templateName } = await projectTemplatesService.prepareTemplate(testCase.templateName, "tempFolder");
+					assert.strictEqual(version, testCase.expectedVersion);
+					assert.strictEqual(templateName, testCase.expectedTemplateName);
+				});
+			});
+		});
 	});
 });


### PR DESCRIPTION
In case you try to create application from scoped package, for example `@nativescript/some-package-name`, CLI fails with `npm install` error.
The problem is that CLI thinks everything after `@` is a version and sets the package name that has to be installed to empty string.
Fix the parsing and add tests

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
The following command fails:
```
tns create myApp --template "@angular/core" 
```

## What is the new behavior?
The following command succeeds:
```
tns create myApp --template "@angular/core" 
```

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/3934

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

