### PR TITLE
fix: don't show warnings for non-nativescript plugins on `tns preview --bundle` command

### DIFF
--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -65,8 +65,12 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 	}
 
 	private getWarningForPlugin(data: IPreviewAppLiveSyncData, localPlugin: string, localPluginVersion: string, devicePluginVersion: string, device: Device): string {
-		if (data && data.appFilesUpdaterOptions && data.appFilesUpdaterOptions.bundle && this.isNativeScriptPluginWithoutNativeCode(localPlugin, device.platform, data.projectDir)) {
-			return null;
+		if (data && data.appFilesUpdaterOptions && data.appFilesUpdaterOptions.bundle) {
+			const pluginPackageJsonPath = path.join(data.projectDir, NODE_MODULES_DIR_NAME, localPlugin, PACKAGE_JSON_FILE_NAME);
+			const isNativeScriptPlugin = this.$pluginsService.isNativeScriptPlugin(pluginPackageJsonPath);
+			if (!isNativeScriptPlugin || (isNativeScriptPlugin && !this.hasNativeCode(localPlugin, device.platform, data.projectDir))) {
+				return null;
+			}
 		}
 
 		return this.getWarningForPluginCore(localPlugin, localPluginVersion, devicePluginVersion, device.id);
@@ -89,11 +93,6 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 		}
 
 		return util.format(PluginComparisonMessages.PLUGIN_NOT_INCLUDED_IN_PREVIEW_APP, localPlugin, deviceId);
-	}
-
-	private isNativeScriptPluginWithoutNativeCode(localPlugin: string, platform: string, projectDir: string): boolean {
-		const pluginPackageJsonPath = path.join(projectDir, NODE_MODULES_DIR_NAME, localPlugin, PACKAGE_JSON_FILE_NAME);
-		return this.$pluginsService.isNativeScriptPlugin(pluginPackageJsonPath) && !this.hasNativeCode(localPlugin, platform, projectDir);
 	}
 
 	private hasNativeCode(localPlugin: string, platform: string, projectDir: string): boolean {

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -265,7 +265,7 @@ describe("previewAppPluginsService", () => {
 	describe("comparePluginsOnDevice with bundle", () => {
 		const testCases = [
 			{
-				name: "should show warning for non nativescript plugin that has lower major version",
+				name: "should not show warning for non nativescript plugin that has lower major version",
 				localPlugins: {
 					lodash: "1.2.3"
 				},
@@ -274,12 +274,10 @@ describe("previewAppPluginsService", () => {
 				},
 				isNativeScriptPlugin: false,
 				hasPluginNativeCode: false,
-				expectedWarnings: [
-					util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_DIFFERENCE_IN_MAJOR_VERSION, "lodash", "1.2.3", "2.3.3")
-				]
+				expectedWarnings: <string[]>[]
 			},
 			{
-				name: "should show warning for non nativescript plugin that has greather major version",
+				name: "should not show warning for non nativescript plugin that has greather major version",
 				localPlugins: {
 					lodash: "3.2.3"
 				},
@@ -288,9 +286,7 @@ describe("previewAppPluginsService", () => {
 				},
 				isNativeScriptPlugin: false,
 				hasPluginNativeCode: false,
-				expectedWarnings: [
-					util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_DIFFERENCE_IN_MAJOR_VERSION, "lodash", "3.2.3", "2.3.3")
-				]
+				expectedWarnings: []
 			},
 			{
 				name: "should show warning for non nativescript plugin that has greather minor version",
@@ -302,9 +298,7 @@ describe("previewAppPluginsService", () => {
 				},
 				isNativeScriptPlugin: false,
 				hasPluginNativeCode: false,
-				expectedWarnings: [
-					util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_GREATHER_MINOR_VERSION, "lodash", "3.4.5", "3.3.0")
-				]
+				expectedWarnings: []
 			},
 			{
 				name: "should not show warning for non nativescript plugin that has the same version",


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Warning is shown for non nativescript plugins on `tns preview --bundle` command

## What is the new behavior?
Warning is not shown for non nativescript plugins on `tns preview --bundle` command
