### PR TITLE
fix(release-build): rebuild project when there are project changes and release option is provided

### DIFF
--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -367,6 +367,10 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 	}
 
 	public async shouldBuild(platform: string, projectData: IProjectData, buildConfig: IBuildConfig, outputPath?: string): Promise<boolean> {
+		if (buildConfig.release && this.$projectChangesService.currentChanges.hasChanges) {
+			return true;
+		}
+
 		if (this.$projectChangesService.currentChanges.changesRequireBuild) {
 			return true;
 		}


### PR DESCRIPTION
LiveSync is not triggered in release mode so we need to rebuild the project when there are project changes in order to apply changes on device

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Changes between two `tns run android --release` commands are not applied on device

## What is the new behavior?
Changes between two `tns run android --release` commands are applied on device

Fixes/Implements/Closes #[Issue Number].
https://github.com/NativeScript/nativescript-cli/issues/4126


