### PR TITLE
feat: expose isShared property from projectData

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -92,6 +92,11 @@ interface IProjectData extends ICreateProjectData {
 	gradleFilesDirectoryPath: string;
 	infoPlistPath: string;
 	buildXcconfigPath: string;
+	/**
+	 * Defines if the project is a code sharing one.
+	 * Value is true when project has nsconfig.json and it has `shared: true` in it.
+	 */
+	isShared: boolean;
 
 	/**
 	 * Initializes project data with the given project directory. If none supplied defaults to --path option or cwd.

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -59,6 +59,7 @@ export class ProjectData implements IProjectData {
 	public appGradlePath: string;
 	public gradleFilesDirectoryPath: string;
 	public buildXcconfigPath: string;
+	public isShared: boolean;
 
 	constructor(private $fs: IFileSystem,
 		private $errors: IErrors,
@@ -131,7 +132,7 @@ export class ProjectData implements IProjectData {
 			this.appGradlePath = path.join(this.gradleFilesDirectoryPath, constants.APP_GRADLE_FILE_NAME);
 			this.infoPlistPath = path.join(this.appResourcesDirectoryPath, this.$devicePlatformsConstants.iOS, constants.INFO_PLIST_FILE_NAME);
 			this.buildXcconfigPath = path.join(this.appResourcesDirectoryPath, this.$devicePlatformsConstants.iOS, constants.BUILD_XCCONFIG_FILE_NAME);
-
+			this.isShared = !!(this.nsConfig && this.nsConfig.shared);
 			return;
 		}
 
@@ -202,7 +203,7 @@ export class ProjectData implements IProjectData {
 	}
 
 	public getNsConfigRelativePath(): string {
-		return  constants.CONFIG_NS_FILE_NAME;
+		return constants.CONFIG_NS_FILE_NAME;
 	}
 
 	private resolveToProjectDir(pathToResolve: string, projectDir?: string): string {

--- a/lib/services/analytics/analytics-service.ts
+++ b/lib/services/analytics/analytics-service.ts
@@ -146,8 +146,7 @@ export class AnalyticsService implements IAnalyticsService, IDisposable {
 		if (projectDir) {
 			const projectData = this.$projectDataService.getProjectData(projectDir);
 			customDimensions[GoogleAnalyticsCustomDimensions.projectType] = projectData.projectType;
-			const isShared = !!(projectData.nsConfig && projectData.nsConfig.shared);
-			customDimensions[GoogleAnalyticsCustomDimensions.isShared] = isShared.toString();
+			customDimensions[GoogleAnalyticsCustomDimensions.isShared] = projectData.isShared.toString();
 		}
 
 		return customDimensions;

--- a/test/services/analytics/analytics-service.ts
+++ b/test/services/analytics/analytics-service.ts
@@ -42,7 +42,8 @@ const createTestInjector = (opts?: { projectHelperErrorMsg?: string, projectDir?
 	testInjector.register("projectDataService", {
 		getProjectData: (projectDir?: string): IProjectData => {
 			return <any>{
-				projectType: sampleProjectType
+				projectType: sampleProjectType,
+				isShared: false
 			};
 		}
 	});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -323,6 +323,7 @@ export class ProjectDataStub implements IProjectData {
 	public appGradlePath: string;
 	public gradleFilesDirectoryPath: string;
 	public buildXcconfigPath: string;
+	public isShared: boolean;
 
 	public initializeProjectData(projectDir?: string): void {
 		this.projectDir = this.projectDir || projectDir;


### PR DESCRIPTION
Expose `isShared` property from projectData, so it will be possible to check if a project is code-sharing when using CLI as a library.
Use the new property in the Analytics service as well. Add tests.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

Related to issue: https://github.com/NativeScript/nativescript-cli/issues/4200.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

