### PR TITLE
fix: allow Debug + HMR using the public API

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -473,8 +473,12 @@ interface IGenerateOptions {
 	collection?: string;
 }
 
-interface IDebugInformation extends IPort, Mobile.IDeviceIdentifier {
+interface IDebugInformation extends IPort, Mobile.IDeviceIdentifier, IHasHasReconnected {
 	url: string;
+}
+
+interface IHasHasReconnected {
+	hasReconnected: boolean;
 }
 
 interface IPort {

--- a/lib/definitions/debug.d.ts
+++ b/lib/definitions/debug.d.ts
@@ -100,6 +100,10 @@ interface IDebugOptions {
 	 * Defines if the handshake(AppLaunching notification) between CLI and runtime should be executed. The handshake is not needed when CLI retries to attach to the debugger.
 	 */
 	skipHandshake?: boolean;
+	/**
+	 * Forces the debugger attach event to be emitted.
+	 */
+	forceDebuggerAttachedEvent?: boolean;
 }
 
 /**
@@ -161,5 +165,9 @@ interface IDeviceDebugService extends IPlatform, NodeJS.EventEmitter {
 	 * @param {IDebugOptions} debugOptions Describe possible options to modify the behaivor of the debug operation, for example stop on the first line.
 	 * @returns {Promise<string>} Full url where the frontend client may be connected.
 	 */
-	debug(debugData: IAppDebugData, debugOptions: IDebugOptions): Promise<string>;
+	debug(debugData: IAppDebugData, debugOptions: IDebugOptions): Promise<IDebugResultInfo>;
+}
+
+interface IDebugResultInfo extends IHasHasReconnected {
+	debugUrl: string;
 }

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -188,7 +188,7 @@ interface ILiveSyncEventData {
 	applicationIdentifier?: string,
 	projectDir: string,
 	syncedFiles?: string[],
-	error? : Error,
+	error?: Error,
 	notification?: string,
 	isFullSync?: boolean
 }
@@ -390,9 +390,16 @@ interface ITransferFilesOptions {
 interface IPlatformLiveSyncService {
 	fullSync(syncInfo: IFullSyncInfo): Promise<ILiveSyncResultInfo>;
 	liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<ILiveSyncResultInfo>;
-	refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void>;
+	refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<IRefreshApplicationInfo>;
 	prepareForLiveSync(device: Mobile.IDevice, data: IProjectDir, liveSyncInfo: ILiveSyncInfo, debugOptions: IDebugOptions): Promise<void>;
 	getDeviceLiveSyncService(device: Mobile.IDevice, projectData: IProjectData): INativeScriptDeviceLiveSyncService;
+}
+
+interface IHasDidRestart {
+	didRestart: boolean;
+}
+
+interface IRefreshApplicationInfo extends IHasDidRestart {
 }
 
 interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase {
@@ -405,7 +412,7 @@ interface INativeScriptDeviceLiveSyncService extends IDeviceLiveSyncServiceBase 
 	 * @return {Promise<void>}
 	 */
 	refreshApplication(projectData: IProjectData,
-		liveSyncInfo: ILiveSyncResultInfo): Promise<void>;
+		liveSyncInfo: ILiveSyncResultInfo): Promise<IRefreshApplicationInfo>;
 
 	/**
 	 * Removes specified files from a connected device

--- a/lib/services/debug-service-base.ts
+++ b/lib/services/debug-service-base.ts
@@ -10,7 +10,7 @@ export abstract class DebugServiceBase extends EventEmitter implements IDeviceDe
 
 	public abstract get platform(): string;
 
-	public abstract async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string>;
+	public abstract async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<IDebugResultInfo>;
 
 	public abstract async debugStart(debugData: IDebugData, debugOptions: IDebugOptions): Promise<void>;
 

--- a/lib/services/ios-device-debug-service.ts
+++ b/lib/services/ios-device-debug-service.ts
@@ -38,7 +38,8 @@ export class IOSDeviceDebugService extends DebugServiceBase implements IDeviceDe
 		return "ios";
 	}
 
-	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
+	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<IDebugResultInfo> {
+		const result: IDebugResultInfo = { hasReconnected: false, debugUrl: null };
 		this.validateOptions(debugOptions);
 
 		await this.startDeviceLogProcess(debugData, debugOptions);
@@ -46,9 +47,12 @@ export class IOSDeviceDebugService extends DebugServiceBase implements IDeviceDe
 
 		if (!debugOptions.start) {
 			await this.startApp(debugData, debugOptions);
+			result.hasReconnected = true;
 		}
 
-		return this.wireDebuggerClient(debugData, debugOptions);
+		result.debugUrl = await this.wireDebuggerClient(debugData, debugOptions);
+
+		return result;
 	}
 
 	public async debugStart(debugData: IDebugData, debugOptions: IDebugOptions): Promise<void> {

--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -15,7 +15,7 @@ export class AndroidDeviceLiveSyncService extends AndroidDeviceLiveSyncServiceBa
 		protected device: Mobile.IAndroidDevice,
 		$filesHashService: IFilesHashService,
 		$logger: ILogger) {
-			super($injector, $platformsData, $filesHashService, $logger, device);
+		super($injector, $platformsData, $filesHashService, $logger, device);
 	}
 
 	public async transferFilesOnDevice(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[]): Promise<void> {
@@ -26,7 +26,8 @@ export class AndroidDeviceLiveSyncService extends AndroidDeviceLiveSyncServiceBa
 		await this.device.fileSystem.transferDirectory(deviceAppData, localToDevicePaths, projectFilesPath);
 	}
 
-	public async refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void> {
+	public async refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<IRefreshApplicationInfo> {
+		const result: IRefreshApplicationInfo = { didRestart: false };
 		const deviceAppData = liveSyncInfo.deviceAppData;
 		const localToDevicePaths = liveSyncInfo.modifiedFilesData;
 		const deviceProjectRootDirname = await this.$devicePathProvider.getDeviceProjectRootPath(liveSyncInfo.deviceAppData.device, {
@@ -48,8 +49,11 @@ export class AndroidDeviceLiveSyncService extends AndroidDeviceLiveSyncServiceBa
 			(localToDevicePath: Mobile.ILocalToDevicePathData) => !this.canExecuteFastSync(liveSyncInfo, localToDevicePath.getLocalPath(), projectData, this.device.deviceInfo.platform));
 
 		if (!canExecuteFastSync) {
-			return this.restartApplication(deviceAppData, projectData.projectName);
+			await this.restartApplication(deviceAppData, projectData.projectName);
+			result.didRestart = true;
 		}
+
+		return result;
 	}
 
 	private async cleanLivesyncDirectories(deviceAppData: Mobile.IDeviceAppData): Promise<void> {

--- a/lib/services/livesync/android-device-livesync-sockets-service.ts
+++ b/lib/services/livesync/android-device-livesync-sockets-service.ts
@@ -92,7 +92,8 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 		return result;
 	}
 
-	public async refreshApplication(projectData: IProjectData, liveSyncInfo: IAndroidLiveSyncResultInfo) {
+	public async refreshApplication(projectData: IProjectData, liveSyncInfo: IAndroidLiveSyncResultInfo): Promise<IRefreshApplicationInfo> {
+		const result: IRefreshApplicationInfo = { didRestart: false };
 		const canExecuteFastSync = !liveSyncInfo.isFullSync && this.canExecuteFastSyncForPaths(liveSyncInfo, liveSyncInfo.modifiedFilesData, projectData, this.device.deviceInfo.platform);
 		if (!canExecuteFastSync || !liveSyncInfo.didRefresh) {
 			await this.device.applicationManager.restartApplication({ appId: liveSyncInfo.deviceAppData.appIdentifier, projectName: projectData.projectName });
@@ -103,7 +104,11 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 					this.$logger.trace("Failed to connect after app restart.");
 				}
 			}
+
+			result.didRestart = true;
 		}
+
+		return result;
 	}
 
 	public async removeFiles(deviceAppData: Mobile.IDeviceAppData, localToDevicePaths: Mobile.ILocalToDevicePathData[], projectFilesPath: string): Promise<void> {

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -27,12 +27,16 @@ export abstract class PlatformLiveSyncServiceBase {
 
 	protected abstract _getDeviceLiveSyncService(device: Mobile.IDevice, data: IProjectData, frameworkVersion: string): INativeScriptDeviceLiveSyncService;
 
-	public async refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void> {
+	public async refreshApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<IRefreshApplicationInfo> {
+		let result: IRefreshApplicationInfo = { didRestart: false };
+
 		if (liveSyncInfo.isFullSync || liveSyncInfo.modifiedFilesData.length) {
 			const deviceLiveSyncService = this.getDeviceLiveSyncService(liveSyncInfo.deviceAppData.device, projectData);
 			this.$logger.info(`Refreshing application on device ${liveSyncInfo.deviceAppData.device.deviceInfo.identifier}...`);
-			await deviceLiveSyncService.refreshApplication(projectData, liveSyncInfo);
+			result = await deviceLiveSyncService.refreshApplication(projectData, liveSyncInfo);
 		}
+
+		return result;
 	}
 
 	public async fullSync(syncInfo: IFullSyncInfo): Promise<ILiveSyncResultInfo> {
@@ -87,7 +91,7 @@ export abstract class PlatformLiveSyncServiceBase {
 				const localToDevicePaths = await this.$projectFilesManager.createLocalToDevicePaths(deviceAppData,
 					projectFilesPath, existingFiles, []);
 				modifiedLocalToDevicePaths.push(...localToDevicePaths);
-				modifiedLocalToDevicePaths = await this.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, projectData, liveSyncInfo.liveSyncDeviceInfo, { isFullSync: false, force: liveSyncInfo.force});
+				modifiedLocalToDevicePaths = await this.transferFiles(deviceAppData, localToDevicePaths, projectFilesPath, projectData, liveSyncInfo.liveSyncDeviceInfo, { isFullSync: false, force: liveSyncInfo.force });
 			}
 		}
 

--- a/test/services/debug-service.ts
+++ b/test/services/debug-service.ts
@@ -11,8 +11,8 @@ const fakeChromeDebugUrl = `fakeChromeDebugUrl?experiments=true&ws=localhost:${f
 const defaultDeviceIdentifier = "Nexus5";
 
 class PlatformDebugService extends EventEmitter /* implements IPlatformDebugService */ {
-	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<string> {
-		return fakeChromeDebugUrl;
+	public async debug(debugData: IDebugData, debugOptions: IDebugOptions): Promise<IDebugResultInfo> {
+		return { debugUrl: fakeChromeDebugUrl, hasReconnected: false };
 	}
 }
 
@@ -226,7 +226,8 @@ describe("debugService", () => {
 					assert.deepEqual(debugInfo, {
 						url: fakeChromeDebugUrl,
 						port: fakeChromeDebugPort,
-						deviceIdentifier: debugData.deviceIdentifier
+						deviceIdentifier: debugData.deviceIdentifier,
+						hasReconnected: false
 					});
 				});
 			});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -645,7 +645,7 @@ function unexpected(msg: string): Error {
 }
 
 export class DebugServiceStub extends EventEmitter implements IDeviceDebugService {
-	public async debug(): Promise<string> {
+	public async debug(): Promise<IDebugResultInfo> {
 		return;
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The debugger attached event used for reconnecting the debugger in SideKick is fired on each LiveSync.

## What is the new behavior?
The debugger attached event used for reconnecting the debugger in SideKick is fired only when the app restarted and the debugger really needs to be reconnected.

related to: https://github.com/NativeScript/nativescript-cli/issues/4222