### PR TITLE
feat(preview): add public API for deviceFound and deviceLost for preview devices

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -134,6 +134,7 @@ $injector.require("usbLiveSyncService", "./services/livesync/livesync-service");
 $injector.require("previewAppLiveSyncService", "./services/livesync/playground/preview-app-livesync-service");
 $injector.require("previewAppPluginsService", "./services/livesync/playground/preview-app-plugins-service");
 $injector.require("previewSdkService", "./services/livesync/playground/preview-sdk-service");
+$injector.requirePublicClass("previewDevicesService", "./services/livesync/playground/devices/preview-devices-service");
 $injector.require("playgroundQrCodeGenerator", "./services/livesync/playground/qr-code-generator");
 $injector.requirePublic("sysInfo", "./sys-info");
 

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -35,8 +35,8 @@ declare global {
 	}
 
 	interface IPreviewDevicesService extends EventEmitter {
-		connectedDevices: Device[];
-		onDevicesPresence(devices: Device[]): void;
+		getConnectedDevices(): Device[];
+		updateConnectedDevices(devices: Device[]): void;
 		getDeviceById(id: string): Device;
 		getDevicesForPlatform(platform: string): Device[];
 	}

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -12,7 +12,6 @@ declare global {
 
 	interface IPreviewSdkService extends EventEmitter {
 		getQrCodeUrl(options: IHasUseHotModuleReloadOption): string;
-		connectedDevices: Device[];
 		initialize(getInitialFiles: (device: Device) => Promise<FilesPayload>): void;
 		applyChanges(filesPayload: FilesPayload): Promise<void>;
 		stop(): void;
@@ -33,5 +32,12 @@ declare global {
 		 * Default value is false.
 		 */
 		link: boolean;
+	}
+
+	interface IPreviewDevicesService extends EventEmitter {
+		connectedDevices: Device[];
+		onDevicesPresence(devices: Device[]): void;
+		getDeviceById(id: string): Device;
+		getDevicesForPlatform(platform: string): Device[];
 	}
 }

--- a/lib/services/livesync/playground/devices/preview-devices-service.ts
+++ b/lib/services/livesync/playground/devices/preview-devices-service.ts
@@ -3,9 +3,13 @@ import { EventEmitter } from "events";
 import { DeviceDiscoveryEventNames } from "../../../../common/constants";
 
 export class PreviewDevicesService extends EventEmitter implements IPreviewDevicesService {
-	public connectedDevices: Device[] = [];
+	private connectedDevices: Device[] = [];
 
-	public onDevicesPresence(devices: Device[]): void {
+	public getConnectedDevices(): Device[] {
+		return this.connectedDevices;
+	}
+
+	public updateConnectedDevices(devices: Device[]): void {
 		_(devices)
 			.reject(d => _.find(this.connectedDevices, device => d.id === device.id))
 			.each(device => this.raiseDeviceFound(device));

--- a/lib/services/livesync/playground/devices/preview-devices-service.ts
+++ b/lib/services/livesync/playground/devices/preview-devices-service.ts
@@ -1,0 +1,36 @@
+import { Device } from "nativescript-preview-sdk";
+import { EventEmitter } from "events";
+import { DeviceDiscoveryEventNames } from "../../../../common/constants";
+
+export class PreviewDevicesService extends EventEmitter implements IPreviewDevicesService {
+	public connectedDevices: Device[] = [];
+
+	public onDevicesPresence(devices: Device[]): void {
+		_(devices)
+			.reject(d => _.find(this.connectedDevices, device => d.id === device.id))
+			.each(device => this.raiseDeviceFound(device));
+
+		_(this.connectedDevices)
+			.reject(d => _.find(devices, device => d.id === device.id))
+			.each(device => this.raiseDeviceLost(device));
+	}
+
+	public getDeviceById(id: string): Device {
+		return _.find(this.connectedDevices, { id });
+	}
+
+	public getDevicesForPlatform(platform: string): Device[] {
+		return _.filter(this.connectedDevices, { platform: platform.toLowerCase() });
+	}
+
+	private raiseDeviceFound(device: Device) {
+		this.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, device);
+		this.connectedDevices.push(device);
+	}
+
+	private raiseDeviceLost(device: Device) {
+		this.emit(DeviceDiscoveryEventNames.DEVICE_LOST, device);
+		_.remove(this.connectedDevices, d => d.id === device.id);
+	}
+}
+$injector.register("previewDevicesService", PreviewDevicesService);

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -56,15 +56,15 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 	public async syncFiles(data: IPreviewAppLiveSyncData, filesToSync: string[], filesToRemove: string[]): Promise<void> {
 		this.showWarningsForNativeFiles(filesToSync);
 
-		for (const device of this.$previewDevicesService.connectedDevices) {
+		const connectedDevices = this.$previewDevicesService.getConnectedDevices();
+		for (const device of connectedDevices) {
 			await this.$previewAppPluginsService.comparePluginsOnDevice(data, device);
 		}
 
-		const platforms = _(this.$previewDevicesService.connectedDevices)
+		const platforms = _(connectedDevices)
 			.map(device => device.platform)
 			.uniq()
 			.value();
-
 		for (const platform of platforms) {
 			await this.syncFilesForPlatformSafe(data, platform, { filesToSync, filesToRemove, useHotModuleReload: data.appFilesUpdaterOptions.useHotModuleReload });
 		}

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -28,6 +28,7 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 		private $projectDataService: IProjectDataService,
 		private $previewSdkService: IPreviewSdkService,
 		private $previewAppPluginsService: IPreviewAppPluginsService,
+		private $previewDevicesService: IPreviewDevicesService,
 		private $projectFilesManager: IProjectFilesManager,
 		private $hmrStatusService: IHmrStatusService,
 		private $projectFilesProvider: IProjectFilesProvider) { }
@@ -55,11 +56,11 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 	public async syncFiles(data: IPreviewAppLiveSyncData, filesToSync: string[], filesToRemove: string[]): Promise<void> {
 		this.showWarningsForNativeFiles(filesToSync);
 
-		for (const device of this.$previewSdkService.connectedDevices) {
+		for (const device of this.$previewDevicesService.connectedDevices) {
 			await this.$previewAppPluginsService.comparePluginsOnDevice(data, device);
 		}
 
-		const platforms = _(this.$previewSdkService.connectedDevices)
+		const platforms = _(this.$previewDevicesService.connectedDevices)
 			.map(device => device.platform)
 			.uniq()
 			.value();
@@ -112,7 +113,7 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 				await promise;
 
 				if (data.appFilesUpdaterOptions.useHotModuleReload && platformHmrData.hash) {
-					const devices = _.filter(this.$previewSdkService.connectedDevices, { platform: platform.toLowerCase() });
+					const devices = this.$previewDevicesService.getDevicesForPlatform(platform);
 
 					await Promise.all(_.map(devices, async (previewDevice: Device) => {
 						const status = await this.$hmrStatusService.getHmrStatus(previewDevice.id, platformHmrData.hash);

--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -74,7 +74,7 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 			onConnectedDevicesChange: (connectedDevices: ConnectedDevices) => ({}),
 			onDeviceConnectedMessage: (deviceConnectedMessage: DeviceConnectedMessage) => ({}),
 			onDeviceConnected: (device: Device) => ({}),
-			onDevicesPresence: (devices: Device[]) => this.$previewDevicesService.onDevicesPresence(devices),
+			onDevicesPresence: (devices: Device[]) => this.$previewDevicesService.updateConnectedDevices(devices),
 			onSendingChange: (sending: boolean) => ({ }),
 			onBiggerFilesUpload: async (filesContent, callback) => {
 				const gzippedContent = Buffer.from(pako.gzip(filesContent));

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -75,7 +75,6 @@ class PreviewSdkServiceMock extends EventEmitter implements IPreviewSdkService {
 		return "my_cool_qr_code_url";
 	}
 
-	public connectedDevices: Device[] = [deviceMockData];
 	public initialize(getInitialFiles: (device: Device) => Promise<FilesPayload>) {
 		this.getInitialFiles = async (device) => {
 			const filesPayload = await getInitialFiles(device);
@@ -157,6 +156,9 @@ function createTestInjector(options?: {
 		executeBeforeHooks: (name: string, args: any) => {
 			isHookCalledWithHMR = args.hookArgs.config.appFilesUpdaterOptions.useHotModuleReload;
 		}
+	});
+	injector.register("previewDevicesService", {
+		connectedDevices: [deviceMockData]
 	});
 
 	return injector;

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -158,7 +158,7 @@ function createTestInjector(options?: {
 		}
 	});
 	injector.register("previewDevicesService", {
-		connectedDevices: [deviceMockData]
+		getConnectedDevices: () => [deviceMockData]
 	});
 
 	return injector;

--- a/test/services/preview-devices-service.ts
+++ b/test/services/preview-devices-service.ts
@@ -27,6 +27,11 @@ function createDevice(id: string): Device {
 	};
 }
 
+function resetDevices() {
+	foundDevices = [];
+	lostDevices = [];
+}
+
 describe("PreviewDevicesService", () => {
 	describe("onDevicesPresence", () => {
 		let previewDevicesService: IPreviewDevicesService = null;
@@ -43,27 +48,31 @@ describe("PreviewDevicesService", () => {
 
 		afterEach(() => {
 			previewDevicesService.removeAllListeners();
-			foundDevices = [];
-			lostDevices = [];
+			resetDevices();
 		});
 
 		it("should add new device", () => {
 			const device = createDevice("device1");
 
-			previewDevicesService.onDevicesPresence([device]);
+			previewDevicesService.updateConnectedDevices([device]);
 
-			assert.deepEqual(previewDevicesService.connectedDevices, [device]);
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device]);
 			assert.deepEqual(foundDevices, [device]);
 			assert.deepEqual(lostDevices, []);
 		});
 		it("should add new device when there are already connected devices", () => {
 			const device1 = createDevice("device1");
 			const device2 = createDevice("device2");
-			previewDevicesService.connectedDevices = [device1];
 
-			previewDevicesService.onDevicesPresence([device1, device2]);
+			previewDevicesService.updateConnectedDevices([device1]);
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device1]);
+			assert.deepEqual(foundDevices, [device1]);
+			assert.deepEqual(lostDevices, []);
+			resetDevices();
 
-			assert.deepEqual(previewDevicesService.connectedDevices, [device1, device2]);
+			previewDevicesService.updateConnectedDevices([device1, device2]);
+
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device1, device2]);
 			assert.deepEqual(foundDevices, [device2]);
 			assert.deepEqual(lostDevices, []);
 		});
@@ -72,17 +81,21 @@ describe("PreviewDevicesService", () => {
 			const device2 = createDevice("device2");
 			const device3 = createDevice("device3");
 
-			previewDevicesService.onDevicesPresence([device1, device2, device3]);
+			previewDevicesService.updateConnectedDevices([device1, device2, device3]);
 
-			assert.deepEqual(previewDevicesService.connectedDevices, [device1, device2, device3]);
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device1, device2, device3]);
 			assert.deepEqual(foundDevices, [device1, device2, device3]);
 			assert.deepEqual(lostDevices, []);
 		});
 		it("should remove device", () => {
 			const device1 = createDevice("device1");
-			previewDevicesService.connectedDevices = [device1];
+			previewDevicesService.updateConnectedDevices([device1]);
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device1]);
+			assert.deepEqual(foundDevices, [device1]);
+			assert.deepEqual(lostDevices, []);
+			resetDevices();
 
-			previewDevicesService.onDevicesPresence([]);
+			previewDevicesService.updateConnectedDevices([]);
 
 			assert.deepEqual(foundDevices, []);
 			assert.deepEqual(lostDevices, [device1]);
@@ -90,11 +103,16 @@ describe("PreviewDevicesService", () => {
 		it("should add and remove devices in the same time", () => {
 			const device1 = createDevice("device1");
 			const device2 = createDevice("device2");
-			previewDevicesService.connectedDevices = [device1];
 
-			previewDevicesService.onDevicesPresence([device2]);
+			previewDevicesService.updateConnectedDevices([device1]);
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device1]);
+			assert.deepEqual(foundDevices, [device1]);
+			assert.deepEqual(lostDevices, []);
+			resetDevices();
 
-			assert.deepEqual(previewDevicesService.connectedDevices, [device2]);
+			previewDevicesService.updateConnectedDevices([device2]);
+
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device2]);
 			assert.deepEqual(foundDevices, [device2]);
 			assert.deepEqual(lostDevices, [device1]);
 		});

--- a/test/services/preview-devices-service.ts
+++ b/test/services/preview-devices-service.ts
@@ -1,0 +1,102 @@
+import { Yok } from "../../lib/common/yok";
+import { PreviewDevicesService } from "../../lib/services/livesync/playground/devices/preview-devices-service";
+import { Device } from "nativescript-preview-sdk";
+import { assert } from "chai";
+import { DeviceDiscoveryEventNames } from "../../lib/common/constants";
+import { LoggerStub } from "../stubs";
+
+let foundDevices: Device[] = [];
+let lostDevices: Device[] = [];
+
+function createTestInjector(): IInjector {
+	const injector = new Yok();
+	injector.register("previewDevicesService", PreviewDevicesService);
+	injector.register("logger", LoggerStub);
+	return injector;
+}
+
+function createDevice(id: string): Device {
+	return {
+		id,
+		platform: "ios",
+		model: "my test model",
+		name: "my test name",
+		osVersion: "10.0.0",
+		previewAppVersion: "19.0.0",
+		runtimeVersion: "5.0.0"
+	};
+}
+
+describe("PreviewDevicesService", () => {
+	describe("onDevicesPresence", () => {
+		let previewDevicesService: IPreviewDevicesService = null;
+		beforeEach(() => {
+			const injector = createTestInjector();
+			previewDevicesService = injector.resolve("previewDevicesService");
+			previewDevicesService.on(DeviceDiscoveryEventNames.DEVICE_FOUND, device => {
+				foundDevices.push(device);
+			});
+			previewDevicesService.on(DeviceDiscoveryEventNames.DEVICE_LOST, device => {
+				lostDevices.push(device);
+			});
+		});
+
+		afterEach(() => {
+			previewDevicesService.removeAllListeners();
+			foundDevices = [];
+			lostDevices = [];
+		});
+
+		it("should add new device", () => {
+			const device = createDevice("device1");
+
+			previewDevicesService.onDevicesPresence([device]);
+
+			assert.deepEqual(previewDevicesService.connectedDevices, [device]);
+			assert.deepEqual(foundDevices, [device]);
+			assert.deepEqual(lostDevices, []);
+		});
+		it("should add new device when there are already connected devices", () => {
+			const device1 = createDevice("device1");
+			const device2 = createDevice("device2");
+			previewDevicesService.connectedDevices = [device1];
+
+			previewDevicesService.onDevicesPresence([device1, device2]);
+
+			assert.deepEqual(previewDevicesService.connectedDevices, [device1, device2]);
+			assert.deepEqual(foundDevices, [device2]);
+			assert.deepEqual(lostDevices, []);
+		});
+		it("should add more than one new device", () => {
+			const device1 = createDevice("device1");
+			const device2 = createDevice("device2");
+			const device3 = createDevice("device3");
+
+			previewDevicesService.onDevicesPresence([device1, device2, device3]);
+
+			assert.deepEqual(previewDevicesService.connectedDevices, [device1, device2, device3]);
+			assert.deepEqual(foundDevices, [device1, device2, device3]);
+			assert.deepEqual(lostDevices, []);
+		});
+		it("should remove device", () => {
+			const device1 = createDevice("device1");
+			previewDevicesService.connectedDevices = [device1];
+
+			previewDevicesService.onDevicesPresence([]);
+
+			assert.deepEqual(foundDevices, []);
+			assert.deepEqual(lostDevices, [device1]);
+		});
+		it("should add and remove devices in the same time", () => {
+			const device1 = createDevice("device1");
+			const device2 = createDevice("device2");
+			previewDevicesService.connectedDevices = [device1];
+
+			previewDevicesService.onDevicesPresence([device2]);
+
+			assert.deepEqual(previewDevicesService.connectedDevices, [device2]);
+			assert.deepEqual(foundDevices, [device2]);
+			assert.deepEqual(lostDevices, [device1]);
+		});
+	});
+});

--- a/test/services/preview-sdk-service.ts
+++ b/test/services/preview-sdk-service.ts
@@ -8,7 +8,7 @@ const getPreviewSdkService = (): IPreviewSdkService => {
 	testInjector.register("logger", LoggerStub);
 	testInjector.register("config", {});
 	testInjector.register("previewSdkService", PreviewSdkService);
-
+	testInjector.register("previewDevicesService", {});
 	testInjector.register("httpClient", {
 		httpRequest: async (options: any, proxySettings?: IProxySettings): Promise<Server.IResponse> => undefined
 	});


### PR DESCRIPTION
We want to expose `deviceFound` and `deviceLost` for preview devices as a public api so Sidekick can use them.
```
const tns = require("nativescript-cli");
tns.previewDevicesService.on("deviceFound", device => {
    console.log("device found", device);
});
tns.previewDevicesService.on("deviceLost", device => {
    console.log("device lost", device);
});
```

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.
