### PR TITLE
fix: install the latest compatible v2 templates in stead of the latest tag

### DIFF
--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -30,8 +30,11 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 		}
 
 		const templateName = constants.RESERVED_TEMPLATE_NAMES[name.toLowerCase()] || name;
-		version = version || await this.$npmInstallationManager.getLatestCompatibleVersion(templateName);
-		const fullTemplateName = `${templateName}@${version}`;
+		if (!this.$fs.exists(templateName)) {
+			version = version || await this.$npmInstallationManager.getLatestCompatibleVersion(templateName);
+		}
+
+		const fullTemplateName = version ? `${templateName}@${version}` : templateName;
 		const templatePackageJsonContent = await this.getTemplatePackageJsonContent(fullTemplateName);
 		const templateVersion = await this.getTemplateVersion(fullTemplateName);
 

--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -30,7 +30,8 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 		}
 
 		const templateName = constants.RESERVED_TEMPLATE_NAMES[name.toLowerCase()] || name;
-		const fullTemplateName = version ? `${templateName}@${version}` : templateName;
+		version = version || await this.$npmInstallationManager.getLatestCompatibleVersion(templateName);
+		const fullTemplateName = `${templateName}@${version}`;
 		const templatePackageJsonContent = await this.getTemplatePackageJsonContent(fullTemplateName);
 		const templateVersion = await this.getTemplateVersion(fullTemplateName);
 

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -8,6 +8,7 @@ import { format } from "util";
 
 let isDeleteDirectoryCalledForNodeModulesDir = false;
 const nativeScriptValidatedTemplatePath = "nsValidatedTemplatePath";
+const compatibleTemplateVersion = "1.2.3";
 
 function createTestInjector(configuration: { shouldNpmInstallThrow?: boolean, packageJsonContent?: any } = {}): IInjector {
 	const injector = new Yok();
@@ -42,6 +43,9 @@ function createTestInjector(configuration: { shouldNpmInstallThrow?: boolean, pa
 			}
 
 			return Promise.resolve(nativeScriptValidatedTemplatePath);
+		},
+		getLatestCompatibleVersion: (packageName: string) => {
+			return compatibleTemplateVersion;
 		}
 	});
 
@@ -164,7 +168,7 @@ describe("project-templates-service", () => {
 				const fs = testInjector.resolve<IFileSystem>("fs");
 				fs.exists = (localPath: string): boolean => path.basename(localPath) !== constants.PACKAGE_JSON_FILE_NAME;
 				const pacoteService = testInjector.resolve<IPacoteService>("pacoteService");
-				pacoteService.manifest = () => Promise.resolve({ });
+				pacoteService.manifest = () => Promise.resolve({});
 				await projectTemplatesService.prepareTemplate(localTemplatePath, "tempFolder");
 				assert.deepEqual(dataSentToGoogleAnalytics, [
 					{
@@ -215,7 +219,7 @@ describe("project-templates-service", () => {
 				const notSupportedVersionString = "not supported version";
 				const testInjector = createTestInjector({ packageJsonContent: { nativescript: { templateVersion: notSupportedVersionString } } });
 				const projectTemplatesService = testInjector.resolve<IProjectTemplatesService>("projectTemplatesService");
-				const expectedError = format(constants.ProjectTemplateErrors.InvalidTemplateVersionStringFormat, 'tns-template-hello-world-ts', notSupportedVersionString);
+				const expectedError = format(constants.ProjectTemplateErrors.InvalidTemplateVersionStringFormat, `tns-template-hello-world-ts@${compatibleTemplateVersion}`, notSupportedVersionString);
 				await assert.isRejected(projectTemplatesService.prepareTemplate("typescript", "tempFolder"), expectedError);
 			});
 
@@ -238,7 +242,7 @@ describe("project-templates-service", () => {
 				{
 					name: "is correct when scoped package name without version is passed",
 					templateName: "@nativescript/vue-template",
-					expectedVersion: "",
+					expectedVersion: compatibleTemplateVersion,
 					expectedTemplateName: "@nativescript/vue-template"
 				},
 				{

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -15,7 +15,7 @@ function createTestInjector(configuration: { shouldNpmInstallThrow?: boolean, pa
 	injector.register("errors", stubs.ErrorsStub);
 	injector.register("logger", stubs.LoggerStub);
 	injector.register("fs", {
-		exists: (pathToCheck: string) => true,
+		exists: (pathToCheck: string) => false,
 
 		readJson: (pathToFile: string) => configuration.packageJsonContent || {},
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
The CLI was not respecting its version when installing v2 templates. e.g. CLI 4.2.4 is installing 5.0.0 templates.

## What is the new behavior?
The CLI is installing the latest compatible version of the v2 templates
