### PR TITLE
fix: prepare node_modules only once

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -309,6 +309,7 @@ interface INodeModulesData extends IPlatform, IProjectDataComposition, IAppFiles
 interface INodeModulesBuilderData {
 	nodeModulesData: INodeModulesData;
 	release: boolean;
+	copyNodeModules?: boolean;
 }
 
 interface INodeModulesBuilder {

--- a/lib/services/prepare-platform-js-service.ts
+++ b/lib/services/prepare-platform-js-service.ts
@@ -109,7 +109,8 @@ export class PreparePlatformJSService extends PreparePlatformService implements 
 					appFilesUpdaterOptions,
 					projectFilesConfig
 				},
-				release: appFilesUpdaterOptions.release
+				release: appFilesUpdaterOptions.release,
+				copyNodeModules: true
 			});
 		} catch (error) {
 			this.$logger.debug(error);


### PR DESCRIPTION
Whenever we prepare node_modules (i.e. moving them to platforms dir), CLI executes the operation twice:
1. When prepare the JS part of the modules.
2. When prepare the native part of the modules.
The first part is a must for cases when you work with cloud builds, so we cannot skip it, but we can safely skip the second one. This improves the initial prepare of `tns-template-master-detail-ng` with around 20 seconds.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Node_modules are prepared twice on first `tns run`

## What is the new behavior?
Node_modules are prepared once.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4010