### PR TITLE
chore(plugin.md) - Remove find and search commands from man pages

### DIFF
--- a/docs/man_pages/lib-management/plugin.md
+++ b/docs/man_pages/lib-management/plugin.md
@@ -17,8 +17,6 @@ Lets you manage the plugins for your project.
 * `add` - Installs the specified plugin and its dependencies.
 * `remove` - Uninstalls the specified plugin and its dependencies.
 * `update` - Uninstalls and installs the specified plugin(s) and its dependencies.
-* `find` - Finds NativeScript plugins in npm.
-* `search` - Finds NativeScript plugins in npm.
 * `build` - Builds the Android parts of a NativeScript plugin.
 * `create` - Creates a project for building a new NativeScript plugin.
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`tns plugin -h` contains deprecated plugin commands `find` and `search`. This removes the commands from the help prompt.

## What is the new behavior?
<!-- Describe the changes. -->
See above.

Fixes #3834 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

