### PR TITLE
fix: build correctly for iOS when IPHONEOS_DEPLOYMENT_TARGET = 11.0; is specified in build.xcconfig

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -88,7 +88,6 @@ interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
 	 * @param {Mobile.IDevice} device The device where the application should be installed.
 	 * @param {IProjectData} projectData DTO with information about the project.
 	 * @param {string} @optional outputPath Directory containing build information and artifacts.
-	 * @returns {Promise<boolean>} true indicates that the application should be installed.
 	 */
 	validateInstall(device: Mobile.IDevice, projectData: IProjectData, release: IRelease, outputPath?: string): Promise<void>;
 

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -84,6 +84,15 @@ interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
 	shouldInstall(device: Mobile.IDevice, projectData: IProjectData, release: IRelease, outputPath?: string): Promise<boolean>;
 
 	/**
+	 * 
+	 * @param {Mobile.IDevice} device The device where the application should be installed.
+	 * @param {IProjectData} projectData DTO with information about the project.
+	 * @param {string} @optional outputPath Directory containing build information and artifacts.
+	 * @returns {Promise<boolean>} true indicates that the application should be installed.
+	 */
+	validateInstall(device: Mobile.IDevice, projectData: IProjectData, release: IRelease, outputPath?: string): Promise<void>;
+
+	/**
 	 * Determines whether the project should undergo the prepare process.
 	 * @param {IShouldPrepareInfo} shouldPrepareInfo Options needed to decide whether to prepare.
 	 * @returns {Promise<boolean>} true indicates that the project should be prepared.
@@ -307,6 +316,13 @@ interface INodeModulesDependenciesBuilder {
 interface IBuildInfo {
 	prepareTime: string;
 	buildTime: string;
+	/** 
+	 * Currently it is used only for iOS.
+	 * As `xcrun` command does not throw an error when IPHONEOS_DEPLOYMENT_TARGET is provided in `xcconfig` file and
+	 * the simulator's version does not match IPHONEOS_DEPLOYMENT_TARGET's value, we need to save it to buildInfo file
+	 * in order check it on livesync and throw an error to the user.
+	*/
+	deploymentTarget?: string;
 }
 
 interface IPlatformDataComposition {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -449,22 +449,7 @@ interface IPlatformProjectService extends NodeJS.EventEmitter, IPlatformProjectS
 	 * Get the deployment target's version
 	 * Currently implemented only for iOS -> returns the value of IPHONEOS_DEPLOYMENT_TARGET property from xcconfig file
 	 */
-	getDeploymentTarget(projectData: IProjectData): IDeploymentTargetData;
-}
-
-interface IDeploymentTargetData {
-	/**
-	 * The whole version's value
-	 */
-	version: string;
-	/**
-	 * The major's version
-	 */
-	majorVersion: number;
-	/**
-	 * The minor's version
-	 */
-	minorVersion: number;
+	getDeploymentTarget(projectData: IProjectData): any;
 }
 
 interface IValidatePlatformOutput {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -444,6 +444,27 @@ interface IPlatformProjectService extends NodeJS.EventEmitter, IPlatformProjectS
 	 * Traverse through the production dependencies and find plugins that need build/rebuild
 	 */
 	checkIfPluginsNeedBuild(projectData: IProjectData): Promise<Array<any>>;
+	
+	/**
+	 * Get the deployment target's version
+	 * Currently implemented only for iOS -> returns the value of IPHONEOS_DEPLOYMENT_TARGET property from xcconfig file
+	 */
+	getDeploymentTarget(projectData: IProjectData): IDeploymentTargetData;
+}
+
+interface IDeploymentTargetData {
+	/**
+	 * The whole version's value
+	 */
+	version: string;
+	/**
+	 * The major's version
+	 */
+	majorVersion: number;
+	/**
+	 * The minor's version
+	 */
+	minorVersion: number;
 }
 
 interface IValidatePlatformOutput {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -665,7 +665,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		// Nothing android specific to check yet.
 	}
 
-	public getDeploymentTarget(projectData: IProjectData): IDeploymentTargetData { return; }
+	public getDeploymentTarget(projectData: IProjectData): semver.SemVer { return; }
 
 	private copy(projectRoot: string, frameworkDir: string, files: string, cpArg: string): void {
 		const paths = files.split(' ').map(p => path.join(frameworkDir, p));

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -665,6 +665,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		// Nothing android specific to check yet.
 	}
 
