### PR TITLE
fix: set correct versions in plugin's build.gradle

### DIFF
--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -27,9 +27,9 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
-def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 24 }
+def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 28 }
 def computeBuildToolsVersion = { ->
-    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "27.0.3"
+    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "28.0.3"
 }
 
 android {
@@ -46,12 +46,20 @@ android {
 }
 
 dependencies {
-    def supportVer = "27.0.1"
+    def supportVer = "28.0.0"
     if (project.hasProperty("supportVersion")) {
         supportVer = supportVersion
     }
     compileOnly "com.android.support:support-v4:$supportVer"
     compileOnly "com.android.support:appcompat-v7:$supportVer"
+
+    configurations.all {
+       resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+           if (details.requested.group == "com.android.support" && !details.requested.name.startsWith("multidex")) {
+               details.useVersion supportVer
+           }
+       }
+    }
 }
 
 def getAppResourcesPath() {


### PR DESCRIPTION
With Gradle 3.3.0 (used in tns-android 5.2.0-... ) dependencies checking is stricter and there are some problems in the resolution of the supportLibrary version when building plugins. Issue is raised when the plugin has any of the following:
* another compile dependency which is built with `compile` of android support library version that is not the same as the one we are using
* plugin defines in its gradle new version of android support library, that is different from the one specified in our build.gradle.

To resolve this, set all versions of `com.android.support` libraries to the passed supportVersion or 28.0.0
Also update other tooling versions to latest versions.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Unable to build .aar for plugins with rc version of Android runtime.

## What is the new behavior?
Plugins can be build.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4353