### PR TITLE
fix: don't detach native debugger on debug command

### DIFF
--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -143,7 +143,6 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 		}
 		this._lldbProcess.stderr.pipe(process.stderr);
 		this._lldbProcess.stdin.write("process continue\n");
-		this._lldbProcess.stdin.write("detach\n");
 
 		return this.wireDebuggerClient(debugData, debugOptions);
 	}


### PR DESCRIPTION

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns debug ios --emulator --debug-brk` does not work

## What is the new behavior?
`tns debug ios --emulator --debug-brk` works


