### PR TITLE
fix(preview-api): remove mandatory release option from IPreviewAppLiveSyncData interface

### DIFF
--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -8,7 +8,7 @@ declare global {
 		stopLiveSync(): Promise<void>;
 	}
 
-	interface IPreviewAppLiveSyncData extends IProjectDir, IAppFilesUpdaterOptionsComposition, IEnvOptions { }
+	interface IPreviewAppLiveSyncData extends IProjectDir, IHasUseHotModuleReloadOption, IBundle, IEnvOptions { }
 
 	interface IPreviewSdkService extends EventEmitter {
 		getQrCodeUrl(options: IHasUseHotModuleReloadOption): string;

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -57,13 +57,13 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		await this.liveSync([], {
 			syncToPreviewApp: true,
 			projectDir: data.projectDir,
-			bundle: data.appFilesUpdaterOptions.bundle,
-			useHotModuleReload: data.appFilesUpdaterOptions.useHotModuleReload,
+			bundle: data.bundle,
+			useHotModuleReload: data.useHotModuleReload,
 			release: false,
 			env: data.env,
 		});
 
-		const url = this.$previewSdkService.getQrCodeUrl({ useHotModuleReload: data.appFilesUpdaterOptions.useHotModuleReload });
+		const url = this.$previewSdkService.getQrCodeUrl({ useHotModuleReload: data.useHotModuleReload });
 		const result = await this.$previewQrCodeService.getLiveSyncQrCode(url);
 		return result;
 	}
@@ -362,13 +362,10 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 		if (liveSyncData.syncToPreviewApp) {
 			await this.$previewAppLiveSyncService.initialize({
-				appFilesUpdaterOptions: {
-					bundle: liveSyncData.bundle,
-					release: liveSyncData.release,
-					useHotModuleReload: liveSyncData.useHotModuleReload
-				},
-				env: liveSyncData.env,
-				projectDir: projectData.projectDir
+				projectDir: projectData.projectDir,
+				bundle: liveSyncData.bundle,
+				useHotModuleReload: liveSyncData.useHotModuleReload,
+				env: liveSyncData.env
 			});
 		} else {
 			// In case liveSync is called for a second time for the same projectDir.
@@ -641,13 +638,10 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 						if (liveSyncData.syncToPreviewApp) {
 							await this.addActionToChain(projectData.projectDir, async () => {
 								await this.$previewAppLiveSyncService.syncFiles({
-									appFilesUpdaterOptions: {
-										bundle: liveSyncData.bundle,
-										release: liveSyncData.release,
-										useHotModuleReload: liveSyncData.useHotModuleReload
-									},
-									env: liveSyncData.env,
-									projectDir: projectData.projectDir
+									projectDir: projectData.projectDir,
+									bundle: liveSyncData.bundle,
+									useHotModuleReload: liveSyncData.useHotModuleReload,
+									env: liveSyncData.env
 								}, currentFilesToSync, currentFilesToRemove);
 							});
 						} else {

--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -60,7 +60,7 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 	}
 
 	private getWarningForPlugin(data: IPreviewAppLiveSyncData, localPlugin: string, localPluginVersion: string, devicePluginVersion: string, device: Device): string {
-		if (data && data.appFilesUpdaterOptions && data.appFilesUpdaterOptions.bundle) {
+		if (data && data.bundle) {
 			const pluginPackageJsonPath = path.join(data.projectDir, NODE_MODULES_DIR_NAME, localPlugin, PACKAGE_JSON_FILE_NAME);
 			const isNativeScriptPlugin = this.$pluginsService.isNativeScriptPlugin(pluginPackageJsonPath);
 			if (!isNativeScriptPlugin || (isNativeScriptPlugin && !this.hasNativeCode(localPlugin, device.platform, data.projectDir))) {

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -60,11 +60,8 @@ const defaultProjectFiles = [
 ];
 const syncFilesMockData = {
 	projectDir: projectDirPath,
-	appFilesUpdaterOptions: {
-		release: false,
-		bundle: false,
-		useHotModuleReload: false
-	},
+	bundle: false,
+	useHotModuleReload: false,
 	env: {}
 };
 
@@ -182,7 +179,7 @@ async function initialSync(input?: IActInput) {
 
 	const { previewAppLiveSyncService, previewSdkService, actOptions } = input;
 	const syncFilesData = _.cloneDeep(syncFilesMockData);
-	syncFilesData.appFilesUpdaterOptions.useHotModuleReload = actOptions.hmr;
+	syncFilesData.useHotModuleReload = actOptions.hmr;
 	await previewAppLiveSyncService.initialize(syncFilesData);
 	if (actOptions.callGetInitialFiles) {
 		await previewSdkService.getInitialFiles(deviceMockData);
@@ -195,7 +192,7 @@ async function syncFiles(input?: IActInput) {
 	const { previewAppLiveSyncService, previewSdkService, projectFiles, actOptions } = input;
 
 	const syncFilesData = _.cloneDeep(syncFilesMockData);
-	syncFilesData.appFilesUpdaterOptions.useHotModuleReload = actOptions.hmr;
+	syncFilesData.useHotModuleReload = actOptions.hmr;
 	await previewAppLiveSyncService.initialize(syncFilesData);
 	if (actOptions.callGetInitialFiles) {
 		await previewSdkService.getInitialFiles(deviceMockData);

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -64,10 +64,8 @@ function createDevice(plugins: string): Device {
 function createPreviewLiveSyncData(options?: { bundle: boolean }) {
 	return {
 		projectDir,
-		appFilesUpdaterOptions: {
-			release: false,
-			bundle: options.bundle
-		},
+		release: false,
+		bundle: options.bundle,
 		env: {}
 	};
 }


### PR DESCRIPTION
Release option does not make sense in the context of the preview app so it should be deleted from public api for livesync to preview app.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
```
tns.liveSyncService.liveSyncToPreviewApp({
    projectDir: "myProjectDir",
    appFilesUpdaterOptions: {
        bundle: false,
        release: false,
        useHotModuleReload: false   
    },
    env: {}
});
```

## What is the new behavior?
```
tns.liveSyncService.liveSyncToPreviewApp({
    projectDir: "myProjectDir",
    bundle: false,
    useHotModuleReload: false,
    env: {}
});
```

This way the api will be consisted with
```
tns.liveSyncService.liveSync(deviceDescriptors, {
    projectDir: "myProjectDir",
    bundle: false,
    useHotModuleReload: false,
    env: {},
    ....
});
```