### PR TITLE
fix(preview-api): raise deviceLost event after timeout of 5 seconds

### DIFF
--- a/lib/services/livesync/playground/devices/preview-devices-service.ts
+++ b/lib/services/livesync/playground/devices/preview-devices-service.ts
@@ -4,7 +4,7 @@ import { DeviceDiscoveryEventNames, DEVICE_LOG_EVENT_NAME } from "../../../../co
 
 export class PreviewDevicesService extends EventEmitter implements IPreviewDevicesService {
 	private connectedDevices: Device[] = [];
-	private deviceTimers: IDictionary<NodeJS.Timer> = {};
+	private deviceLostTimers: IDictionary<NodeJS.Timer> = {};
 
 	constructor(private $previewAppLogProvider: IPreviewAppLogProvider,
 		private $previewAppPluginsService: IPreviewAppPluginsService) {
@@ -46,8 +46,8 @@ export class PreviewDevicesService extends EventEmitter implements IPreviewDevic
 	}
 
 	private raiseDeviceFound(device: Device) {
-		if (this.deviceTimers[device.id]) {
-			clearTimeout(this.deviceTimers[device.id]);
+		if (this.deviceLostTimers[device.id]) {
+			clearTimeout(this.deviceLostTimers[device.id]);
 		}
 
 		this.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, device);
@@ -60,12 +60,12 @@ export class PreviewDevicesService extends EventEmitter implements IPreviewDevic
 	}
 
 	private raiseDeviceLostAfterTimeout(device: Device) {
-		if (!this.deviceTimers[device.id]) {
+		if (!this.deviceLostTimers[device.id]) {
 			const timeoutId = setTimeout(() => {
 				this.raiseDeviceLost(device);
 				clearTimeout(timeoutId);
 			}, 5 * 1000);
-			this.deviceTimers[device.id] = timeoutId;
+			this.deviceLostTimers[device.id] = timeoutId;
 		}
 	}
 }

--- a/test/services/preview-devices-service.ts
+++ b/test/services/preview-devices-service.ts
@@ -4,6 +4,7 @@ import { Device } from "nativescript-preview-sdk";
 import { assert } from "chai";
 import { DeviceDiscoveryEventNames } from "../../lib/common/constants";
 import { LoggerStub, ErrorsStub } from "../stubs";
+import * as sinon from "sinon";
 
 let foundDevices: Device[] = [];
 let lostDevices: Device[] = [];
@@ -40,6 +41,7 @@ function resetDevices() {
 describe("PreviewDevicesService", () => {
 	describe("onDevicesPresence", () => {
 		let previewDevicesService: IPreviewDevicesService = null;
+		let clock: sinon.SinonFakeTimers = null;
 		beforeEach(() => {
 			const injector = createTestInjector();
 			previewDevicesService = injector.resolve("previewDevicesService");
@@ -49,11 +51,13 @@ describe("PreviewDevicesService", () => {
 			previewDevicesService.on(DeviceDiscoveryEventNames.DEVICE_LOST, device => {
 				lostDevices.push(device);
 			});
+			clock = sinon.useFakeTimers();
 		});
 
 		afterEach(() => {
 			previewDevicesService.removeAllListeners();
 			resetDevices();
+			clock.restore();
 		});
 
 		it("should add new device", () => {
@@ -101,6 +105,7 @@ describe("PreviewDevicesService", () => {
 			resetDevices();
 
 			previewDevicesService.updateConnectedDevices([]);
+			clock.tick(5000);
 
 			assert.deepEqual(foundDevices, []);
 			assert.deepEqual(lostDevices, [device1]);
@@ -116,6 +121,7 @@ describe("PreviewDevicesService", () => {
 			resetDevices();
 
 			previewDevicesService.updateConnectedDevices([device2]);
+			clock.tick(5000);
 
 			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device2]);
 			assert.deepEqual(foundDevices, [device2]);

--- a/test/services/preview-devices-service.ts
+++ b/test/services/preview-devices-service.ts
@@ -39,7 +39,7 @@ function resetDevices() {
 }
 
 describe("PreviewDevicesService", () => {
-	describe("onDevicesPresence", () => {
+	describe("getConnectedDevices", () => {
 		let previewDevicesService: IPreviewDevicesService = null;
 		let clock: sinon.SinonFakeTimers = null;
 		beforeEach(() => {
@@ -126,6 +126,25 @@ describe("PreviewDevicesService", () => {
 			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device2]);
 			assert.deepEqual(foundDevices, [device2]);
 			assert.deepEqual(lostDevices, [device1]);
+		});
+		it("shouldn't emit deviceFound or deviceLost when preview app is restarted on device", () => {
+			const device1 = createDevice("device1");
+
+			previewDevicesService.updateConnectedDevices([device1]);
+
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device1]);
+			assert.deepEqual(foundDevices, [device1]);
+			assert.deepEqual(lostDevices, []);
+			resetDevices();
+
+			// preview app is restarted
+			previewDevicesService.updateConnectedDevices([]);
+			clock.tick(500);
+			previewDevicesService.updateConnectedDevices([device1]);
+
+			assert.deepEqual(foundDevices, []);
+			assert.deepEqual(lostDevices, []);
+			assert.deepEqual(previewDevicesService.getConnectedDevices(), [device1]);
 		});
 	});
 });


### PR DESCRIPTION
In case when some `.js` file is changed, preview app is restarted on device e.g preview app is stopped and started again. When the preview app is stopped, Pubnub reports the device as lost and when preview app is started, Pubnub reports the device as found. With this fix, we want to delay the emitting of deviceLost event. This way we'll give a chance to find the device before reporting it as lost.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

