### PR TITLE
fix: cli's local adb is not used

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -156,10 +156,10 @@ export class StaticConfig implements IStaticConfig {
 			$hostInfo: IHostInfo = this.$injector.resolve("$hostInfo");
 
 		// prepare the directory to host our copy of adb
-		const defaultAdbDirPath = path.join(__dirname, `resources/platform-tools/android/${process.platform}`);
-		const pathToPackageJson = path.join(__dirname, "..", "..", "package.json");
-		const commonLibVersion = require(pathToPackageJson).version;
-		const tmpDir = path.join(os.tmpdir(), `telerik-common-lib-${commonLibVersion}`);
+		const defaultAdbDirPath = path.join(__dirname, "common", "resources", "platform-tools", "android", process.platform);
+		const pathToPackageJson = path.join(__dirname, "..", "package.json");
+		const nsCliVersion = require(pathToPackageJson).version;
+		const tmpDir = path.join(os.tmpdir(), `nativescript-cli-${nsCliVersion}`);
 		$fs.createDirectory(tmpDir);
 
 		// copy the adb and associated files


### PR DESCRIPTION
In case there's no ANDROI_HOME on user's machine, CLI tries to use its local copy of adb. However, the current path to adb is not correct and CLI does not work with any Android devices in this case.
Fix the path to local copy of adb.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When you do not have ANDROID_HOME set and Android device is attached, CLI does not discover it, i.e. `tns devices` will not show the devices.

## What is the new behavior?
When you do not have ANDROID_HOME set and Android device is attached, CLI will discover it, i.e. `tns devices` will show the device.

