### PR TITLE
fix: revert the code share fix in order to avoid getting started issues.

### DIFF
--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -33,10 +33,15 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 	public getExternalPlugins(device: Device): string[] {
 		const devicePlugins = this.getDevicePlugins(device);
 		const result = _.keys(devicePlugins)
-			// The core theme links are custom and
-			// should be handled by webpack during build.
-			.filter(plugin => plugin !== "nativescript-theme-core");
+			.filter(plugin => plugin.indexOf("nativescript") !== -1)
+			// exclude angular and vue related dependencies as they do not contain
+			// any native code. In this way, we will read them from the bundle
+			// and improve the app startup time by not reading a lot of
+			// files from the file system instead. Also, the core theme links
+			// are custom and should be handled by us build time.
+			.filter(plugin => !_.includes(["nativescript-angular", "nativescript-vue", "nativescript-intl", "nativescript-theme-core"], plugin));
 
+		result.push(...["tns-core-modules", "tns-core-modules-widgets"]);
 		return result;
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Angular apps with lazy loading (e.g. the drawer navigation template) are throwing an exception on start.

## What is the new behavior?
The templates recommended in `tns create` should work as expected.

Related to #3969 and #3813 