### PR TITLE
Having two plugins with Podfiles and a postinstall script fails with tns 5.x

### DIFF
--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -90,7 +90,7 @@ export class CocoaPodsService implements ICocoaPodsService {
 				finalPodfileContent = finalPodfileContent.replace(postInstallHookStart, `${postInstallHookStart}${postInstallHookContent}`);
 			} else {
 				const postInstallHook = `${postInstallHookStart}${postInstallHookContent}end`;
-				finalPodfileContent = `${finalPodfileContent}${postInstallHook}`;
+				finalPodfileContent = `${finalPodfileContent}${EOL}${EOL}${postInstallHook}`;
 			}
 		}
 

--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -89,8 +89,11 @@ export class CocoaPodsService implements ICocoaPodsService {
 			if (index !== -1) {
 				finalPodfileContent = finalPodfileContent.replace(postInstallHookStart, `${postInstallHookStart}${postInstallHookContent}`);
 			} else {
+				if (finalPodfileContent.length > 0) {
+					finalPodfileContent += `${EOL}${EOL}`;
+				}
 				const postInstallHook = `${postInstallHookStart}${postInstallHookContent}end`;
-				finalPodfileContent = `${finalPodfileContent}${EOL}${EOL}${postInstallHook}`;
+				finalPodfileContent = `${finalPodfileContent}${postInstallHook}`;
 			}
 		}
 


### PR DESCRIPTION
With NativeScript 5.0.0-2018-09-25-12302 having fi. `nativescript-plugin-firebase` and `nativescript-imagepicker` in your project will fail because there's some whitespace missing.

Building [this app](https://github.com/EddyVerbruggen/nativescript-plugin-firebase/tree/master/demo-ng) fails because this is how the Pods are merged (mind the line `# End Podfilepost_install` near the end):

```
use_frameworks!

target "demong" do
# Begin Podfile - /Users/eddyverbruggen/sandboxes/nativescript-plugin-firebase/demo-ng/node_modules/nativescript-plugin-firebase/platforms/ios/Podfile
pod 'Firebase/Core', '~> 5.6.0' 

# Authentication
pod 'Firebase/Auth'

# Realtime DB
#pod 'Firebase/Database'

# Cloud Firestore
pod 'Firebase/Firestore'

# Remote Config
#pod 'Firebase/RemoteConfig'

# Crash Reporting
#pod 'Firebase/Crash'

# Crashlytics
pod 'Fabric'
pod 'Crashlytics'

# Crashlytics works best without bitcode
def post_installnativescript_plugin_firebase_0 (installer)
    installer.pods_project.targets.each do |target|
        target.build_configurations.each do |config|
            config.build_settings['ENABLE_BITCODE'] = "NO"
            config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = "YES"
        end
    end
end

# Firebase Cloud Messaging (FCM)
#pod 'Firebase/Messaging'

# Firebase Cloud Storage
#pod 'Firebase/Storage'

# Firebase Cloud Functions
#pod 'Firebase/Functions'

# AdMob
#pod 'Firebase/AdMob'

# Invites
#pod 'Firebase/Invites'

# Dynamic Links
#pod 'Firebase/DynamicLinks'

# ML Kit
pod 'Firebase/MLVision'
pod 'Firebase/MLVisionTextModel'
pod 'Firebase/MLVisionBarcodeModel'
pod 'Firebase/MLVisionFaceModel'
pod 'Firebase/MLVisionLabelModel'
pod 'Firebase/MLModelInterpreter'

# Facebook Authentication
#pod 'FBSDKCoreKit'
#pod 'FBSDKLoginKit'

# Google Authentication
#pod 'GoogleSignIn'
# End Podfile

# Begin Podfile - /Users/eddyverbruggen/sandboxes/nativescript-plugin-firebase/demo-ng/node_modules/nativescript-imagepicker/platforms/ios/Podfile
pod 'QBImagePickerController', '~> 3.4.0'
# End Podfilepost_install do |installer|
  post_installnativescript_plugin_firebase_0 installer
end
end
```

So let's add some whitespace in the line `# End Podfilepost_install` (this fix), so they are merged like this:

```
use_frameworks!

target "demong" do
# Begin Podfile - /Users/eddyverbruggen/sandboxes/nativescript-plugin-firebase/demo-ng/node_modules/nativescript-plugin-firebase/platforms/ios/Podfile
pod 'Firebase/Core', '~> 5.6.0' 

# Authentication
pod 'Firebase/Auth'

# Realtime DB
#pod 'Firebase/Database'

# Cloud Firestore
pod 'Firebase/Firestore'

# Remote Config
#pod 'Firebase/RemoteConfig'

# Crash Reporting
#pod 'Firebase/Crash'

# Crashlytics
pod 'Fabric'
pod 'Crashlytics'

# Crashlytics works best without bitcode
def post_installnativescript_plugin_firebase_0 (installer)
    installer.pods_project.targets.each do |target|
        target.build_configurations.each do |config|
            config.build_settings['ENABLE_BITCODE'] = "NO"
            config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = "YES"
        end
    end
end

# Firebase Cloud Messaging (FCM)
#pod 'Firebase/Messaging'

# Firebase Cloud Storage
#pod 'Firebase/Storage'

# Firebase Cloud Functions
#pod 'Firebase/Functions'

# AdMob
#pod 'Firebase/AdMob'

# Invites
#pod 'Firebase/Invites'

# Dynamic Links
#pod 'Firebase/DynamicLinks'

# ML Kit
pod 'Firebase/MLVision'
pod 'Firebase/MLVisionTextModel'
pod 'Firebase/MLVisionBarcodeModel'
pod 'Firebase/MLVisionFaceModel'
pod 'Firebase/MLVisionLabelModel'
pod 'Firebase/MLModelInterpreter'

# Facebook Authentication
#pod 'FBSDKCoreKit'
#pod 'FBSDKLoginKit'

# Google Authentication
#pod 'GoogleSignIn'
# End Podfile

# Begin Podfile - /Users/eddyverbruggen/sandboxes/nativescript-plugin-firebase/demo-ng/node_modules/nativescript-imagepicker/platforms/ios/Podfile
pod 'QBImagePickerController', '~> 3.4.0'
# End Podfile

post_install do |installer|
  post_installnativescript_plugin_firebase_0 installer
end
end
```

For the time being I've locally patched `~/.nvm/versions/node/v8.11.1/lib/node_modules/nativescript/lib/services/cocoapods-service.js`.