### PR TITLE
fix: replace %s with deviceIdentifier on debug command

### DIFF
--- a/lib/common/services/livesync-service-base.ts
+++ b/lib/common/services/livesync-service-base.ts
@@ -247,7 +247,7 @@ class LiveSyncServiceBase implements ILiveSyncServiceBase {
 				action.call(this.$logger, util.format(message, path.basename(file.getLocalPath()).yellow), deviceIdentifier);
 			});
 		} else {
-			action.call(this.$logger, util.format(message, "all files"));
+			action.call(this.$logger, util.format(message, "all files", deviceIdentifier));
 		}
 	}
 

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -145,7 +145,7 @@ export abstract class PlatformLiveSyncServiceBase {
 				action.call(this.$logger, util.format(message, path.basename(file.getLocalPath()).yellow), deviceIdentifier);
 			});
 		} else {
-			action.call(this.$logger, util.format(message, "all files"));
+			action.call(this.$logger, util.format(message, "all files", deviceIdentifier));
 		}
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
"Successfully transferred all files on device %s" message is shown on `tns debug ios --debug-brk` command on iOS simulator

## What is the new behavior?
"Successfully transferred all files on device FEE9701C-B925-4AF9-BCEC-862BEE21B4BA"  message is shown on `tns debug ios --debug-brk` command on iOS simulator
