### PR TITLE
fix: fix debugger attaching after a page reload

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -739,8 +739,7 @@ interface IAppDebugSocketProxyFactory extends NodeJS.EventEmitter {
 	getTCPSocketProxy(deviceIdentifier: string, appId: string): any;
 	addTCPSocketProxy(device: Mobile.IiOSDevice, appId: string): Promise<any>;
 
-	getWebSocketProxy(deviceIdentifier: string, appId: string): any;
-	addWebSocketProxy(device: Mobile.IiOSDevice, appId: string): Promise<any>;
+	ensureWebSocketProxy(device: Mobile.IiOSDevice, appId: string): Promise<any>;
 
 	removeAllProxies(): void;
 }

--- a/lib/services/ios-device-debug-service.ts
+++ b/lib/services/ios-device-debug-service.ts
@@ -164,8 +164,7 @@ export class IOSDeviceDebugService extends DebugServiceBase implements IDeviceDe
 		if (debugOptions.chrome) {
 			this.$logger.info("'--chrome' is the default behavior. Use --inspector to debug iOS applications using the Safari Web Inspector.");
 		}
-		const existingWebProxy = this.$appDebugSocketProxyFactory.getWebSocketProxy(this.deviceIdentifier, debugData.applicationIdentifier);
-		const webSocketProxy = existingWebProxy || await this.$appDebugSocketProxyFactory.addWebSocketProxy(this.device, debugData.applicationIdentifier);
+		const webSocketProxy = await this.$appDebugSocketProxyFactory.ensureWebSocketProxy(this.device, debugData.applicationIdentifier);
 
 		return this.getChromeDebugUrl(debugOptions, webSocketProxy.options.port);
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Take a look at the below-mentioned issue.

## What is the new behavior?
We are printing the debug proxy port even if we reuse an existing proxy. In this way, VSCode can reattach to the same proxy after a JS file change and we are able to connect and disconnect unlimited number of clients. 

Related to https://github.com/NativeScript/nativescript-cli/issues/4236