### PR TITLE
chore: stop travis build execution when grunt step fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ before_script:
 - npm test
 - node_modules/.bin/grunt enableScripts:true
 script:
-- node_modules/.bin/grunt lint
-- node_modules/.bin/grunt pack --no-color
+- node_modules/.bin/grunt lint && node_modules/.bin/grunt pack --no-color
 before_deploy:
 - node .travis/add-publishConfig.js $TRAVIS_BRANCH
 deploy:


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Travis build does not stop when the grunt step fails

## What is the new behavior?
Travis build stops when the grunt step fails
