### PR TITLE
feat(preview-api): emit previewAppLiveSyncError when some error is thrown while livesyncing to preview app

### DIFF
--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -2,7 +2,7 @@ import { FilePayload, Device, FilesPayload } from "nativescript-preview-sdk";
 import { EventEmitter } from "events";
 
 declare global {
-	interface IPreviewAppLiveSyncService {
+	interface IPreviewAppLiveSyncService extends EventEmitter {
 		initialize(data: IPreviewAppLiveSyncData): void;
 		syncFiles(data: IPreviewAppLiveSyncData, filesToSync: string[], filesToRemove: string[]): Promise<void>;
 		stopLiveSync(): Promise<void>;

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -7,6 +7,7 @@ import { PACKAGE_JSON_FILE_NAME, LiveSyncTrackActionNames, USER_INTERACTION_NEED
 import { DeviceTypes, DeviceDiscoveryEventNames, HmrConstants } from "../../common/constants";
 import { cache } from "../../common/decorators";
 import * as constants from "../../constants";
+import { PreviewAppLiveSyncEvents } from "./playground/preview-app-constants";
 
 const deviceDescriptorPrimaryKey = "identifier";
 
@@ -14,6 +15,7 @@ const LiveSyncEvents = {
 	liveSyncStopped: "liveSyncStopped",
 	// In case we name it error, EventEmitter expects instance of Error to be raised and will also raise uncaught exception in case there's no handler
 	liveSyncError: "liveSyncError",
+	previewAppLiveSyncError: PreviewAppLiveSyncEvents.PREVIEW_APP_LIVE_SYNC_ERROR,
 	liveSyncExecuted: "liveSyncExecuted",
 	liveSyncStarted: "liveSyncStarted",
 	liveSyncNotification: "notify"
@@ -54,6 +56,10 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	}
 
 	public async liveSyncToPreviewApp(data: IPreviewAppLiveSyncData): Promise<IQrCodeImageData> {
+		this.$previewAppLiveSyncService.on(LiveSyncEvents.previewAppLiveSyncError, liveSyncData => {
+			this.emit(LiveSyncEvents.previewAppLiveSyncError, liveSyncData);
+		});
+
 		await this.liveSync([], {
 			syncToPreviewApp: true,
 			projectDir: data.projectDir,
@@ -102,6 +108,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 
 				if (liveSyncProcessInfo.syncToPreviewApp) {
 					await this.$previewAppLiveSyncService.stopLiveSync();
+					this.$previewAppLiveSyncService.removeAllListeners();
 				}
 
 				// Kill typescript watcher

--- a/lib/services/livesync/playground/preview-app-constants.ts
+++ b/lib/services/livesync/playground/preview-app-constants.ts
@@ -18,3 +18,7 @@ export class PluginComparisonMessages {
 	public static LOCAL_PLUGIN_WITH_DIFFERENCE_IN_MAJOR_VERSION = "Local plugin %s differs in major version from plugin in preview app. The local plugin has version %s and the plugin in preview app has version %s. Some features might not work as expected.";
 	public static LOCAL_PLUGIN_WITH_GREATHER_MINOR_VERSION = "Local plugin %s differs in minor version from plugin in preview app. The local plugin has version %s and the plugin in preview app has version %s. Some features might not work as expected.";
 }
+
+export class PreviewAppLiveSyncEvents {
+	public static PREVIEW_APP_LIVE_SYNC_ERROR = "previewAppLiveSyncError";
+}


### PR DESCRIPTION
Usage:
```
tns.liveSyncService.on("previewAppLiveSyncError", data => {
    console.log("LiveSync error: " + data);
});
```

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
No api exposed to get the errors from livesync operation

## What is the new behavior?
Expose an api to get the errors from livesync operation

