### PR TITLE
fix: get correct hmr hash when more than one webpacks are started

### DIFF
--- a/lib/definitions/hmr-status-service.d.ts
+++ b/lib/definitions/hmr-status-service.d.ts
@@ -1,4 +1,4 @@
 interface IHmrStatusService {
 	getHmrStatus(deviceId: string, operationHash: string): Promise<number>;
-	attachToHrmStatusEvent(): void;
+	attachToHmrStatusEvent(): void;
 }

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -356,7 +356,7 @@ interface ILiveSyncWatchInfo extends IProjectDataComposition, IHasUseHotModuleRe
 	isReinstalled: boolean;
 	syncAllFiles: boolean;
 	liveSyncDeviceInfo: ILiveSyncDeviceInfo;
-	hmrData: { hash: string; fallbackFiles: IDictionary<string[]> };
+	hmrData: IPlatformHmrData;
 	force?: boolean;
 }
 
@@ -375,6 +375,11 @@ interface IFullSyncInfo extends IProjectDataComposition, IHasUseHotModuleReloadO
 	syncAllFiles: boolean;
 	liveSyncDeviceInfo: ILiveSyncDeviceInfo;
 	force?: boolean;
+}
+
+interface IPlatformHmrData {
+	hash: string;
+	fallbackFiles: string[];
 }
 
 interface ITransferFilesOptions {

--- a/lib/services/hmr-status-service.ts
+++ b/lib/services/hmr-status-service.ts
@@ -34,7 +34,7 @@ export class HmrStatusService implements IHmrStatusService {
 	}
 
 	@cache()
-	public attachToHrmStatusEvent(): void {
+	public attachToHmrStatusEvent(): void {
 		this.$logParserService.addParseRule({
 			regex: HmrStatusService.HMR_STATUS_LOG_REGEX,
 			handler: this.handleHmrStatusFound.bind(this),
@@ -62,7 +62,7 @@ export class HmrStatusService implements IHmrStatusService {
 			}
 		}
 
-		this.$logger.trace("Found hmr status.", {status, hash});
+		this.$logger.trace("Found hmr status.", { status, hash });
 
 		if (status) {
 			this.setData(status, hash, deviceId);

--- a/lib/services/livesync/android-livesync-service.ts
+++ b/lib/services/livesync/android-livesync-service.ts
@@ -30,7 +30,7 @@ export class AndroidLiveSyncService extends PlatformLiveSyncServiceBase implemen
 		// This is the case when the app has crashed and is in ErrorActivity.
 		// As the app might not have time to apply the patches, we will send the whole bundle.js(fallbackFiles)
 		if (liveSyncInfo.useHotModuleReload && !result.didRefresh && liveSyncInfo.hmrData && liveSyncInfo.hmrData.hash) {
-			liveSyncInfo.filesToSync = liveSyncInfo.hmrData.fallbackFiles[device.deviceInfo.platform];
+			liveSyncInfo.filesToSync = liveSyncInfo.hmrData.fallbackFiles;
 			result = await this.liveSyncWatchActionCore(device, liveSyncInfo);
 			result.didRecover = true;
 		}

--- a/lib/services/log-parser-service.ts
+++ b/lib/services/log-parser-service.ts
@@ -29,7 +29,7 @@ export class LogParserService extends EventEmitter implements ILogParserService 
 	private processDeviceLogResponse(message: string, deviceIdentifier: string, devicePlatform: string) {
 		const lines = message.split("\n");
 		_.forEach(lines, line => {
-			_.forEach(this.parseRules, (parseRule) => {
+			_.forEach(this.parseRules, parseRule => {
 				if (!devicePlatform || !parseRule.platform || parseRule.platform.toLowerCase() === devicePlatform.toLowerCase()) {
 					const matches = parseRule.regex.exec(line);
 


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Hmr status is not correct when more than one webpacks are started.

## What is the new behavior?
Hmr status is correct when more than one webpacks are started.

Should be merged with this PR: https://github.com/NativeScript/nativescript-dev-webpack/pull/690

