### PR TITLE
fix: fix "MaxEventListeners detected" error when livesync is started more than 11 times from sidekick

### DIFF
--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -56,9 +56,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	}
 
 	public async liveSyncToPreviewApp(data: IPreviewAppLiveSyncData): Promise<IQrCodeImageData> {
-		this.$previewAppLiveSyncService.on(LiveSyncEvents.previewAppLiveSyncError, liveSyncData => {
-			this.emit(LiveSyncEvents.previewAppLiveSyncError, liveSyncData);
-		});
+		this.attachToPreviewAppLiveSyncError();
 
 		await this.liveSync([], {
 			syncToPreviewApp: true,
@@ -137,6 +135,13 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		const liveSyncProcessesInfo = this.liveSyncProcessesInfo[projectDir] || <ILiveSyncProcessInfo>{};
 		const currentDescriptors = liveSyncProcessesInfo.deviceDescriptors;
 		return currentDescriptors || [];
+	}
+
+	@cache()
+	private attachToPreviewAppLiveSyncError(): void {
+		this.$previewAppLiveSyncService.on(LiveSyncEvents.previewAppLiveSyncError, liveSyncData => {
+			this.emit(LiveSyncEvents.previewAppLiveSyncError, liveSyncData);
+		});
 	}
 
 	private handleWarnings(liveSyncData: ILiveSyncInfo, projectData: IProjectData) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5250,9 +5250,9 @@
       }
     },
     "nativescript-preview-sdk": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/nativescript-preview-sdk/-/nativescript-preview-sdk-0.3.1.tgz",
-      "integrity": "sha512-8xKl150/LJk2YvmbDgCKJHOd1pFwYf/2s5PtXXF/D0fw6DpwGgFNBe26IaTHNiZJ2U0w9n4o2L9YSrHRk7kjqQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/nativescript-preview-sdk/-/nativescript-preview-sdk-0.3.2.tgz",
+      "integrity": "sha512-ydFlM7PgLT5sboiTOmoA0+ttPUys6FJpjG5CMgnSMTVyJ9AjQYMqi4qUT7mdO3xlZOPAyYdKH3AbpUI312qklQ==",
       "requires": {
         "@types/axios": "0.14.0",
         "@types/pubnub": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
     "nativescript-doctor": "1.8.1",
-    "nativescript-preview-sdk": "0.3.1",
+    "nativescript-preview-sdk": "0.3.2",
     "open": "0.0.5",
     "ora": "2.0.0",
     "osenv": "0.1.3",


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
An error is thrown from sidekick when livesync to preview app is started more than 11 times

## What is the new behavior?
No error is thrown from sidekick when livesync to preview app is started more than 11 times
