### PR TITLE
fix: add missing image resources for generation

### DIFF
--- a/resources/assets/image-definitions.json
+++ b/resources/assets/image-definitions.json
@@ -174,6 +174,14 @@
 				"filename": "LaunchScree.AspectFill@3x.png",
 				"resizeOperation": "blank",
 				"scale": "3x"
+			},
+			{
+				"width": 768,
+				"height": 1024,
+				"directory": "Assets.xcassets/LaunchScreen.AspectFill.imageset",
+				"filename": "LaunchScreen.AspectFill@3x.png",
+				"resizeOperation": "blank",
+				"scale": "3x"
 			}
 		],
 		"splashCenterImages": [
@@ -324,10 +332,26 @@
 				"scale": "2x"
 			},
 			{
+				"width": 896,
+				"height": 414,
+				"directory": "Assets.xcassets/LaunchImage.launchimage",
+				"filename": "Default-Landscape-XR.png",
+				"resizeOperation": "overlayWith",
+				"scale": "2x"
+			},
+			{
 				"width": 414,
 				"height": 896,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "iPhone XR - Portarit iOS 12.png",
+				"resizeOperation": "overlayWith",
+				"scale": "2x"
+			},
+			{
+				"width": 414,
+				"height": 896,
+				"directory": "Assets.xcassets/LaunchImage.launchimage",
+				"filename": "Default-Portrait-XR.png",
 				"resizeOperation": "overlayWith",
 				"scale": "2x"
 			},
@@ -340,10 +364,26 @@
 				"scale": "3x"
 			},
 			{
+				"width": 896,
+				"height": 414,
+				"directory": "Assets.xcassets/LaunchImage.launchimage",
+				"filename": "Default-Landscape-XS-Max.png",
+				"resizeOperation": "overlayWith",
+				"scale": "3x"
+			},
+			{
 				"width": 414,
 				"height": 896,
 				"directory": "Assets.xcassets/LaunchImage.launchimage",
 				"filename": "Phone XS Max - Portarit iOS 12.png",
+				"resizeOperation": "overlayWith",
+				"scale": "3x"
+			},
+			{
+				"width": 414,
+				"height": 896,
+				"directory": "Assets.xcassets/LaunchImage.launchimage",
+				"filename": "Default-Portrait-XS-Max.png",
 				"resizeOperation": "overlayWith",
 				"scale": "3x"
 			}


### PR DESCRIPTION
Add missing image resources for generation of splashscreens and icons. The last released templates have different names of the images, which breaks the generation.
A permanent fix for this case will be applied later.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Resources generation fails for splashscreens:
```
tns create blankJs --template tns-template-blank
cd blankJs
tns resources generate splashes <path to image> 
```
Last command will fail.

## What is the new behavior?
Users are able to generate new splashscreens.

Fixes issue: https://github.com/NativeScript/nativescript-cli/issues/4347