### PR TITLE
fix: `tns debug ios --hmr` does not refresh DevTools

### DIFF
--- a/lib/services/android-device-debug-service.ts
+++ b/lib/services/android-device-debug-service.ts
@@ -59,14 +59,6 @@ export class AndroidDeviceDebugService extends DebugServiceBase implements IDevi
 		return this.removePortForwarding();
 	}
 
-	protected getChromeDebugUrl(debugOptions: IDebugOptions, port: number): string {
-		const debugOpts = _.cloneDeep(debugOptions);
-		debugOpts.useBundledDevTools = debugOpts.useBundledDevTools === undefined ? true : debugOpts.useBundledDevTools;
-
-		const chromeDebugUrl = super.getChromeDebugUrl(debugOpts, port);
-		return chromeDebugUrl;
-	}
-
 	private async debugOnEmulator(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
 		// Assure we've detected the emulator as device
 		// For example in case deployOnEmulator had stated new emulator instance

--- a/lib/services/debug-service-base.ts
+++ b/lib/services/debug-service-base.ts
@@ -34,12 +34,16 @@ export abstract class DebugServiceBase extends EventEmitter implements IDeviceDe
 
 	protected getChromeDebugUrl(debugOptions: IDebugOptions, port: number): string {
 		// corresponds to 55.0.2883 Chrome version
+		// SHA is taken from https://chromium.googlesource.com/chromium/src/+/55.0.2883.100
+		// This SHA is old and does not support debugging with HMR.
+		// In case we want to stick with concrete SHA, get it from one of the tags https://chromium.googlesource.com/chromium/src/
+		// IMPORTANT: When you get the SHA, ensure you are using the `parent` commit, not the actual one.
+		// Using the actual commit will result in 404 error in the remote serve.
 		const commitSHA = debugOptions.devToolsCommit || "02e6bde1bbe34e43b309d4ef774b1168d25fd024";
-		debugOptions.useHttpUrl = debugOptions.useHttpUrl === undefined ? false : debugOptions.useHttpUrl;
 
 		let chromeDevToolsPrefix = `chrome-devtools://devtools/remote/serve_file/@${commitSHA}`;
 
-		if (debugOptions.useBundledDevTools) {
+		if (debugOptions.useBundledDevTools === undefined || debugOptions.useBundledDevTools) {
 			chromeDevToolsPrefix = "chrome-devtools://devtools/bundled";
 		}
 

--- a/lib/services/ios-device-debug-service.ts
+++ b/lib/services/ios-device-debug-service.ts
@@ -61,14 +61,6 @@ export class IOSDeviceDebugService extends DebugServiceBase implements IDeviceDe
 		await this.stopAppDebuggerOnSimulator();
 	}
 
-	protected getChromeDebugUrl(debugOptions: IDebugOptions, port: number): string {
-		const debugOpts = _.cloneDeep(debugOptions);
-		debugOpts.useBundledDevTools = debugOpts.useBundledDevTools === undefined ? false : debugOpts.useBundledDevTools;
-
-		const chromeDebugUrl = super.getChromeDebugUrl(debugOpts, port);
-		return chromeDebugUrl;
-	}
-
 	private async startApp(debugData: IDebugData, debugOptions: IDebugOptions) {
 		if (this.device.isEmulator) {
 			await this.startAppOnSimulator(debugData, debugOptions);

--- a/test/services/ios-device-debug-service.ts
+++ b/test/services/ios-device-debug-service.ts
@@ -78,7 +78,7 @@ describe("iOSDeviceDebugService", () => {
 			{
 				scenarioName: "useBundledDevTools and useHttpUrl are not passed",
 				debugOptions: {},
-				expectedChromeUrl: `chrome-devtools://devtools/remote/serve_file/@${expectedDevToolsCommitSha}/inspector.html?experiments=true&ws=localhost:${expectedPort}`,
+				expectedChromeUrl: `chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:${expectedPort}`,
 			},
 
 			// When useBundledDevTools is true
@@ -137,7 +137,7 @@ describe("iOSDeviceDebugService", () => {
 				debugOptions: {
 					useHttpUrl: false
 				},
-				expectedChromeUrl: `chrome-devtools://devtools/remote/serve_file/@${expectedDevToolsCommitSha}/inspector.html?experiments=true&ws=localhost:${expectedPort}`,
+				expectedChromeUrl: `chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:${expectedPort}`,
 			},
 			{
 				scenarioName: "useBundledDevTools is not passed and useHttpUrl is true",
@@ -149,16 +149,18 @@ describe("iOSDeviceDebugService", () => {
 
 			// devToolsCommit tests
 			{
-				scenarioName: "devToolsCommit defaults to ${expectedDevToolsCommitSha} and is used in result when useBundledDevTools is not passed",
-				debugOptions: {},
+				scenarioName: `devToolsCommit defaults to ${expectedDevToolsCommitSha} and is used in result when useBundledDevTools is not passed`,
+				debugOptions: {
+					useBundledDevTools: false
+				},
 				expectedChromeUrl: `chrome-devtools://devtools/remote/serve_file/@${expectedDevToolsCommitSha}/inspector.html?experiments=true&ws=localhost:${expectedPort}`,
 			},
 			{
-				scenarioName: "devToolsCommit is set to passed value when useBundledDevTools is not passed",
+				scenarioName: "devToolsCommit is disregarded when useBundledDevTools is not passed",
 				debugOptions: {
 					devToolsCommit: customDevToolsCommit
 				},
-				expectedChromeUrl: `chrome-devtools://devtools/remote/serve_file/@${customDevToolsCommit}/inspector.html?experiments=true&ws=localhost:${expectedPort}`,
+				expectedChromeUrl: `chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:${expectedPort}`,
 			},
 			{
 				scenarioName: "devToolsCommit is set to passed value when useBundledDevTools is set to false",


### PR DESCRIPTION
Using `tns debug ios --hmr` leads to incorrect behavior as the application and debug session are not restarted, but the new code is not visible in Chrome DevTools. The problem is that we are not using the latest DevTools, but the one used in Chrome 55. Switching to Bundled tools (included in user's Chrome version) fixes the behavior. In the past we were stuck with the Chrome 55 due to concerns that new Chrome versions may break the behavior.

To fix the issue, remove the getChromeDebugUrl from AndroidDeviceDebugService and IosDeviceDebugService, as they are now sharing the same logic, so all of it is in the base class.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Changes in code during `tns debug ios --hmr` are not visible in Chrome DevTools.

## What is the new behavior?
Changes in code during `tns debug ios --hmr` are visible in Chrome DevTools and you can continue debugging.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4230