### PR TITLE
fix(platform-add): respect nativePlatformStatus property from .nsprepare file when adding the platform

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -69,12 +69,26 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			this.validatePlatform(platform, projectData);
 			const platformPath = path.join(projectData.platformsDir, platform);
 
-			if (this.$fs.exists(platformPath)) {
+			const isPlatformAdded = this.isPlatformAdded(platform, platformPath, projectData);
+			if (isPlatformAdded) {
 				this.$errors.failWithoutHelp(`Platform ${platform} already added`);
 			}
 
 			await this.addPlatform(platform.toLowerCase(), platformTemplate, projectData, config, frameworkPath);
 		}
+	}
+
+	private isPlatformAdded(platform: string, platformPath: string, projectData: IProjectData): boolean {
+		if (!this.$fs.exists(platformPath)) {
+			return false;
+		}
+
+		const prepareInfo = this.$projectChangesService.getPrepareInfo(platform, projectData);
+		if (!prepareInfo) {
+			return true;
+		}
+
+		return prepareInfo.nativePlatformStatus !== constants.NativePlatformStatus.requiresPlatformAdd;
 	}
 
 	public getCurrentPlatformVersion(platform: string, projectData: IProjectData): string {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -78,19 +78,6 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 	}
 
-	private isPlatformAdded(platform: string, platformPath: string, projectData: IProjectData): boolean {
-		if (!this.$fs.exists(platformPath)) {
-			return false;
-		}
-
-		const prepareInfo = this.$projectChangesService.getPrepareInfo(platform, projectData);
-		if (!prepareInfo) {
-			return true;
-		}
-
-		return prepareInfo.nativePlatformStatus !== constants.NativePlatformStatus.requiresPlatformAdd;
-	}
-
 	public getCurrentPlatformVersion(platform: string, projectData: IProjectData): string {
 		const platformData = this.$platformsData.getPlatformData(platform, projectData);
 		const currentPlatformData: any = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
@@ -978,6 +965,19 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		}
 
 		return null;
+	}
+
+	private isPlatformAdded(platform: string, platformPath: string, projectData: IProjectData): boolean {
+		if (!this.$fs.exists(platformPath)) {
+			return false;
+		}
+
+		const prepareInfo = this.$projectChangesService.getPrepareInfo(platform, projectData);
+		if (!prepareInfo) {
+			return true;
+		}
+
+		return prepareInfo.nativePlatformStatus !== constants.NativePlatformStatus.requiresPlatformAdd;
 	}
 }
 


### PR DESCRIPTION
As the preview command add only the .js part of the platform, we need to check nativePlatformStatus in order to decide correctly if platform add is necessary.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
```
tns preview
tns platform add
```
throws an error "Platform already added" but actually no native platform is added.

## What is the new behavior?
```
tns preview
tns platform add
```
adds both js and native platform.

rel to: 
https://github.com/NativeScript/nativescript-cli/issues/4090

