### PR TITLE
fix: show correct messages on `tns test init` command

### DIFF
--- a/lib/commands/test-init.ts
+++ b/lib/commands/test-init.ts
@@ -93,9 +93,10 @@ class TestInitCommand implements ICommand {
 		await this.$pluginsService.add('nativescript-unit-test-runner', this.$projectData);
 
 		const testsDir = path.join(this.$projectData.appDirectoryPath, 'tests');
+		const relativeTestsDir = path.relative(this.$projectData.projectDir, testsDir);
 		let shouldCreateSampleTests = true;
 		if (this.$fs.exists(testsDir)) {
-			this.$logger.info('app/tests/ directory already exists, will not create an example test project.');
+			this.$logger.info(`${relativeTestsDir} directory already exists, will not create an example test project.`);
 			shouldCreateSampleTests = false;
 		}
 
@@ -113,9 +114,9 @@ class TestInitCommand implements ICommand {
 
 		if (shouldCreateSampleTests && this.$fs.exists(exampleFilePath)) {
 			this.$fs.copyFile(exampleFilePath, path.join(testsDir, 'example.js'));
-			this.$logger.info('\nExample test file created in app/tests/'.yellow);
+			this.$logger.info(`\nExample test file created in ${relativeTestsDir}`.yellow);
 		} else {
-			this.$logger.info('\nPlace your test files under app/tests/'.yellow);
+			this.$logger.info(`\nPlace your test files under ${relativeTestsDir}`.yellow);
 		}
 
 		this.$logger.info('Run your tests using the "$ tns test <platform>" command.'.yellow);


### PR DESCRIPTION
Currently `tns test init` command always print `Place your test files under app/tests`. However this is not correct when the project has `nsconfig.json` file. So this PR replaces the hardcoded `app/tests` with the correct location to tests folder.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`app/tests` folder is hardcoded even for projects with `nsconfig.json` file 

## What is the new behavior?
Respect `nsconfig.json` file and prints the correct location to tests folder.
