### PR TITLE
feat(preview-api): expose public api for getting device's warnings

### DIFF
--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -18,7 +18,7 @@ declare global {
 	}
 
 	interface IPreviewAppPluginsService {
-		getDeviceWarnings(device: Device): string[];
+		getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[];
 		comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void>;
 		getExternalPlugins(device: Device): string[];
 	}
@@ -50,5 +50,6 @@ declare global {
 		updateConnectedDevices(devices: Device[]): void;
 		getDeviceById(id: string): Device;
 		getDevicesForPlatform(platform: string): Device[];
+		getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[];
 	}
 }

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -18,6 +18,7 @@ declare global {
 	}
 
 	interface IPreviewAppPluginsService {
+		getDeviceWarnings(device: Device): string[];
 		comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void>;
 		getExternalPlugins(device: Device): string[];
 	}

--- a/lib/services/livesync/playground/devices/preview-devices-service.ts
+++ b/lib/services/livesync/playground/devices/preview-devices-service.ts
@@ -34,14 +34,14 @@ export class PreviewDevicesService extends EventEmitter implements IPreviewDevic
 		return _.filter(this.connectedDevices, { platform: platform.toLowerCase() });
 	}
 
+	public getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[] {
+		return this.$previewAppPluginsService.getPluginsUsageWarnings(data, device);
+	}
+
 	private initialize(): void {
 		this.$previewAppLogProvider.on(DEVICE_LOG_EVENT_NAME, (deviceId: string, message: string) => {
 			this.emit(DEVICE_LOG_EVENT_NAME, deviceId, message);
 		});
-	}
-
-	public getDeviceWarnings(device: Device): string[] {
-		return this.$previewAppPluginsService.getDeviceWarnings(device);
 	}
 
 	private raiseDeviceFound(device: Device) {

--- a/lib/services/livesync/playground/devices/preview-devices-service.ts
+++ b/lib/services/livesync/playground/devices/preview-devices-service.ts
@@ -5,10 +5,11 @@ import { DeviceDiscoveryEventNames, DEVICE_LOG_EVENT_NAME } from "../../../../co
 export class PreviewDevicesService extends EventEmitter implements IPreviewDevicesService {
 	private connectedDevices: Device[] = [];
 
-	constructor(private $previewAppLogProvider: IPreviewAppLogProvider) {
-		super();
+	constructor(private $previewAppLogProvider: IPreviewAppLogProvider,
+		private $previewAppPluginsService: IPreviewAppPluginsService) {
+			super();
 
-		this.initialize();
+			this.initialize();
 	}
 
 	public getConnectedDevices(): Device[] {
@@ -37,6 +38,10 @@ export class PreviewDevicesService extends EventEmitter implements IPreviewDevic
 		this.$previewAppLogProvider.on(DEVICE_LOG_EVENT_NAME, (deviceId: string, message: string) => {
 			this.emit(DEVICE_LOG_EVENT_NAME, deviceId, message);
 		});
+	}
+
+	public getDeviceWarnings(device: Device): string[] {
+		return this.$previewAppPluginsService.getDeviceWarnings(device);
 	}
 
 	private raiseDeviceFound(device: Device) {

--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -14,7 +14,7 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 		private $logger: ILogger,
 		private $pluginsService: IPluginsService) { }
 
-	public getDeviceWarnings(device: Device): string[] {
+	public getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[] {
 		if (!device) {
 			this.$errors.failWithoutHelp("No device provided.");
 		}
@@ -23,10 +23,6 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 			this.$errors.failWithoutHelp("No version of preview app provided.");
 		}
 
-		return this.previewAppVersionWarnings[device.previewAppVersion];
-	}
-
-	public async comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void> {
 		if (!this.previewAppVersionWarnings[device.previewAppVersion]) {
 			const devicePlugins = this.getDevicePlugins(device);
 			const localPlugins = this.getLocalPlugins(data.projectDir);
@@ -40,7 +36,12 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 			this.previewAppVersionWarnings[device.previewAppVersion] = warnings;
 		}
 
-		this.previewAppVersionWarnings[device.previewAppVersion].map(warning => this.$logger.warn(warning));
+		return this.previewAppVersionWarnings[device.previewAppVersion];
+	}
+
+	public async comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void> {
+		const warnings = this.getPluginsUsageWarnings(data, device);
+		_.map(warnings, warning => this.$logger.warn(warning));
 	}
 
 	public getExternalPlugins(device: Device): string[] {

--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -9,9 +9,22 @@ import { PLATFORMS_DIR_NAME, PACKAGE_JSON_FILE_NAME } from "../../../constants";
 export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 	private previewAppVersionWarnings: IDictionary<string[]> = {};
 
-	constructor(private $fs: IFileSystem,
+	constructor(private $errors: IErrors,
+		private $fs: IFileSystem,
 		private $logger: ILogger,
 		private $pluginsService: IPluginsService) { }
+
+	public getDeviceWarnings(device: Device): string[] {
+		if (!device) {
+			this.$errors.failWithoutHelp("No device provided.");
+		}
+
+		if (!device.previewAppVersion) {
+			this.$errors.failWithoutHelp("No version of preview app provided.");
+		}
+
+		return this.previewAppVersionWarnings[device.previewAppVersion];
+	}
 
 	public async comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void> {
 		if (!this.previewAppVersionWarnings[device.previewAppVersion]) {

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -4,6 +4,7 @@ import { Device } from "nativescript-preview-sdk";
 import { assert } from "chai";
 import * as util from "util";
 import { PluginComparisonMessages } from "../../../lib/services/livesync/playground/preview-app-constants";
+import { ErrorsStub } from "../../stubs";
 
 let readJsonParams: string[] = [];
 let warnParams: string[] = [];
@@ -43,6 +44,7 @@ function createTestInjector(localPlugins: IStringDictionary, options?: { isNativ
 		trace: () => ({}),
 		warn: (message: string) =>  warnParams.push(message)
 	});
+	injector.register("errors", ErrorsStub);
 	injector.register("previewAppPluginsService", PreviewAppPluginsService);
 	return injector;
 }

--- a/test/services/preview-devices-service.ts
+++ b/test/services/preview-devices-service.ts
@@ -3,17 +3,19 @@ import { PreviewDevicesService } from "../../lib/services/livesync/playground/de
 import { Device } from "nativescript-preview-sdk";
 import { assert } from "chai";
 import { DeviceDiscoveryEventNames } from "../../lib/common/constants";
-import { LoggerStub } from "../stubs";
+import { LoggerStub, ErrorsStub } from "../stubs";
 
 let foundDevices: Device[] = [];
 let lostDevices: Device[] = [];
 
 function createTestInjector(): IInjector {
 	const injector = new Yok();
+	injector.register("errors", ErrorsStub);
 	injector.register("previewDevicesService", PreviewDevicesService);
 	injector.register("previewAppLogProvider", {
 		on: () => ({})
 	});
+	injector.register("previewAppPluginsService", {});
 	injector.register("logger", LoggerStub);
 	return injector;
 }


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
No api for getting warnings from device

## What is the new behavior?
```
const deviceWarnings = tns.previewDevicesService.getDeviceWarnings({ previewAppVersion: "19.0.0" });
console.log(deviceWarnings);
```

