### PR TITLE
feat: set min required compile Android SDK to 28

### DIFF
--- a/lib/android-tools-info.ts
+++ b/lib/android-tools-info.ts
@@ -18,7 +18,7 @@ export class AndroidToolsInfo implements IAndroidToolsInfo {
 		"android-27",
 		"android-28",
 	];
-	private static MIN_REQUIRED_COMPILE_TARGET = 22;
+	private static MIN_REQUIRED_COMPILE_TARGET = 28;
 	private static REQUIRED_BUILD_TOOLS_RANGE_PREFIX = ">=23";
 	private static VERSION_REGEX = /((\d+\.){2}\d+)/;
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5100,9 +5100,9 @@
       "integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A=="
     },
     "nativescript-doctor": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.5.0.tgz",
-      "integrity": "sha512-gxDRor5HWfWLTBO+QvOoP8YAyGs24U70CFeezq6PRT08ONkZQLg4aEVSzhAHYiRsAnmS2GTDpzXKQj93NEaU2g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.6.0.tgz",
+      "integrity": "sha512-TOjRseq2LqUVofoWVXsWPuaxZkMJKtvTS+U6mwuDt3X2d7DgHis54mckIdSEIZw9QdeC+Q15lggEeOWIpPON1Q==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.5.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-doctor": "1.5.0",
+    "nativescript-doctor": "1.6.0",
     "nativescript-preview-sdk": "0.3.0",
     "open": "0.0.5",
     "ora": "2.0.0",


### PR DESCRIPTION
As we are going to set min required Android Support Library to be 28 (in the modules), we need to set the min required compile SDK to 28 as well (as Android Support Library 28 relies on resources included in this version of the SDK and the project cannot be build without them). This way CLI will not allow building an application without installing the Android SDK 28 first.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
CLI allows you to build applications when Android SDK 28 is not installed. Using next of tns-core-modules and trying to build it will fail with some missing resources error.

## What is the new behavior?
CLI does not allow you to build applications in case Android SDK 28 is not installed. 
Implements issue https://github.com/NativeScript/nativescript-cli/issues/3991 


BREAKING CHANGES:
You will not be able to build applications for Android without installing SDK 28

Migration steps:
Install Android SDK 28 and build tools 28:
```
$ANDROID_HOME/tools/bin/sdkmanager "build-tools;28.0.1"
$ANDROID_HOME/tools/bin/sdkmanager "platforms;android-28"
```
