### PR TITLE
chore: fix travis build of next/rc/release-patch versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 !vendor/*.js
 !resources/**
 *.js.map
-
+!.travis/**/*
 coverage
 lib-cov
 *.seed

--- a/.npmignore
+++ b/.npmignore
@@ -30,3 +30,5 @@ scratch/
 .travis.yml
 docs/html/
 dev/
+
+.travis/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,8 @@ before_script:
 - gem install xcodeproj
 - gem install cocoapods
 - npm install grunt
-- node_modules/.bin/grunt enableScripts:false
-- grunt rebuild
-- "./bin/nativescript error-reporting disable"
-- "./bin/nativescript usage-reporting disable"
-- npm test
-- node_modules/.bin/grunt enableScripts:true
 script:
-- node_modules/.bin/grunt lint && node_modules/.bin/grunt pack --no-color
+- node_modules/.bin/grunt lint && node_modules/.bin/grunt travisPack --no-color
 before_deploy:
 - node .travis/add-publishConfig.js $TRAVIS_BRANCH
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,20 +28,6 @@ deploy:
   skip_cleanup: true
   email: nativescript@telerik.com
   on:
-    branch: master
-  api_key:
-    secure: "FM9QLOkFq6JpHlfHkT1i2Ht1ZlttZLq7K3kQNLabw7Z5+BPMcy/f3LRJkAkYMezrKLKRkq1uXmhY0BapoTnR9AVEO/t4g6dtbZ1TZ3xBH/HHnFofTFubOrc7+61DJzKduYtnQ/sn3EEOkN8jrXSY9uas4qZh7PSm1hcfjPI8gdI="
-- provider: npm
-  skip_cleanup: true
-  email: nativescript@telerik.com
-  on:
-    branch: release
-  api_key:
-    secure: "FM9QLOkFq6JpHlfHkT1i2Ht1ZlttZLq7K3kQNLabw7Z5+BPMcy/f3LRJkAkYMezrKLKRkq1uXmhY0BapoTnR9AVEO/t4g6dtbZ1TZ3xBH/HHnFofTFubOrc7+61DJzKduYtnQ/sn3EEOkN8jrXSY9uas4qZh7PSm1hcfjPI8gdI="
-- provider: npm
-  skip_cleanup: true
-  email: nativescript@telerik.com
-  on:
-    branch: release-patch
+    all_branches: true
   api_key:
     secure: "FM9QLOkFq6JpHlfHkT1i2Ht1ZlttZLq7K3kQNLabw7Z5+BPMcy/f3LRJkAkYMezrKLKRkq1uXmhY0BapoTnR9AVEO/t4g6dtbZ1TZ3xBH/HHnFofTFubOrc7+61DJzKduYtnQ/sn3EEOkN8jrXSY9uas4qZh7PSm1hcfjPI8gdI="

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,8 +2,6 @@ const childProcess = require("child_process");
 const EOL = require("os").EOL;
 const now = new Date().toISOString();
 
-const CONFIG_JSON_PATH = "config/config.json";
-
 const ENVIRONMENTS = {
 	live: "live",
 	dev: "dev"
@@ -143,7 +141,7 @@ module.exports = function (grunt) {
 						"isWindows": true,
 						"isMacOS": true,
 						"isLinux": true,
-						"formatListOfNames": () => {},
+						"formatListOfNames": () => { },
 						"constants": ""
 					}
 				},
@@ -173,29 +171,13 @@ module.exports = function (grunt) {
 
 		var packageJson = grunt.file.readJSON("package.json");
 		var versionParts = packageJson.version.split("-");
-		if (process.env["RELEASE_BUILD"]) {
-			// HACK - excluded until 1.0.0 release or we refactor our project infrastructure (whichever comes first)
-			//			packageJson.version = versionParts[0];
-		} else {
-			versionParts[1] = buildVersion;
-			packageJson.version = versionParts.join("-");
-		}
+		versionParts[1] = buildVersion;
+		packageJson.version = versionParts.join("-");
 		grunt.file.write("package.json", JSON.stringify(packageJson, null, "  "));
 	});
 
 	grunt.registerTask("tslint:build", function (version) {
 		childProcess.execSync("npm run tslint", { stdio: "inherit" });
-	});
-
-	grunt.registerTask("enableScripts", function (enable) {
-		var enableTester = /false/i;
-		var newScriptsAttr = !enableTester.test(enable) ? "scripts" : "skippedScripts";
-		var packageJson = grunt.file.readJSON("package.json");
-		var oldScriptsAttrValue = packageJson.scripts || packageJson.skippedScripts;
-		delete packageJson.scripts;
-		delete packageJson.skippedScripts;
-		packageJson[newScriptsAttr] = oldScriptsAttrValue;
-		grunt.file.write("package.json", JSON.stringify(packageJson, null, "  "));
 	});
 
 	const setConfig = (key, value) => {
@@ -205,18 +187,18 @@ module.exports = function (grunt) {
 		grunt.file.write(CONFIG_DATA.filePath, stringConfigContent);
 	}
 
-	grunt.registerTask("set_live_ga_id", function() {
+	grunt.registerTask("set_live_ga_id", function () {
 		setConfig(CONFIG_DATA.gaKey, GA_TRACKING_IDS[ENVIRONMENTS.live]);
 	});
 
-	grunt.registerTask("set_dev_ga_id", function() {
+	grunt.registerTask("set_dev_ga_id", function () {
 		setConfig(CONFIG_DATA.gaKey, GA_TRACKING_IDS[ENVIRONMENTS.dev]);
 	});
 
-	grunt.registerTask("verify_live_ga_id", function() {
+	grunt.registerTask("verify_live_ga_id", function () {
 		var configJson = grunt.file.readJSON(CONFIG_DATA.filePath);
 
-		if(configJson[CONFIG_DATA.gaKey] !== GA_TRACKING_IDS[ENVIRONMENTS.live]) {
+		if (configJson[CONFIG_DATA.gaKey] !== GA_TRACKING_IDS[ENVIRONMENTS.live]) {
 			throw new Error("Google Analytics id is not configured correctly.");
 		}
 	});
@@ -234,6 +216,14 @@ module.exports = function (grunt) {
 		"set_package_version",
 		"shell:build_package"
 	]);
+
+	grunt.registerTask("travisPack", function () {
+		if (travis && process.env.TRAVIS_PULL_REQUEST_BRANCH) {
+			return grunt.task.run("pack");
+		}
+
+		console.log(`Skipping travisPack step as the current build is not from PR, so it will be packed from the deploy provider.`);
+	});
 	grunt.registerTask("lint", ["tslint:build"]);
 	grunt.registerTask("all", ["clean", "test", "lint"]);
 	grunt.registerTask("rebuild", ["clean", "ts:devlib"]);


### PR DESCRIPTION
Currently the Travis build of `next`, `rc` and `release-patch` versions takes way too long as the packaging and execution of unit tests is done twice - first time from `grunt pack` execution inside the script and the second time from the npm deploy provider.
To fix this introduce new Grunt task - `travisPack` - it checks if the build is from PR and in case it is, the grunt pack task is skipped. This way the `grunt travisPack` command in the `.travis.yml` script section will be skipped in case we are not in PR build, but the one from npm deploy step will still be executed.

Also delete some unused and not needed logic.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
