### PR TITLE
fix: works correctly with projects with `.nsconfig` file on `tns preview` command

### DIFF
--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -110,11 +110,10 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 	}
 
 	private getFilesPayload(platformData: IPlatformData, projectData: IProjectData, files?: string[]): FilesPayload {
-		const appFolderPath = path.join(projectData.projectDir, APP_FOLDER_NAME);
 		const platformsAppFolderPath = path.join(platformData.appDestinationDirectoryPath, APP_FOLDER_NAME);
 
 		if (files && files.length) {
-			files = files.map(file => path.join(platformsAppFolderPath, path.relative(appFolderPath, file)));
+			files = files.map(file => this.$projectFilesProvider.mapFilePath(file, platformData.normalizedPlatformName, projectData));
 		} else {
 			files = this.$projectFilesManager.getProjectFiles(platformsAppFolderPath);
 		}

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -148,7 +148,8 @@ function createTestInjector(options?: {
 				onDeviceFileName: path.basename(filePath),
 				shouldIncludeFile: true
 			};
-		}
+		},
+		mapFilePath: (filePath: string) => path.join(path.join(platformsDirPath, "app"), path.relative(path.join(projectDirPath, "app"), filePath))
 	});
 	injector.register("hooksService", {
 		executeBeforeHooks: (name: string, args: any) => {


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
An error is thrown on projects with `.nsconfig` file when `tns preview` command is executed

## What is the new behavior?
Works correctly on projects with `.nsconfig` file when `tns preview` command is executed

## Steps to reproduce:
1. `tns create myApp --template https://github.com/NativeScript/template-hello-world-ng/tarball/master`
2. cd myApp 
3. `tns preview`
4. Apply a change in the code
