### PR TITLE
fix: throw an error when the path to android avd home dir is not found

### DIFF
--- a/lib/common/mobile/android/android-virtual-device-service.ts
+++ b/lib/common/mobile/android/android-virtual-device-service.ts
@@ -14,6 +14,7 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 		private $childProcess: IChildProcess,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $emulatorHelper: Mobile.IEmulatorHelper,
+		private $errors: IErrors,
 		private $fs: IFileSystem,
 		private $hostInfo: IHostInfo,
 		private $logger: ILogger) {
@@ -202,7 +203,12 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 	@cache()
 	private get pathToAvdHomeDir(): string {
 		const searchPaths = [process.env.ANDROID_AVD_HOME, path.join(osenv.home(), AndroidVirtualDevice.ANDROID_DIR_NAME, AndroidVirtualDevice.AVD_DIR_NAME)];
-		return searchPaths.find(p => p && this.$fs.exists(p));
+		const result = searchPaths.find(p => p && this.$fs.exists(p));
+		if (!result) {
+			this.$errors.failWithoutHelp(`Unable to find the path to the AVD directory in the following searched paths: ${searchPaths}.
+				Please set ANDROID_AVD_HOME environment variable to the correct location of your AVD directory.`);
+		}
+		return result;
 	}
 
 	@cache()


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`No connected devices` is printed on `tns devices` when an emulator is running and avd home dir is not found.

## What is the new behavior?
An error is thrown when an emulator is running and avd home dir is not found.