### PR TITLE
fix: project properties are not tracked on every analytics hit

### DIFF
--- a/lib/common/test/unit-tests/analytics-service.ts
+++ b/lib/common/test/unit-tests/analytics-service.ts
@@ -96,6 +96,9 @@ function createTestInjector(testScenario: ITestScenario): IInjector {
 	testInjector.register("childProcess", {});
 	testInjector.register("projectDataService", {});
 	testInjector.register("mobileHelper", {});
+	testInjector.register("projectHelper", {
+		projectDir: ""
+	});
 
 	return testInjector;
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -519,8 +519,15 @@ export class ProjectDataService implements IProjectDataService {
 }
 
 export class ProjectHelperStub implements IProjectHelper {
-	get projectDir(): string {
-		return "";
+	constructor(public projectHelperErrorMsg?: string, public customProjectDir?: string) {
+	}
+
+	public get projectDir(): string {
+		if (this.projectHelperErrorMsg) {
+			throw new Error(this.projectHelperErrorMsg);
+		}
+
+		return this.customProjectDir || "";
 	}
 
 	generateDefaultAppId(appName: string, baseAppId: string): string {


### PR DESCRIPTION
Currently projectType and isShared properties are tracked only when we send events to Google Analytics and when the caller sends the projectDir to the method. In fact we need to track them(based on the projectDir) for every hit in Google Analytics.
To achieve this, use the projectHelper, which tries to determine the projectDir. Track the projectType on every page and event send to Google Analytics.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
When tracking pageviews in Google Analytics, the respective projectType is not tracked.
Also for some of the events, the projectType is not tracked.

## What is the new behavior?
ProjecType is tracked for every hit (when action is executed inside project dir or with `--path`)


