### PR TITLE
fix(preview-publicApi): Add force option when getting the plugin's warnings

### DIFF
--- a/lib/services/livesync/playground/preview-app-plugins-service.ts
+++ b/lib/services/livesync/playground/preview-app-plugins-service.ts
@@ -7,8 +7,6 @@ import { NODE_MODULES_DIR_NAME } from "../../../common/constants";
 import { PLATFORMS_DIR_NAME, PACKAGE_JSON_FILE_NAME } from "../../../constants";
 
 export class PreviewAppPluginsService implements IPreviewAppPluginsService {
-	private previewAppVersionWarnings: IDictionary<string[]> = {};
-
 	constructor(private $errors: IErrors,
 		private $fs: IFileSystem,
 		private $logger: ILogger,
@@ -23,20 +21,17 @@ export class PreviewAppPluginsService implements IPreviewAppPluginsService {
 			this.$errors.failWithoutHelp("No version of preview app provided.");
 		}
 
-		if (!this.previewAppVersionWarnings[device.previewAppVersion]) {
-			const devicePlugins = this.getDevicePlugins(device);
-			const localPlugins = this.getLocalPlugins(data.projectDir);
-			const warnings = _.keys(localPlugins)
-				.map(localPlugin => {
-					const localPluginVersion = localPlugins[localPlugin];
-					const devicePluginVersion = devicePlugins[localPlugin];
-					return this.getWarningForPlugin(data, localPlugin, localPluginVersion, devicePluginVersion, device);
-				})
-				.filter(item => !!item);
-			this.previewAppVersionWarnings[device.previewAppVersion] = warnings;
-		}
+		const devicePlugins = this.getDevicePlugins(device);
+		const localPlugins = this.getLocalPlugins(data.projectDir);
+		const warnings = _.keys(localPlugins)
+			.map(localPlugin => {
+				const localPluginVersion = localPlugins[localPlugin];
+				const devicePluginVersion = devicePlugins[localPlugin];
+				return this.getWarningForPlugin(data, localPlugin, localPluginVersion, devicePluginVersion, device);
+			})
+			.filter(item => !!item);
 
-		return this.previewAppVersionWarnings[device.previewAppVersion];
+		return warnings;
 	}
 
 	public async comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void> {

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -86,55 +86,6 @@ function setup(localPlugins: IStringDictionary, previewAppPlugins: IStringDictio
 
 describe("previewAppPluginsService", () => {
 	describe("comparePluginsOnDevice without bundle", () => {
-		it("should persist warnings per preview app's version", async () => {
-			const localPlugins = {
-				"nativescript-facebook": "2.2.3",
-				"nativescript-theme-core": "1.0.4",
-				"tns-core-modules": "4.2.0"
-			};
-			const previewAppPlugins = {
-				"nativescript-theme-core": "2.0.4",
-				"tns-core-modules": "4.2.0"
-			};
-			const injector = createTestInjector(localPlugins);
-			const previewAppPluginsService = injector.resolve("previewAppPluginsService");
-
-			let isGetDevicePluginsCalled = false;
-			const originalGetDevicePlugins = (<any>previewAppPluginsService).getDevicePlugins;
-			(<any>previewAppPluginsService).getDevicePlugins = (device: Device) => {
-				isGetDevicePluginsCalled = true;
-				return originalGetDevicePlugins(device);
-			};
-			let isGetLocalPluginsCalled = false;
-			const originalGetLocalPlugins = (<any>previewAppPluginsService).getLocalPlugins;
-			(<any>previewAppPluginsService).getLocalPlugins = () => {
-				isGetLocalPluginsCalled = true;
-				return originalGetLocalPlugins.apply(previewAppPluginsService, [projectDir]);
-			};
-
-			const previewLiveSyncData = createPreviewLiveSyncData({ bundle: false });
-
-			await previewAppPluginsService.comparePluginsOnDevice(previewLiveSyncData, createDevice(JSON.stringify(previewAppPlugins)));
-
-			const expectedWarnings = [
-				util.format(PluginComparisonMessages.PLUGIN_NOT_INCLUDED_IN_PREVIEW_APP, "nativescript-facebook", deviceId),
-				util.format(PluginComparisonMessages.LOCAL_PLUGIN_WITH_DIFFERENCE_IN_MAJOR_VERSION, "nativescript-theme-core", "1.0.4", "2.0.4")
-			];
-			assert.isTrue(isGetDevicePluginsCalled);
-			assert.isTrue(isGetLocalPluginsCalled);
-			assert.deepEqual(warnParams, expectedWarnings);
-
-			isGetDevicePluginsCalled = false;
-			isGetLocalPluginsCalled = false;
-			warnParams = [];
-
-			await previewAppPluginsService.comparePluginsOnDevice(previewLiveSyncData, createDevice(JSON.stringify(previewAppPlugins)));
-
-			assert.isFalse(isGetDevicePluginsCalled);
-			assert.isFalse(isGetLocalPluginsCalled);
-			assert.deepEqual(warnParams, expectedWarnings);
-		});
-
 		const testCases = [
 			{
 				name: "should show warning for plugin not included in preview app",


### PR DESCRIPTION

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

