### PR TITLE
fix: works correctly when `adb` is not added to PATH

### DIFF
--- a/lib/common/static-config-base.ts
+++ b/lib/common/static-config-base.ts
@@ -94,7 +94,8 @@ export abstract class StaticConfigBase implements Config.IStaticConfig {
 
 		// prepare the directory to host our copy of adb
 		const defaultAdbDirPath = path.join(__dirname, `resources/platform-tools/android/${process.platform}`);
-		const commonLibVersion = require(path.join(__dirname, "package.json")).version;
+		const pathToPackageJson = path.join(__dirname, "..", "..", "package.json");
+		const commonLibVersion = require(pathToPackageJson).version;
 		const tmpDir = path.join(os.tmpdir(), `telerik-common-lib-${commonLibVersion}`);
 		$fs.createDirectory(tmpDir);
 


### PR DESCRIPTION
{N} CLI tries to use the version from `common/package.json` file when `adb` is not added to PATH.  As we deleted `common/package.json` file, the command silently fails and does not return any result.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns devices` does not return any devices when `adb` is not added to PATH

## What is the new behavior?
`tns devices` returns devices when `adb` is not added to PATH
