### PR TITLE
fix: show more descriptive message when `tns preview -hmr` command is executed and the project has webpack plugin with version lower than 0.17.0

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -230,5 +230,5 @@ export class IosProjectConstants {
 
 export class BundleValidatorMessages {
 	public static MissingBundlePlugin = "Passing --bundle requires a bundling plugin. No bundling plugin found or the specified bundling plugin is invalid.";
-	public static NotSupportedVersion = `The NativeScript CLI requires nativescript-dev-webpack %s or later to work properly.`;
+	public static NotSupportedVersion = `The NativeScript CLI requires nativescript-dev-webpack %s or later to work properly. After updating nativescript-dev-webpack you need to ensure "webpack.config.js" file is up to date with the one in the new version of nativescript-dev-webpack. You can automatically update it using "./node_modules/.bin/update-ns-webpack --configs" command.`;
 }


### PR DESCRIPTION
When the user executes `tns preview --hmr` and the project is with `nativescript-dev-webpack` version lower than 0.17.0, {N} CLI does not show descriptive message. We should to notify the user to ensure `webpack.config.js` file is properly updated after updating `nativescript-dev-webpack`.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
