### PR TITLE
fix: start log process on `tns debug ios --justlaunch` command

### DIFF
--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -143,10 +143,6 @@ declare module Mobile {
 				--predicate 'eventType == logEvent and subsystem contains "com.example.my_subsystem"'
 		 */
 		predicate?: string;
-		/**
-		 * If set to true, device's log will not be displayed on the console.
-		 */
-		muted?: boolean;
 	}
 
 	interface IDeviceAppData extends IPlatform, IConnectTimeoutOption {
@@ -221,12 +217,18 @@ declare module Mobile {
 		 * @param {string} projectName The project name of the currently running application for which we need the logs.
 		 */
 		setProjectNameForDevice(deviceIdentifier: string, projectName: string): void;
+
+		/**
+		 * Disables logs on the specified device and does not print any logs on the console.
+		 * @param {string} deviceIdentifier The unique identifier of the device.
+		 */
+		muteLogsForDevice(deviceIdentifier: string): void;
 	}
 
 	/**
 	 * Describes different options for filtering device logs.
 	 */
-	interface IDeviceLogOptions extends IStringDictionary {
+	interface IDeviceLogOptions extends IDictionary<string | boolean> {
 		/**
 		 * Process id of the application on the device.
 		 */
@@ -241,6 +243,11 @@ declare module Mobile {
 		 * The project name.
 		 */
 		projectName?: string;
+
+		/**
+		 * Specifies if the logs will be printed on the console.
+		 */
+		muteLogs?: boolean;
 	}
 
 	/**

--- a/lib/common/mobile/device-log-provider-base.ts
+++ b/lib/common/mobile/device-log-provider-base.ts
@@ -26,6 +26,10 @@ export abstract class DeviceLogProviderBase extends EventEmitter implements Mobi
 		this.setLogLevel(logLevel, deviceIdentifier);
 	}
 
+	public muteLogsForDevice(deviceIdentifier: string): void {
+		this.setDeviceLogOptionsProperty(deviceIdentifier, (deviceLogOptions: Mobile.IDeviceLogOptions) => deviceLogOptions.muteLogs, true);
+	}
+
 	protected getApplicationPidForDevice(deviceIdentifier: string): string {
 		return this.devicesLogOptions[deviceIdentifier] && this.devicesLogOptions[deviceIdentifier].applicationPid;
 	}
@@ -39,7 +43,7 @@ export abstract class DeviceLogProviderBase extends EventEmitter implements Mobi
 		return this.devicesLogOptions[deviceIdentifier];
 	}
 
-	protected setDeviceLogOptionsProperty(deviceIdentifier: string, propNameFunction: Function, propertyValue: string): void {
+	protected setDeviceLogOptionsProperty(deviceIdentifier: string, propNameFunction: Function, propertyValue: string | boolean): void {
 		const propertyName = getPropertyName(propNameFunction);
 
 		if (propertyName) {

--- a/lib/common/mobile/device-log-provider.ts
+++ b/lib/common/mobile/device-log-provider.ts
@@ -11,13 +11,19 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 		const loggingOptions = this.getDeviceLogOptionsForDevice(deviceIdentifier);
 		const data = this.$logFilter.filterData(platform, lineText, loggingOptions);
 		if (data) {
-			this.$logger.write(data);
+			this.logDataCore(data, loggingOptions);
 			this.emit(DEVICE_LOG_EVENT_NAME, lineText, deviceIdentifier, platform);
 		}
 	}
 
 	public setLogLevel(logLevel: string, deviceIdentifier?: string): void {
 		this.$logFilter.loggingLevel = logLevel.toUpperCase();
+	}
+
+	private logDataCore(data: string, loggingOptions: Mobile.IDeviceLogOptions): void {
+		if (!loggingOptions || (loggingOptions && !loggingOptions.muteLogs)) {
+			this.$logger.write(data);
+		}
 	}
 }
 $injector.register("deviceLogProvider", DeviceLogProvider);

--- a/lib/common/test/unit-tests/stubs.ts
+++ b/lib/common/test/unit-tests/stubs.ts
@@ -171,4 +171,6 @@ export class DeviceLogProviderStub extends EventEmitter implements Mobile.IDevic
 	setProjectNameForDevice(deviceIdentifier: string, projectName: string): void {
 		this.currentDeviceProjectNames[deviceIdentifier] = projectName;
 	}
+
+	muteLogsForDevice(deviceIdentifier: string): void { }
 }

--- a/lib/services/ios-debug-service.ts
+++ b/lib/services/ios-debug-service.ts
@@ -50,20 +50,7 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 			debugOptions.emulator = true;
 		}
 
-		if (!debugOptions.justlaunch) {
-			let projectName = debugData.projectName;
-			if (!projectName && debugData.projectDir) {
-				const projectData = this.$projectDataService.getProjectData(debugData.projectDir);
-				projectName = projectData.projectName;
-			}
-
-			if (projectName) {
-				this.$deviceLogProvider.setProjectNameForDevice(debugData.deviceIdentifier, projectName);
-			}
-
-			await this.device.openDeviceLogStream({ predicate: IOS_LOG_PREDICATE });
-		}
-
+		await this.startDeviceLogProcess(debugData, debugOptions);
 		await this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(this.device, debugData, debugOptions);
 
 		if (debugOptions.emulator) {
@@ -111,6 +98,26 @@ export class IOSDebugService extends DebugServiceBase implements IPlatformDebugS
 
 		const chromeDebugUrl = super.getChromeDebugUrl(debugOpts, port);
 		return chromeDebugUrl;
+	}
+
+	private async startDeviceLogProcess(debugData: IDebugData, debugOptions: IDebugOptions): Promise<void> {
+		if (debugOptions.justlaunch) {
+			// No logs should be printed on console when `--justlaunch` option is passed.
+			// On the other side we need to start log process in order to get debugger port from logs.
+			this.$deviceLogProvider.muteLogsForDevice(debugData.deviceIdentifier);
+		}
+
+		let projectName = debugData.projectName;
+		if (!projectName && debugData.projectDir) {
+			const projectData = this.$projectDataService.getProjectData(debugData.projectDir);
+			projectName = projectData.projectName;
+		}
+
+		if (projectName) {
+			this.$deviceLogProvider.setProjectNameForDevice(debugData.deviceIdentifier, projectName);
+		}
+
+		await this.device.openDeviceLogStream({ predicate: IOS_LOG_PREDICATE });
 	}
 
 	private async killProcess(childProcess: ChildProcess): Promise<void> {


### PR DESCRIPTION
Currently log process is not started when `--justlaunch` option is provided. This leads to error on `tns debug ios --justlaunch` command. Actually we need to start log process in order to get debugger port. On the other side we should not print any logs on the console when `--justlaunch` option is provided. So this PR starts log process when `--justlaunch` option is specified and doesn't print any logs on the console.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns debug ios --justlaunch` throws an error

## What is the new behavior?
`tns debug ios --justlaunch` does not throw an error

Rel to: https://github.com/NativeScript/nativescript-cli/issues/4076
