### PR TITLE
removing @next from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ NativeScript Command-Line Interface
 Master Branch [![Build Status](https://travis-ci.org/NativeScript/nativescript-cli.svg?branch=build)][2].
 [![Waffle.io - NativeScript CLI](https://badge.waffle.io/NativeScript/nativescript-cli.svg?columns=In%20Progress)](https://waffle.io/NativeScript/nativescript-cli)
 
-Get it using: `npm install nativescript@next -g`
+Get it using: `npm install -g nativescript`
 
 The NativeScript CLI lets you create, build, and deploy [NativeScript][7]-based projects on iOS and Android devices.
 


### PR DESCRIPTION
We probably shouldn't have @next in the installation command for the CLI