### PR TITLE
feat(preview-api): expose api for getting logs from preview app

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -132,6 +132,7 @@ $injector.require("androidLiveSyncService", "./services/livesync/android-livesyn
 $injector.require("iOSLiveSyncService", "./services/livesync/ios-livesync-service");
 $injector.require("usbLiveSyncService", "./services/livesync/livesync-service"); // The name is used in https://github.com/NativeScript/nativescript-dev-typescript
 $injector.require("previewAppLiveSyncService", "./services/livesync/playground/preview-app-livesync-service");
+$injector.require("previewAppLogProvider", "./services/livesync/playground/preview-app-log-provider");
 $injector.require("previewAppPluginsService", "./services/livesync/playground/preview-app-plugins-service");
 $injector.require("previewSdkService", "./services/livesync/playground/preview-sdk-service");
 $injector.requirePublicClass("previewDevicesService", "./services/livesync/playground/devices/preview-devices-service");

--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -1,3 +1,5 @@
+import { DEVICE_LOG_EVENT_NAME } from "../common/constants";
+
 export class PreviewCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 	private static MIN_SUPPORTED_WEBPACK_VERSION = "0.17.0";
@@ -5,12 +7,18 @@ export class PreviewCommand implements ICommand {
 	constructor(private $bundleValidatorHelper: IBundleValidatorHelper,
 		private $errors: IErrors,
 		private $liveSyncService: ILiveSyncService,
+		private $logger: ILogger,
 		private $networkConnectivityValidator: INetworkConnectivityValidator,
 		private $projectData: IProjectData,
 		private $options: IOptions,
+		private $previewAppLogProvider: IPreviewAppLogProvider,
 		private $previewQrCodeService: IPreviewQrCodeService) { }
 
 	public async execute(): Promise<void> {
+		this.$previewAppLogProvider.on(DEVICE_LOG_EVENT_NAME, (deviceId: string, message: string) => {
+			this.$logger.info(message);
+		});
+
 		await this.$liveSyncService.liveSync([], {
 			syncToPreviewApp: true,
 			projectDir: this.$projectData.projectDir,

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -22,6 +22,10 @@ declare global {
 		getExternalPlugins(device: Device): string[];
 	}
 
+	interface IPreviewAppLogProvider extends EventEmitter {
+		logData(log: string, deviceName: string, deviceId: string): void;
+	}
+
 	interface IPreviewQrCodeService {
 		getPlaygroundAppQrCode(options?: IPlaygroundAppQrCodeOptions): Promise<IDictionary<IQrCodeImageData>>;
 		getLiveSyncQrCode(url: string): Promise<IQrCodeImageData>;

--- a/lib/services/livesync/playground/devices/preview-devices-service.ts
+++ b/lib/services/livesync/playground/devices/preview-devices-service.ts
@@ -1,9 +1,15 @@
 import { Device } from "nativescript-preview-sdk";
 import { EventEmitter } from "events";
-import { DeviceDiscoveryEventNames } from "../../../../common/constants";
+import { DeviceDiscoveryEventNames, DEVICE_LOG_EVENT_NAME } from "../../../../common/constants";
 
 export class PreviewDevicesService extends EventEmitter implements IPreviewDevicesService {
 	private connectedDevices: Device[] = [];
+
+	constructor(private $previewAppLogProvider: IPreviewAppLogProvider) {
+		super();
+
+		this.initialize();
+	}
 
 	public getConnectedDevices(): Device[] {
 		return this.connectedDevices;
@@ -25,6 +31,12 @@ export class PreviewDevicesService extends EventEmitter implements IPreviewDevic
 
 	public getDevicesForPlatform(platform: string): Device[] {
 		return _.filter(this.connectedDevices, { platform: platform.toLowerCase() });
+	}
+
+	private initialize(): void {
+		this.$previewAppLogProvider.on(DEVICE_LOG_EVENT_NAME, (deviceId: string, message: string) => {
+			this.emit(DEVICE_LOG_EVENT_NAME, deviceId, message);
+		});
 	}
 
 	private raiseDeviceFound(device: Device) {

--- a/lib/services/livesync/playground/preview-app-log-provider.ts
+++ b/lib/services/livesync/playground/preview-app-log-provider.ts
@@ -1,0 +1,10 @@
+import { EventEmitter } from "events";
+import { DEVICE_LOG_EVENT_NAME } from "../../../common/constants";
+
+export class PreviewAppLogProvider extends EventEmitter implements IPreviewAppLogProvider {
+	public logData(log: string, deviceName: string, deviceId: string): void {
+		const message = `LOG from device ${deviceName}: ${log}`;
+		this.emit(DEVICE_LOG_EVENT_NAME, deviceId, message);
+	}
+}
+$injector.register("previewAppLogProvider", PreviewAppLogProvider);

--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -1,7 +1,6 @@
 import { MessagingService, Config, Device, DeviceConnectedMessage, SdkCallbacks, ConnectedDevices, FilesPayload } from "nativescript-preview-sdk";
 import { PubnubKeys } from "./preview-app-constants";
 import { EventEmitter } from "events";
-import { DEVICE_LOG_EVENT_NAME } from "../../../common/constants";
 const pako = require("pako");
 
 export class PreviewSdkService extends EventEmitter implements IPreviewSdkService {
@@ -12,7 +11,8 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 	constructor(private $config: IConfiguration,
 		private $httpClient: Server.IHttpClient,
 		private $logger: ILogger,
-		private $previewDevicesService: IPreviewDevicesService) {
+		private $previewDevicesService: IPreviewDevicesService,
+		private $previewAppLogProvider: IPreviewAppLogProvider) {
 			super();
 	}
 
@@ -61,9 +61,7 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 				this.$logger.trace("Received onLogSdkMessage message: ", log);
 			},
 			onLogMessage: (log: string, deviceName: string, deviceId: string) => {
-				const device = this.$previewDevicesService.getDeviceById(deviceId);
-				this.emit(DEVICE_LOG_EVENT_NAME, log, deviceId, device ? device.platform : "");
-				this.$logger.info(`LOG from device ${deviceName}: ${log}`);
+				this.$previewAppLogProvider.logData(log, deviceName, deviceId);
 			},
 			onRestartMessage: () => {
 				this.$logger.trace("Received onRestartMessage event.");

--- a/test/services/preview-devices-service.ts
+++ b/test/services/preview-devices-service.ts
@@ -11,6 +11,9 @@ let lostDevices: Device[] = [];
 function createTestInjector(): IInjector {
 	const injector = new Yok();
 	injector.register("previewDevicesService", PreviewDevicesService);
+	injector.register("previewAppLogProvider", {
+		on: () => ({})
+	});
 	injector.register("logger", LoggerStub);
 	return injector;
 }

--- a/test/services/preview-sdk-service.ts
+++ b/test/services/preview-sdk-service.ts
@@ -9,6 +9,7 @@ const getPreviewSdkService = (): IPreviewSdkService => {
 	testInjector.register("config", {});
 	testInjector.register("previewSdkService", PreviewSdkService);
 	testInjector.register("previewDevicesService", {});
+	testInjector.register("previewAppLogProvider", {});
 	testInjector.register("httpClient", {
 		httpRequest: async (options: any, proxySettings?: IProxySettings): Promise<Server.IResponse> => undefined
 	});


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
No api for getting logs from preview app

## What is the new behavior?
```
tns.previewDevicesService.on("deviceLogData", (deviceId, log) => {
    console.log(`received log ${log} from device: ${deviceId}`);
});
```
