### PR TITLE
fix: prompt to install Xcode Command Line Tools when listing devices

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3578,9 +3578,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.8.tgz",
-      "integrity": "sha512-/yk204on3c1qFux7h3u3rS6z051yB6OzVTLoGry210JizaqKYmkPJr6KKfLSeZIyZxF4GsBZI2KMzlFbavjUhA==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.0.9.tgz",
+      "integrity": "sha512-hnHhQY5IrqE6XikmgG6JrL7/gYViifEZCGylvUstAfm56v0vXSwGDmtlg7vWcVCNgs46AB8WUgGT+WZ8tDcMzA==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "inquirer": "6.2.0",
     "ios-device-lib": "0.5.1",
     "ios-mobileprovision-finder": "1.0.10",
-    "ios-sim-portable": "4.0.8",
+    "ios-sim-portable": "4.0.9",
     "istextorbinary": "2.2.1",
     "jimp": "0.2.28",
     "lockfile": "1.0.3",


### PR DESCRIPTION
`tns devices --availableDevices` prompts to install Xcode Command Line Tools (with popup), when command line tools (Xcode) are not installed on the machine. Update the `ios-sim-portable` package, where the issue is resolved.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
In case Xcode and Xcode Command Line tools are not installed, calling `tns run` or `tns devices --availableDevices` leads to a UI prompt (from the OS) to install the missing components.

## What is the new behavior?
The command lists the currently attached devices/available devices, and does not prompt to install anything.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4327

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

