### PR TITLE
fix: respect nsconfig file on `tns test` command

### DIFF
--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -332,7 +332,8 @@ class TestExecutionService implements ITestExecutionService {
 				options: {
 					debugTransport: this.$options.debugTransport,
 					debugBrk: this.$options.debugBrk,
-					watch: !!this.$options.watch
+					watch: !!this.$options.watch,
+					appDirectoryRelativePath: projectData.getAppDirectoryRelativePath()
 				}
 			},
 		};


### PR DESCRIPTION
Rel to:
NativeScript/nativescript-angular#1310
NativeScript/nativescript-cli#4244

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The user is not able to execute `tns test` command out of the box for new ng project

## What is the new behavior?
The user is able to execute `tns test` command out of the box for new ng project

Should be merged with this PR: https://github.com/NativeScript/nativescript-unit-test-runner/pull/28

