### PR TITLE
fix: tns preview warns incorrectly for exceeding file size limit

### DIFF
--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -3,7 +3,7 @@ import { PubnubKeys } from "./preview-app-constants";
 const pako = require("pako");
 
 export class PreviewSdkService implements IPreviewSdkService {
-	private static MAX_FILES_UPLOAD_BYTE_LENGTH = 30000;
+	private static MAX_FILES_UPLOAD_BYTE_LENGTH = 15 * 1024 * 1024; // In MBs
 	private messagingService: MessagingService = null;
 	private instanceId: string = null;
 	public connectedDevices: Device[] = [];
@@ -76,7 +76,8 @@ export class PreviewSdkService implements IPreviewSdkService {
 			onSendingChange: (sending: boolean) => ({ }),
 			onBiggerFilesUpload: async (filesContent, callback) => {
 				const gzippedContent = Buffer.from(pako.gzip(filesContent));
-				const byteLength = gzippedContent.byteLength;
+				const byteLength = filesContent.length;
+
 				if (byteLength > PreviewSdkService.MAX_FILES_UPLOAD_BYTE_LENGTH) {
 					this.$logger.warn("The files to upload exceed the maximum allowed size of 15MB. Your app might not work as expected.");
 				}


### PR DESCRIPTION
The check in `tns preview` relies on the zipped content instead of checking the actual file content. This way, based on what is the zipped content, we may end up with 30000 bytes length for 15 MB input files or for 100KBs input.
The check is not correct, it should rely on the input file size, as when extracted on device, their size is the actual limitation.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns preview` shows warning that file size limit is exceeded even for small projects.

## What is the new behavior?
`tns preview` shows warning only when input files that have to be transferred are larger than 15MBs
