### PR TITLE
fix: clean the installed extensions and inspector cache on intentional CLI uninstall

### DIFF
--- a/lib/common/commands/preuninstall.ts
+++ b/lib/common/commands/preuninstall.ts
@@ -5,11 +5,40 @@ export class PreUninstallCommand implements ICommand {
 
 	public allowedParameters: ICommandParameter[] = [];
 
-	constructor(private $fs: IFileSystem,
+	constructor(private $extensibilityService: IExtensibilityService,
+		private $fs: IFileSystem,
+		private $packageInstallationManager: IPackageInstallationManager,
 		private $settingsService: ISettingsService) { }
 
 	public async execute(args: string[]): Promise<void> {
+		if (this.isIntentionalUninstall()) {
+			this.handleIntentionalUninstall();
+		}
+
 		this.$fs.deleteFile(path.join(this.$settingsService.getProfileDir(), "KillSwitches", "cli"));
+	}
+
+	private isIntentionalUninstall(): boolean {
+		let isIntentionalUninstall = false;
+		if (process.env && process.env.npm_config_argv) {
+			try {
+				const npmConfigArgv = JSON.parse(process.env.npm_config_argv);
+				const uninstallAliases = ["uninstall", "remove", "rm", "r", "un", "unlink"];
+				if (_.intersection(npmConfigArgv.original, uninstallAliases).length > 0) {
+					isIntentionalUninstall = true;
+				}
+			} catch (error) {
+				// ignore
+			}
+
+		}
+
+		return isIntentionalUninstall;
+	}
+
+	private handleIntentionalUninstall(): void {
+		this.$extensibilityService.removeAllExtensions();
+		this.$packageInstallationManager.clearInspectorCache();
 	}
 }
 

--- a/lib/common/declarations.d.ts
+++ b/lib/common/declarations.d.ts
@@ -289,11 +289,18 @@ interface IFileSystem {
 	deleteFile(path: string): void;
 
 	/**
-	 * Deletes whole directory. Implementation uses shelljs.
+	 * Deletes whole directory.
 	 * @param {string} directory Path to directory that has to be deleted.
 	 * @returns {void}
 	 */
 	deleteDirectory(directory: string): void;
+
+	/**
+	 * Deletes whole directory without throwing exceptions.
+	 * @param {string} directory Path to directory that has to be deleted.
+	 * @returns {void}
+	 */
+	deleteDirectorySafe(directory: string): void;
 
 	/**
 	 * Returns the size of specified file.

--- a/lib/common/definitions/extensibility.d.ts
+++ b/lib/common/definitions/extensibility.d.ts
@@ -85,6 +85,12 @@ interface IExtensibilityService {
 	uninstallExtension(extensionName: string): Promise<void>;
 
 	/**
+	 * Removes all installed extensions.
+	 * @returns {void}
+	 */
+	removeAllExtensions(): void;
+
+	/**
 	 * Loads all extensions, so their methods and commands can be used from CLI.
 	 * For each of the extensions, a new Promise is returned. It will be rejected in case the extension cannot be loaded. However other promises will not be reflected by this failure.
 	 * In case a promise is rejected, the error will have additional property (extensionName) that shows which is the extension that cannot be loaded in the process.

--- a/lib/common/file-system.ts
+++ b/lib/common/file-system.ts
@@ -130,6 +130,14 @@ export class FileSystem implements IFileSystem {
 		}
 	}
 
+	public deleteDirectorySafe(directory: string): void {
+		try {
+			this.deleteDirectory(directory);
+		} catch (e) {
+			return;
+		}
+	}
+
 	public getFileSize(path: string): number {
 		const stat = this.getFsStats(path);
 		return stat.size;

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -82,6 +82,7 @@ interface IPackageInstallationManager {
 	getLatestCompatibleVersion(packageName: string, referenceVersion?: string): Promise<string>;
 	getLatestCompatibleVersionSafe(packageName: string, referenceVersion?: string): Promise<string>;
 	getInspectorFromCache(inspectorNpmPackageName: string, projectDir: string): Promise<string>;
+	clearInspectorCache(): void;
 }
 
 /**

--- a/lib/package-installation-manager.ts
+++ b/lib/package-installation-manager.ts
@@ -71,7 +71,7 @@ export class PackageInstallationManager implements IPackageInstallationManager {
 			return inspectorPath;
 		}
 
-		const cachePath = path.join(this.$settingsService.getProfileDir(), constants.INSPECTOR_CACHE_DIRNAME);
+		const cachePath = this.getInspectorCachePath();
 		this.prepareCacheDir(cachePath);
 		const pathToPackageInCache = path.join(cachePath, constants.NODE_MODULES_FOLDER_NAME, inspectorNpmPackageName);
 		const iOSFrameworkNSValue = this.$projectDataService.getNSValue(projectDir, constants.TNS_IOS_RUNTIME_NAME);
@@ -93,6 +93,14 @@ export class PackageInstallationManager implements IPackageInstallationManager {
 
 		this.$logger.out("Using inspector from cache.");
 		return pathToPackageInCache;
+	}
+
+	public clearInspectorCache(): void {
+		this.$fs.deleteDirectorySafe(this.getInspectorCachePath());
+	}
+
+	private getInspectorCachePath(): string {
+		return path.join(this.$settingsService.getProfileDir(), constants.INSPECTOR_CACHE_DIRNAME);
 	}
 
 	private prepareCacheDir(cacheDirName: string): void {

--- a/lib/services/extensibility-service.ts
+++ b/lib/services/extensibility-service.ts
@@ -54,6 +54,11 @@ export class ExtensibilityService implements IExtensibilityService {
 		this.$logger.trace(`Finished uninstallation of extension '${extensionName}'.`);
 	}
 
+	public removeAllExtensions(): void {
+		this.$fs.deleteDirectorySafe(this.pathToExtensions);
+		this.$logger.info(`Removed all NativeScript CLI extensions.`);
+	}
+
 	public getInstalledExtensionsData(): IExtensionData[] {
 		const installedExtensions = this.getInstalledExtensions();
 		return _.keys(installedExtensions).map(installedExtension => this.getInstalledExtensionData(installedExtension));

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -57,6 +57,9 @@ export class ProcessServiceStub implements IProcessService {
 }
 
 export class FileSystemStub implements IFileSystem {
+	deleteDirectorySafe(directory: string): void {
+		return this.deleteDirectory(directory);
+	}
 	async zipFiles(zipFile: string, files: string[], zipPathCallback: (path: string) => string): Promise<void> {
 		return undefined;
 	}
@@ -73,8 +76,8 @@ export class FileSystemStub implements IFileSystem {
 		return undefined;
 	}
 
-	async deleteDirectory(directory: string): Promise<void> {
-		return Promise.resolve();
+	deleteDirectory(directory: string): void {
+		return undefined;
 	}
 
 	getFileSize(path: string): number {
@@ -227,6 +230,9 @@ export class ErrorsStub implements IErrors {
 }
 
 export class PackageInstallationManagerStub implements IPackageInstallationManager {
+	clearInspectorCache(): void {
+		return undefined;
+	}
 	async install(packageName: string, pathToSave?: string, options?: INpmInstallOptions): Promise<string> {
 		return Promise.resolve("");
 	}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The NativeScript CLI extensions and Inspector cache are not removed even when the CLI is uninstalled by the user.

## What is the new behavior?
These resources are removed along with the CLI.

Related to https://github.com/NativeScript/nativescript-cli/issues/4255

