### PR TITLE
fix: unable to install application every other time with Xcode 10

### DIFF
--- a/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -33,7 +33,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 			}
 		}
 
-		return this.iosSim.installApplication(this.device.deviceInfo.identifier, packageFilePath);
+		await this.iosSim.installApplication(this.device.deviceInfo.identifier, packageFilePath);
 	}
 
 	public async uninstallApplication(appIdentifier: string): Promise<void> {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2944,7 +2944,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-uri": {
@@ -3814,9 +3814,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.2.tgz",
-      "integrity": "sha512-zNMcrUWUU/KnuOmwd7VW8mzf6pM+mwUQiINJbj5Sx/G7FwwzLBSfIN4ekSpSkgNGPB6ME9MbO3b2Qc9IxsV5TQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.3.tgz",
+      "integrity": "sha512-vgNif6/akztliDeh9iUxBnrhoFMEGHbnXms1sIyJWBd5B3gQEnWXpe0v0hqsJtUhezKqHfjrZs4ksQjHZLOzKA==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",
@@ -7043,9 +7043,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
     },
     "spdx-expression-parse": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inquirer": "6.2.0",
     "ios-device-lib": "0.4.15",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "4.0.2",
+    "ios-sim-portable": "4.0.3",
     "istextorbinary": "2.2.1",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",


### PR DESCRIPTION
When using Xcode 10, the `xcrun simctl install ...` command fails every other time with error:
```
Error: Command xcrun with arguments simctl install 5516E083-C749-47A7-A6FC-2EE2E414D025 /Users/vladimirov/Work/nativescript-cli/scratch/app1/platforms/ios/build/emulator/app1.app failed with exit code 1. Error output:
 An error was encountered processing the command (domain=IXUserPresentableErrorDomain, code=1):
This app could not be installed at this time.
Failed to load Info.plist from bundle at path /Users/vladimirov/Library/Developer/CoreSimulator/Devices/5516E083-C749-47A7-A6FC-2EE2E414D025/data/Library/Caches/com.apple.mobile.installd.staging/temp.ZdmYQa/extracted/Payload/app1.app
Failed to load Info.plist from bundle at path /Users/vladimirov/Library/Developer/CoreSimulator/Devices/5516E083-C749-47A7-A6FC-2EE2E414D025/data/Library/Caches/com.apple.mobile.installd.staging/temp.ZdmYQa/extracted/Payload/app1.app
Underlying error (domain=MIInstallerErrorDomain, code=35):
	Failed to load Info.plist from bundle at path /Users/vladimirov/Library/Developer/CoreSimulator/Devices/5516E083-C749-47A7-A6FC-2EE2E414D025/data/Library/Caches/com.apple.mobile.installd.staging/temp.ZdmYQa/extracted/Payload/app1.app
```

It looks like during install of the application, the content of the built `.app` is extracted to a temp folder in some cases. While the installation is in progress, Xcode decides it is done and deletes the temp dir. However, the package is installed on device, but it is still loading some data from the package that is installed (the temp dir). It fails, as it searches for Info.plist file in the package we've installed, but it is not there. So the installation process fails and app remains on device with inconsitent state.
Retrying the operation fixes the behavior.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns run ios` command often fails when installing the application on simulator.

## What is the new behavior?
`tns run ios` succeeds installing the application on iOS Simulator.

Fixes issues: https://github.com/NativeScript/nativescript-cli/issues/3957 
 https://github.com/NativeScript/nativescript-cli/issues/3920

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

