### PR TITLE
feat: skip postinstall steps in case CLI is not installed globally

### DIFF
--- a/lib/common/commands/post-install.ts
+++ b/lib/common/commands/post-install.ts
@@ -1,38 +1,12 @@
 export class PostInstallCommand implements ICommand {
-	constructor(private $fs: IFileSystem,
-		private $staticConfig: Config.IStaticConfig,
-		private $commandsService: ICommandsService,
-		private $helpService: IHelpService,
-		private $settingsService: ISettingsService,
-		private $analyticsService: IAnalyticsService,
-		protected $logger: ILogger) {
+	constructor(protected $errors: IErrors) {
 	}
 
 	public disableAnalytics = true;
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
-		if (process.platform !== "win32") {
-			// when running under 'sudo' we create a working dir with wrong owner (root) and
-			// it is no longer accessible for the user initiating the installation
-			// patch the owner here
-			if (process.env.SUDO_USER) {
-				await this.$fs.setCurrentUserAsOwner(this.$settingsService.getProfileDir(), process.env.SUDO_USER);
-			}
-		}
-
-		await this.$helpService.generateHtmlPages();
-
-		// Explicitly ask for confirmation of usage-reporting:
-		await this.$analyticsService.checkConsent();
-
-		await this.$commandsService.tryExecuteCommand("autocomplete", []);
-
-		if (this.$staticConfig.INSTALLATION_SUCCESS_MESSAGE) {
-			// Make sure the success message is separated with at least one line from all other messages.
-			this.$logger.out();
-			this.$logger.printMarkdown(this.$staticConfig.INSTALLATION_SUCCESS_MESSAGE);
-		}
+		this.$errors.fail("This command is deprecated. Use `tns dev-post-install-cli` instead");
 	}
 }
 $injector.registerCommand("dev-post-install", PostInstallCommand);

--- a/lib/common/commands/preuninstall.ts
+++ b/lib/common/commands/preuninstall.ts
@@ -1,4 +1,5 @@
 ﻿import * as path from "path";
