### PR TITLE
fix: execute correctly local build after cloud build from sidekick

### DIFF
--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -171,7 +171,7 @@ export class ProjectChangesService implements IProjectChangesService {
 
 	public setNativePlatformStatus(platform: string, projectData: IProjectData, addedPlatform: IAddedNativePlatform): void {
 		this._prepareInfo = this._prepareInfo || this.getPrepareInfo(platform, projectData);
-		if (this._prepareInfo) {
+		if (this._prepareInfo && addedPlatform.nativePlatformStatus === NativePlatformStatus.alreadyPrepared) {
 			this._prepareInfo.nativePlatformStatus = addedPlatform.nativePlatformStatus;
 		} else {
 			this._prepareInfo = {

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -187,5 +187,51 @@ describe("Project Changes Service Tests", () => {
 				assert.deepEqual(actualPrepareInfo, { nativePlatformStatus: Constants.NativePlatformStatus.requiresPrepare });
 			}
 		});
+
+		it(`shouldn't reset prepare info when native platform status is ${Constants.NativePlatformStatus.alreadyPrepared} and there is existing prepare info`, async () => {
+			for (const platform of ["ios", "android"]) {
+				await serviceTest.projectChangesService.checkForChanges({
+					platform,
+					projectData: serviceTest.projectData,
+					projectChangesOptions: {
+						bundle: false,
+						release: false,
+						provision: undefined,
+						teamId: undefined,
+						useHotModuleReload: false
+					}
+				});
+				serviceTest.projectChangesService.savePrepareInfo(platform, serviceTest.projectData);
+				const prepareInfo = serviceTest.projectChangesService.getPrepareInfo(platform, serviceTest.projectData);
+
+				serviceTest.projectChangesService.setNativePlatformStatus(platform, serviceTest.projectData, { nativePlatformStatus: Constants.NativePlatformStatus.alreadyPrepared });
+
+				const actualPrepareInfo = serviceTest.projectChangesService.getPrepareInfo(platform, serviceTest.projectData);
+				prepareInfo.nativePlatformStatus = Constants.NativePlatformStatus.alreadyPrepared;
+				assert.deepEqual(actualPrepareInfo, prepareInfo);
+			}
+		});
+
+		_.each([Constants.NativePlatformStatus.requiresPlatformAdd, Constants.NativePlatformStatus.requiresPrepare], nativePlatformStatus => {
+			it(`should reset prepare info when native platform status is ${nativePlatformStatus} and there is existing prepare info`, async () => {
+				for (const platform of ["ios", "android"]) {
+					await serviceTest.projectChangesService.checkForChanges({
+						platform,
+						projectData: serviceTest.projectData,
+						projectChangesOptions: {
+							bundle: false,
+							release: false,
+							provision: undefined,
+							teamId: undefined,
+							useHotModuleReload: false
+						}
+					});
+					serviceTest.projectChangesService.setNativePlatformStatus(platform, serviceTest.projectData, { nativePlatformStatus: nativePlatformStatus });
+
+					const actualPrepareInfo = serviceTest.projectChangesService.getPrepareInfo(platform, serviceTest.projectData);
+					assert.deepEqual(actualPrepareInfo, { nativePlatformStatus: nativePlatformStatus });
+				}
+			});
+		});
 	});
 });


### PR DESCRIPTION
Reset prepare info when native platform status is not alreadyPrepared in order to ensure the project will be prepared and all properties of this._prepareInfo will be correctly populated.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The user is not able to execute local build after cloud from sidekick.

## What is the new behavior?
The user is able to execute local build after cloud from sidekick.

