### PR TITLE
feat(extensibility): setting a custom path for the extensions

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -19,6 +19,7 @@ const tns = require("nativescript");
 	* [getIOSAssetsStructure](#getiosassetsstructure)
 	* [getAndroidAssetsStructure](#getandroidassetsstructure)
 * [extensibilityService](#extensibilityservice)
+	* [pathToExtensions](#pathToExtensions)
 	* [installExtension](#installextension)
 	* [uninstallExtension](#uninstallextension)
 	* [getInstalledExtensions](#getinstalledextensions)
@@ -289,6 +290,16 @@ interface IExtensionData {
 	 */
 	extensionName: string;
 }
+```
+### pathToExtensions
+Get/Set the to the CLI extensions.
+
+* Definition:
+```TypeScript
+/**
+ * The path to the CLI extensions.
+ */
+pathToExtensions: string;
 ```
 
 ### installExtension

--- a/lib/services/extensibility-service.ts
+++ b/lib/services/extensibility-service.ts
@@ -4,12 +4,18 @@ import * as constants from "../constants";
 import { createRegExp, regExpEscape } from "../common/helpers";
 
 export class ExtensibilityService implements IExtensibilityService {
-	private get pathToExtensions(): string {
-		return path.join(this.$settingsService.getProfileDir(), "extensions");
-	}
+	private customPathToExtensions: string = null;
 
 	private get pathToPackageJson(): string {
 		return path.join(this.pathToExtensions, constants.PACKAGE_JSON_FILE_NAME);
+	}
+
+	public get pathToExtensions(): string {
+		return this.customPathToExtensions || path.join(this.$settingsService.getProfileDir(), "extensions");
+	}
+
+	public set pathToExtensions(pathToExtensions: string) {
+		this.customPathToExtensions = pathToExtensions;
 	}
 
 	constructor(private $fs: IFileSystem,


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no way to set a different path for loading the CLI extensions.

## What is the new behavior?
<!-- Describe the changes. -->
There is a property `pathToExtensions` which can be set on the `extensibilityService`.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

