### PR TITLE
fix(analytics): undefined file is created on every command

### DIFF
--- a/lib/services/analytics/analytics-service.ts
+++ b/lib/services/analytics/analytics-service.ts
@@ -147,12 +147,10 @@ export class AnalyticsService implements IAnalyticsService, IDisposable {
 	@cache()
 	private getAnalyticsBroker(): Promise<ChildProcess> {
 		return new Promise<ChildProcess>((resolve, reject) => {
+			const brokerProcessArgs = this.getBrokerProcessArgs();
+
 			const broker = this.$childProcess.spawn(process.execPath,
-				[
-					path.join(__dirname, "analytics-broker-process.js"),
-					this.$staticConfig.PATH_TO_BOOTSTRAP,
-					this.$options.analyticsLogFile // TODO: Check if passing path with space or quotes will work
-				],
+				brokerProcessArgs,
 				{
 					stdio: ["ignore", "ignore", "ignore", "ipc"],
 					detached: true
@@ -198,6 +196,19 @@ export class AnalyticsService implements IAnalyticsService, IDisposable {
 				}
 			});
 		});
+	}
+
+	private getBrokerProcessArgs(): string[] {
+		const brokerProcessArgs = [
+			path.join(__dirname, "analytics-broker-process.js"),
+			this.$staticConfig.PATH_TO_BOOTSTRAP,
+		];
+
+		if (this.$options.analyticsLogFile) {
+			brokerProcessArgs.push(this.$options.analyticsLogFile);
+		}
+
+		return brokerProcessArgs;
 	}
 
 	private async sendInfoForTracking(trackingInfo: ITrackingInformation, settingName: string): Promise<void> {


### PR DESCRIPTION
When analytics are enabled, `undefined` file is created at the location where a command is executed. This is because the `$options.analyticsLoggingFile` is undefined, but we've set it as args to the spawned Analytics process. The value in the child process is the string "undefined", so that's why CLI always creates this file.
Pass the path to file only when it is passed by user.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When analytics are enabled, CLI always produces file called `undefined`, in which it saves the information what has been tracked.

## What is the new behavior?
When analytics are enabled, CLI will produce file with name specified by user with `--analyticsLogFile <name>`, in which it saves the information what has been tracked.

Part of the implementation of: https://github.com/NativeScript/nativescript-cli/issues/4152
