### PR TITLE
fix: builing of nativescript-cloud package fails

### DIFF
--- a/lib/services/analytics/analytics-constants.d.ts
+++ b/lib/services/analytics/analytics-constants.d.ts
@@ -1,7 +1,7 @@
 /**
  * Defines messages used in communication between CLI's process and analytics subprocesses.
  */
-const enum AnalyticsMessages {
+declare const enum AnalyticsMessages {
 	/**
 	 * Analytics Broker is initialized and is ready to receive information for tracking.
 	 */
@@ -11,7 +11,7 @@ const enum AnalyticsMessages {
 /**
  * Defines the type of the messages that should be written in the local analyitcs log file (in case such is specified).
  */
-const enum AnalyticsLoggingMessageType {
+declare const enum AnalyticsLoggingMessageType {
 	/**
 	 * Information message. This is the default value in case type is not specified.
 	 */


### PR DESCRIPTION
Building the nativescript-cloud package fails with error:
```
node_modules/nativescript/lib/services/analytics/analytics.d.ts(67,9): error TS2304: Cannot find name 'AnalyticsLoggingMessageType'.
```

The problem is that the build of `nativescript-cloud` extension needs to get all interfaces from CLI and include them in the global scope of the `nativescript-cloud`, so it can be transpiled. Currently this is done by iterrating over all files in nativescript and searching for `.d.ts` files.
For each `.d.ts` file, we create a new entry in a `references.d.ts` file in the root of `nativescript-cloud`. When trying to transpile the project, it fails as one of the included references (`analytics.d.ts`) uses a type (enum in this case) that is not available in the included references.
Fix this by moving the enums to `.d.ts` files - this way the transpiled `.js` files will not change (TypeScript strips all const enums from produced `.js` by replacing the enum usage with the actual value) and the transpilation of `nativescript-cloud` will work as well.
