### PR TITLE
chore: set options.watch to false when --justlaunch is passed to command

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -223,6 +223,11 @@ export class Options {
 		this.$settingsService.setSettings({ profileDir: this.argv.profileDir });
 		this.argv.profileDir = this.argv["profile-dir"] = this.$settingsService.getProfileDir();
 
+		// if justlaunch is set, it takes precedence over the --watch flag and the default true value
+		if (this.argv.justlaunch) {
+			this.argv.watch = false;
+		}
+
 		// Default to "nativescript-dev-webpack" if only `--bundle` is passed
 		if (this.argv.bundle !== undefined || this.argv.hmr) {
 			this.argv.bundle = this.argv.bundle || "webpack";


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns run android --justlaunch` command does not exit

## What is the new behavior?
`tns run android --justlaunch` command  exits

