### PR TITLE
fix: recover android application if with hmr and in ErrorActivity

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -349,6 +349,7 @@ interface ILiveSyncWatchInfo extends IProjectDataComposition, IHasUseHotModuleRe
 	isReinstalled: boolean;
 	syncAllFiles: boolean;
 	liveSyncDeviceInfo: ILiveSyncDeviceInfo;
+	hmrData: { hash: string; fallbackFiles: IDictionary<string[]> };
 	force?: boolean;
 }
 
@@ -356,6 +357,7 @@ interface ILiveSyncResultInfo extends IHasUseHotModuleReloadOption {
 	modifiedFilesData: Mobile.ILocalToDevicePathData[];
 	isFullSync: boolean;
 	deviceAppData: Mobile.IDeviceAppData;
+	didRecover?: boolean
 }
 
 interface IAndroidLiveSyncResultInfo extends ILiveSyncResultInfo, IAndroidLivesyncSyncOperationResult { }

--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -24,8 +24,24 @@ export class AndroidLiveSyncService extends PlatformLiveSyncServiceBase implemen
 	}
 
 	public async liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<IAndroidLiveSyncResultInfo> {
+		let result = await this.liveSyncWatchActionCore(device, liveSyncInfo);
+
+		// When we use hmr, there is only one case when result.didRefresh is false.
+		// This is the case when the app has crashed and is in ErrorActivity.
+		// As the app might not have time to apply the patches, we will send the whole bundle.js(fallbackFiles)
+		if (liveSyncInfo.useHotModuleReload && !result.didRefresh && liveSyncInfo.hmrData && liveSyncInfo.hmrData.hash) {
+			liveSyncInfo.filesToSync = liveSyncInfo.hmrData.fallbackFiles[device.deviceInfo.platform];
+			result = await this.liveSyncWatchActionCore(device, liveSyncInfo);
+			result.didRecover = true;
+		}
+
+		return result;
+	}
+
+	private async liveSyncWatchActionCore(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<IAndroidLiveSyncResultInfo> {
 		const liveSyncResult = await super.liveSyncWatchAction(device, liveSyncInfo);
 		const result = await this.finalizeSync(device, liveSyncInfo.projectData, liveSyncResult);
+
 		return result;
 	}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -666,6 +666,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 											filesToSync: currentFilesToSync,
 											isReinstalled: appInstalledOnDeviceResult.appInstalled,
 											syncAllFiles: liveSyncData.watchAllFiles,
+											hmrData: currentHmrData,
 											useHotModuleReload: liveSyncData.useHotModuleReload,
 											force: liveSyncData.force
 										};
@@ -674,11 +675,13 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 										await this.refreshApplication(projectData, liveSyncResultInfo, deviceBuildInfoDescriptor.debugOptions, deviceBuildInfoDescriptor.outputPath);
 
-										if (liveSyncData.useHotModuleReload && currentHmrData.hash) {
+										//If didRecover is true, this means we were in ErrorActivity and fallback files were already transfered and app will be restarted.
+										if (!liveSyncResultInfo.didRecover && liveSyncData.useHotModuleReload && currentHmrData.hash) {
 											const status = await this.$hmrStatusService.getHmrStatus(device.deviceInfo.identifier, currentHmrData.hash);
 											if (status === HmrConstants.HMR_ERROR_STATUS) {
 												settings.filesToSync = currentHmrData.fallbackFiles[device.deviceInfo.platform];
 												liveSyncResultInfo = await service.liveSyncWatchAction(device, settings);
+												//We want to force a restart of the application.
 												liveSyncResultInfo.isFullSync = true;
 												await this.refreshApplication(projectData, liveSyncResultInfo, deviceBuildInfoDescriptor.debugOptions, deviceBuildInfoDescriptor.outputPath);
 											}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When the the update that fixes the error is send the app is restarted, but crashes again, because it doesn't manage to apply the patch.

## What is the new behavior?
<!-- Describe the changes. -->
The app is restarted and loads normally.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

