### PR TITLE
feat: speed-up livesync with HMR

### DIFF
--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -149,7 +149,7 @@ declare module Mobile {
 		muted?: boolean;
 	}
 
-	interface IDeviceAppData extends IPlatform {
+	interface IDeviceAppData extends IPlatform, IConnectTimeoutOption {
 		appIdentifier: string;
 		device: Mobile.IDevice;
 		getDeviceProjectRootPath(): Promise<string>;

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -343,7 +343,14 @@ interface IShouldSkipEmitLiveSyncNotification {
 interface IAttachDebuggerOptions extends IDebuggingAdditionalOptions, IEnableDebuggingDeviceOptions, IIsEmulator, IPlatform, IOptionalOutputPath {
 }
 
-interface ILiveSyncWatchInfo extends IProjectDataComposition, IHasUseHotModuleReloadOption {
+interface IConnectTimeoutOption {
+	/**
+	 * Time to wait for successful connection. Defaults to 30000 miliseconds.
+	 */
+	connectTimeout?: number;
+}
+
+interface ILiveSyncWatchInfo extends IProjectDataComposition, IHasUseHotModuleReloadOption, IConnectTimeoutOption {
 	filesToRemove: string[];
 	filesToSync: string[];
 	isReinstalled: boolean;
@@ -362,7 +369,7 @@ interface ILiveSyncResultInfo extends IHasUseHotModuleReloadOption {
 
 interface IAndroidLiveSyncResultInfo extends ILiveSyncResultInfo, IAndroidLivesyncSyncOperationResult { }
 
-interface IFullSyncInfo extends IProjectDataComposition, IHasUseHotModuleReloadOption {
+interface IFullSyncInfo extends IProjectDataComposition, IHasUseHotModuleReloadOption, IConnectTimeoutOption {
 	device: Mobile.IDevice;
 	watch: boolean;
 	syncAllFiles: boolean;
@@ -510,7 +517,7 @@ interface IDoSyncOperationOptions {
 	operationId?: string
 }
 
-interface IAndroidLivesyncToolConfiguration {
+interface IAndroidLivesyncToolConfiguration extends IConnectTimeoutOption {
 	/**
 	 * The application identifier.
 	 */
@@ -531,10 +538,6 @@ interface IAndroidLivesyncToolConfiguration {
 	 * If provider will call it when an error occurs.
 	 */
 	errorHandler?: any;
-	/**
-	 * Time to wait for successful connection. Defaults to 30000 miliseconds.
-	 */
-	connectTimeout?: number;
 }
 
 interface IAndroidLivesyncSyncOperationResult {

--- a/lib/services/livesync/android-device-livesync-sockets-service.ts
+++ b/lib/services/livesync/android-device-livesync-sockets-service.ts
@@ -23,16 +23,23 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 		private $fs: IFileSystem,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$filesHashService: IFilesHashService) {
-			super($injector, $platformsData, $filesHashService, $logger, device);
-			this.livesyncTool = this.$injector.resolve(AndroidLivesyncTool);
+		super($injector, $platformsData, $filesHashService, $logger, device);
+		this.livesyncTool = this.$injector.resolve(AndroidLivesyncTool);
 	}
 
 	public async beforeLiveSyncAction(deviceAppData: Mobile.IDeviceAppData): Promise<void> {
-		const pathToLiveSyncFile = temp.path({ prefix: "livesync" });
-		this.$fs.writeFile(pathToLiveSyncFile, "");
-		await this.device.fileSystem.putFile(pathToLiveSyncFile, this.getPathToLiveSyncFileOnDevice(deviceAppData.appIdentifier), deviceAppData.appIdentifier);
-		await this.device.applicationManager.startApplication({ appId: deviceAppData.appIdentifier, projectName: this.data.projectName, justLaunch: true });
-		await this.connectLivesyncTool(this.data.projectIdentifiers.android);
+		if (!this.livesyncTool.hasConnection()) {
+			try {
+				const pathToLiveSyncFile = temp.path({ prefix: "livesync" });
+				this.$fs.writeFile(pathToLiveSyncFile, "");
+				await this.device.fileSystem.putFile(pathToLiveSyncFile, this.getPathToLiveSyncFileOnDevice(deviceAppData.appIdentifier), deviceAppData.appIdentifier);
+				await this.device.applicationManager.startApplication({ appId: deviceAppData.appIdentifier, projectName: this.data.projectName, justLaunch: true });
+				await this.connectLivesyncTool(this.data.projectIdentifiers.android, deviceAppData.connectTimeout);
+			} catch (err) {
+				await this.device.fileSystem.deleteFile(this.getPathToLiveSyncFileOnDevice(deviceAppData.appIdentifier), deviceAppData.appIdentifier);
+				throw err;
+			}
+		}
 	}
 
 	private getPathToLiveSyncFileOnDevice(appIdentifier: string): string {
@@ -59,7 +66,7 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 
 		if (liveSyncInfo.modifiedFilesData.length) {
 			const canExecuteFastSync = !liveSyncInfo.isFullSync && this.canExecuteFastSyncForPaths(liveSyncInfo, liveSyncInfo.modifiedFilesData, projectData, this.device.deviceInfo.platform);
-			const doSyncPromise = this.livesyncTool.sendDoSyncOperation({ doRefresh: canExecuteFastSync, operationId});
+			const doSyncPromise = this.livesyncTool.sendDoSyncOperation({ doRefresh: canExecuteFastSync, operationId });
 
 			const syncInterval: NodeJS.Timer = setInterval(() => {
 				if (this.livesyncTool.isOperationInProgress(operationId)) {
@@ -114,14 +121,15 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 		await this.livesyncTool.sendDirectory(projectFilesPath);
 	}
 
-	private async connectLivesyncTool(appIdentifier: string) {
+	private async connectLivesyncTool(appIdentifier: string, connectTimeout?: number) {
 		const platformData = this.$platformsData.getPlatformData(this.$devicePlatformsConstants.Android, this.data);
 		const projectFilesPath = path.join(platformData.appDestinationDirectoryPath, APP_FOLDER_NAME);
 		if (!this.livesyncTool.hasConnection()) {
 			await this.livesyncTool.connect({
 				appIdentifier,
 				deviceIdentifier: this.device.deviceInfo.identifier,
-				appPlatformsPath: projectFilesPath
+				appPlatformsPath: projectFilesPath,
+				connectTimeout
 			});
 		}
 	}

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -135,7 +135,8 @@ export abstract class PlatformLiveSyncServiceBase {
 			platform: syncInfo.device.deviceInfo.platform,
 			getDeviceProjectRootPath: () => this.$devicePathProvider.getDeviceProjectRootPath(syncInfo.device, deviceProjectRootOptions),
 			deviceSyncZipPath: this.$devicePathProvider.getDeviceSyncZipPath(syncInfo.device),
-			isLiveSyncSupported: async () => true
+			isLiveSyncSupported: async () => true,
+			connectTimeout: syncInfo.connectTimeout
 		};
 	}
 


### PR DESCRIPTION
In case HMR is used, webpack reports to CLI the already prepared files, so there's no need for CLI to do any preparation, just sync the files. Try sending them as soon as possible and if we fail, go through the normal worklfow.

Ensure the code is called only when webpack had produced files for us and we are with HMR enabled.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Applying a change when CLI is livesyncing with HMR takes from 1.5 to 5 seconds.

## What is the new behavior?
Applying a change when CLI is livesyncing with HMR takes from below 1 second.
