### PR TITLE
fix: improve the message when not able to start an emulator so it can be useful for sidekick as well.

### DIFF
--- a/lib/common/constants.ts
+++ b/lib/common/constants.ts
@@ -155,5 +155,5 @@ export class AndroidVirtualDevice {
 	static TIMEOUT_SECONDS = 120;
 	static GENYMOTION_DEFAULT_STDERR_STRING = "Logging activities to file";
 
-	static UNABLE_TO_START_EMULATOR_MESSAGE = "Cannot run your app in the native emulator. Increase the timeout of the operation with the --timeout option or try to restart your adb server with 'adb kill-server' command. Alternatively, run the Android Virtual Device manager and increase the allocated RAM for the virtual device.";
+	static UNABLE_TO_START_EMULATOR_MESSAGE = "Cannot run the app in the selected native emulator. Try to restart the adb server by running the `adb kill-server` command in the Command Prompt, or increase the allocated RAM of the virtual device through the Android Virtual Device manager. NativeScript CLI users can try to increase the timeout of the operation by adding the `--timeout` flag.";
 }


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The message that is shown when {N} CLI is not able to start an emulator is not meaningful/useful for sidekick.

## What is the new behavior?
The message that is shown when {N} CLI is not able to start an emulator is meaningful/useful for sidekick.
