### PR TITLE
fix-next(preview): externalize all plugins from the Preview app

### DIFF
--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -33,15 +33,9 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 	public getExternalPlugins(device: Device): string[] {
 		const devicePlugins = this.getDevicePlugins(device);
 		const result = _.keys(devicePlugins)
-			.filter(plugin => plugin.indexOf("nativescript") !== -1)
-			// The core theme links are custom and should be handled by us build time.
-			.filter(plugin => !_.includes(["nativescript-theme-core"], plugin));
-
-		result.push(
-			"tns-core-modules",
-			"tns-core-modules-widgets",
-			"@angular"
-		);
+			// The core theme links are custom and
+			// should be handled by webpack during build.
+			.filter(plugin => plugin !== "nativescript-theme-core");
 
 		return result;
 	}

--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -34,14 +34,15 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 		const devicePlugins = this.getDevicePlugins(device);
 		const result = _.keys(devicePlugins)
 			.filter(plugin => plugin.indexOf("nativescript") !== -1)
-			// exclude angular and vue related dependencies as they do not contain
-			// any native code. In this way, we will read them from the bundle
-			// and improve the app startup time by not reading a lot of
-			// files from the file system instead. Also, the core theme links
-			// are custom and should be handled by us build time.
-			.filter(plugin => !_.includes(["nativescript-angular", "nativescript-vue", "nativescript-intl", "nativescript-theme-core"], plugin));
+			// The core theme links are custom and should be handled by us build time.
+			.filter(plugin => !_.includes(["nativescript-theme-core"], plugin));
 
-		result.push(...["tns-core-modules", "tns-core-modules-widgets"]);
+		result.push(
+			"tns-core-modules",
+			"tns-core-modules-widgets",
+			"@angular"
+		);
+
 		return result;
 	}
 

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -417,36 +417,36 @@ describe("previewAppPluginsService", () => {
 	describe("getExternalPlugins", () => {
 		const testCases = [
 			{
-				name: "should return default plugins(`tns-core-modules` and `tns-core-modules-widgets`) when no plugins are provided",
+				name: "should return default plugins(`tns-core-modules`, `tns-core-modules-widgets` and `@angular`) when no plugins are provided",
 				plugins: {},
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets"]
+				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets", "@angular"]
 			},
 			{
-				name: "should exclude `nativescript-vue`",
+				name: "should include `nativescript-vue`",
 				plugins: { "nativescript-vue": "1.2.3" },
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets"]
+				expectedPlugins: ["nativescript-vue", "tns-core-modules", "tns-core-modules-widgets", "@angular"]
 			},
 			{
-				name: "should exclude `nativescript-intl`",
+				name: "should include `nativescript-intl`",
 				plugins: { "nativescript-intl": "4.5.6" },
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets"]
+				expectedPlugins: ["nativescript-intl", "tns-core-modules", "tns-core-modules-widgets", "@angular"]
 			},
 			{
-				name: "should exclude `nativescript-angular`",
+				name: "should include `nativescript-angular`",
 				plugins: { "nativescript-angular": "7.8.9" },
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets"]
+				expectedPlugins: ["nativescript-angular", "tns-core-modules", "tns-core-modules-widgets", "@angular"]
 			},
 			{
 				name: "should exclude `nativescript-theme-core`",
 				plugins: { "nativescript-theme-core": "1.3.5" },
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets"]
+				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets", "@angular"]
 			},
 			{
 				name: "should return plugins that contain `nativescript` in their names",
 				plugins: {
 					"nativescript-facebook": "4.5.6"
 				},
-				expectedPlugins: ["nativescript-facebook", "tns-core-modules", "tns-core-modules-widgets"]
+				expectedPlugins: ["nativescript-facebook", "tns-core-modules", "tns-core-modules-widgets", "@angular"]
 			},
 			{
 				name: "should not return plugins that do not contain `nativescript` in their names",
@@ -454,7 +454,7 @@ describe("previewAppPluginsService", () => {
 					lodash: "4.5.6",
 					xmlhttprequest: "1.2.3"
 				},
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets"]
+				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets", "@angular"]
 			}
 		];
 

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -415,55 +415,11 @@ describe("previewAppPluginsService", () => {
 		});
 	});
 	describe("getExternalPlugins", () => {
-		const testCases = [
-			{
-				name: "should return default plugins(`tns-core-modules`, `tns-core-modules-widgets` and `@angular`) when no plugins are provided",
-				plugins: {},
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets", "@angular"]
-			},
-			{
-				name: "should include `nativescript-vue`",
-				plugins: { "nativescript-vue": "1.2.3" },
-				expectedPlugins: ["nativescript-vue", "tns-core-modules", "tns-core-modules-widgets", "@angular"]
-			},
-			{
-				name: "should include `nativescript-intl`",
-				plugins: { "nativescript-intl": "4.5.6" },
-				expectedPlugins: ["nativescript-intl", "tns-core-modules", "tns-core-modules-widgets", "@angular"]
-			},
-			{
-				name: "should include `nativescript-angular`",
-				plugins: { "nativescript-angular": "7.8.9" },
-				expectedPlugins: ["nativescript-angular", "tns-core-modules", "tns-core-modules-widgets", "@angular"]
-			},
-			{
-				name: "should exclude `nativescript-theme-core`",
-				plugins: { "nativescript-theme-core": "1.3.5" },
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets", "@angular"]
-			},
-			{
-				name: "should return plugins that contain `nativescript` in their names",
-				plugins: {
-					"nativescript-facebook": "4.5.6"
-				},
-				expectedPlugins: ["nativescript-facebook", "tns-core-modules", "tns-core-modules-widgets", "@angular"]
-			},
-			{
-				name: "should not return plugins that do not contain `nativescript` in their names",
-				plugins: {
-					lodash: "4.5.6",
-					xmlhttprequest: "1.2.3"
-				},
-				expectedPlugins: ["tns-core-modules", "tns-core-modules-widgets", "@angular"]
-			}
-		];
-
-		_.each(testCases, testCase => {
-			it(`${testCase.name}`, () => {
-				const { previewAppPluginsService, device } = setup(testCase.plugins, testCase.plugins);
-				const actualPlugins = previewAppPluginsService.getExternalPlugins(device);
-				assert.deepEqual(actualPlugins, testCase.expectedPlugins);
-			});
+		it("should exclude `nativescript-theme-core`", () => {
+			const plugins = { "nativescript-theme-core": "1.3.5" };
+			const { previewAppPluginsService, device } = setup(plugins, plugins);
+			const actualPlugins = previewAppPluginsService.getExternalPlugins(device);
+			assert.notInclude(actualPlugins, "nativescript-theme-core");
 		});
 	});
 });


### PR DESCRIPTION
Mark all plugins that are already in the Preview app as external. This
will prevent webpack from bundling them. Having two instances of one
plugin, may cause problems.