### PR TITLE
fix: reset devices list when stopLiveSync method is called

### DIFF
--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -72,6 +72,7 @@ export class PreviewAppLiveSyncService implements IPreviewAppLiveSyncService {
 
 	public async stopLiveSync(): Promise<void> {
 		this.$previewSdkService.stop();
+		this.$previewDevicesService.updateConnectedDevices([]);
 	}
 
 	private async initializePreviewForDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<FilesPayload> {


### PR DESCRIPTION
When stopLiveSync method is called, we want to reset devices list and emit deviceLost event for all connected devices.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`deviceLost` event is not emitted when there are connected devices and `stopLiveSync` method is called

## What is the new behavior?
`deviceLost` event is emitted when there are connected devices and `stopLiveSync` method is called
