### PR TITLE
fix: use `npm view` command to get gradle versions from registry in order to fix the problems when private npm registry is configured

### DIFF
--- a/lib/base-package-manager.ts
+++ b/lib/base-package-manager.ts
@@ -93,7 +93,7 @@ export abstract class BasePackageManager implements INodePackageManager {
 				array.push(`--${flag}`);
 				array.push(`${config[flag]}`);
 			} else if (config[flag]) {
-				if (flag === "dist-tags" || flag === "versions" || flag === "name") {
+				if (flag === "dist-tags" || flag === "versions" || flag === "name" || flag === "gradle") {
 					array.push(` ${flag}`);
 					continue;
 				}

--- a/test/services/android-plugin-build-service.ts
+++ b/test/services/android-plugin-build-service.ts
@@ -112,6 +112,34 @@ describe('androidPluginBuildService', () => {
 				};
 
 				return result;
+			},
+			view: async (packageName: string, config: any): Promise<any> => {
+				let result: any = null;
+				if (config && config.gradle) {
+					const packageVersion = packageName.split("@")[1];
+					switch (packageVersion) {
+						case "1.0.0":
+							result = {
+								version: options.projectRuntimeGradleVersion,
+								android: options.projectRuntimeGradleAndroidVersion
+							};
+							break;
+						case "4.1.2":
+							result = {
+								version: options.latestRuntimeGradleVersion,
+								android: options.latestRuntimeGradleAndroidVersion
+							};
+							break;
+					}
+				}
+
+				if (config && config["dist-tags"]) {
+					result = {
+						latest: "4.1.2"
+					};
+				}
+
+				return result;
 			}
 		};
 	}


### PR DESCRIPTION
Rel to https://github.com/NativeScript/nativescript-cli/issues/4283

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
{N} CLI does not work when private `npm` registry is configured

## What is the new behavior?
{N} CLI works when private `npm` registry is configured

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

