### PR TITLE
feat(package-manager): expose `package-manager get` command

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -83,6 +83,7 @@ $injector.requirePublic("packageManager", "./package-manager");
 $injector.requirePublic("npm", "./node-package-manager");
 $injector.requirePublic("yarn", "./yarn-package-manager");
 $injector.requireCommand("package-manager|set", "./commands/package-manager-set");
+$injector.requireCommand("package-manager|get", "./commands/package-manager-get");
 
 $injector.require("packageInstallationManager", "./package-installation-manager");
 $injector.require("dynamicHelpProvider", "./dynamic-help-provider");

--- a/lib/common/commands/package-manager-get.ts
+++ b/lib/common/commands/package-manager-get.ts
@@ -1,0 +1,22 @@
+
+export class PackageManagerGetCommand implements ICommand {
+
+	constructor(
+		private $errors: IErrors,
+		private $logger: ILogger,
+		private $userSettingsService: IUserSettingsService
+	) { }
+
+	public allowedParameters: ICommandParameter[] = [];
+
+	public async execute(args: string[]): Promise<void> {
+		if (args && args.length) {
+			this.$errors.fail(`The arguments '${args.join(" ")}' are not valid for the 'package-manager get' command.`);
+		}
+
+		const result = await this.$userSettingsService.getSettingValue("packageManager");
+		this.$logger.info(`Your current package manager is ${result || "npm"}.`);
+	}
+}
+
+$injector.registerCommand("package-manager|get", PackageManagerGetCommand);


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
No command for getting the current package manager.

## What is the new behavior?
`tns package-manager get`

Rel to: https://github.com/NativeScript/nativescript-cli/issues/2737