### PR TITLE
fix: sync on all platforms when `tns run --hmr` command is executed

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -596,6 +596,10 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 			const startSyncFilesTimeout = (platform?: string) => {
 				timeoutTimer = setTimeout(async () => {
+					if (platform && liveSyncData.bundle) {
+						filesToSync = filesToSyncMap[platform];
+					}
+
 					if (filesToSync.length || filesToRemove.length) {
 						const currentFilesToSync = _.cloneDeep(filesToSync);
 						filesToSync.splice(0, filesToSync.length);
@@ -732,9 +736,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 					filesToRemove,
 					startSyncFilesTimeout: async (platform: string) => {
 						if (platform) {
-							filesToSync = filesToSyncMap[platform];
-							await startSyncFilesTimeout();
-							filesToSyncMap[platform] = [];
+							await startSyncFilesTimeout(platform);
 						} else {
 							// This code is added for backwards compatibility with old versions of nativescript-dev-webpack plugin.
 							await startSyncFilesTimeout();


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns run --hmr` syncs changes only on one platform when iOS and android devices are attached

## What is the new behavior?
`tns run --hmr` syncs changes on both platforms when iOS and android devices are attached

