### PR TITLE
fix: reset errors when fallback to list avds from directory

### DIFF
--- a/lib/common/mobile/android/android-virtual-device-service.ts
+++ b/lib/common/mobile/android/android-virtual-device-service.ts
@@ -151,6 +151,7 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 	private async getEmulatorImagesCore(): Promise<Mobile.IEmulatorImagesOutput> {
 		let result: ISpawnResult = null;
 		let devices: Mobile.IDeviceInfo[] = [];
+		let errors: string[] = [];
 
 		if (this.pathToAvdManagerExecutable && this.$fs.exists(this.pathToAvdManagerExecutable)) {
 			result = await this.$childProcess.trySpawnFromCloseEvent(this.pathToAvdManagerExecutable, ["list", "avds"]);
@@ -160,11 +161,12 @@ export class AndroidVirtualDeviceService implements Mobile.IAndroidVirtualDevice
 
 		if (result && result.stdout) {
 			devices = this.parseListAvdsOutput(result.stdout);
+			errors = result && result.stderr ? [result.stderr] : [];
 		} else {
 			devices = this.listAvdsFromDirectory();
 		}
 
-		return { devices, errors: result && result.stderr ? [result.stderr] : [] };
+		return { devices, errors };
 	}
 
 	private async getRunningEmulatorData(runningEmulatorId: string, availableEmulators: Mobile.IDeviceInfo[]): Promise<Mobile.IDeviceInfo> {

--- a/lib/common/test/unit-tests/mobile/android-virtual-device-service.ts
+++ b/lib/common/test/unit-tests/mobile/android-virtual-device-service.ts
@@ -176,14 +176,13 @@ describe("androidVirtualDeviceService", () => {
 				assert.deepEqual(result.devices, []);
 				assert.deepEqual(result.errors, []);
 			});
-			it("should return an empty array when `avdmanager list avds` command fails", async () => {
+			it("should return an empty array and no errors when `avdmanager list avds` command fails", async () => {
 				const avdManagerError = "some error while executing avdmanager list avds";
 				const avdService = mockAvdService({ avdManagerError });
 				const result = await avdService.getEmulatorImages([]);
 				assert.lengthOf(result.devices, 0);
 				assert.deepEqual(result.devices, []);
-				assert.lengthOf(result.errors, 1);
-				assert.deepEqual(result.errors, [avdManagerError]);
+				assert.lengthOf(result.errors, 0);
 			});
 			it("should return all emulators when there are available emulators and no running emulators", async () => {
 				const avdService = mockAvdService({

--- a/lib/common/test/unit-tests/mobile/android-virtual-device-service.ts
+++ b/lib/common/test/unit-tests/mobile/android-virtual-device-service.ts
@@ -214,6 +214,24 @@ describe("androidVirtualDeviceService", () => {
 				assert.deepEqual(result[1], getAvailableEmulatorData({ displayName: "Nexus_5X_API_28", imageIdentifier: "Nexus_5X_API_28", version: "9.0.0", model: "Nexus 5X" }));
 				assert.deepEqual(result[2], getAvailableEmulatorData({ displayName: "Nexus_6P_API_28", imageIdentifier: "Nexus_6P_API_28", version: "9.0.0", model: "Nexus 6P" }));
 			});
+			// In this case we should fallback to list avd directory and should't report errors from avdmanager
+			it("should return devices and no errors when there is an error on avdmanager's stderr", async () => {
+				const iniFilesData = getIniFilesData();
+				const testInjector = createTestInjector({
+					avdManagerOutput: "",
+					avdManagerError: "my test error",
+					iniFilesData
+				});
+
+				const fs = testInjector.resolve("fs");
+				fs.readDirectory = () => _.keys(iniFilesData);
+
+				const avdService = testInjector.resolve("androidVirtualDeviceService");
+				const result = await avdService.getEmulatorImages(["emulator-5554 device"]);
+
+				assert.deepEqual(result.devices.length, 3);
+				assert.deepEqual(result.errors.length, 0);
+			});
 		});
 
 		describe("when avdmanager is not found", () => {


### PR DESCRIPTION
When there are errors on avdmanager's stderr and no data on avdmanager's stdout, {N} CLI fallback to list avds from directory and returns both devices (from directory) and errors from avdmanager's stderr. However this is incorrect behavior. In case we fallback to list avds from directory, we need to reset errors output.


## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When there are errors on avdmanager's stderr and no data on avdmanager's stdout, {N} CLI fallback to list avds from directory and returns both devices (from directory) and errors from avdmanager's stderr

## What is the new behavior?
When there are errors on avdmanager's stderr and no data on avdmanager's stdout, {N} CLI fallback to list avds from directory and returns devices (from directory) and no errors

