### PR TITLE
feat: respect removed files on preview command

### DIFF
--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -3,7 +3,7 @@ import { FilePayload, Device, FilesPayload } from "nativescript-preview-sdk";
 declare global {
 	interface IPreviewAppLiveSyncService {
 		initialize(data: IPreviewAppLiveSyncData): void;
-		syncFiles(data: IPreviewAppLiveSyncData, filesToSync: string[]): Promise<void>;
+		syncFiles(data: IPreviewAppLiveSyncData, filesToSync: string[], filesToRemove: string[]): Promise<void>;
 		stopLiveSync(): Promise<void>;
 	}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -588,9 +588,15 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 			const startSyncFilesTimeout = (platform?: string) => {
 				timeoutTimer = setTimeout(async () => {
-					if (liveSyncData.syncToPreviewApp) {
-						await this.addActionToChain(projectData.projectDir, async () => {
-							if (filesToSync.length || filesToRemove.length) {
+					if (filesToSync.length || filesToRemove.length) {
+						const currentFilesToSync = _.cloneDeep(filesToSync);
+						filesToSync.splice(0, filesToSync.length);
+
+						const currentFilesToRemove = _.cloneDeep(filesToRemove);
+						filesToRemove = [];
+
+						if (liveSyncData.syncToPreviewApp) {
+							await this.addActionToChain(projectData.projectDir, async () => {
 								await this.$previewAppLiveSyncService.syncFiles({
 									appFilesUpdaterOptions: {
 										bundle: liveSyncData.bundle,
@@ -599,22 +605,12 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 									},
 									env: liveSyncData.env,
 									projectDir: projectData.projectDir
-								}, filesToSync);
-								filesToSync = [];
-								filesToRemove = [];
-							}
-						});
-					} else {
-						// Push actions to the queue, do not start them simultaneously
-						await this.addActionToChain(projectData.projectDir, async () => {
-							if (filesToSync.length || filesToRemove.length) {
+								}, currentFilesToSync, currentFilesToRemove);
+							});
+						} else {
+							// Push actions to the queue, do not start them simultaneously
+							await this.addActionToChain(projectData.projectDir, async () => {
 								try {
-									const currentFilesToSync = _.cloneDeep(filesToSync);
-									filesToSync.splice(0, filesToSync.length);
-
-									const currentFilesToRemove = _.cloneDeep(filesToRemove);
-									filesToRemove = [];
-
 									const allModifiedFiles = [].concat(currentFilesToSync).concat(currentFilesToRemove);
 
 									const preparedPlatforms: string[] = [];
@@ -681,8 +677,8 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 										}
 									}
 								}
-							}
-						});
+							});
+						}
 					}
 				}, 250);
 

--- a/lib/services/livesync/playground/preview-app-constants.ts
+++ b/lib/services/livesync/playground/preview-app-constants.ts
@@ -1,5 +1,6 @@
 export class PreviewSdkEventNames {
 	public static CHANGE_EVENT_NAME = "change";
+	public static UNLINK_EVENT_NAME = "unlink";
 }
 
 export class PubnubKeys {

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -46,9 +46,9 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 		let promise = Promise.resolve<FilesPayload>(null);
 		const startSyncFilesTimeout = async (platform: string) => {
 			await promise
-				.then(async () => {
-					const projectData = this.$projectDataService.getProjectData(data.projectDir);
-					promise = this.applyChanges(this.$platformsData.getPlatformData(platform, projectData), projectData, filesToSyncMap[platform]);
+			.then(async () => {
+					// We don't need to prepare when webpack emits changed files. We just need to send a message to pubnub.
+					promise = this.syncFilesForPlatformSafe(data, platform, { filesToSync: filesToSyncMap[platform], skipPrepare: true });
 					await promise;
 				});
 			filesToSyncMap[platform] = [];
@@ -67,13 +67,12 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 			}
 		});
 		await this.$previewAppPluginsService.comparePluginsOnDevice(data, device);
-		const payloads = await this.syncFilesForPlatformSafe(data, device.platform);
-		payloads.deviceId = device.id;
+		const payloads = await this.syncFilesForPlatformSafe(data, device.platform, { isInitialSync: true });
 		return payloads;
 	}
 
