### PR TITLE
fix: fix debug iOS connection issues

### DIFF
--- a/lib/common/declarations.d.ts
+++ b/lib/common/declarations.d.ts
@@ -1958,67 +1958,6 @@ interface IiOSNotificationService {
 	postNotification(deviceIdentifier: string, notification: string, commandType?: string): Promise<number>;
 }
 
-/**
- * Copied from @types/lockfile
- * Describes the options that can be passed to lockfile methods.
- */
-interface ILockFileOptions {
-	/**
-	 * A number of milliseconds to wait for locks to expire before giving up.
-	 * Only used by lockFile.lock. Poll for opts.wait ms.
-	 * If the lock is not cleared by the time the wait expires, then it returns with the original error.
-	 */
-	wait?: number;
-
-	/**
-	 * When using opts.wait, this is the period in ms in which it polls to check if the lock has expired. Defaults to 100.
-	 */
-	pollPeriod?: number;
-
-	/**
-	 * A number of milliseconds before locks are considered to have expired.
-	 */
-	stale?: number;
-
-	/**
-	 * Used by lock and lockSync. Retry n number of times before giving up.
-	 */
-	retries?: number;
-
-	/**
-	 * Used by lock. Wait n milliseconds before retrying.
-	 */
-	retryWait?: number;
-}
-
-/**
- * Describes methods that can be used to use file locking.
- */
-interface ILockFile {
-	/**
-	 * Acquire a file lock on the specified path.
-	 * @param {string} lockFilePath Path to lockfile that has to be created. Defaults to `<profile dir>/lockfile.lock`
-	 * @param {ILockFileOptions} lockFileOpts Options used for creating the lockfile.
-	 * @returns {Promise<void>}
-	 */
-	lock(lockFilePath?: string, lockFileOpts?: ILockFileOptions): Promise<void>;
-
-	/**
-	 * Close and unlink the lockfile.
-	 * @param {string} lockFilePath Path to lockfile that has to be created. Defaults to `<profile dir>/lockfile.lock`
-	 * @returns {void}
-	 */
-	unlock(lockFilePath?: string): void;
-
-	/**
-	 * Check if the lockfile is locked and not stale.
-	 * @param {string} lockFilePath Path to lockfile that has to be created. Defaults to `<profile dir>/lockfile.lock`
-	 * @param {ILockFileOptions} lockFileOpts Options used for creating the lockfile.
-	 * @returns {boolean} true in case file is locked, false otherwise
-	 */
-	check(lockFilePath?: string, lockFileOpts?: ILockFileOptions): boolean;
-}
-
 declare module "stringify-package" {
 	function stringifyPackage(data: any, indent: any, newline: string): string
 	export = stringifyPackage

--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -495,6 +495,7 @@ export async function connectEventuallyUntilTimeout(factory: () => Promise<net.S
 				socket.on("error", tryConnectAfterTimeout);
 			} catch (e) {
 				lastKnownError = e;
+				tryConnectAfterTimeout(e);
 			}
 		}
 

