### PR TITLE
fix: reset deviceLostTimer after clearing the device's timeout

### DIFF
--- a/lib/services/livesync/playground/devices/preview-devices-service.ts
+++ b/lib/services/livesync/playground/devices/preview-devices-service.ts
@@ -48,6 +48,7 @@ export class PreviewDevicesService extends EventEmitter implements IPreviewDevic
 	private raiseDeviceFound(device: Device) {
 		if (this.deviceLostTimers[device.id]) {
 			clearTimeout(this.deviceLostTimers[device.id]);
+			this.deviceLostTimers[device.id] = null;
 		}
 
 		this.emit(DeviceDiscoveryEventNames.DEVICE_FOUND, device);


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
