### PR TITLE
fix: vscode debug is not working for iOS

### DIFF
--- a/lib/device-sockets/ios/app-debug-socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/app-debug-socket-proxy-factory.ts
@@ -152,6 +152,8 @@ export class AppDebugSocketProxyFactory extends EventEmitter implements IAppDebu
 			appDebugSocket.on("close", () => {
 				this.$logger.info("Backend socket closed!");
 				webSocket.close();
+				server.close();
+				delete this.deviceWebServers[cacheKey];
 			});
 
 			webSocket.on("close", () => {


### PR DESCRIPTION
VSCode debugging is not working on iOS when a change in .js is applied. The problem is that the server is reused for the new connections, but VSCode waits for message 'Opened localhost...' which is printed from CLI only when creating the new server.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
