### PR TITLE
fix: show deviceIdentifier on installing and refreshing messages

### DIFF
--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -30,7 +30,7 @@ export abstract class PlatformLiveSyncServiceBase {
 	public async refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void> {
 		if (liveSyncInfo.isFullSync || liveSyncInfo.modifiedFilesData.length) {
 			const deviceLiveSyncService = this.getDeviceLiveSyncService(liveSyncInfo.deviceAppData.device, projectData);
-			this.$logger.info("Refreshing application...");
+			this.$logger.info(`Refreshing application on device ${liveSyncInfo.deviceAppData.device.deviceInfo.identifier}...`);
 			await deviceLiveSyncService.refreshApplication(projectData, liveSyncInfo);
 		}
 	}

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -481,7 +481,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	public async installApplication(device: Mobile.IDevice, buildConfig: IBuildConfig, projectData: IProjectData, packageFile?: string, outputFilePath?: string): Promise<void> {
-		this.$logger.out("Installing...");
+		this.$logger.out(`Installing on device ${device.deviceInfo.identifier}...`);
 
 		await this.$analyticsService.trackEventActionInGoogleAnalytics({
 			action: constants.TrackActionNames.Deploy,


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`Installing...` msg is shown when app is installing on device.
`Refresing...` msg is shown when app is refreshing on device.

## What is the new behavior?
`Installing on device <id>` msg is shown when app is installing on device.
`Refreshing on device <id>` msg is shown when app is refreshing on device.