-	public async syncFiles(data: IPreviewAppLiveSyncData, files?: string[]): Promise<void> {
-		this.showWarningsForNativeFiles(files);
+	public async syncFiles(data: IPreviewAppLiveSyncData, filesToSync: string[], filesToRemove: string[]): Promise<void> {
+		this.showWarningsForNativeFiles(filesToSync);
 
 		for (const device of this.$previewSdkService.connectedDevices) {
 			await this.$previewAppPluginsService.comparePluginsOnDevice(data, device);
@@ -85,7 +84,7 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 			.value();
 
 		for (const platform of platforms) {
-			await this.syncFilesForPlatformSafe(data, platform, files);
+			await this.syncFilesForPlatformSafe(data, platform, { filesToSync, filesToRemove });
 		}
 	}
 
@@ -93,47 +92,42 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 		this.$previewSdkService.stop();
 	}
 
-	private async syncFilesForPlatformSafe(data: IPreviewAppLiveSyncData, platform: string, files?: string[]): Promise<FilesPayload> {
+	private async syncFilesForPlatformSafe(data: IPreviewAppLiveSyncData, platform: string, opts?: { filesToSync?: string[], filesToRemove?: string[], isInitialSync?: boolean, skipPrepare?: boolean }): Promise<FilesPayload> {
 		this.$logger.info(`Start syncing changes for platform ${platform}.`);
+
+		opts = opts || {};
+		const { filesToSync, filesToRemove } = opts;
+		let payloads = null;
 
 		try {
 			const { appFilesUpdaterOptions, env, projectDir } = data;
 			const projectData = this.$projectDataService.getProjectData(projectDir);
 			const platformData = this.$platformsData.getPlatformData(platform, projectData);
-			await this.preparePlatform(platform, appFilesUpdaterOptions, env, projectData);
 
-			let result: FilesPayload = null;
-			if (files && files.length) {
-				result = await this.applyChanges(platformData, projectData, files);
-				this.$logger.info(`Successfully synced ${result.files.map(filePayload => filePayload.file.yellow)} for platform ${platform}.`);
-			} else {
-				result = await this.getFilesPayload(platformData, projectData);
-				this.$logger.info(`Successfully synced changes for platform ${platform}.`);
+			if (!opts.skipPrepare) {
+				await this.preparePlatform(platform, appFilesUpdaterOptions, env, projectData);
 			}
 
-			return result;
+			if (opts.isInitialSync) {
+				const platformsAppFolderPath = path.join(platformData.appDestinationDirectoryPath, APP_FOLDER_NAME);
+				const files = this.$projectFilesManager.getProjectFiles(platformsAppFolderPath);
+				payloads = this.getFilesPayload(platformData, projectData, files);
+				this.$logger.info(`Successfully synced changes for platform ${platform}.`);
+			} else {
+				const files = _.map(filesToSync, file => this.$projectFilesProvider.mapFilePath(file, platformData.normalizedPlatformName, projectData));
+				payloads = this.getFilesPayload(platformData, projectData, files, filesToRemove);
+				await this.$previewSdkService.applyChanges(payloads);
+				this.$logger.info(`Successfully synced ${payloads.files.map(filePayload => filePayload.file.yellow)} for platform ${platform}.`);
+			}
+
+			return payloads;
 		} catch (err) {
 			this.$logger.warn(`Unable to apply changes for platform ${platform}. Error is: ${err}, ${JSON.stringify(err, null, 2)}.`);
 		}
 	}
 
-	private async applyChanges(platformData: IPlatformData, projectData: IProjectData, files: string[]): Promise<FilesPayload> {
-		const payloads = this.getFilesPayload(platformData, projectData, _(files).uniq().value());
-		await this.$previewSdkService.applyChanges(payloads);
-
-		return payloads;
-	}
-
-	private getFilesPayload(platformData: IPlatformData, projectData: IProjectData, files?: string[]): FilesPayload {
-		const platformsAppFolderPath = path.join(platformData.appDestinationDirectoryPath, APP_FOLDER_NAME);
-
-		if (files && files.length) {
-			files = files.map(file => this.$projectFilesProvider.mapFilePath(file, platformData.normalizedPlatformName, projectData));
-		} else {
-			files = this.$projectFilesManager.getProjectFiles(platformsAppFolderPath);
-		}
-
-		const filesToTransfer = files
+	private getFilesPayload(platformData: IPlatformData, projectData: IProjectData, filesToSync?: string[], filesToRemove?: string[]): FilesPayload {
+		const filesToTransfer = filesToSync
 			.filter(file => file.indexOf(TNS_MODULES_FOLDER_NAME) === -1)
 			.filter(file => file.indexOf(APP_RESOURCES_FOLDER_NAME) === -1)
 			.filter(file => !_.includes(this.excludedFiles, path.basename(file)))
@@ -141,27 +135,9 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 
 		this.$logger.trace(`Transferring ${filesToTransfer.join("\n")}.`);
 
-		const payloads = filesToTransfer
-			.map(file => {
-				const projectFileInfo = this.$projectFilesProvider.getProjectFileInfo(file, platformData.normalizedPlatformName, null);
-				const relativePath = path.relative(platformsAppFolderPath, file);
-				const filePayload: FilePayload = {
-					event: PreviewSdkEventNames.CHANGE_EVENT_NAME,
-					file: path.join(path.dirname(relativePath), projectFileInfo.onDeviceFileName),
-					binary: isTextOrBinary.isBinarySync(file),
-					fileContents: ""
-				};
-
-				if (filePayload.binary) {
-					const bitmap = <string>this.$fs.readFile(file);
-					const base64 = Buffer.from(bitmap).toString('base64');
-					filePayload.fileContents = base64;
-				} else {
-					filePayload.fileContents = this.$fs.readText(path.join(path.dirname(projectFileInfo.filePath), projectFileInfo.onDeviceFileName));
-				}
-
-				return filePayload;
-			});
+		const payloadsToSync = filesToTransfer.map(file => this.createFilePayload(file, platformData, projectData, PreviewSdkEventNames.CHANGE_EVENT_NAME));
+		const payloadsToRemove = _.map(filesToRemove, file => this.createFilePayload(file, platformData, projectData, PreviewSdkEventNames.UNLINK_EVENT_NAME));
+		const payloads = payloadsToSync.concat(payloadsToRemove);
 
 		return { files: payloads, platform: platformData.normalizedPlatformName.toLowerCase() };
 	}
@@ -187,6 +163,37 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 	private showWarningsForNativeFiles(files: string[]): void {
 		_.filter(files, file => file.indexOf(APP_RESOURCES_FOLDER_NAME) > -1)
 			.forEach(file => this.$logger.warn(`Unable to apply changes from ${APP_RESOURCES_FOLDER_NAME} folder. You need to build your application in order to make changes in ${APP_RESOURCES_FOLDER_NAME} folder.`));
+	}
+
+	private createFilePayload(file: string, platformData: IPlatformData, projectData: IProjectData, event: string): FilePayload {
+		const projectFileInfo = this.$projectFilesProvider.getProjectFileInfo(file, platformData.normalizedPlatformName, null);
+		const binary = isTextOrBinary.isBinarySync(file);
+		let fileContents = "";
+		let filePath = "";
+
+		if (event === PreviewSdkEventNames.CHANGE_EVENT_NAME) {
+			const relativePath = path.relative(path.join(platformData.appDestinationDirectoryPath, APP_FOLDER_NAME), file);
+			filePath = path.join(path.dirname(relativePath), projectFileInfo.onDeviceFileName);
+
+			if (binary) {
+				const bitmap = <string>this.$fs.readFile(file);
+				const base64 = Buffer.from(bitmap).toString('base64');
+				fileContents = base64;
+			} else {
+				fileContents = this.$fs.readText(path.join(path.dirname(projectFileInfo.filePath), projectFileInfo.onDeviceFileName));
+			}
+		} else if (event === PreviewSdkEventNames.UNLINK_EVENT_NAME) {
+			filePath = path.relative(path.join(projectData.projectDir, APP_FOLDER_NAME), file);
+		}
+
+		const filePayload = {
+			event,
+			file: filePath,
+			binary,
+			fileContents
+		};
+
+		return filePayload;
 	}
 }
 $injector.register("previewAppLiveSyncService", PreviewAppLiveSyncService);

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -197,7 +197,7 @@ async function syncFiles(input?: IActInput) {
 		await previewSdkService.getInitialFiles(deviceMockData);
 	}
 
-	await previewAppLiveSyncService.syncFiles(syncFilesMockData, projectFiles);
+	await previewAppLiveSyncService.syncFiles(syncFilesMockData, projectFiles, []);
 }
 
 async function assert(expectedFiles: string[], options?: IAssertOptions) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
If the user delete a file on `preview` command, the deleted file is not respected

## What is the new behavior?
The removed files are respected on preview command
