### PR TITLE
fix(unit-testing): add correct files pattern in karma.conf.js when the project has nsconfig file

### DIFF
--- a/lib/commands/test-init.ts
+++ b/lib/commands/test-init.ts
@@ -105,8 +105,9 @@ class TestInitCommand implements ICommand {
 		const frameworks = [frameworkToInstall].concat(this.karmaConfigAdditionalFrameworks[frameworkToInstall] || [])
 			.map(fw => `'${fw}'`)
 			.join(', ');
+		const testFiles = `'${relativeTestsDir}/**/*.js'`;
 		const karmaConfTemplate = this.$resources.readText('test/karma.conf.js');
-		const karmaConf = _.template(karmaConfTemplate)({ frameworks });
+		const karmaConf = _.template(karmaConfTemplate)({ frameworks, testFiles });
 
 		this.$fs.writeFile(path.join(projectDir, 'karma.conf.js'), karmaConf);
 

--- a/resources/test/karma.conf.js
+++ b/resources/test/karma.conf.js
@@ -12,7 +12,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'app/**/*.js',
+      ${ testFiles }
     ],
 
 


### PR DESCRIPTION
Rel to: https://github.com/NativeScript/nativescript-cli/issues/4071

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns test <platform>` does not execute any unit tests when the project has nsconfig file

## What is the new behavior?
`tns test <platform>` executes unit tests when the project has nsconfig file
