### PR TITLE
fix: require user interaction for developer disk image only in debug

### DIFF
--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -330,11 +330,9 @@ interface IEnableDebuggingDeviceOptions extends Mobile.IDeviceIdentifier, IOptio
 /**
  * Describes settings passed to livesync service in order to control event emitting during refresh application.
  */
-interface IShouldSkipEmitLiveSyncNotification {
-	/**
- 	* Whether to skip emitting an event during refresh. Default is false.
- 	*/
+interface IRefreshApplicationSettings {
 	shouldSkipEmitLiveSyncNotification: boolean;
+	shouldCheckDeveloperDiscImage: boolean;
 }
 
 /**

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -164,7 +164,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 			this.refreshApplicationWithoutDebug(projectData, liveSyncResultInfo, debugOpts, outputPath);
 	}
 
-	private async refreshApplicationWithoutDebug(projectData: IProjectData, liveSyncResultInfo: ILiveSyncResultInfo, debugOpts?: IDebugOptions, outputPath?: string, settings?: IShouldSkipEmitLiveSyncNotification): Promise<IRefreshApplicationInfo> {
+	private async refreshApplicationWithoutDebug(projectData: IProjectData, liveSyncResultInfo: ILiveSyncResultInfo, debugOpts?: IDebugOptions, outputPath?: string, settings?: IRefreshApplicationSettings): Promise<IRefreshApplicationInfo> {
 		let result: IRefreshApplicationInfo = { didRestart: false };
 		const platform = liveSyncResultInfo.deviceAppData.platform;
 		const platformLiveSyncService = this.getLiveSyncService(platform);
@@ -184,7 +184,9 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				});
 			}
 
-			this.handleDeveloperDiskImageError(err, liveSyncResultInfo, projectData, debugOpts, outputPath);
+			if (settings && settings.shouldCheckDeveloperDiscImage) {
+				this.handleDeveloperDiskImageError(err, liveSyncResultInfo, projectData, debugOpts, outputPath);
+			}
 		}
 
 		this.emitLivesyncEvent(LiveSyncEvents.liveSyncExecuted, {
@@ -214,7 +216,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				this.handleDeveloperDiskImageError(err, liveSyncResultInfo, projectData, debugOptions, outputPath);
 			}
 		} else {
-			const refreshInfo = await this.refreshApplicationWithoutDebug(projectData, liveSyncResultInfo, debugOptions, outputPath, { shouldSkipEmitLiveSyncNotification: true });
+			const refreshInfo = await this.refreshApplicationWithoutDebug(projectData, liveSyncResultInfo, debugOptions, outputPath, { shouldSkipEmitLiveSyncNotification: true, shouldCheckDeveloperDiscImage: true });
 			didRestart = refreshInfo.didRestart;
 		}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The CLI is firing the `userInteractionNeeded` event both in `run` and `debug`.

## What is the new behavior?
The CLI is firing the `userInteractionNeeded` event only in `debug` as we have a workaround with a manual app start in `run`.

Related to https://github.com/NativeScript/nativescript-cli/issues/4261
