### PR TITLE
fix: increase timeout for establishing LS socket connection.

### DIFF
--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -7,7 +7,7 @@ const SIZE_BYTE_LENGTH = 1;
 const REPORT_LENGTH = 1;
 const DO_REFRESH_LENGTH = 1;
 const SYNC_OPERATION_TIMEOUT = 60000;
-const TRY_CONNECT_TIMEOUT = 30000;
+const TRY_CONNECT_TIMEOUT = 60000;
 const DEFAULT_LOCAL_HOST_ADDRESS = "127.0.0.1";
 
 export class AndroidLivesyncTool implements IAndroidLivesyncTool {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Sometimes with big applications the assets unpacking step in android runtime takes too long and the LS socket connection fails, despite the application process being already started.

## What is the new behavior?
<!-- Describe the changes. -->
The runtime has two times more time to unpack the assets, before CLI stops to attempt to connect and throws an error.

Fixes https://github.com/NativeScript/nativescript-cli/issues/3818

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

