### PR TITLE
fix: fix unhandled promise rejection error from sidekick when livesync to preview app with bundle

### DIFF
--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -42,9 +42,14 @@ export class PreviewAppLiveSyncService extends EventEmitter implements IPreviewA
 				} finally {
 					this.deviceInitializationPromise[device.id] = null;
 				}
-			} catch (err) {
-				this.$logger.error(err);
-				this.emit(PreviewAppLiveSyncEvents.PREVIEW_APP_LIVE_SYNC_ERROR, err);
+			} catch (error) {
+				this.$logger.error(error);
+				this.emit(PreviewAppLiveSyncEvents.PREVIEW_APP_LIVE_SYNC_ERROR, {
+					error,
+					data,
+					platform: device.platform,
+					deviceId: device.id
+				});
 			}
 		});
 	}

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -26,20 +26,25 @@ export class PreviewAppLiveSyncService extends EventEmitter implements IPreviewA
 
 	public async initialize(data: IPreviewAppLiveSyncData): Promise<void> {
 		await this.$previewSdkService.initialize(async (device: Device) => {
-			if (!device) {
-				this.$errors.failWithoutHelp("Sending initial preview files without a specified device is not supported.");
-			}
-
-			if (this.deviceInitializationPromise[device.id]) {
-				return this.deviceInitializationPromise[device.id];
-			}
-
-			this.deviceInitializationPromise[device.id] = this.getInitialFilesForDevice(data, device);
 			try {
-				const payloads = await this.deviceInitializationPromise[device.id];
-				return payloads;
-			} finally {
-				this.deviceInitializationPromise[device.id] = null;
+				if (!device) {
+					this.$errors.failWithoutHelp("Sending initial preview files without a specified device is not supported.");
+				}
+
+				if (this.deviceInitializationPromise[device.id]) {
+					return this.deviceInitializationPromise[device.id];
+				}
+
+				this.deviceInitializationPromise[device.id] = this.getInitialFilesForDevice(data, device);
+				try {
+					const payloads = await this.deviceInitializationPromise[device.id];
+					return payloads;
+				} finally {
+					this.deviceInitializationPromise[device.id] = null;
+				}
+			} catch (err) {
+				this.$logger.error(err);
+				this.emit(PreviewAppLiveSyncEvents.PREVIEW_APP_LIVE_SYNC_ERROR, err);
 			}
 		});
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
An unhandled promise rejection error is thrown from sidekick when livesync to preview app with bundle 

## What is the new behavior?
An unhandled promise rejection error is not thrown from sidekick when livesync to preview app with bundle 