+	public getDeploymentTarget(projectData: IProjectData): IDeploymentTargetData { return; }
+
 	private copy(projectRoot: string, frameworkDir: string, files: string, cpArg: string): void {
 		const paths = files.split(' ').map(p => path.join(frameworkDir, p));
 		shell.cp(cpArg, paths, projectRoot);

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -454,7 +454,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		const frameworkVersion = this.getFrameworkVersion(projectData);
 		if (semver.valid(frameworkVersion) && semver.validRange(frameworkVersion) && semver.lt(semver.coerce(frameworkVersion), "5.1.0")) {
 			const target = this.getDeploymentTarget(projectData);
-			if (target && target.majorVersion >= 11) {
+			if (target && target.major >= 11) {
 				// We need to strip 32bit architectures as of deployment target >= 11 it is not allowed to have such
 				architectures = _.filter(architectures, arch => {
 					const is64BitArchitecture = arch === "x86_64" || arch === "arm64";
@@ -1045,18 +1045,13 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 		return [];
 	}
 
-	public getDeploymentTarget(projectData: IProjectData): IDeploymentTargetData {
+	public getDeploymentTarget(projectData: IProjectData): semver.SemVer {
 		const target = this.$xCConfigService.readPropertyValue(this.getBuildXCConfigFilePath(projectData), "IPHONEOS_DEPLOYMENT_TARGET");
 		if (!target) {
 			return null;
 		}
 
-		const parts = target.split(".");
-		return {
-			version: target,
-			majorVersion: parseInt(parts[0]),
-			minorVersion: parseInt(parts[1])
-		};
+		return semver.coerce(target);
 	}
 
 	private getAllLibsForPluginWithFileExtension(pluginData: IPluginData, fileExtension: string): string[] {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -384,12 +384,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	private async buildForDevice(projectRoot: string, args: string[], buildConfig: IBuildConfig, projectData: IProjectData): Promise<void> {
-		const defaultArchitectures = [
-			'ARCHS=armv7 arm64',
-			'VALID_ARCHS=armv7 arm64'
-		];
-
-		// build only for device specific architecture
 		if (!buildConfig.release && !buildConfig.architectures) {
 			await this.$devicesService.initialize({
 				platform: this.$devicePlatformsConstants.iOS.toLowerCase(), deviceId: buildConfig.device,
@@ -402,10 +396,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				.uniq()
 				.value();
 			if (devicesArchitectures.length > 0) {
-				const architectures = [
-					`ARCHS=${devicesArchitectures.join(" ")}`,
-					`VALID_ARCHS=${devicesArchitectures.join(" ")}`
-				];
+				const architectures = this.getBuildArchitectures(projectData, buildConfig, devicesArchitectures);
 				if (devicesArchitectures.length > 1) {
 					architectures.push('ONLY_ACTIVE_ARCH=NO');
 				}
@@ -413,7 +404,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			}
 		}
 
-		args = args.concat((buildConfig && buildConfig.architectures) || defaultArchitectures);
+		args = args.concat((buildConfig && buildConfig.architectures) || this.getBuildArchitectures(projectData, buildConfig, ["armv7", "arm64"]));
 
 		args = args.concat([
 			"-sdk", "iphoneos",
@@ -455,6 +446,28 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		}
 
 		return commandResult;
+	}
+
+	private getBuildArchitectures(projectData: IProjectData, buildConfig: IBuildConfig, architectures: string[]): string[] {
+		let result: string[] = [];
+
+		const frameworkVersion = this.getFrameworkVersion(projectData);
+		if (semver.valid(frameworkVersion) && semver.validRange(frameworkVersion) && semver.lt(semver.coerce(frameworkVersion), "5.1.0")) {
+			const target = this.getDeploymentTarget(projectData);
+			if (target && target.majorVersion >= 11) {
+				// We need to strip 32bit architectures as of deployment target >= 11 it is not allowed to have such
+				architectures = _.filter(architectures, arch => {
+					const is64BitArchitecture = arch === "x86_64" || arch === "arm64";
+					if (!is64BitArchitecture) {
+						this.$logger.warn(`The architecture ${arch} will be stripped as it is not supported for deployment target ${target.version}.`);
+					}
+					return is64BitArchitecture;
+				});
+			}
+			result = [`ARCHS=${architectures.join(" ")}`, `VALID_ARCHS=${architectures.join(" ")}`];
+		}
+
+		return result;
 	}
 
 	private async setupSigningFromTeam(projectRoot: string, projectData: IProjectData, teamId: string) {
@@ -555,13 +568,14 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	private async buildForSimulator(projectRoot: string, args: string[], projectData: IProjectData, buildConfig?: IBuildConfig): Promise<void> {
+		const architectures = this.getBuildArchitectures(projectData, buildConfig, ["i386", "x86_64"]);
+
 		args = args
+			.concat(architectures)
 			.concat([
 				"build",
 				"-configuration", buildConfig.release ? "Release" : "Debug",
 				"-sdk", "iphonesimulator",
-				"ARCHS=i386 x86_64",
-				"VALID_ARCHS=i386 x86_64",
 				"ONLY_ACTIVE_ARCH=NO",
 				"CONFIGURATION_BUILD_DIR=" + path.join(projectRoot, "build", "emulator"),
 				"CODE_SIGN_IDENTITY=",
@@ -1029,6 +1043,20 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 
 	public async checkIfPluginsNeedBuild(projectData: IProjectData): Promise<Array<any>> {
 		return [];
+	}
+
+	public getDeploymentTarget(projectData: IProjectData): IDeploymentTargetData {
+		const target = this.$xCConfigService.readPropertyValue(this.getBuildXCConfigFilePath(projectData), "IPHONEOS_DEPLOYMENT_TARGET");
+		if (!target) {
+			return null;
+		}
+
+		const parts = target.split(".");
+		return {
+			version: target,
+			majorVersion: parseInt(parts[0]),
+			minorVersion: parseInt(parts[1])
+		};
 	}
 
 	private getAllLibsForPluginWithFileExtension(pluginData: IPluginData, fileExtension: string): string[] {

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -463,6 +463,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 			});
 		}
 
+		await this.$platformService.validateInstall(options.device, options.projectData, options, options.deviceBuildInfoDescriptor.outputPath);
 		const shouldInstall = await this.$platformService.shouldInstall(options.device, options.projectData, options, options.deviceBuildInfoDescriptor.outputPath);
 		if (shouldInstall) {
 			await this.$platformService.installApplication(options.device, { release: false }, options.projectData, pathToBuildItem, options.deviceBuildInfoDescriptor.outputPath);

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -1055,3 +1055,128 @@ describe("Merge Project XCConfig files", () => {
 		}
 	});
 });
+
+describe("buildProject", () => {
+	let xcodeBuildCommandArgs: string[] = [];
+
+	function setup(data: { frameworkVersion: string, deploymentTarget: string, devices?: Mobile.IDevice[] }): IInjector {
+		const projectPath = "myTestProjectPath";
+		const projectName = "myTestProjectName";
+		const testInjector = createTestInjector(projectPath, projectName);
+
+		const childProcess = testInjector.resolve("childProcess");
+		childProcess.spawnFromEvent = (command: string, args: string[]) => {
+			if (command === "xcodebuild" && args[0] !== "-exportArchive") {
+				xcodeBuildCommandArgs = args;
+			}
+		};
+
+		const projectDataService = testInjector.resolve("projectDataService");
+		projectDataService.getNSValue = (projectDir: string, propertyName: string) => {
+			if (propertyName === "tns-ios") {
+				return {
+					name: "tns-ios",
+					version: data.frameworkVersion
+				};
+			}
+		};
+
+		const projectData = testInjector.resolve("projectData");
+		projectData.appResourcesDirectoryPath = path.join(projectPath, "app", "App_Resources");
+
+		const devicesService = testInjector.resolve("devicesService");
+		devicesService.initialize = () => ({});
+		devicesService.getDeviceInstances = () => data.devices || [];
+
+		const xCConfigService = testInjector.resolve("xCConfigService");
+		xCConfigService.readPropertyValue = (projectDir: string, propertyName: string) => {
+			if (propertyName === "IPHONEOS_DEPLOYMENT_TARGET") {
+				return data.deploymentTarget;
+			}
+		};
+
+		const pbxprojDomXcode = testInjector.resolve("pbxprojDomXcode");
+		pbxprojDomXcode.Xcode = {
+			open: () => ({
+				getSigning: () => ({}),
+				setAutomaticSigningStyle: () => ({}),
+				save: () => ({})
+			})
+		};
+
+		const iOSProvisionService = testInjector.resolve("iOSProvisionService");
+		iOSProvisionService.getDevelopmentTeams = () => ({});
+		iOSProvisionService.getTeamIdsWithName = () => ({});
+
+		return testInjector;
+	}
+
+	function executeTests(testCases: any[], data: { buildForDevice: boolean }) {
+		_.each(testCases, testCase => {
+			it(`${testCase.name}`, async () => {
+				const testInjector = setup({ frameworkVersion: testCase.frameworkVersion, deploymentTarget: testCase.deploymentTarget });
+				const projectData: IProjectData = testInjector.resolve("projectData");
+
+				const iOSProjectService = <IOSProjectService>testInjector.resolve("iOSProjectService");
+				(<any>iOSProjectService).getExportOptionsMethod = () => ({});
+				await iOSProjectService.buildProject("myProjectRoot", projectData, <any>{ buildForDevice: data.buildForDevice });
+
+				const archsItem = xcodeBuildCommandArgs.find(item => item.startsWith("ARCHS="));
+				if (testCase.expectedArchs) {
+					const archsValue = archsItem.split("=")[1];
+					assert.deepEqual(archsValue, testCase.expectedArchs);
+				} else {
+					assert.deepEqual(undefined, archsItem);
+				}
+			});
+		});
+	}
+
+	describe("for device", () => {
+		afterEach(() => {
+			xcodeBuildCommandArgs = [];
+		});
+
+		const testCases = <any[]>[{
+			name: "shouldn't exclude armv7 architecture when deployment target 10",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: "10.0",
+			expectedArchs: "armv7 arm64"
+		}, {
+			name: "should exclude armv7 architecture when deployment target is 11",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: "11.0",
+			expectedArchs: "arm64"
+		}, {
+			name: "shouldn't pass architecture to xcodebuild command when frameworkVersion is 5.1.0",
+			frameworkVersion: "5.1.0",
+			deploymentTarget: "11.0"
+		}];
+
+		executeTests(testCases, { buildForDevice: true });
+	});
+
+	describe("for simulator", () => {
+		afterEach(() => {
+			xcodeBuildCommandArgs = [];
+		});
+
+		const testCases = [{
+			name: "shouldn't exclude i386 architecture when deployment target is 10",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: "10.0",
+			expectedArchs: "i386 x86_64"
+		}, {
+			name: "should exclude i386 architecture when deployment target is 11",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: "11.0",
+			expectedArchs: "x86_64"
+		}, {
+			name: "shouldn't pass architecture to xcodebuild command when frameworkVersion is 5.1.0",
+			frameworkVersion: "5.1.0",
+			deploymentTarget: "11.0"
+		}];
+
+		executeTests(testCases, { buildForDevice: false });
+	});
+});

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -1151,6 +1151,21 @@ describe("buildProject", () => {
 			name: "shouldn't pass architecture to xcodebuild command when frameworkVersion is 5.1.0",
 			frameworkVersion: "5.1.0",
 			deploymentTarget: "11.0"
+		}, {
+			name: "should pass only 64bit architecture to xcodebuild command when frameworkVersion is 5.0.0 and deployment target is 11.0",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: "11.0",
+			expectedArchs: "arm64"
+		}, {
+			name: "should pass both architectures to xcodebuild command when frameworkVersion is 5.0.0 and deployment target is 10.0",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: "10.0",
+			expectedArchs: "armv7 arm64"
+		}, {
+			name: "should pass both architectures to xcodebuild command when frameworkVersion is 5.0.0 and no deployment target",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: null,
+			expectedArchs: "armv7 arm64"
 		}];
 
 		executeTests(testCases, { buildForDevice: true });
@@ -1175,6 +1190,21 @@ describe("buildProject", () => {
 			name: "shouldn't pass architecture to xcodebuild command when frameworkVersion is 5.1.0",
 			frameworkVersion: "5.1.0",
 			deploymentTarget: "11.0"
+		}, {
+			name: "should pass only 64bit architecture to xcodebuild command when frameworkVersion is 5.0.0 and deployment target is 11.0",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: "11.0",
+			expectedArchs: "x86_64"
+		}, {
+			name: "should pass both architectures to xcodebuild command when frameworkVersion is 5.0.0 and deployment target is 10.0",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: "10.0",
+			expectedArchs: "i386 x86_64"
+		}, {
+			name: "should pass both architectures to xcodebuild command when frameworkVersion is 5.0.0 and no deployment target",
+			frameworkVersion: "5.0.0",
+			deploymentTarget: null,
+			expectedArchs: "i386 x86_64"
 		}];
 
 		executeTests(testCases, { buildForDevice: false });

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -467,6 +467,9 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	getPluginPlatformsFolderPath(pluginData: IPluginData, platform: string): string {
 		return "";
 	}
+	getDeploymentTarget(projectData: IProjectData): IDeploymentTargetData {
+		return;
+	}
 }
 
 export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
@@ -826,6 +829,10 @@ export class PlatformServiceStub extends EventEmitter implements IPlatformServic
 
 	public async shouldInstall(device: Mobile.IDevice): Promise<boolean> {
 		return true;
+	}
+
+	public async validateInstall(device: Mobile.IDevice): Promise<void> {
+		return;
 	}
 
 	public installApplication(device: Mobile.IDevice, options: IRelease): Promise<void> {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -467,7 +467,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	getPluginPlatformsFolderPath(pluginData: IPluginData, platform: string): string {
 		return "";
 	}
-	getDeploymentTarget(projectData: IProjectData): IDeploymentTargetData {
+	getDeploymentTarget(projectData: IProjectData): any {
 		return;
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
iOS build fails when `IPHONEOS_DEPLOYMENT_TARGET = 11.0;` is specified in `build.xcconfig`

## What is the new behavior?
iOS build doesn't fail when `IPHONEOS_DEPLOYMENT_TARGET = 11.0;` is specified in `build.xcconfig`

Rel to: https://github.com/NativeScript/nativescript-cli/issues/4197
