### PR TITLE
fix: debugging in VSCode is not working on iOS Simulator

### DIFF
--- a/lib/common/mobile/ios/device/ios-application-manager.ts
+++ b/lib/common/mobile/ios/device/ios-application-manager.ts
@@ -8,7 +8,7 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 
 	constructor(protected $logger: ILogger,
 		protected $hooksService: IHooksService,
-		private device: Mobile.IDevice,
+		private device: Mobile.IiOSDevice,
 		private $errors: IErrors,
 		private $iOSNotificationService: IiOSNotificationService,
 		private $iosDeviceOperations: IIOSDeviceOperations,
@@ -87,6 +87,9 @@ export class IOSApplicationManager extends ApplicationManagerBase {
 
 	public async stopApplication(appData: Mobile.IApplicationData): Promise<void> {
 		const { appId } = appData;
+
+		this.device.destroyDebugSocket(appId);
+		this.device.destroyLiveSyncSocket(appId);
 
 		const action = () => this.$iosDeviceOperations.stop([{ deviceId: this.device.deviceInfo.identifier, ddi: this.$options.ddi, appId }]);
 

--- a/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -47,7 +47,12 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	}
 
 	public async stopApplication(appData: Mobile.IApplicationData): Promise<void> {
-		return this.iosSim.stopApplication(this.device.deviceInfo.identifier, appData.appId, appData.projectName);
+		const { appId } = appData;
+
+		this.device.destroyDebugSocket(appId);
+		this.device.destroyLiveSyncSocket(appId);
+
+		await this.iosSim.stopApplication(this.device.deviceInfo.identifier, appData.appId, appData.projectName);
 	}
 
 	public async getApplicationInfo(applicationIdentifier: string): Promise<Mobile.IApplicationInfo> {


### PR DESCRIPTION
When you've stopped on breakpoint in VSCode and apply a change in the code, CLI tries to restart application. However, at this point the command for killing the application may not kill it immediately and it needs 30 seconds. The problem is that the runtime loops indefinitely while on breakpoint. After some seconds (looks like 30), the OS kills the application. In order to resolve the issue, disconnect all sockets before stopping the application, so the runtime can successfully break the indefinite loop and after that application can be safely killed.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

