### PR TITLE
fix: incorrect paths to CLI resources and files break commands

### DIFF
--- a/lib/common/services/micro-templating-service.ts
+++ b/lib/common/services/micro-templating-service.ts
@@ -1,6 +1,6 @@
 import * as util from "util";
 import * as os from "os";
-import * as constants from "../constants";
+import * as constants from "../../constants";
 import { formatListOfNames } from '../helpers';
 
 export class MicroTemplateService implements IMicroTemplateService {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -42,7 +42,7 @@ export class StaticConfig implements IStaticConfig {
 	public get PROFILE_DIR_NAME(): string {
 		return ".nativescript-cli";
 	}
-	public RESOURCE_DIR_PATH = path.join(__dirname, "../../resources");
+	public RESOURCE_DIR_PATH = path.join(__dirname, "..", "resources");
 
 	constructor(private $injector: IInjector) {
 	}
@@ -118,7 +118,7 @@ export class StaticConfig implements IStaticConfig {
 	}
 
 	public get HTML_COMMON_HELPERS_DIR(): string {
-		return path.join(__dirname, "lib", "common", "docs", "helpers");
+		return path.join(__dirname, "common", "docs", "helpers");
 	}
 
 	private async getAdbFilePathCore(): Promise<string> {


### PR DESCRIPTION
Some CLI commands are broken due to incorrect paths to resources.
- `postinstall` is broken as the path to common helpers is incorrect. Also we are not injecting correct constants and the generation of `.html` for `test init` command fails. Inject correct constants when generating help.
- `test init` command is broken as path to CLI's resource dir is not correct

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns dev-post-install-cli` command fails.
`tns dev-generate-help` command fails.
`tns test init` command fails.

## What is the new behavior?
Mentioned commands are working.