### PR TITLE
fix: tns debug ios command fails in some cases

### DIFF
--- a/lib/common/commands/device/device-log-stream.ts
+++ b/lib/common/commands/device/device-log-stream.ts
@@ -1,5 +1,3 @@
-import { IOS_LOG_PREDICATE } from "../../constants";
-
 export class OpenDeviceLogStreamCommand implements ICommand {
 	private static NOT_SPECIFIED_DEVICE_ERROR_MESSAGE = "More than one device found. Specify device explicitly.";
 
@@ -25,7 +23,7 @@ export class OpenDeviceLogStreamCommand implements ICommand {
 			this.$errors.fail(OpenDeviceLogStreamCommand.NOT_SPECIFIED_DEVICE_ERROR_MESSAGE);
 		}
 
-		const action = (device: Mobile.IiOSDevice) => device.openDeviceLogStream({predicate: IOS_LOG_PREDICATE});
+		const action = (device: Mobile.IiOSDevice) => device.openDeviceLogStream();
 		await this.$devicesService.execute(action);
 	}
 }

--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -470,7 +470,7 @@ export async function connectEventuallyUntilTimeout(factory: () => Promise<net.S
 		const connectionTimer = setTimeout(function () {
 			if (!isResolved) {
 				isResolved = true;
-				reject(lastKnownError);
+				reject(lastKnownError || new Error(`Unable to connect for ${timeout}ms`));
 			}
 		}, timeout);
 

--- a/lib/common/mobile/ios/simulator/ios-simulator-device.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-device.ts
@@ -55,6 +55,8 @@ export class IOSSimulator implements Mobile.IiOSSimulator {
 
 	@cache()
 	public async openDeviceLogStream(options?: Mobile.IiOSLogStreamOptions): Promise<void> {
+		options = options || {};
+		options.predicate = options.hasOwnProperty("predicate") ? options.predicate : constants.IOS_LOG_PREDICATE;
 		return this.$iOSSimulatorLogProvider.startLogProcess(this.simulator.id, options);
 	}
 }

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as log4js from "log4js";
 import { ChildProcess } from "child_process";
 import { DebugServiceBase } from "./debug-service-base";
+import { IOS_LOG_PREDICATE } from "../common/constants";
 import { CONNECTION_ERROR_EVENT_NAME, AWAIT_NOTIFICATION_TIMEOUT_SECONDS } from "../constants";
 import { getPidFromiOSSimulatorLogs } from "../common/helpers";
 const inspectorAppName = "NativeScript Inspector.app";
@@ -15,7 +16,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 	private _sockets: net.Socket[] = [];
 	private _socketProxy: any;
 
-	constructor(protected device: Mobile.IDevice,
+	constructor(protected device: Mobile.IiOSDevice,
 		protected $devicesService: Mobile.IDevicesService,
 		private $platformService: IPlatformService,
 		private $iOSEmulatorServices: Mobile.IiOSSimulatorService,
@@ -60,7 +61,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 				this.$deviceLogProvider.setProjectNameForDevice(debugData.deviceIdentifier, projectName);
 			}
 
-			await this.device.openDeviceLogStream();
+			await this.device.openDeviceLogStream({ predicate: IOS_LOG_PREDICATE });
 		}
 
 		await this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(this.device, debugData, debugOptions);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3814,9 +3814,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.3.tgz",
-      "integrity": "sha512-vgNif6/akztliDeh9iUxBnrhoFMEGHbnXms1sIyJWBd5B3gQEnWXpe0v0hqsJtUhezKqHfjrZs4ksQjHZLOzKA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.4.tgz",
+      "integrity": "sha512-B8Wu31MVRjTxJJwOXj8UYby7rM4u1xnH3fOisZx4AZcOkqdBzgDOkByKD5Sd1le2a2zkpgThD4Mw4wW0HXeu0w==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",
@@ -3892,7 +3892,7 @@
         },
         "yargs-parser": {
           "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "requires": {
             "camelcase": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "inquirer": "6.2.0",
     "ios-device-lib": "0.4.15",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "4.0.3",
+    "ios-sim-portable": "4.0.4",
     "istextorbinary": "2.2.1",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",


### PR DESCRIPTION
`tns debug ios --start` and `tns debug ios --inspector` command fails in some cases as CLI is not able to get the debug port from the device logs. The problem is that ios-sim-portable starts the log process with child_process.spawn, but this does not start the actual process. Fix the case by waiting for the first message on the stdout of the log process (handled in ios-sim-portable). This way the actual logic that parses the logs will start after the process has really started.

Fix a case where we fail the connection to socket with `undefined` error - show correct error in such case.
Fix `tns device log` command of iOS devices/simulators - it must show full logs from device, but instead a predicate had been passed. Remove it from there and pass it only where required.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns debug ios --start` fails.
`tns debug ios --inspector` fails.

## What is the new behavior?
`tns debug ios --start` fails.
`tns debug ios --inspector` fails.
