### PR TITLE
fix: fix project creation with github url passed as template

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -26,6 +26,27 @@ interface INodePackageManager {
 	view(packageName: string, config: Object): Promise<any>;
 
 	/**
+	 * Checks if the specified string is name of a packaged published in the NPM registry.
+	 * @param  {string} packageName The string to be checked.
+	 * @return {Promise<boolean>} True if the specified string is a registered package name, false otherwise.
+	 */
+	isRegistered(packageName: string): Promise<boolean>;
+
+	/**
+	 * Separates the package name and version from a specified fullPackageName.
+	 * @param  {string} fullPackageName The full name of the package like nativescript@10.0.0.
+	 * @return {INpmPackageNameParts} An object containing the separated package name and version.
+	 */
+	getPackageNameParts(fullPackageName: string): INpmPackageNameParts
+
+	/**
+	 * Returns the full name of an npm package based on the provided name and version.
+	 * @param  {INpmPackageNameParts} packageNameParts An object containing the package name and version.
+	 * @return {string} The full name of the package like nativescript@10.0.0.
+	 */
+	getPackageFullName(packageNameParts: INpmPackageNameParts): string
+
+	/**
 	 * Searches for a package.
 	 * @param  {string[]}                            filter Keywords with which to perform the search.
 	 * @param  {IDictionary<string | boolean>} config      Additional options that can be passed to manipulate search.
@@ -59,6 +80,7 @@ interface INpmInstallationManager {
 	getLatestVersion(packageName: string): Promise<string>;
 	getNextVersion(packageName: string): Promise<string>;
 	getLatestCompatibleVersion(packageName: string, referenceVersion?: string): Promise<string>;
+	getLatestCompatibleVersionSafe(packageName: string, referenceVersion?: string): Promise<string>;
 	getInspectorFromCache(inspectorNpmPackageName: string, projectDir: string): Promise<string>;
 }
 
@@ -351,6 +373,11 @@ interface INpmsPackageData {
 	author: { name: string };
 	publisher: INpmsUser;
 	maintainers: INpmsUser[];
+}
+
+interface INpmPackageNameParts {
+	name: string;
+	version: string;
 }
 
 interface IUsername {

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -112,6 +112,46 @@ export class NodePackageManager implements INodePackageManager {
 		return JSON.parse(viewResult);
 	}
 
+	public async isRegistered(packageName: string): Promise<boolean> {
+		if (this.isURL(packageName) || this.$fs.exists(packageName) || this.isTgz(packageName)) {
+			return false;
+		}
+
+		try {
+			const viewResult = await this.view(packageName, { name: true });
+
+			// `npm view nonExistingPackageName` will return `nativescript`
+			// if executed in the root dir of the CLI (npm 6.4.1)
+			const packageNameRegex = new RegExp(packageName, "i");
+			const isProperResult = packageNameRegex.test(viewResult);
+
+			return isProperResult;
+		} catch (e) {
+			return false;
+		}
+	}
+
+	public getPackageNameParts(fullPackageName: string): INpmPackageNameParts {
+		// support <reserved_name>@<version> syntax, for example typescript@1.0.0
+		// support <scoped_package_name>@<version> syntax, for example @nativescript/vue-template@1.0.0
+		const lastIndexOfAtSign = fullPackageName.lastIndexOf("@");
+		let version = "";
+		let templateName = "";
+		if (lastIndexOfAtSign > 0) {
+			templateName = fullPackageName.substr(0, lastIndexOfAtSign).toLowerCase();
+			version = fullPackageName.substr(lastIndexOfAtSign + 1);
+		}
+
+		return {
+			name: templateName || fullPackageName,
+			version: version
+		}
+	}
+
+	public getPackageFullName(packageNameParts: INpmPackageNameParts): string {
+		return packageNameParts.version ? `${packageNameParts.name}@${packageNameParts.version}` : packageNameParts.name;
+	}
+
 	public async searchNpms(keyword: string): Promise<INpmsResult> {
 		// TODO: Fix the generation of url - in case it contains @ or / , the call may fail.
 		const httpRequestResult = await this.$httpClient.httpRequest(`https://api.npms.io/v2/search?q=keywords:${keyword}`);
@@ -136,6 +176,16 @@ export class NodePackageManager implements INodePackageManager {
 		return path.join(cachePath.trim(), CACACHE_DIRECTORY_NAME);
 	}
 
+	private isTgz(packageName: string): boolean {
+		return packageName.indexOf(".tgz") >= 0;
+	}
+
+	private isURL(str: string): boolean {
+		const urlRegex = '^(?!mailto:)(?:(?:http|https|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$';
+		const url = new RegExp(urlRegex, 'i');
+		return str.length < 2083 && url.test(str);
+	}
+
 	private getNpmExecutableName(): string {
 		let npmExecutableName = "npm";
 
@@ -153,7 +203,7 @@ export class NodePackageManager implements INodePackageManager {
 				array.push(`--${flag}`);
 				array.push(`${config[flag]}`);
 			} else if (config[flag]) {
-				if (flag === "dist-tags" || flag === "versions") {
+				if (flag === "dist-tags" || flag === "versions" || flag === "name") {
 					array.push(` ${flag}`);
 					continue;
 				}
@@ -171,8 +221,8 @@ export class NodePackageManager implements INodePackageManager {
 		// TODO: Add tests for this functionality
 		try {
 			const originalOutput: INpmInstallCLIResult | INpm5InstallCliResult = JSON.parse(npmDryRunInstallOutput);
-			const npm5Output = <INpm5InstallCliResult> originalOutput;
-			const npmOutput = <INpmInstallCLIResult> originalOutput;
+			const npm5Output = <INpm5InstallCliResult>originalOutput;
+			const npmOutput = <INpmInstallCLIResult>originalOutput;
 			let name: string;
 			_.forOwn(npmOutput.dependencies, (peerDependency: INpmPeerDependencyInfo, key: string) => {
 				if (!peerDependency.required && !peerDependency.peerMissing) {

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -145,7 +145,7 @@ export class NodePackageManager implements INodePackageManager {
 		return {
 			name: templateName || fullPackageName,
 			version: version
-		}
+		};
 	}
 
 	public getPackageFullName(packageNameParts: INpmPackageNameParts): string {

--- a/lib/npm-installation-manager.ts
+++ b/lib/npm-installation-manager.ts
@@ -38,6 +38,16 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		return maxSatisfying || latestVersion;
 	}
 
+	public async getLatestCompatibleVersionSafe(packageName: string, referenceVersion?: string): Promise<string> {
+		let version = "";
+		const canGetVersionFromNpm = await this.$npm.isRegistered(packageName);
+		if (canGetVersionFromNpm) {
+			version = await this.getLatestCompatibleVersion(packageName, referenceVersion);
+		}
+
+		return version;
+	}
+
 	public async install(packageToInstall: string, projectDir: string, opts?: INpmInstallOptions): Promise<any> {
 		try {
 			const pathToSave = projectDir;
@@ -100,6 +110,7 @@ export class NpmInstallationManager implements INpmInstallationManager {
 		if (this.$fs.exists(pathToInspector)) {
 			return true;
 		}
+
 		return false;
 	}
 
@@ -109,28 +120,13 @@ export class NpmInstallationManager implements INpmInstallationManager {
 			packageName = possiblePackageName;
 		}
 
-		// check if the packageName is url or local file and if it is, let npm install deal with the version
-		if (this.isURL(packageName) || this.$fs.exists(packageName) || this.isTgz(packageName)) {
-			version = null;
-		} else {
-			version = version || await this.getLatestCompatibleVersion(packageName);
-		}
-
+		version = version || await this.getLatestCompatibleVersionSafe(packageName);
 		const installResultInfo = await this.npmInstall(packageName, pathToSave, version, dependencyType);
 		const installedPackageName = installResultInfo.name;
 
 		const pathToInstalledPackage = path.join(pathToSave, "node_modules", installedPackageName);
+
 		return pathToInstalledPackage;
-	}
-
-	private isTgz(packageName: string): boolean {
-		return packageName.indexOf(".tgz") >= 0;
-	}
-
-	private isURL(str: string): boolean {
-		const urlRegex = '^(?!mailto:)(?:(?:http|https|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$';
-		const url = new RegExp(urlRegex, 'i');
-		return str.length < 2083 && url.test(str);
 	}
 
 	private async npmInstall(packageName: string, pathToSave: string, version: string, dependencyType: string): Promise<INpmInstallResultInfo> {

--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -23,7 +23,7 @@ export class ProjectTemplatesService implements IProjectTemplatesService {
 		const templateNameParts = this.$npm.getPackageNameParts(templateValue);
 		templateValue = constants.RESERVED_TEMPLATE_NAMES[templateNameParts.name] || templateNameParts.name;
 
-		let version = templateNameParts.version || await this.$npmInstallationManager.getLatestCompatibleVersionSafe(templateValue);
+		const version = templateNameParts.version || await this.$npmInstallationManager.getLatestCompatibleVersionSafe(templateValue);
 		const fullTemplateName = this.$npm.getPackageFullName({ name: templateValue, version: version });
 
 		const templatePackageJsonContent = await this.getTemplatePackageJsonContent(fullTemplateName);

--- a/test/node-package-manager.ts
+++ b/test/node-package-manager.ts
@@ -5,84 +5,84 @@ import { NodePackageManager } from "../lib/node-package-manager";
 
 function createTestInjector(configuration: {
 } = {}): IInjector {
-    const injector = new Yok();
-    injector.register("hostInfo", {});
-    injector.register("errors", stubs.ErrorsStub);
-    injector.register("logger", stubs.LoggerStub);
-    injector.register("childProcess", stubs.ChildProcessStub);
-    injector.register("httpClient", {});
-    injector.register("fs", stubs.FileSystemStub);
-    injector.register("npm", NodePackageManager);
+	const injector = new Yok();
+	injector.register("hostInfo", {});
+	injector.register("errors", stubs.ErrorsStub);
+	injector.register("logger", stubs.LoggerStub);
+	injector.register("childProcess", stubs.ChildProcessStub);
+	injector.register("httpClient", {});
+	injector.register("fs", stubs.FileSystemStub);
+	injector.register("npm", NodePackageManager);
 
-    return injector;
+	return injector;
 }
 
-describe.only("node-package-manager", () => {
+describe("node-package-manager", () => {
 
-    describe("getPackageNameParts", () => {
-        [
-            {
-                name: "should return both name and version when valid fullName passed",
-                templateFullName: "some-template@1.0.0",
-                expectedVersion: "1.0.0",
-                expectedName: "some-template",
-            },
-            {
-                name: "should return both name and version when valid fullName with scope passed",
-                templateFullName: "@nativescript/some-template@1.0.0",
-                expectedVersion: "1.0.0",
-                expectedName: "@nativescript/some-template",
-            },
-            {
-                name: "should return only name when version is not specified and the template is scoped",
-                templateFullName: "@nativescript/some-template",
-                expectedVersion: "",
-                expectedName: "@nativescript/some-template",
-            },
-            {
-                name: "should return only name when version is not specified",
-                templateFullName: "some-template",
-                expectedVersion: "",
-                expectedName: "some-template",
-            }
-        ].forEach(testCase => {
-            it(testCase.name, async () => {
-                const testInjector = createTestInjector();
-                const npm = testInjector.resolve<NodePackageManager>("npm");
-                const templateNameParts = await npm.getPackageNameParts(testCase.templateFullName);
-                assert.strictEqual(templateNameParts.name, testCase.expectedName);
-                assert.strictEqual(templateNameParts.version, testCase.expectedVersion);
-            });
-        });
-    });
+	describe("getPackageNameParts", () => {
+		[
+			{
+				name: "should return both name and version when valid fullName passed",
+				templateFullName: "some-template@1.0.0",
+				expectedVersion: "1.0.0",
+				expectedName: "some-template",
+			},
+			{
+				name: "should return both name and version when valid fullName with scope passed",
+				templateFullName: "@nativescript/some-template@1.0.0",
+				expectedVersion: "1.0.0",
+				expectedName: "@nativescript/some-template",
+			},
+			{
+				name: "should return only name when version is not specified and the template is scoped",
+				templateFullName: "@nativescript/some-template",
+				expectedVersion: "",
+				expectedName: "@nativescript/some-template",
+			},
+			{
+				name: "should return only name when version is not specified",
+				templateFullName: "some-template",
+				expectedVersion: "",
+				expectedName: "some-template",
+			}
+		].forEach(testCase => {
+			it(testCase.name, async () => {
+				const testInjector = createTestInjector();
+				const npm = testInjector.resolve<NodePackageManager>("npm");
+				const templateNameParts = await npm.getPackageNameParts(testCase.templateFullName);
+				assert.strictEqual(templateNameParts.name, testCase.expectedName);
+				assert.strictEqual(templateNameParts.version, testCase.expectedVersion);
+			});
+		});
+	});
 
-    describe("getPackageFullName", () => {
-        [
-            {
-                name: "should return name and version when specified",
-                templateName: "some-template",
-                templateVersion: "1.0.0",
-                expectedFullName: "some-template@1.0.0",
-            },
-            {
-                name: "should return only the github url when no version specified",
-                templateName: "https://github.com/NativeScript/template-drawer-navigation-ng#master",
-                templateVersion: "",
-                expectedFullName: "https://github.com/NativeScript/template-drawer-navigation-ng#master",
-            },
-            {
-                name: "should return only the name when no version specified",
-                templateName: "some-template",
-                templateVersion: "",
-                expectedFullName: "some-template",
-            }
-        ].forEach(testCase => {
-            it(testCase.name, async () => {
-                const testInjector = createTestInjector();
-                const npm = testInjector.resolve<NodePackageManager>("npm");
-                const templateFullName = await npm.getPackageFullName({ name: testCase.templateName, version: testCase.templateVersion });
-                assert.strictEqual(templateFullName, testCase.expectedFullName);
-            });
-        });
-    });
+	describe("getPackageFullName", () => {
+		[
+			{
+				name: "should return name and version when specified",
+				templateName: "some-template",
+				templateVersion: "1.0.0",
+				expectedFullName: "some-template@1.0.0",
+			},
+			{
+				name: "should return only the github url when no version specified",
+				templateName: "https://github.com/NativeScript/template-drawer-navigation-ng#master",
+				templateVersion: "",
+				expectedFullName: "https://github.com/NativeScript/template-drawer-navigation-ng#master",
+			},
+			{
+				name: "should return only the name when no version specified",
+				templateName: "some-template",
+				templateVersion: "",
+				expectedFullName: "some-template",
+			}
+		].forEach(testCase => {
+			it(testCase.name, async () => {
+				const testInjector = createTestInjector();
+				const npm = testInjector.resolve<NodePackageManager>("npm");
+				const templateFullName = await npm.getPackageFullName({ name: testCase.templateName, version: testCase.templateVersion });
+				assert.strictEqual(templateFullName, testCase.expectedFullName);
+			});
+		});
+	});
 });

--- a/test/node-package-manager.ts
+++ b/test/node-package-manager.ts
@@ -1,0 +1,88 @@
+import { Yok } from "../lib/common/yok";
+import * as stubs from "./stubs";
+import { assert } from "chai";
+import { NodePackageManager } from "../lib/node-package-manager";
+
+function createTestInjector(configuration: {
+} = {}): IInjector {
+    const injector = new Yok();
+    injector.register("hostInfo", {});
+    injector.register("errors", stubs.ErrorsStub);
+    injector.register("logger", stubs.LoggerStub);
+    injector.register("childProcess", stubs.ChildProcessStub);
+    injector.register("httpClient", {});
+    injector.register("fs", stubs.FileSystemStub);
+    injector.register("npm", NodePackageManager);
+
+    return injector;
+}
+
+describe.only("node-package-manager", () => {
+
+    describe("getPackageNameParts", () => {
+        [
+            {
+                name: "should return both name and version when valid fullName passed",
+                templateFullName: "some-template@1.0.0",
+                expectedVersion: "1.0.0",
+                expectedName: "some-template",
+            },
+            {
+                name: "should return both name and version when valid fullName with scope passed",
+                templateFullName: "@nativescript/some-template@1.0.0",
+                expectedVersion: "1.0.0",
+                expectedName: "@nativescript/some-template",
+            },
+            {
+                name: "should return only name when version is not specified and the template is scoped",
+                templateFullName: "@nativescript/some-template",
+                expectedVersion: "",
+                expectedName: "@nativescript/some-template",
+            },
+            {
+                name: "should return only name when version is not specified",
+                templateFullName: "some-template",
+                expectedVersion: "",
+                expectedName: "some-template",
+            }
+        ].forEach(testCase => {
+            it(testCase.name, async () => {
+                const testInjector = createTestInjector();
+                const npm = testInjector.resolve<NodePackageManager>("npm");
+                const templateNameParts = await npm.getPackageNameParts(testCase.templateFullName);
+                assert.strictEqual(templateNameParts.name, testCase.expectedName);
+                assert.strictEqual(templateNameParts.version, testCase.expectedVersion);
+            });
+        });
+    });
+
+    describe("getPackageFullName", () => {
+        [
+            {
+                name: "should return name and version when specified",
+                templateName: "some-template",
+                templateVersion: "1.0.0",
+                expectedFullName: "some-template@1.0.0",
+            },
+            {
+                name: "should return only the github url when no version specified",
+                templateName: "https://github.com/NativeScript/template-drawer-navigation-ng#master",
+                templateVersion: "",
+                expectedFullName: "https://github.com/NativeScript/template-drawer-navigation-ng#master",
+            },
+            {
+                name: "should return only the name when no version specified",
+                templateName: "some-template",
+                templateVersion: "",
+                expectedFullName: "some-template",
+            }
+        ].forEach(testCase => {
+            it(testCase.name, async () => {
+                const testInjector = createTestInjector();
+                const npm = testInjector.resolve<NodePackageManager>("npm");
+                const templateFullName = await npm.getPackageFullName({ name: testCase.templateName, version: testCase.templateVersion });
+                assert.strictEqual(templateFullName, testCase.expectedFullName);
+            });
+        });
+    });
+});

--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -10,7 +10,6 @@ let isDeleteDirectoryCalledForNodeModulesDir = false;
 const nativeScriptValidatedTemplatePath = "nsValidatedTemplatePath";
 const compatibleTemplateVersion = "1.2.3";
 
-
 function createTestInjector(configuration: {
 	shouldNpmInstallThrow?: boolean,
 	packageJsonContent?: any,
@@ -44,7 +43,7 @@ function createTestInjector(configuration: {
 			return {
 				name: configuration.packageName || fullPackageName,
 				version: configuration.packageVersion || ""
-			}
+			};
 		}
 	}
 

--- a/test/services/android-debug-service.ts
+++ b/test/services/android-debug-service.ts
@@ -27,6 +27,7 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("devicesService", {});
 	testInjector.register("errors", stubs.ErrorsStub);
 	testInjector.register("logger", stubs.LoggerStub);
+	testInjector.register("npm", stubs.NodePackageManagerStub);
 	testInjector.register("androidDeviceDiscovery", {});
 	testInjector.register("androidProcessService", {});
 	testInjector.register("net", {});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -243,8 +243,59 @@ export class NpmInstallationManagerStub implements INpmInstallationManager {
 		return Promise.resolve("");
 	}
 
+	async getLatestCompatibleVersionSafe(packageName: string): Promise<string> {
+		return Promise.resolve("");
+	}
+
 	async getInspectorFromCache(name: string, projectDir: string): Promise<string> {
 		return Promise.resolve("");
+	}
+}
+
+export class NodePackageManagerStub implements INodePackageManager {
+	constructor() { }
+
+	public async install(packageName: string, pathToSave: string, config: INodePackageManagerInstallOptions): Promise<INpmInstallResultInfo> {
+		return null;
+	}
+
+	public async uninstall(packageName: string, config?: any, path?: string): Promise<string> {
+		return "";
+	}
+
+	public async search(filter: string[], config: any): Promise<string> {
+		return "";
+	}
+
+	public async view(packageName: string, config: Object): Promise<any> {
+		return {};
+	}
+
+	public async isRegistered(packageName: string): Promise<boolean> {
+		return true;
+	}
+
+	public getPackageNameParts(fullPackageName: string): INpmPackageNameParts {
+		return {
+			name: fullPackageName,
+			version: ""
+		}
+	}
+
+	public getPackageFullName(packageNameParts: INpmPackageNameParts): string {
+		return packageNameParts.version ? `${packageNameParts.name}@${packageNameParts.version}` : packageNameParts.name;
+	}
+
+	public async searchNpms(keyword: string): Promise<INpmsResult> {
+		return null;
+	}
+
+	public async getRegistryPackageData(packageName: string): Promise<any> {
+		return null
+	}
+
+	public async getCachePath(): Promise<string> {
+		return "";
 	}
 }
 
@@ -275,7 +326,7 @@ export class ProjectDataStub implements IProjectData {
 
 	public initializeProjectData(projectDir?: string): void {
 		this.projectDir = this.projectDir || projectDir;
-		this.projectIdentifiers = { android: "", ios: ""};
+		this.projectIdentifiers = { android: "", ios: "" };
 		this.projectId = "";
 	}
 	public initializeProjectDataFromContent(): void {
@@ -429,7 +480,7 @@ export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
 			normalizedPlatformName: "",
 			appDestinationDirectoryPath: "",
 			deviceBuildOutputPath: "",
-			getValidBuildOutputData: (buildOptions: IBuildOutputOptions) => ({ packageNames: []}),
+			getValidBuildOutputData: (buildOptions: IBuildOutputOptions) => ({ packageNames: [] }),
 			frameworkFilesExtensions: [],
 			relativeToFrameworkConfigurationFilePath: "",
 			fastLivesyncFileExtensions: []

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -279,7 +279,7 @@ export class NodePackageManagerStub implements INodePackageManager {
 		return {
 			name: fullPackageName,
 			version: ""
-		}
+		};
 	}
 
 	public getPackageFullName(packageNameParts: INpmPackageNameParts): string {
@@ -291,7 +291,7 @@ export class NodePackageManagerStub implements INodePackageManager {
 	}
 
 	public async getRegistryPackageData(packageName: string): Promise<any> {
-		return null
+		return null;
 	}
 
 	public async getCachePath(): Promise<string> {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
`tns create NewApp --template https://github.com/NativeScript/template-drawer-navigation-ng#master` is throwing an error.

## What is the new behavior?
`tns create NewApp --template https://github.com/NativeScript/template-drawer-navigation-ng#master` is creating a new project based on the specified repo url.

related to #4096