### PR TITLE
fix: apply changes correctly when app is uninstalled from device during the execution of `tns run android --hmr` command

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -649,6 +649,11 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 											skipModulesNativeCheck: !liveSyncData.watchAllFiles
 										}, { skipNativePrepare: deviceBuildInfoDescriptor.skipNativePrepare });
 
+										if (liveSyncData.useHotModuleReload && appInstalledOnDeviceResult.appInstalled) {
+											const additionalFilesToSync = currentHmrData && currentHmrData.fallbackFiles && currentHmrData.fallbackFiles[device.deviceInfo.platform];
+											_.each(additionalFilesToSync, fileToSync => currentFilesToSync.push(fileToSync));
+										}
+
 										const service = this.getLiveSyncService(device.deviceInfo.platform);
 										const settings: ILiveSyncWatchInfo = {
 											liveSyncDeviceInfo: deviceBuildInfoDescriptor,


### PR DESCRIPTION
In case when `tns run android --hmr` command is executed and the app is uninstalled from device during the execution of command, {N} CLI installs the application again on device but the changes are not applied. When a change occurs during the execution of command, {N} CLI sends only `.hot-update` files on device. (without `bundle.js` and `vendor.js`). But in this specific case {N} CLI should send all files on device including `bundle.js` and/or `vendor.js`.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## Steps to reproduce:;
1. `run android --hmr`

2. make changes – applied 

3. Uninstall app without stop the proccess 

4. Make new changes and save 

5. The app will install without new changes 
