### PR TITLE
fix: validate bundle version on `tns preview --bundle` and `tns run --hmr` commands

### DIFF
--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -1,5 +1,6 @@
 export class PreviewCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
+	private static MIN_SUPPORTED_WEBPACK_VERSION = "0.17.0";
 
 	constructor(private $bundleValidatorHelper: IBundleValidatorHelper,
 		private $liveSyncService: ILiveSyncService,
@@ -30,7 +31,7 @@ export class PreviewCommand implements ICommand {
 
 	public async canExecute(args: string[]): Promise<boolean> {
 		await this.$networkConnectivityValidator.validate();
-		this.$bundleValidatorHelper.validate();
+		this.$bundleValidatorHelper.validate(PreviewCommand.MIN_SUPPORTED_WEBPACK_VERSION);
 		return true;
 	}
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -227,3 +227,8 @@ export class IosProjectConstants {
 	public static XcodeProjExtName = ".xcodeproj";
 	public static XcodeSchemeExtName = ".xcscheme";
 }
+
+export class BundleValidatorMessages {
+	public static MissingBundlePlugin = "Passing --bundle requires a bundling plugin. No bundling plugin found or the specified bundling plugin is invalid.";
+	public static NotSupportedVersion = `The NativeScript CLI requires nativescript-dev-webpack %s or later to work properly.`;
+}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -841,9 +841,11 @@ interface IDeployCommandHelper {
 interface IBundleValidatorHelper {
 	/**
 	 * Validates bundling options.
+	 * In case when minSupportedVersion is provided, gets the current version of nativescript-dev-webpack from package json and compares with the provided version.
+	 * @param {string} minSupportedVersion the minimum supported version of nativescript-dev-webpack
 	 * @return {void}
 	 */
-	validate(): void;
+	validate(minSupportedVersion?: string): void;
 }
 
 interface INativeScriptCloudExtensionService {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -841,7 +841,7 @@ interface IDeployCommandHelper {
 interface IBundleValidatorHelper {
 	/**
 	 * Validates bundling options.
-	 * In case when minSupportedVersion is provided, gets the current version of nativescript-dev-webpack from package json and compares with the provided version.
+	 * In case when minSupportedVersion is provided, gets the current version of nativescript-dev-webpack from package.json and compares with the provided version.
 	 * @param {string} minSupportedVersion the minimum supported version of nativescript-dev-webpack
 	 * @return {void}
 	 */

--- a/lib/helpers/bundle-validator-helper.ts
+++ b/lib/helpers/bundle-validator-helper.ts
@@ -1,3 +1,7 @@
+import * as semver from "semver";
+import * as util from "util";
+import { BundleValidatorMessages } from "../constants";
+
 export class BundleValidatorHelper implements IBundleValidatorHelper {
 	private bundlersMap: IStringDictionary = {
 		webpack: "nativescript-dev-webpack"
@@ -9,13 +13,21 @@ export class BundleValidatorHelper implements IBundleValidatorHelper {
 		this.$projectData.initializeProjectData();
 	}
 
-	public validate(): void {
+	public validate(minSupportedVersion?: string): void {
 		if (this.$options.bundle) {
 			const bundlePluginName = this.bundlersMap[this.$options.bundle];
 			const hasBundlerPluginAsDependency = this.$projectData.dependencies && this.$projectData.dependencies[bundlePluginName];
 			const hasBundlerPluginAsDevDependency = this.$projectData.devDependencies && this.$projectData.devDependencies[bundlePluginName];
 			if (!bundlePluginName || (!hasBundlerPluginAsDependency && !hasBundlerPluginAsDevDependency)) {
-				this.$errors.fail("Passing --bundle requires a bundling plugin. No bundling plugin found or the specified bundling plugin is invalid.");
+				this.$errors.fail(BundleValidatorMessages.MissingBundlePlugin);
+			}
+
+			if (minSupportedVersion) {
+				const currentVersion = hasBundlerPluginAsDependency || hasBundlerPluginAsDevDependency;
+				const isBundleSupported = semver.gte(semver.coerce(currentVersion), semver.coerce(minSupportedVersion));
+				if (!isBundleSupported) {
+					this.$errors.fail(util.format(BundleValidatorMessages.NotSupportedVersion, minSupportedVersion));
+				}
 			}
 		}
 	}

--- a/lib/helpers/bundle-validator-helper.ts
+++ b/lib/helpers/bundle-validator-helper.ts
@@ -16,17 +16,17 @@ export class BundleValidatorHelper implements IBundleValidatorHelper {
 	public validate(minSupportedVersion?: string): void {
 		if (this.$options.bundle) {
 			const bundlePluginName = this.bundlersMap[this.$options.bundle];
-			const hasBundlerPluginAsDependency = this.$projectData.dependencies && this.$projectData.dependencies[bundlePluginName];
-			const hasBundlerPluginAsDevDependency = this.$projectData.devDependencies && this.$projectData.devDependencies[bundlePluginName];
-			if (!bundlePluginName || (!hasBundlerPluginAsDependency && !hasBundlerPluginAsDevDependency)) {
+			const bundlerVersionInDependencies = this.$projectData.dependencies && this.$projectData.dependencies[bundlePluginName];
+			const bundlerVersionInDevDependencies = this.$projectData.devDependencies && this.$projectData.devDependencies[bundlePluginName];
+			if (!bundlePluginName || (!bundlerVersionInDependencies && !bundlerVersionInDevDependencies)) {
 				this.$errors.fail(BundleValidatorMessages.MissingBundlePlugin);
 			}
 
 			if (minSupportedVersion) {
-				const currentVersion = hasBundlerPluginAsDependency || hasBundlerPluginAsDevDependency;
+				const currentVersion = bundlerVersionInDependencies || bundlerVersionInDevDependencies;
 				const isBundleSupported = semver.gte(semver.coerce(currentVersion), semver.coerce(minSupportedVersion));
 				if (!isBundleSupported) {
-					this.$errors.fail(util.format(BundleValidatorMessages.NotSupportedVersion, minSupportedVersion));
+					this.$errors.failWithoutHelp(util.format(BundleValidatorMessages.NotSupportedVersion, minSupportedVersion));
 				}
 			}
 		}

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -1,4 +1,5 @@
 export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
+	private static MIN_SUPPORTED_WEBPACK_VERSION_WITH_HMR = "0.17.0";
 
 	constructor(private $platformService: IPlatformService,
 		private $projectData: IProjectData,
@@ -133,7 +134,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			result[availablePlatform.toLowerCase()] = validateOutput;
 		}
 
-		this.$bundleValidatorHelper.validate();
+		const minSupportedWebpackVersion = this.$options.hmr ? LiveSyncCommandHelper.MIN_SUPPORTED_WEBPACK_VERSION_WITH_HMR : null;
+		this.$bundleValidatorHelper.validate(minSupportedWebpackVersion);
 
 		return result;
 	}

--- a/test/helpers/bundle-validator-helper.ts
+++ b/test/helpers/bundle-validator-helper.ts
@@ -1,0 +1,91 @@
+import { Yok } from "../../lib/common/yok";
+import { BundleValidatorHelper } from "../../lib/helpers/bundle-validator-helper";
+import { assert } from "chai";
+import { format } from "util";
+import { BundleValidatorMessages } from "../../lib/constants";
+
+interface ITestCase {
+	name: string;
+	isDependency?: boolean;
+	currentWebpackVersion?: string;
+	minSupportedWebpackVersion?: string;
+	expectedError?: string;
+}
+
+let error: string = null;
+
+function createTestInjector(options: { dependencies?: IStringDictionary, devDependencies?: IStringDictionary }) {
+	const testInjector = new Yok();
+	testInjector.register("projectData", {
+		initializeProjectData: () => ({}),
+		dependencies: options.dependencies,
+		devDependencies: options.devDependencies
+	});
+	testInjector.register("errors", {
+		fail: (err: string) => error = err
+	});
+	testInjector.register("options", ({ bundle: "webpack" }));
+	testInjector.register("bundleValidatorHelper", BundleValidatorHelper);
+
+	return testInjector;
+}
+
+describe.only("BundleValidatorHelper", () => {
+	beforeEach(() => error = null);
+
+	let testCases: ITestCase[] = [
+		{
+			name: "should throw an error when no webpack plugin is installed",
+			expectedError: BundleValidatorMessages.MissingBundlePlugin
+		}
+	];
+
+	["dependencies", "devDependencies"]
+		.forEach(key => {
+			const isDependency = key === "dependencies";
+
+			testCases = testCases.concat([
+				{
+					name: `should not throw an error when webpack is added as ${key}`,
+					isDependency,
+					currentWebpackVersion: "0.12.0",
+					expectedError: null
+				},
+				{
+					name: `should not throw an error when webpack's version is grather than minSupportedVersion in case when webpack is installed as ${key}`,
+					isDependency,
+					currentWebpackVersion: "0.13.1",
+					minSupportedWebpackVersion: "0.13.0",
+					expectedError: null
+				},
+				{
+					name: `should not throw an error when webpack's version is equal to minSupportedVersion in case when webpack is installed as ${key}`,
+					isDependency,
+					currentWebpackVersion: "0.10.0",
+					minSupportedWebpackVersion: "0.10.0",
+					expectedError: null
+				},
+				{
+					name: `should throw an error when webpack's version is lower than minSupportedVersion in case when webpack is installed as ${key}`,
+					isDependency,
+					currentWebpackVersion: "0.17.0",
+					minSupportedWebpackVersion: "0.18.0",
+					expectedError: format(BundleValidatorMessages.NotSupportedVersion, "0.18.0")
+				}
+			]);
+		});
+
+		_.each(testCases, (testCase: any) => {
+			const deps = {
+				"nativescript-dev-webpack": testCase.currentWebpackVersion
+			};
+
+			it(`${testCase.name}`, async () => {
+				const injector = createTestInjector({ dependencies: testCase.isDependency ? deps : null, devDependencies: !testCase.isDependency ? deps : null });
+				const bundleValidatorHelper = injector.resolve("bundleValidatorHelper");
+				bundleValidatorHelper.validate(testCase.minSupportedWebpackVersion);
+
+				assert.deepEqual(error, testCase.expectedError);
+			});
+		});
+});

--- a/test/helpers/bundle-validator-helper.ts
+++ b/test/helpers/bundle-validator-helper.ts
@@ -22,7 +22,8 @@ function createTestInjector(options: { dependencies?: IStringDictionary, devDepe
 		devDependencies: options.devDependencies
 	});
 	testInjector.register("errors", {
-		fail: (err: string) => error = err
+		fail: (err: string) => error = err,
+		failWithoutHelp: (err: string) => error = err
 	});
 	testInjector.register("options", ({ bundle: "webpack" }));
 	testInjector.register("bundleValidatorHelper", BundleValidatorHelper);
@@ -30,7 +31,7 @@ function createTestInjector(options: { dependencies?: IStringDictionary, devDepe
 	return testInjector;
 }
 
-describe.only("BundleValidatorHelper", () => {
+describe("BundleValidatorHelper", () => {
 	beforeEach(() => error = null);
 
 	let testCases: ITestCase[] = [
@@ -52,25 +53,32 @@ describe.only("BundleValidatorHelper", () => {
 					expectedError: null
 				},
 				{
-					name: `should not throw an error when webpack's version is grather than minSupportedVersion in case when webpack is installed as ${key}`,
+					name: `should not throw an error when webpack's version is greater than minSupportedVersion when webpack is installed as ${key}`,
 					isDependency,
 					currentWebpackVersion: "0.13.1",
 					minSupportedWebpackVersion: "0.13.0",
 					expectedError: null
 				},
 				{
-					name: `should not throw an error when webpack's version is equal to minSupportedVersion in case when webpack is installed as ${key}`,
+					name: `should not throw an error when webpack's version is equal to minSupportedVersion when webpack is installed as ${key}`,
 					isDependency,
 					currentWebpackVersion: "0.10.0",
 					minSupportedWebpackVersion: "0.10.0",
 					expectedError: null
 				},
 				{
-					name: `should throw an error when webpack's version is lower than minSupportedVersion in case when webpack is installed as ${key}`,
+					name: `should throw an error when webpack's version is lower than minSupportedVersion when webpack is installed as ${key}`,
 					isDependency,
 					currentWebpackVersion: "0.17.0",
 					minSupportedWebpackVersion: "0.18.0",
 					expectedError: format(BundleValidatorMessages.NotSupportedVersion, "0.18.0")
+				},
+				{
+					name: `should not throw an error when prerelease version of webpack is installed as ${key}`,
+					isDependency,
+					currentWebpackVersion: "0.17.0-2018-09-28-173604-01",
+					minSupportedWebpackVersion: "0.17.0",
+					expectedError: null
 				}
 			]);
 		});


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
No error message is shown when installeld `nativescript-dev-webpack` plugin does not support `hmr` option or `preview-sync` hook.

## What is the new behavior?
An error message is shown when installeld `nativescript-dev-webpack` plugin does not support `hmr` option or `preview-sync` hook.
