### PR TITLE
fix: error may be raised during restart of app on ios Sim

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3981,9 +3981,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.7.tgz",
-      "integrity": "sha512-8tbgbyOTLn4PVdv/40C8tWeaKriZ+w7yOof8xC6qFlAUGpkKopHJ954akekG2sqVUnfTI3ibaXgF5tkxGtrhGA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.8.tgz",
+      "integrity": "sha512-/yk204on3c1qFux7h3u3rS6z051yB6OzVTLoGry210JizaqKYmkPJr6KKfLSeZIyZxF4GsBZI2KMzlFbavjUhA==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "inquirer": "6.2.0",
     "ios-device-lib": "0.5.0",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "4.0.7",
+    "ios-sim-portable": "4.0.8",
     "istextorbinary": "2.2.1",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",


### PR DESCRIPTION
On slower mac machines, an error may be raised during restart of app on iOS Simulator. The problem is that we stop the application and try to start it after that. However, the stop method may be resolved before the application is actually killed. Trying to start it after that leads to undefined behavior and errors in some cases.
To fix this, update ios-sim-portable to 4.0.8 where a possible fix is applied.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
On slower mac machines trying to use `tns run ios --emulator` leads to error while restarting the app.

## What is the new behavior?
CLI should be able to restart the app on all machines and `tns run ios --emulator` should work.
