### PR TITLE
fix: avoid nre when the device log is reported before the device itself during preview

### DIFF
--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -63,7 +63,7 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 			onConnectedDevicesChange: (connectedDevices: ConnectedDevices) => ({ }),
 			onLogMessage: (log: string, deviceName: string, deviceId: string) => {
 				const device = _.find(this.connectedDevices, { id: deviceId});
-				this.emit(DEVICE_LOG_EVENT_NAME, log, deviceId, device.platform);
+				this.emit(DEVICE_LOG_EVENT_NAME, log, deviceId, device ? device.platform : "");
 				this.$logger.info(`LOG from device ${deviceName}: ${log}`);
 			},
 			onRestartMessage: () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
"Cannot read property 'platform' of undefined" is thrown when the device report log before reporting itself.

## What is the new behavior?
We won't know the platform of the preview logs in such cases.

