### PR TITLE
feat: allow using Android SDK 28 for compilation

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -5,7 +5,19 @@ import { androidToolsInfo } from "nativescript-doctor";
 
 export class AndroidToolsInfo implements IAndroidToolsInfo {
 	private static ANDROID_TARGET_PREFIX = "android";
-	private static SUPPORTED_TARGETS = ["android-17", "android-18", "android-19", "android-21", "android-22", "android-23", "android-24", "android-25", "android-26", "android-27"];
+	private static SUPPORTED_TARGETS = [
+		"android-17",
+		"android-18",
+		"android-19",
+		"android-21",
+		"android-22",
+		"android-23",
+		"android-24",
+		"android-25",
+		"android-26",
+		"android-27",
+		"android-28",
+	];
 	private static MIN_REQUIRED_COMPILE_TARGET = 22;
 	private static REQUIRED_BUILD_TOOLS_RANGE_PREFIX = ">=23";
 	private static VERSION_REGEX = /((\d+\.){2}\d+)/;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -53,7 +53,7 @@
     "@types/color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.0.tgz",
-      "integrity": "sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==",
+      "integrity": "sha1-QPimvy/YbpaYdrM5qDfY/xsKbjA=",
       "dev": true,
       "requires": {
         "@types/color-convert": "*"
@@ -62,7 +62,7 @@
     "@types/color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
+      "integrity": "sha1-v6ggPkHnxlRx6YQdfjBqfNi1Fy0=",
       "dev": true,
       "requires": {
         "@types/color-name": "*"
@@ -71,7 +71,7 @@
     "@types/color-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.0.tgz",
-      "integrity": "sha512-gZ/Rb+MFXF0pXSEQxdRoPMm5jeO3TycjOdvbpbcpHX/B+n9AqaHFe5q6Ga9CsZ7ir/UgIWPfrBzUzn3F19VH/w==",
+      "integrity": "sha1-km929+ZvScxZrYgLsVsDCrvwtm0=",
       "dev": true
     },
     "@types/events": {
@@ -110,7 +110,7 @@
     "@types/ora": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/ora/-/ora-1.3.3.tgz",
-      "integrity": "sha512-XaSVRyCfnGq1xGlb6iuoxnomMXPIlZnvIIkKiGNMTCeVOg7G1Si+FA9N1lPrykPEfiRHwbuZXuTCSoYcHyjcdg==",
+      "integrity": "sha1-0xhkGMPPN6gxeZs3a+ykqOG/yi0=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -332,7 +332,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -937,7 +937,7 @@
     "color": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -4272,7 +4272,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
     },
     "mime-db": {
       "version": "1.36.0",
@@ -4477,9 +4477,9 @@
       "integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A=="
     },
     "nativescript-doctor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.3.0.tgz",
-      "integrity": "sha512-0d8WQcAnaRxOW+nqlkJbXbhozxd/dLnPoCfRMvSt0hKc3cdGQBXya1vTAQIBCmLlEcV/sydqA50nx3wW51QqTg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.4.0.tgz",
+      "integrity": "sha512-TUizA1lhDGdsPmWlaQiTddzb7K3EABNErEivU5KMSj680AZpAAm3mifflu6W7yVwZusjNxq44CfKg/VIM8xijw==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.3.0",
@@ -6836,7 +6836,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "1.3.0",
+    "nativescript-doctor": "1.4.0",
     "nativescript-preview-sdk": "0.2.11",
     "open": "0.0.5",
     "ora": "2.0.0",


### PR DESCRIPTION
Allow using the SDK 28 for compileSdk of applications by adding it in the verified versions.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

