### PR TITLE
fix: don't throw `TypeError: Invalid Version: null` in sidekick when emulator is stopped immediately after start

### DIFF
--- a/lib/common/mobile/android/logcat-helper.ts
+++ b/lib/common/mobile/android/logcat-helper.ts
@@ -58,20 +58,6 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 		}
 	}
 
-	private async getLogcatStream(deviceIdentifier: string, pid?: string) {
-		const device = await this.$devicesService.getDevice(deviceIdentifier);
-		const minAndroidWithLogcatPidSupport = "7.0.0";
-		const isLogcatPidSupported = !!device.deviceInfo.version && semver.gte(semver.coerce(device.deviceInfo.version), minAndroidWithLogcatPidSupport);
-		const adb: Mobile.IDeviceAndroidDebugBridge = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: deviceIdentifier });
-		const logcatCommand = ["logcat"];
-
-		if (pid && isLogcatPidSupported) {
-			logcatCommand.push(`--pid=${pid}`);
-		}
-		const logcatStream = await adb.executeCommand(logcatCommand, { returnChildProcess: true });
-		return logcatStream;
-	}
-
 	public async dump(deviceIdentifier: string): Promise<void> {
 		const adb: Mobile.IDeviceAndroidDebugBridge = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: deviceIdentifier });
 		const logcatDumpStream = await adb.executeCommand(["logcat", "-d"], { returnChildProcess: true });
@@ -100,6 +86,20 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 			this.mapDevicesLoggingData[deviceIdentifier].lineStream.removeAllListeners();
 			delete this.mapDevicesLoggingData[deviceIdentifier];
 		}
+	}
+
+	private async getLogcatStream(deviceIdentifier: string, pid?: string) {
+		const device = await this.$devicesService.getDevice(deviceIdentifier);
+		const minAndroidWithLogcatPidSupport = "7.0.0";
+		const isLogcatPidSupported = !!device.deviceInfo.version && semver.gte(semver.coerce(device.deviceInfo.version), minAndroidWithLogcatPidSupport);
+		const adb: Mobile.IDeviceAndroidDebugBridge = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: deviceIdentifier });
+		const logcatCommand = ["logcat"];
+
+		if (pid && isLogcatPidSupported) {
+			logcatCommand.push(`--pid=${pid}`);
+		}
+		const logcatStream = await adb.executeCommand(logcatCommand, { returnChildProcess: true });
+		return logcatStream;
 	}
 }
 

--- a/lib/common/mobile/android/logcat-helper.ts
+++ b/lib/common/mobile/android/logcat-helper.ts
@@ -61,7 +61,7 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 	private async getLogcatStream(deviceIdentifier: string, pid?: string) {
 		const device = await this.$devicesService.getDevice(deviceIdentifier);
 		const minAndroidWithLogcatPidSupport = "7.0.0";
-		const isLogcatPidSupported =  semver.gte(semver.coerce(device.deviceInfo.version), minAndroidWithLogcatPidSupport);
+		const isLogcatPidSupported = !!device.deviceInfo.version && semver.gte(semver.coerce(device.deviceInfo.version), minAndroidWithLogcatPidSupport);
 		const adb: Mobile.IDeviceAndroidDebugBridge = this.$injector.resolve(DeviceAndroidDebugBridge, { identifier: deviceIdentifier });
 		const logcatCommand = ["logcat"];
 


### PR DESCRIPTION
`TypeError: Invalid Version: null` error is shown is Sidekick when emulator is stopped immediately after start. This happens because emulator is stopped too early and it is not fully initialized. In this case reported emulator is with `version: null` and the semver comparison fails. So we need to ensure the device's version is not `null` before comparison.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`TypeError: Invalid Version: null` error is thrown in Sidekick when emulator is stopped immediately after start.

## What is the new behavior?
No error is thrown in Sidekick when emulator is stopped immediately after start.
