### PR TITLE
feat(yarn): implement get cache directory path and remove `npm --dry-run` logic

### DIFF
--- a/lib/base-package-manager.ts
+++ b/lib/base-package-manager.ts
@@ -4,6 +4,7 @@ export class BasePackageManager {
 	constructor(
 		protected $childProcess: IChildProcess,
 		private $hostInfo: IHostInfo,
+		private $pacoteService: IPacoteService,
 		private packageManager: string
 	) { }
 
@@ -17,10 +18,23 @@ export class BasePackageManager {
 		return npmExecutableName;
 	}
 
-	protected async processPackageManagerInstall(params: string[], opts: { cwd: string }) {
+	protected async processPackageManagerInstall(packageName: string, params: string[], opts: { cwd: string, isInstallingAllDependencies: boolean }): Promise<INpmInstallResultInfo> {
 		const npmExecutable = this.getPackageManagerExecutableName();
 		const stdioValue = isInteractive() ? "inherit" : "pipe";
-		return await this.$childProcess.spawnFromEvent(npmExecutable, params, "close", { cwd: opts.cwd, stdio: stdioValue });
+		await this.$childProcess.spawnFromEvent(npmExecutable, params, "close", { cwd: opts.cwd, stdio: stdioValue });
+
+		// Whenever calling "npm install" or "yarn add" without any arguments (hence installing all dependencies) no output is emitted on stdout
+		// Luckily, whenever you call "npm install" or "yarn add" to install all dependencies chances are you won't need the name/version of the package you're installing because there is none.
+		const { isInstallingAllDependencies } = opts;
+		if (isInstallingAllDependencies) {
+			return null;
+		}
+
+		const packageMetadata = await this.$pacoteService.manifest(packageName);
+		return {
+			name: packageMetadata.name,
+			version: packageMetadata.version
+		};
 	}
 
 	protected getFlagsString(config: any, asArray: boolean): any {

--- a/lib/definitions/pacote-service.d.ts
+++ b/lib/definitions/pacote-service.d.ts
@@ -9,7 +9,7 @@ declare global {
 		 * @param packageName The name of the package
 		 * @param options The provided options can control which properties from package.json file will be returned. In case when fullMetadata option is provided, all data from package.json file will be returned.
 		 */
-		manifest(packageName: string, options: IPacoteManifestOptions): Promise<any>;
+		manifest(packageName: string, options?: IPacoteManifestOptions): Promise<any>;
 		/**
 		 * Downloads the specified package and extracts it in specified destination directory
 		 * @param packageName The name of the package

--- a/lib/yarn-package-manager.ts
+++ b/lib/yarn-package-manager.ts
@@ -11,9 +11,9 @@ export class YarnPackageManager extends BasePackageManager implements INodePacka
 		$hostInfo: IHostInfo,
 		private $httpClient: Server.IHttpClient,
 		private $logger: ILogger,
-		private $pacoteService: IPacoteService
+		$pacoteService: IPacoteService
 	) {
-		super($childProcess, $hostInfo, 'yarn');
+		super($childProcess, $hostInfo, $pacoteService, 'yarn');
 	}
 
 	@exported("yarn")
@@ -39,18 +39,8 @@ export class YarnPackageManager extends BasePackageManager implements INodePacka
 		const cwd = pathToSave;
 
 		try {
-			await this.processPackageManagerInstall(params, { cwd });
-
-			if (isInstallingAllDependencies) {
-				return null;
-			}
-
-			const packageMetadata = await this.$pacoteService.manifest(packageName, {});
-			return {
-				name: packageMetadata.name,
-				version: packageMetadata.version
-			};
-
+			const result = await this.processPackageManagerInstall(packageName, params, { cwd, isInstallingAllDependencies });
+			return result;
 		} catch (e) {
 			this.$fs.writeJson(packageJsonPath, jsonContentBefore);
 			throw e;
@@ -102,9 +92,9 @@ export class YarnPackageManager extends BasePackageManager implements INodePacka
 	}
 
 	@exported("yarn")
-	getCachePath(): Promise<string> {
-		this.$errors.fail("Method not implemented");
-		return null;
+	public async getCachePath(): Promise<string> {
+		const result = await this.$childProcess.exec(`yarn cache dir`);
+		return result;
 	}
 }
 

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -132,6 +132,26 @@ function createTestInjector() {
 		generateHashes: async (files: string[]): Promise<IStringDictionary> => ({})
 	});
 	testInjector.register("pacoteService", {
+		manifest: async (packageName: string) => {
+			const projectData = testInjector.resolve("projectData");
+			const fs = testInjector.resolve("fs");
+			let result = {};
+			let packageJsonPath = null;
+
+			const packageToInstall = packageName.split("@")[0];
+
+			if (fs.exists(packageToInstall)) {
+				packageJsonPath = path.join(packageName, "package.json");
+			} else {
+				packageJsonPath = path.join(projectData.projectDir, "node_modules", packageToInstall, "package.json");
+			}
+
+			if (fs.exists(packageJsonPath)) {
+				result = fs.readJson(packageJsonPath);
+			}
+
+			return result;
+		},
 		extractPackage: async (packageName: string, destinationDirectory: string, options?: IPacoteExtractOptions): Promise<void> => undefined
 	});
 	return testInjector;


### PR DESCRIPTION
Remove the last hardcoded `npm` command so yarn will be used all the time when it is set as package manager. Also remove `--dry run` logic and use `$pacoteService.manifest` instead.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

rel to: https://github.com/NativeScript/nativescript-cli/issues/2737

