### PR TITLE
fix: validate correctly when `next` is written as a version of nativescript-dev-webpack in package.json

### DIFF
--- a/lib/helpers/bundle-validator-helper.ts
+++ b/lib/helpers/bundle-validator-helper.ts
@@ -24,9 +24,12 @@ export class BundleValidatorHelper implements IBundleValidatorHelper {
 
 			if (minSupportedVersion) {
 				const currentVersion = bundlerVersionInDependencies || bundlerVersionInDevDependencies;
-				const isBundleSupported = semver.gte(semver.coerce(currentVersion), semver.coerce(minSupportedVersion));
-				if (!isBundleSupported) {
-					this.$errors.failWithoutHelp(util.format(BundleValidatorMessages.NotSupportedVersion, minSupportedVersion));
+				const shouldSkipCheck = !semver.valid(currentVersion) && !semver.validRange(currentVersion);
+				if (!shouldSkipCheck) {
+					const isBundleSupported = semver.gte(semver.coerce(currentVersion), semver.coerce(minSupportedVersion));
+					if (!isBundleSupported) {
+						this.$errors.failWithoutHelp(util.format(BundleValidatorMessages.NotSupportedVersion, minSupportedVersion));
+					}
 				}
 			}
 		}

--- a/test/helpers/bundle-validator-helper.ts
+++ b/test/helpers/bundle-validator-helper.ts
@@ -79,6 +79,13 @@ describe("BundleValidatorHelper", () => {
 					currentWebpackVersion: "0.17.0-2018-09-28-173604-01",
 					minSupportedWebpackVersion: "0.17.0",
 					expectedError: null
+				},
+				{
+					name: `should not throw an error when next version of webpack is installed as ${key}`,
+					isDependency,
+					currentWebpackVersion: "next",
+					minSupportedWebpackVersion: "0.17.0",
+					expectedError: null
 				}
 			]);
 		});


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns preview --hmr` fails when next is written as a version of `nativescript-dev-webpack`

## What is the new behavior?
`tns preview --hmr` does not fail when next is written as a version of `nativescript-dev-webpack`