### PR TITLE
fix: remove persisted emulator's data on deviceLost event

### DIFF
--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -730,6 +730,12 @@ declare module Mobile {
 		 * @returns {Promise<IStartEmulatorOutput>} Starts the emulator and returns the errors if some error occurs.
 		 */
 		startEmulator(options: Mobile.IStartEmulatorOptions): Promise<IStartEmulatorOutput>;
+
+		/**
+		 * Called when emulator is lost. Its purpose is to clean any resources used by the instance.
+		 * @returns {void}
+		 */
+		detach?(deviceInfo: Mobile.IDeviceInfo): void;
 	}
 
 	interface IStartEmulatorOutput {
@@ -772,6 +778,11 @@ declare module Mobile {
 		 * @param imageIdentifier - The imagerIdentifier of the emulator.
 		 */
 		startEmulatorArgs(imageIdentifier: string): string[];
+		/**
+		 * Called when emulator is lost. Its purpose is to clean any resources used by the instance.
+		 * @returns {void}
+		 */
+		detach?(deviceInfo: Mobile.IDeviceInfo): void;
 	}
 
 	interface IVirtualBoxService {

--- a/lib/common/mobile/android/android-device.ts
+++ b/lib/common/mobile/android/android-device.ts
@@ -121,6 +121,12 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		}
 	}
 
+	public detach(): void {
+		if (this.isEmulator) {
+			this.$androidEmulatorServices.detach(this.deviceInfo);
+		}
+	}
+
 	private async getDeviceDetails(shellCommandArgs: string[]): Promise<IAndroidDeviceDetails> {
 		const parsedDetails: any = {};
 

--- a/lib/common/mobile/android/android-emulator-services.ts
+++ b/lib/common/mobile/android/android-emulator-services.ts
@@ -59,6 +59,10 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 		};
 	}
 
+	public detach(deviceInfo: Mobile.IDeviceInfo) {
+		this.$androidVirtualDeviceService.detach(deviceInfo);
+	}
+
 	private async startEmulatorCore(options: Mobile.IAndroidStartEmulatorOptions): Promise<{runningEmulator: Mobile.IDeviceInfo, errors: string[], endTimeEpoch: number}> {
 		const timeout = options.timeout || AndroidVirtualDevice.TIMEOUT_SECONDS;
 		const endTimeEpoch = getCurrentEpochTime() + this.$utils.getMilliSecondsTimeout(timeout);

--- a/lib/common/mobile/android/android-virtual-device-service.ts
+++ b/lib/common/mobile/android/android-virtual-device-service.ts
@@ -142,6 +142,12 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 		});
 	}
 
+	public detach(deviceInfo: Mobile.IDeviceInfo) {
+		if (this.mapEmulatorIdToImageIdentifier[deviceInfo.identifier]) {
+			delete this.mapEmulatorIdToImageIdentifier[deviceInfo.identifier];
+		}
+	}
+
 	private async getEmulatorImagesCore(): Promise<Mobile.IEmulatorImagesOutput> {
 		let result: ISpawnResult = null;
 		let devices: Mobile.IDeviceInfo[] = [];


### PR DESCRIPTION
If the user starts an android emulator from sidekick, {N} CLI persist the emulator in a dictionary. The started emulator is with id `emulator-5554` so {N} CLI adds a record with key `emulator-5554` in the dictionary.
If the user stops the emulator and starts an another one, the started emulator is again with id `emulator-5554`. {N} CLI checks that an emulator with id `emulator-5554` is persisted and returns the emulator's data. But the returned data is not correct because it belongs to the first started emulator. So we need to remove persisted emulator's data when the user stops the emulator (e.g deviceLost event is emitted).

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The emulator's data is not removed on deviceLost event

## What is the new behavior?
The emulator's data is removed on deviceLost event

