### PR TITLE
fix: do not show error from preview initialization when stop is called

### DIFF
--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -19,17 +19,11 @@ export class PreviewCommand implements ICommand {
 			this.$logger.info(message);
 		});
 
-		await this.$liveSyncService.liveSync([], {
-			syncToPreviewApp: true,
-			projectDir: this.$projectData.projectDir,
-			skipWatcher: !this.$options.watch,
-			watchAllFiles: this.$options.syncAllFiles,
-			clean: this.$options.clean,
+		await this.$liveSyncService.liveSyncToPreviewApp({
 			bundle: !!this.$options.bundle,
-			release: this.$options.release,
-			env: this.$options.env,
-			timeout: this.$options.timeout,
-			useHotModuleReload: this.$options.hmr
+			useHotModuleReload: this.$options.hmr,
+			projectDir: this.$projectData.projectDir,
+			env: this.$options.env
 		});
 
 		await this.$previewQrCodeService.printLiveSyncQrCode({ useHotModuleReload: this.$options.hmr, link: this.$options.link });

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -243,6 +243,13 @@ interface ILiveSyncService {
 	liveSync(deviceDescriptors: ILiveSyncDeviceInfo[], liveSyncData: ILiveSyncInfo): Promise<void>;
 
 	/**
+	 * Starts LiveSync operation to Preview app.
+	 * @param {IPreviewAppLiveSyncData} data Describes information about the current operation.
+	 * @returns {Promise<IQrCodeImageData>} Data of the QR code that should be used to start the LiveSync operation.
+	 */
+	liveSyncToPreviewApp(data: IPreviewAppLiveSyncData): Promise<IQrCodeImageData>;
+
+	/**
 	 * Stops LiveSync operation for specified directory.
 	 * @param {string} projectDir The directory for which to stop the operation.
 	 * @param {string[]} @optional deviceIdentifiers Device ids for which to stop the application. In case nothing is passed, LiveSync operation will be stopped for all devices.

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -137,12 +137,13 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 		return currentDescriptors || [];
 	}
 
-	@cache()
 	private attachToPreviewAppLiveSyncError(): void {
-		this.$previewAppLiveSyncService.on(LiveSyncEvents.previewAppLiveSyncError, liveSyncData => {
-			this.$logger.error(liveSyncData.error);
-			this.emit(LiveSyncEvents.previewAppLiveSyncError, liveSyncData);
-		});
+		if (!this.$usbLiveSyncService.isInitialized) {
+			this.$previewAppLiveSyncService.on(LiveSyncEvents.previewAppLiveSyncError, liveSyncData => {
+				this.$logger.error(liveSyncData.error);
+				this.emit(LiveSyncEvents.previewAppLiveSyncError, liveSyncData);
+			});
+		}
 	}
 
 	private handleWarnings(liveSyncData: ILiveSyncInfo, projectData: IProjectData) {

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -140,6 +140,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	@cache()
 	private attachToPreviewAppLiveSyncError(): void {
 		this.$previewAppLiveSyncService.on(LiveSyncEvents.previewAppLiveSyncError, liveSyncData => {
+			this.$logger.error(liveSyncData.error);
 			this.emit(LiveSyncEvents.previewAppLiveSyncError, liveSyncData);
 		});
 	}

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -43,7 +43,7 @@ export class PreviewAppLiveSyncService extends EventEmitter implements IPreviewA
 					this.deviceInitializationPromise[device.id] = null;
 				}
 			} catch (error) {
-				this.$logger.error(error);
+				this.$logger.trace(`Error while sending files on device ${device && device.id}. Error is`, error);
 				this.emit(PreviewAppLiveSyncEvents.PREVIEW_APP_LIVE_SYNC_ERROR, {
 					error,
 					data,

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -661,6 +661,10 @@ export class DebugServiceStub extends EventEmitter implements IDeviceDebugServic
 }
 
 export class LiveSyncServiceStub implements ILiveSyncService {
+	public async liveSyncToPreviewApp(data: IPreviewAppLiveSyncData): Promise<IQrCodeImageData> {
+		return;
+	}
+
 	public async liveSync(deviceDescriptors: ILiveSyncDeviceInfo[], liveSyncData: ILiveSyncInfo): Promise<void> {
 		return;
 	}


### PR DESCRIPTION
When preview is called with webpack from Public API, if you stop the livesync (via stopLiveSync method) while webpack is still working, in the output you'll see an error as webpack's child process exits with `null` exit code.
However, this error does not have any meaning for the user, so we shouldn't raise it.
Move the logging of the error to LiveSyncService's handler of `previewAppLiveSyncError` event - in the described case it will not be raised as LiveSyncService had already removed all listeners.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
