### PR TITLE
Apply before-plugins.gradle file in the plugin build.gradle

### DIFF
--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -429,7 +429,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		];
 
 		try {
-			await this.$childProcess.spawnFromEvent(gradlew, localArgs, "close", { cwd: pluginBuildSettings.pluginDir });
+			await this.$childProcess.spawnFromEvent(gradlew, localArgs, "close", { cwd: pluginBuildSettings.pluginDir, stdio: "inherit" });
 		} catch (err) {
 			this.$errors.failWithoutHelp(`Failed to build plugin ${pluginBuildSettings.pluginName} : \n${err}`);
 		}

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -1,3 +1,4 @@
+import groovy.json.JsonSlurper
 
 buildscript {
     repositories {
@@ -32,6 +33,8 @@ def computeBuildToolsVersion = { ->
 }
 
 android {
+    applyBeforePluginGradleConfiguration()
+
     compileSdkVersion computeCompileSdkVersion()
     buildToolsVersion computeBuildToolsVersion()
 
@@ -49,4 +52,43 @@ dependencies {
     }
     compileOnly "com.android.support:support-v4:$supportVer"
     compileOnly "com.android.support:appcompat-v7:$supportVer"
+}
+
+def getAppResourcesPath() {
+    def relativePathToApp = "app"
+    def relativePathToAppResources
+    def absolutePathToAppResources
+    def projectRoot = "$rootDir/../../.."
+    def nsConfigFile = file("$projectRoot/nsconfig.json")
+    def nsConfig
+
+    if (nsConfigFile.exists()) {
+        nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+    }
+
+    if(nsConfig != null && nsConfig.appPath != null){
+        relativePathToApp = nsConfig.appPath
+    }
+
+    if(nsConfig != null && nsConfig.appResourcesPath != null ) {
+        relativePathToAppResources = nsConfig.appResourcesPath
+    } else {
+        relativePathToAppResources  = "$relativePathToApp/App_Resources"
+    }
+
+    absolutePathToAppResources = java.nio.file.Paths.get(projectRoot).resolve(relativePathToAppResources).toAbsolutePath()
+
+    project.ext.appResourcesPath = absolutePathToAppResources
+
+    return absolutePathToAppResources
+}
+
+def applyBeforePluginGradleConfiguration() {
+    def appResourcesPath = getAppResourcesPath()
+    def pathToBeforePluginGradle = "$appResourcesPath/Android/before-plugins.gradle"
+    def beforePluginGradle = file(pathToBeforePluginGradle)
+    if (beforePluginGradle.exists()) {
+        println "\t + applying user-defined configuration from ${beforePluginGradle}"
+        apply from: pathToBeforePluginGradle
+    }
 }


### PR DESCRIPTION
Related to #4100
If there's a **before-plugins.gradle** file in the app it should be called before the plugin build.gradle