### PR TITLE
fix: issues when yarn is set as package manager

### DIFF
--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -13,8 +13,8 @@ export class UpdateCommand extends ValidatePlatformCommandBase implements IComma
 		private $projectDataService: IProjectDataService,
 		private $fs: IFileSystem,
 		private $logger: ILogger) {
-			super($options, $platformsData, $platformService, $projectData);
-			this.$projectData.initializeProjectData();
+		super($options, $platformsData, $platformService, $projectData);
+		this.$projectData.initializeProjectData();
 	}
 
 	static readonly folders: string[] = [
@@ -83,8 +83,10 @@ export class UpdateCommand extends ValidatePlatformCommandBase implements IComma
 		}
 
 		await this.$platformService.removePlatforms(platforms.installed, this.$projectData);
-		await this.$pluginsService.remove("tns-core-modules", this.$projectData);
-		await this.$pluginsService.remove("tns-core-modules-widgets", this.$projectData);
+		await this.$pluginsService.remove(constants.TNS_CORE_MODULES_NAME, this.$projectData);
+		if (!!this.$projectData.dependencies[constants.TNS_CORE_MODULES_WIDGETS_NAME]) {
+			await this.$pluginsService.remove(constants.TNS_CORE_MODULES_WIDGETS_NAME, this.$projectData);
+		}
 
 		for (const folder of UpdateCommand.folders) {
 			this.$fs.deleteDirectory(path.join(this.$projectData.projectDir, folder));
@@ -95,16 +97,16 @@ export class UpdateCommand extends ValidatePlatformCommandBase implements IComma
 				await this.$platformService.addPlatforms([platform + "@" + args[0]], this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
 			}
 
-			await this.$pluginsService.add("tns-core-modules@" + args[0], this.$projectData);
+			await this.$pluginsService.add(`${constants.TNS_CORE_MODULES_NAME}@${args[0]}`, this.$projectData);
 		} else {
 			await this.$platformService.addPlatforms(platforms.packagePlatforms, this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
-			await this.$pluginsService.add("tns-core-modules", this.$projectData);
+			await this.$pluginsService.add(constants.TNS_CORE_MODULES_NAME, this.$projectData);
 		}
 
 		await this.$pluginsService.ensureAllDependenciesAreInstalled(this.$projectData);
 	}
 
-	private getPlatforms(): {installed: string[], packagePlatforms: string[]} {
+	private getPlatforms(): { installed: string[], packagePlatforms: string[] } {
 		const installedPlatforms = this.$platformService.getInstalledPlatforms(this.$projectData);
 		const availablePlatforms = this.$platformService.getAvailablePlatforms(this.$projectData);
 		const packagePlatforms: string[] = [];

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -7,6 +7,7 @@ export const NATIVESCRIPT_KEY_NAME = "nativescript";
 export const NODE_MODULES_FOLDER_NAME = "node_modules";
 export const TNS_MODULES_FOLDER_NAME = "tns_modules";
 export const TNS_CORE_MODULES_NAME = "tns-core-modules";
+export const TNS_CORE_MODULES_WIDGETS_NAME = "tns-core-modules-widgets";
 export const TNS_ANDROID_RUNTIME_NAME = "tns-android";
 export const TNS_IOS_RUNTIME_NAME = "tns-ios";
 export const PACKAGE_JSON_FILE_NAME = "package.json";

--- a/lib/yarn-package-manager.ts
+++ b/lib/yarn-package-manager.ts
@@ -96,7 +96,7 @@ export class YarnPackageManager extends BasePackageManager {
 	@exported("yarn")
 	public async getCachePath(): Promise<string> {
 		const result = await this.$childProcess.exec(`yarn cache dir`);
-		return result;
+		return result.toString().trim();
 	}
 }
 

--- a/test/update.ts
+++ b/test/update.ts
@@ -37,7 +37,11 @@ function createTestInjector(
 	testInjector.register("staticConfig", StaticConfig);
 	testInjector.register("androidProjectService", AndroidProjectService);
 	testInjector.register("androidToolsInfo", stubs.AndroidToolsInfoStub);
-	testInjector.register("projectData", { projectDir, initializeProjectData: () => { /* empty */ } });
+	testInjector.register("projectData", {
+		projectDir,
+		initializeProjectData: () => { /* empty */ },
+		dependencies: {}
+	});
 	testInjector.register("projectDataService", {
 		getNSValue: () => {
 			return "1.0.0";
@@ -134,7 +138,7 @@ describe("update command method tests", () => {
 			sandbox.restore();
 		});
 
-		it("if backup fails, pltforms not deleted and added, temp removed", async () => {
+		it("if backup fails, platforms not deleted and added, temp removed", async () => {
 			const installedPlatforms: string[] = ["android"];
 			const testInjector = createTestInjector(installedPlatforms);
 			const fs = testInjector.resolve("fs");
@@ -229,6 +233,12 @@ describe("update command method tests", () => {
 			sandbox.spy(pluginsService, "remove");
 			sandbox.spy(pluginsService, "add");
 			sandbox.spy(pluginsService, "ensureAllDependenciesAreInstalled");
+			const $projectData = testInjector.resolve("projectData");
+			$projectData.dependencies = {
+				"tns-core-modules": "1.0.0",
+				"tns-core-modules-widgets": "1.0.0"
+			};
+
 			const updateCommand = testInjector.resolve<UpdateCommand>(UpdateCommand);
 			return updateCommand.execute([]).then(() => {
 				assert(pluginsService.add.calledWith("tns-core-modules"));


### PR DESCRIPTION
### fix: unable to use yarn on Windows
When you've set package manager to `yarn` on Windows, CLI is unable to create a project - it hangs during the operation. The problem is that getting the path to yarn cache returns result with `\n` at the end. This makes the `pacote` package hangs instead of just failing.
Fix this by trimming the result of `yarn cache dir` call.

### fix: `tns update` does not work when yarn is set
When yarn is set as package manager, `tns update` command fails. The problem is that during command's execution, we try to remove `tns-core-modules-widgets` from the project. When `tns-core-modules-widgets` pacakage is not a dependency of the project (this is the default case as this package is dependency of `tns-core-modules` not a direct dependency of the project), calling `yarn remove` fails.
In the same case `npm` does not fail.
To resolve the issue, check if `tns-core-modules-widgets` are dependency of the project and uninstall this package only in such case.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
When you've set `yarn` as package manager, calling `tns create myApp --js` hangs on Windows.
`tns update` command always fails when `yarn` is set as package manager.

## What is the new behavior?
You can set yarn as package manager and use it on Windows. Also you can use `tns update` on all OSes.

Fixes issues: 