### PR TITLE
fix: remove all .ts files when building in release

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -306,10 +306,15 @@ interface INodeModulesData extends IPlatform, IProjectDataComposition, IAppFiles
 	projectFilesConfig: IProjectFilesConfig;
 }
 
+interface INodeModulesBuilderData {
+	nodeModulesData: INodeModulesData;
+	release: boolean;
+}
+
 interface INodeModulesBuilder {
-	prepareNodeModules(nodeModulesData: INodeModulesData): Promise<void>;
-	prepareJSNodeModules(jsNodeModulesData: INodeModulesData): Promise<void>;
-	cleanNodeModules(absoluteOutputPath: string, platform: string): void;
+	prepareNodeModules(opts: INodeModulesBuilderData): Promise<void>;
+	prepareJSNodeModules(opts: INodeModulesBuilderData): Promise<void>;
+	cleanNodeModules(absoluteOutputPath: string): void;
 }
 
 interface INodeModulesDependenciesBuilder {
@@ -369,7 +374,7 @@ interface IOptionalFilesToRemove {
 	filesToRemove?: string[];
 }
 
-interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync, IOptionalFilesToRemove, IOptionalNativePrepareComposition { 
+interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync, IOptionalFilesToRemove, IOptionalNativePrepareComposition {
 	skipCopyTnsModules?: boolean;
 	skipCopyAppResourcesFiles?: boolean;
 }

--- a/lib/services/prepare-platform-js-service.ts
+++ b/lib/services/prepare-platform-js-service.ts
@@ -101,12 +101,15 @@ export class PreparePlatformJSService extends PreparePlatformService implements 
 			const absoluteOutputPath = path.join(appDestinationDirectoryPath, constants.TNS_MODULES_FOLDER_NAME);
 			// Process node_modules folder
 			await this.$nodeModulesBuilder.prepareJSNodeModules({
-				absoluteOutputPath,
-				platform,
-				lastModifiedTime,
-				projectData,
-				appFilesUpdaterOptions,
-				projectFilesConfig
+				nodeModulesData: {
+					absoluteOutputPath,
+					platform,
+					lastModifiedTime,
+					projectData,
+					appFilesUpdaterOptions,
+					projectFilesConfig
+				},
+				release: appFilesUpdaterOptions.release
 			});
 		} catch (error) {
 			this.$logger.debug(error);

--- a/lib/services/prepare-platform-native-service.ts
+++ b/lib/services/prepare-platform-native-service.ts
@@ -54,7 +54,7 @@ export class PreparePlatformNativeService extends PreparePlatformService impleme
 			};
 
 			// Process node_modules folder
-			await this.$nodeModulesBuilder.prepareNodeModules(nodeModulesData);
+			await this.$nodeModulesBuilder.prepareNodeModules({ nodeModulesData, release: config.appFilesUpdaterOptions.release });
 		}
 
 		if (!config.changesInfo || config.changesInfo.configChanged || config.changesInfo.modulesChanged) {


### PR DESCRIPTION
When building application in release mode, the `.ts` files of all plugins should be removed from the final application. Currently this is happening only for `tns-core-modules`. Do this for all the plugins.
Remove logic that deletes the `node_modules` directory of the `tns-core-modules` when it is copied to `platforms`. This is not required anymore and it breaks use-case when linking tns-core-modules.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Applications built in release have `.ts` files inside them.
Also you are unable to use a linked copy of `tns-core-modules`.

## What is the new behavior?
Applications built in release does NOT have `.ts` files inside them.
You can use symlink for tns-core-modules.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4007