--- a/lib/common/mobile/ios/device/ios-device.ts
+++ b/lib/common/mobile/ios/device/ios-device.ts
@@ -17,6 +17,7 @@ export class IOSDevice extends IOSDeviceBase {
 		protected $errors: IErrors,
 		private $injector: IInjector,
 		protected $iOSDebuggerPortService: IIOSDebuggerPortService,
+		protected $lockfile: ILockFile,
 		private $iOSSocketRequestExecutor: IiOSSocketRequestExecutor,
 		protected $processService: IProcessService,
 		private $deviceLogProvider: Mobile.IDeviceLogProvider,
@@ -63,6 +64,7 @@ export class IOSDevice extends IOSDeviceBase {
 		await this.$iOSSocketRequestExecutor.executeAttachRequest(this, constants.AWAIT_NOTIFICATION_TIMEOUT_SECONDS, appId);
 		const port = await this.getDebuggerPort(appId);
 		const deviceId = this.deviceInfo.identifier;
+
 		const socket = await helpers.connectEventuallyUntilTimeout(
 			async () => {
 				const deviceResponse = _.first((await this.$iosDeviceOperations.connectToPort([{ deviceId: deviceId, port: port }]))[deviceId]);

--- a/lib/common/mobile/ios/ios-device-base.ts
+++ b/lib/common/mobile/ios/ios-device-base.ts
@@ -5,6 +5,7 @@ export abstract class IOSDeviceBase implements Mobile.IiOSDevice {
 	protected abstract $errors: IErrors;
 	protected abstract $iOSDebuggerPortService: IIOSDebuggerPortService;
 	protected abstract $processService: IProcessService;
+	protected abstract $lockfile: ILockFile;
 	abstract deviceInfo: Mobile.IDeviceInfo;
 	abstract applicationManager: Mobile.IDeviceApplicationManager;
 	abstract fileSystem: Mobile.IDeviceFileSystem;
@@ -24,21 +25,23 @@ export abstract class IOSDeviceBase implements Mobile.IiOSDevice {
 	}
 
 	public async getSocket(appId: string): Promise<net.Socket> {
-		if (this.cachedSockets[appId]) {
+		return this.$lockfile.executeActionWithLock(async () => {
+			if (this.cachedSockets[appId]) {
+				return this.cachedSockets[appId];
+			}
+
+			this.cachedSockets[appId] = await this.getSocketCore(appId);
+
+			if (this.cachedSockets[appId]) {
+				this.cachedSockets[appId].on("close", () => {
+					this.destroySocket(appId);
+				});
+
+				this.$processService.attachToProcessExitSignals(this, () => this.destroySocket(appId));
+			}
+
 			return this.cachedSockets[appId];
-		}
-
-		this.cachedSockets[appId] = await this.getSocketCore(appId);
-
-		if (this.cachedSockets[appId]) {
-			this.cachedSockets[appId].on("close", () => {
-				this.destroySocket(appId);
-			});
-
-			this.$processService.attachToProcessExitSignals(this, () => this.destroySocket(appId));
-		}
-
-		return this.cachedSockets[appId];
+		}, "ios-debug-socket.lock");
 	}
 
 	public destroyLiveSyncSocket(appId: string) {

--- a/lib/common/mobile/ios/simulator/ios-simulator-device.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-device.ts
@@ -14,6 +14,7 @@ export class IOSSimulator extends IOSDeviceBase implements Mobile.IiOSDevice {
 	constructor(private simulator: Mobile.IiSimDevice,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		protected $errors: IErrors,
+		protected $lockfile: ILockFile,
 		private $injector: IInjector,
 		protected $iOSDebuggerPortService: IIOSDebuggerPortService,
 		private $iOSSimResolver: Mobile.IiOSSimResolver,

--- a/lib/common/services/lockfile.ts
+++ b/lib/common/services/lockfile.ts
@@ -3,53 +3,82 @@ import * as path from "path";
 import { cache } from "../decorators";
 
 export class LockFile implements ILockFile {
+	private currentlyLockedFiles: string[] = [];
 
 	@cache()
 	private get defaultLockFilePath(): string {
-		return path.join(this.$settingsService.getProfileDir(), "lockfile.lock");
+		return this.getAbsoluteLockFilePath("lockfile.lock");
 	}
 
-	private get defaultLockParams(): lockfile.Options {
+	private getAbsoluteLockFilePath(relativeLockFilePath: string) {
+		return path.join(this.$settingsService.getProfileDir(), relativeLockFilePath);
+	}
+
+	private get defaultLockParams(): ILockFileOptions {
 		// We'll retry 100 times and time between retries is 100ms, i.e. full wait in case we are unable to get lock will be 10 seconds.
-		// In case lock is older than 3 minutes, consider it stale and try to get a new lock.
-		const lockParams: lockfile.Options = {
+		// In case lock is older than the `stale` value, consider it stale and try to get a new lock.
+		const lockParams: ILockFileOptions = {
 			retryWait: 100,
 			retries: 100,
-			stale: 180 * 1000,
+			stale: 30 * 1000,
 		};
 
 		return lockParams;
 	}
 
 	constructor(private $fs: IFileSystem,
-		private $settingsService: ISettingsService) {
-	}
-
-	public lock(lockFilePath?: string, lockFileOpts?: lockfile.Options): Promise<void> {
-		const { filePath, fileOpts } = this.getLockFileSettings(lockFilePath, lockFileOpts);
-
-		// Prevent ENOENT error when the dir, where lock should be created, does not exist.
-		this.$fs.ensureDirectoryExists(path.dirname(filePath));
-
-		return new Promise<void>((resolve, reject) => {
-			lockfile.lock(filePath, fileOpts, (err: Error) => {
-				err ? reject(err) : resolve();
+		private $settingsService: ISettingsService,
+		private $processService: IProcessService) {
+		this.$processService.attachToProcessExitSignals(this, () => {
+			const locksToRemove = _.clone(this.currentlyLockedFiles);
+			_.each(locksToRemove, lock => {
+				this.unlock(lock);
 			});
 		});
 	}
 
+	public lock(lockFilePath?: string, lockFileOpts?: ILockFileOptions): Promise<string> {
+		const { filePath, fileOpts } = this.getLockFileSettings(lockFilePath, lockFileOpts);
+		this.currentlyLockedFiles.push(filePath);
+
+		// Prevent ENOENT error when the dir, where lock should be created, does not exist.
+		this.$fs.ensureDirectoryExists(path.dirname(filePath));
+
+		return new Promise<string>((resolve, reject) => {
+			lockfile.lock(filePath, fileOpts, (err: Error) => {
+				err ? reject(new Error(`Timeout while waiting for lock "${filePath}"`)) : resolve(filePath);
+			});
+		});
+	}
+
+	public async executeActionWithLock<T>(action: () => Promise<T>, lockFilePath?: string, lockFileOpts?: ILockFileOptions): Promise<T> {
+		const resolvedLockFilePath = await this.lock(lockFilePath, lockFileOpts);
+
+		try {
+			const result = await action();
+			return result;
+		} finally {
+			this.unlock(resolvedLockFilePath);
+		}
+	}
+
 	public unlock(lockFilePath?: string): void {
 		const { filePath } = this.getLockFileSettings(lockFilePath);
+		_.remove(this.currentlyLockedFiles, e => e === lockFilePath);
 		lockfile.unlockSync(filePath);
 	}
 
-	public check(lockFilePath?: string, lockFileOpts?: lockfile.Options): boolean {
+	public check(lockFilePath?: string, lockFileOpts?: ILockFileOptions): boolean {
 		const { filePath, fileOpts } = this.getLockFileSettings(lockFilePath, lockFileOpts);
 
 		return lockfile.checkSync(filePath, fileOpts);
 	}
 
-	private getLockFileSettings(filePath?: string, fileOpts?: lockfile.Options): { filePath: string, fileOpts: lockfile.Options } {
+	private getLockFileSettings(filePath?: string, fileOpts?: ILockFileOptions): { filePath: string, fileOpts: ILockFileOptions } {
+		if (filePath && !path.isAbsolute(filePath)) {
+			filePath = this.getAbsoluteLockFilePath(filePath);
+		}
+
 		filePath = filePath || this.defaultLockFilePath;
 		fileOpts = fileOpts || this.defaultLockParams;
 

--- a/lib/common/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/lib/common/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -4,7 +4,7 @@ import { Yok } from "../../../yok";
 import { assert } from "chai";
 import { DeviceDiscoveryEventNames, CONNECTED_STATUS } from "../../../constants";
 import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
-import { ErrorsStub, CommonLoggerStub, HooksServiceStub } from "../stubs";
+import { ErrorsStub, CommonLoggerStub, HooksServiceStub, LockFileStub } from "../stubs";
 import { FileSystemStub } from "../../../../../test/stubs";
 
 let currentlyRunningSimulators: Mobile.IiSimDevice[];
@@ -16,6 +16,7 @@ function createTestInjector(): IInjector {
 	injector.register("injector", injector);
 	injector.register("errors", ErrorsStub);
 	injector.register("iOSDebuggerPortService", {});
+	injector.register("lockfile", LockFileStub);
 	injector.register("iOSSimResolver", {
 		iOSSim: {
 			getRunningSimulators: async () => currentlyRunningSimulators

--- a/lib/common/test/unit-tests/stubs.ts
+++ b/lib/common/test/unit-tests/stubs.ts
@@ -3,6 +3,13 @@
 import * as util from "util";
 import { EventEmitter } from "events";
 
+export class LockFileStub implements ILockFile {
+	public async executeActionWithLock<T>(action: () => Promise<T>, lockFilePath?: string, lockFileOpts?: ILockFileOptions): Promise<T> {
+		const result = await action();
+		return result;
+	}
+}
+
 export class CommonLoggerStub implements ILogger {
 	setLevel(level: string): void { }
 	getLevel(): string { return undefined; }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -755,7 +755,7 @@ interface IiOSNotification extends NodeJS.EventEmitter {
 }
 
 interface IiOSSocketRequestExecutor {
-	executeLaunchRequest(deviceIdentifier: string, timeout: number, readyForAttachTimeout: number, projectId: string, debugOptions: IDebugOptions): Promise<void>;
+	executeLaunchRequest(device: Mobile.IiOSDevice, timeout: number, readyForAttachTimeout: number, projectId: string, debugOptions: IDebugOptions): Promise<void>;
 	executeAttachRequest(device: Mobile.IiOSDevice, timeout: number, projectId: string): Promise<void>;
 }
 

--- a/lib/definitions/lockfile.d.ts
+++ b/lib/definitions/lockfile.d.ts
@@ -1,0 +1,19 @@
+import * as lockfile from "lockfile";
+
+declare global {
+    interface ILockFileOptions extends lockfile.Options { }
+
+    /**
+     * Describes methods that can be used to use file locking.
+     */
+    interface ILockFile {
+        /**
+         * @param action The code to be locked.
+         * @param {string} lockFilePath Path to lockfile that has to be created. Defaults to `<profile dir>/lockfile.lock`
+         * @param {ILockFileOptions} lockFileOpts Options used for creating the lockfile.
+         * @returns {Promise<T>}
+         */
+        executeActionWithLock<T>(action: () => Promise<T>, lockFilePath?: string, lockFileOpts?: ILockFileOptions): Promise<T>
+        // TODO: expose as decorator
+    }
+}

--- a/lib/device-sockets/ios/app-debug-socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/app-debug-socket-proxy-factory.ts
@@ -123,7 +123,7 @@ export class AppDebugSocketProxyFactory extends EventEmitter implements IAppDebu
 					this.$logger.trace(err);
 					this.emit(CONNECTION_ERROR_EVENT_NAME, err);
 					acceptHandshake = false;
-					this.$logger.warn(`Cannot connect to device socket. The error message is '${err.message}'. Try starting the application manually.`);
+					this.$logger.warn(`Cannot connect to device socket. The error message is '${err.message}'.`);
 				}
 
 				callback(acceptHandshake);

--- a/lib/device-sockets/ios/socket-request-executor.ts
+++ b/lib/device-sockets/ios/socket-request-executor.ts
@@ -8,47 +8,21 @@ export class IOSSocketRequestExecutor implements IiOSSocketRequestExecutor {
 
 	public async executeAttachRequest(device: Mobile.IiOSDevice, timeout: number, projectId: string): Promise<void> {
 		const deviceIdentifier = device.deviceInfo.identifier;
-
-		const observeNotificationSockets = [
-			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAlreadyConnected(projectId), constants.IOS_OBSERVE_NOTIFICATION_COMMAND_TYPE),
-			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getReadyForAttach(projectId), constants.IOS_OBSERVE_NOTIFICATION_COMMAND_TYPE),
-			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAttachAvailable(projectId), constants.IOS_OBSERVE_NOTIFICATION_COMMAND_TYPE)
-		];
-
-		const observeNotificationPromises = _(observeNotificationSockets)
-			.uniq()
-			.map(s => {
-				return this.$iOSNotificationService.awaitNotification(deviceIdentifier, s, timeout);
-			})
-			.value();
-
-		// Trigger the notifications update.
-		await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAttachAvailabilityQuery(projectId));
-
-		let receivedNotification: string;
 		try {
-			receivedNotification = await Promise.race(observeNotificationPromises);
+			// We should create this promise here because we need to send the ObserveNotification on the device
+			// before we send the PostNotification.
+			const readyForAttachSocket = await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getReadyForAttach(projectId), constants.IOS_OBSERVE_NOTIFICATION_COMMAND_TYPE);
+			const readyForAttachPromise = this.$iOSNotificationService.awaitNotification(deviceIdentifier, +readyForAttachSocket, timeout);
+			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAttachRequest(projectId, deviceIdentifier));
+			await readyForAttachPromise;
 		} catch (e) {
-			this.$errors.failWithoutHelp(`The application ${projectId} does not appear to be running on ${device.deviceInfo.displayName} or is not built with debugging enabled.`);
-		}
-
-		switch (receivedNotification) {
-			case this.$iOSNotification.getAlreadyConnected(projectId):
-				this.$errors.failWithoutHelp("A client is already connected.");
-				break;
-			case this.$iOSNotification.getAttachAvailable(projectId):
-				await this.executeAttachAvailable(deviceIdentifier, projectId, timeout);
-				break;
-			case this.$iOSNotification.getReadyForAttach(projectId):
-				break;
-			default:
-				this.$logger.trace("Response from attach availability query:");
-				this.$logger.trace(receivedNotification);
-				this.$errors.failWithoutHelp("No notification received while executing attach request.");
+			this.$errors.failWithoutHelp(`The application ${projectId} does not appear to be running on ${deviceIdentifier} or is not built with debugging enabled. Try starting the application manually.`);
 		}
 	}
 
-	public async executeLaunchRequest(deviceIdentifier: string, timeout: number, readyForAttachTimeout: number, projectId: string, debugOptions: IDebugOptions): Promise<void> {
+	public async executeLaunchRequest(device: Mobile.IiOSDevice, timeout: number, readyForAttachTimeout: number, projectId: string, debugOptions: IDebugOptions): Promise<void> {
+		const deviceIdentifier = device.deviceInfo.identifier;
+
 		try {
 			if (!debugOptions.skipHandshake) {
 				await this.executeHandshake(deviceIdentifier, projectId, timeout);
@@ -58,24 +32,10 @@ export class IOSSocketRequestExecutor implements IiOSSocketRequestExecutor {
 				await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getWaitForDebug(projectId));
 			}
 
-			await this.executeAttachAvailable(deviceIdentifier, projectId, readyForAttachTimeout);
+			await this.executeAttachRequest(device, readyForAttachTimeout, projectId);
 		} catch (e) {
 			this.$logger.trace("Launch request error: ", e);
 			this.$errors.failWithoutHelp("Error while waiting for response from NativeScript runtime.");
-		}
-	}
-
-	private async executeAttachAvailable(deviceIdentifier: string, projectId: string, timeout: number): Promise<void> {
-		try {
-			// We should create this promise here because we need to send the ObserveNotification on the device
-			// before we send the PostNotification.
-			const readyForAttachSocket = await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getReadyForAttach(projectId), constants.IOS_OBSERVE_NOTIFICATION_COMMAND_TYPE);
-			const readyForAttachPromise = this.$iOSNotificationService.awaitNotification(deviceIdentifier, +readyForAttachSocket, timeout);
-			await this.$iOSNotificationService.postNotification(deviceIdentifier, this.$iOSNotification.getAttachRequest(projectId, deviceIdentifier));
-			await readyForAttachPromise;
-		} catch (e) {
-			this.$logger.trace("Attach available error: ", e);
-			this.$errors.failWithoutHelp(`The application ${projectId} timed out when performing the socket handshake.`);
 		}
 	}
 

--- a/lib/services/android-device-debug-service.ts
+++ b/lib/services/android-device-debug-service.ts
@@ -147,7 +147,7 @@ export class AndroidDeviceDebugService extends DebugServiceBase implements IDevi
 
 	private async validateRunningApp(deviceId: string, packageName: string): Promise<void> {
 		if (!(await this.isAppRunning(packageName, deviceId))) {
-			this.$errors.failWithoutHelp(`The application ${packageName} does not appear to be running on ${deviceId} or is not built with debugging enabled.`);
+			this.$errors.failWithoutHelp(`The application ${packageName} does not appear to be running on ${deviceId} or is not built with debugging enabled. Try starting the application manually.`);
 		}
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The CLI could become in an invalid state if you open the debug URL and make a few fast refreshes.

## What is the new behavior?
The CLI will lock and handle the connections one by one if you open the debug URL and make a few fast refreshes.

Notes:
We also replaced the old 4 iOS attach messages with a single Attach Request. In this way, the Runtime has a single place of attaching and will be able to handle the bug with invalid app state after locking the phone while debugging. 
