### PR TITLE
feat: forbid working with Xcode below 9

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5041,9 +5041,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.2.5.tgz",
-      "integrity": "sha512-mOYdCQS3xdgu81Hg3EQEhORykMk53Pkzg15Y6I+O9T3db9qHPf9z6nXzQBCUaHXlQs57eRKotDTzYlYACL+5uA=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.2.6.tgz",
+      "integrity": "sha512-um9vXiM407BaRbBNa0aKPzFBSD2fDbVmmA9TzCWWlxZvEBzTbixM7ss6GDS4G/cNMYeZSNFx5SzAgWoG1uHU9g=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5086,21 +5086,21 @@
       "integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A=="
     },
     "nativescript-doctor": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.4.0.tgz",
-      "integrity": "sha512-TUizA1lhDGdsPmWlaQiTddzb7K3EABNErEivU5KMSj680AZpAAm3mifflu6W7yVwZusjNxq44CfKg/VIM8xijw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.5.0.tgz",
+      "integrity": "sha512-gxDRor5HWfWLTBO+QvOoP8YAyGs24U70CFeezq6PRT08ONkZQLg4aEVSzhAHYiRsAnmS2GTDpzXKQj93NEaU2g==",
       "requires": {
         "osenv": "0.1.3",
-        "semver": "5.3.0",
+        "semver": "5.5.1",
         "temp": "0.8.3",
         "unzip": "0.1.11",
         "winreg": "1.2.2"
       },
       "dependencies": {
         "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+          "version": "5.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
         },
         "winreg": {
           "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "1.4.0",
+    "nativescript-doctor": "1.5.0",
     "nativescript-preview-sdk": "0.2.11",
     "open": "0.0.5",
     "ora": "2.0.0",


### PR DESCRIPTION
Currently iOS Applications cannot be build with Xcode versions below 9. So forbid using such versions and show information to user that Xcode must be updated.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
When you have Xcode 8, you can try `tns build ios` and it will fail at some point with a native error.

## What is the new behavior?
When you have Xcode 8, you can try `tns build ios` and it will fail with message that this Xcode is not supported and you have to upgrade it to build your app.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/3887