+import { doesCurrentNpmCommandMatch } from "../helpers";
 
 export class PreUninstallCommand implements ICommand {
 	public disableAnalytics = true;
@@ -11,29 +12,12 @@ export class PreUninstallCommand implements ICommand {
 		private $settingsService: ISettingsService) { }
 
 	public async execute(args: string[]): Promise<void> {
-		if (this.isIntentionalUninstall()) {
+		const isIntentionalUninstall = doesCurrentNpmCommandMatch([/^uninstall$/, /^remove$/, /^rm$/, /^r$/, /^un$/, /^unlink$/]);
+		if (isIntentionalUninstall) {
 			this.handleIntentionalUninstall();
 		}
 
 		this.$fs.deleteFile(path.join(this.$settingsService.getProfileDir(), "KillSwitches", "cli"));
-	}
-
-	private isIntentionalUninstall(): boolean {
-		let isIntentionalUninstall = false;
-		if (process.env && process.env.npm_config_argv) {
-			try {
-				const npmConfigArgv = JSON.parse(process.env.npm_config_argv);
-				const uninstallAliases = ["uninstall", "remove", "rm", "r", "un", "unlink"];
-				if (_.intersection(npmConfigArgv.original, uninstallAliases).length > 0) {
-					isIntentionalUninstall = true;
-				}
-			} catch (error) {
-				// ignore
-			}
-
-		}
-
-		return isIntentionalUninstall;
 	}
 
 	private handleIntentionalUninstall(): void {

--- a/lib/common/definitions/config.d.ts
+++ b/lib/common/definitions/config.d.ts
@@ -23,7 +23,6 @@ declare module Config {
 		RESOURCE_DIR_PATH: string;
 		PATH_TO_BOOTSTRAP: string;
 		QR_SIZE: number;
-		INSTALLATION_SUCCESS_MESSAGE?: string;
 		PROFILE_DIR_NAME: string
 	}
 

--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -5,6 +5,7 @@ import { ReadStream } from "tty";
 import { Configurations } from "./constants";
 import { EventEmitter } from "events";
 import * as crypto from "crypto";
+import * as _ from "lodash";
 
 const Table = require("cli-table");
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -38,7 +38,6 @@ export class StaticConfig implements IStaticConfig {
 	public TRACK_FEATURE_USAGE_SETTING_NAME = "TrackFeatureUsage";
 	public ERROR_REPORT_SETTING_NAME = "TrackExceptions";
 	public ANALYTICS_INSTALLATION_ID_SETTING_NAME = "AnalyticsInstallationID";
-	public INSTALLATION_SUCCESS_MESSAGE = "Installation successful. You are good to go. Connect with us on `http://twitter.com/NativeScript`.";
 	public get PROFILE_DIR_NAME(): string {
 		return ".nativescript-cli";
 	}

--- a/postinstall.js
+++ b/postinstall.js
@@ -5,5 +5,7 @@ var path = require("path");
 var constants = require(path.join(__dirname, "lib", "constants"));
 var commandArgs = [path.join(__dirname, "bin", "tns"), constants.POST_INSTALL_COMMAND_NAME];
 var nodeArgs = require(path.join(__dirname, "lib", "common", "scripts", "node-args")).getNodeArgs();
-
-child_process.spawn(process.argv[0], nodeArgs.concat(commandArgs), { stdio: "inherit" });
+var helpers = require(path.join(__dirname, "lib", "common", "helpers"));
+if (helpers.isInstallingNativeScriptGlobally()) {
+	child_process.spawn(process.argv[0], nodeArgs.concat(commandArgs), { stdio: "inherit" });
+}

--- a/test/commands/post-install.ts
+++ b/test/commands/post-install.ts
@@ -43,6 +43,8 @@ const createTestInjector = (): IInjector => {
 
 	testInjector.registerCommand("post-install-cli", PostInstallCliCommand);
 
+	testInjector.register("hostInfo", {});
+
 	return testInjector;
 };
 

--- a/test/post-install.ts
+++ b/test/post-install.ts
@@ -2,26 +2,38 @@ import { assert } from "chai";
 
 // Use require instead of import in order to replace the `spawn` method of child_process
 const childProcess = require("child_process");
+const helpers = require("../lib/common/helpers");
 
 import { SpawnOptions, ChildProcess } from "child_process";
 import * as path from "path";
 import { POST_INSTALL_COMMAND_NAME } from "../lib/constants";
 
 describe("postinstall.js", () => {
-	it("calls post-install-cli command of CLI", () => {
-		const originalSpawn = childProcess.spawn;
-		let isSpawnCalled = false;
-		let argsPassedToSpawn: string[] = [];
+	let isSpawnCalled = false;
+	let argsPassedToSpawn: string[] = [];
+	const originalSpawn = childProcess.spawn;
+	const originalIsInstallingNativeScriptGlobally = helpers.isInstallingNativeScriptGlobally;
+
+	beforeEach(() => {
+		isSpawnCalled = false;
+		argsPassedToSpawn = [];
 		childProcess.spawn = (command: string, args?: string[], options?: SpawnOptions): ChildProcess => {
 			isSpawnCalled = true;
 			argsPassedToSpawn = args;
 
 			return null;
 		};
+	});
+
+	afterEach(() => {
+		childProcess.spawn = originalSpawn;
+		helpers.isInstallingNativeScriptGlobally = originalIsInstallingNativeScriptGlobally;
+	});
+
+	it("calls post-install-cli command of CLI when it is global installation", () => {
+		helpers.isInstallingNativeScriptGlobally = () => true;
 
 		require(path.join(__dirname, "..", "postinstall"));
-
-		childProcess.spawn = originalSpawn;
 
 		assert.isTrue(isSpawnCalled, "child_process.spawn must be called from postinstall.js");
 
@@ -31,5 +43,11 @@ describe("postinstall.js", () => {
 				Expected path is: ${expectedPathToCliExecutable}, current args are: ${argsPassedToSpawn}.`);
 		assert.isTrue(argsPassedToSpawn.indexOf(POST_INSTALL_COMMAND_NAME) !== -1, `The spawned args must contain the name of the post-install command.
 				Expected path is: ${expectedPathToCliExecutable}, current args are: ${argsPassedToSpawn}.`);
+	});
+
+	it("does not call post-install-cli command of CLI when it is not global install", () => {
+		helpers.isInstallingNativeScriptGlobally = () => false;
+		require(path.join(__dirname, "..", "postinstall"));
+		assert.isFalse(isSpawnCalled, "child_process.spawn must NOT be called from postinstall.js when CLI is not installed globally");
 	});
 });


### PR DESCRIPTION
In case the CLI package is not installed globally, probably it is installed as a dependency of a project or as a dependency of other dependency.
In this case the postinstall actions have no meaning for the user, as probably CLI will be used as a library.
Skip all of the postinstall actions in such case. Remove the execution code of the old `post-install` command and move it to `post-install-cli` command.
Add unit tests. Remove a property from staticConfig - it has no meaning to be there, just place it in the postinstall command directly.
Handle case when CLI is installed globally with npm or yarn - in both cases the `npm_config_argv` will be populated with the original command. For example:
* `npm i -g nativescript`  - the `npm_config_argv` will be: `["i", "-g", "nativescript"]`
* `yarn global add nativescript`  - the `npm_config_argv` will be: `["global", "add", "nativescript"]`

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
When executing `npm i nativescript`, you are prompted to enable autocompletion and all other post install tasks.

## What is the new behavior?
CLI will ask you to enable autocompletion (and other questions asked on post-install) only when `npm i -g nativescript` or `yarn global add nativescript` is used.

Implements issue https://github.com/NativeScript/nativescript-cli/issues/4323
