### PR TITLE
fix: fix yarn view method to return correct data

### DIFF
--- a/lib/yarn-package-manager.ts
+++ b/lib/yarn-package-manager.ts
@@ -64,7 +64,9 @@ export class YarnPackageManager extends BasePackageManager {
 		} catch (e) {
 			this.$errors.failWithoutHelp(e.message);
 		}
-		return JSON.parse(viewResult);
+
+		const result = JSON.parse(viewResult);
+		return result.data;
 	}
 
 	@exported("yarn")


### PR DESCRIPTION
As --json flag is hardcoded for `yarn info` command, it always returns a json object in following format: { data: someResult }. As the other methods expect only `someResult` as a result from view command, we need to return `.data` property from `yarn info` output.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns doctor` does not return the correct components info when yarn is set as package manager.

## What is the new behavior?
`tns doctor` returns the correct components info when yarn is set as package manager.

Fixes/Implements/Closes #[Issue Number].

Rel to: https://github.com/NativeScript/nativescript-cli/issues/2737

