### PR TITLE
fix: getNodeWarning always returns warning

### DIFF
--- a/lib/common/verify-node-version.ts
+++ b/lib/common/verify-node-version.ts
@@ -78,9 +78,13 @@ export function getNodeWarning(): ISystemWarning {
 		}
 	}
 
-	return {
-		message: warningMessage,
-		severity: SystemWarningsSeverity.medium
-	};
+	if (warningMessage) {
+		return {
+			message: warningMessage,
+			severity: SystemWarningsSeverity.medium
+		};
+	}
+
+	return null;
 }
 /* tslint:enable */


### PR DESCRIPTION
`getNodeWarning` always returns a warning, even when there's no such. It returns object with empty message, when it has to return null.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
