### PR TITLE
chore: enable debugging of unit test runner process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,14 @@
 			"request": "launch",
 			"cwd": "${workspaceRoot}",
 			"sourceMaps": true,
+			// In case you want to debug child processes started from CLI:
+			// "autoAttachChildProcesses": true,
 			"name": "Launch CLI (Node 6+)",
 			"program": "${workspaceRoot}/lib/nativescript-cli.js",
 
 			// example commands
 			"args": [ "create", "cliapp"]
+			// "args": [ "test", "android", "--justlaunch"]
 			// "args": [ "platform", "add", "android@1.3.0", "--path", "cliapp"]
 			// "args": [ "platform", "remove", "android", "--path", "cliapp"]
 			// "args": [ "plugin", "add", "nativescript-barcodescanner", "--path", "cliapp"]

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -171,7 +171,8 @@ class TestExecutionService implements ITestExecutionService {
 		});
 
 		const karmaConfig = this.getKarmaConfiguration(platform, projectData),
-			karmaRunner = this.$childProcess.fork(path.join(__dirname, "karma-execution.js")),
+			// In case you want to debug the unit test runner, add "--inspect-brk=<port>" as a first element in the array of args.
+			karmaRunner = this.$childProcess.spawn(process.execPath, [ path.join(__dirname, "karma-execution.js")], { stdio: ["inherit", "inherit", "inherit", "ipc"] }),
 			launchKarmaTests = async (karmaData: any) => {
 				this.$logger.trace("## Unit-testing: Parent process received message", karmaData);
 				let port: string;


### PR DESCRIPTION
When CLI executes unit tests (for the NativeScript application), it forks a new Node.js process and communicates with it via IPC.
However, the Node.js fork method has an issue when you want to debug your main process - it passes the `--inspect[-brk]` option to the forked process as well. The main process had already used the port, so debugging fails.
In order to fix this, replace the `fork` with `spawn`.

