### PR TITLE
fix: ensure all dependencies are installed on `tns preview` command

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -44,6 +44,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 	public async liveSync(deviceDescriptors: ILiveSyncDeviceInfo[], liveSyncData: ILiveSyncInfo): Promise<void> {
 		const projectData = this.$projectDataService.getProjectData(liveSyncData.projectDir);
+		await this.$pluginsService.ensureAllDependenciesAreInstalled(projectData);
 		await this.liveSyncOperation(deviceDescriptors, liveSyncData, projectData);
 	}
 
@@ -337,7 +338,6 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				projectDir: projectData.projectDir
 			});
 		} else {
-			await this.$pluginsService.ensureAllDependenciesAreInstalled(projectData);
 			// In case liveSync is called for a second time for the same projectDir.
 			const isAlreadyLiveSyncing = this.liveSyncProcessesInfo[projectData.projectDir] && !this.liveSyncProcessesInfo[projectData.projectDir].isStopped;
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
An error is thrown when some dependency is not installed on `tns preview` command

## What is the new behavior?
{N} CLI ensures all dependencies are installed on `tns preview` command
