### PR TITLE
fix: don't show "Sync to Playground" option on build command when env is not properly configured

### DIFF
--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -97,7 +97,7 @@ export class BuildIosCommand extends BuildCommandBase implements ICommand {
 
 		super.validatePlatform(platform);
 
-		let result = await super.canExecuteCommandBase(platform);
+		let result = await super.canExecuteCommandBase(platform, { notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true }});
 		if (result.canExecute) {
 			result = await super.validateArgs(args, platform);
 		}
@@ -129,7 +129,7 @@ export class BuildAndroidCommand extends BuildCommandBase implements ICommand {
 		const platform = this.$devicePlatformsConstants.Android;
 		super.validatePlatform(platform);
 
-		let result = await super.canExecuteCommandBase(platform);
+		let result = await super.canExecuteCommandBase(platform, { notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true }});
 		if (result.canExecute) {
 			if (this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
 				this.$errors.fail(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
"Sync to Playground" option is shown when env is not properly configured

## What is the new behavior?
"Sync to Playground" option is not shown when env is not properly configured
