### PR TITLE
fix: update natives, so CLI can work on Node.js 11

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5091,9 +5091,9 @@
       }
     },
     "natives": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.5.tgz",
-      "integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
     },
     "nativescript-doctor": {
       "version": "1.6.0",


### PR DESCRIPTION
Upate the natives library, so CLI can work wiht Node.js 11.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When Node.js 11 is installed, CLI fails to execute any command with error:
```
Support for Node.js 11.0.0 is not verified. NativeScript CLI might not install or run properly.

ReferenceError: internalBinding is not defined
    at fs.js:25:1
    at req_ (D:\Rosen\Work\nativescript-cli\node_modules\natives\index.js:140:5)
    at Object.req [as require] (D:\Rosen\Work\nativescript-cli\node_modules\natives\index.js:54:10)
    at Object.<anonymous> (D:\Rosen\Work\nativescript-cli\node_modules\fstream\node_modules\graceful-fs\fs.js:1:99)
    at Module._compile (internal/modules/cjs/loader.js:707:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:718:10)
    at Module.load (internal/modules/cjs/loader.js:605:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:544:12)
    at Function.Module._load (internal/modules/cjs/loader.js:536:3)
    at Module.require (internal/modules/cjs/loader.js:643:17)
```

## What is the new behavior?
CLI can execute commands with Node.js 11

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

