### PR TITLE
chore: skip tns_modules cleanup from CLI

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -284,7 +284,6 @@ interface INodeModulesBuilderData {
 interface INodeModulesBuilder {
 	prepareNodeModules(opts: INodeModulesBuilderData): Promise<void>;
 	prepareJSNodeModules(opts: INodeModulesBuilderData): Promise<void>;
-	cleanNodeModules(absoluteOutputPath: string): void;
 }
 
 interface INodeModulesDependenciesBuilder {

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -1,4 +1,3 @@
-import * as shelljs from "shelljs";
 import { TnsModulesCopy, NpmPluginPrepare } from "./node-modules-dest-copy";
 
 export class NodeModulesBuilder implements INodeModulesBuilder {
@@ -23,20 +22,14 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		const { nodeModulesData } = opts;
 		const productionDependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(nodeModulesData.projectData.projectDir);
 
-		if (opts.copyNodeModules) {
+		if (opts.copyNodeModules && !nodeModulesData.appFilesUpdaterOptions.bundle) {
 			this.initialPrepareNodeModules(opts, productionDependencies);
-		} else if (nodeModulesData.appFilesUpdaterOptions.bundle) {
-			this.cleanNodeModules(nodeModulesData.absoluteOutputPath);
 		}
 
 		return productionDependencies;
 	}
 
-	public cleanNodeModules(absoluteOutputPath: string): void {
-		shelljs.rm("-rf", absoluteOutputPath);
-	}
-
-	private initialPrepareNodeModules(opts: INodeModulesBuilderData, productionDependencies: IDependencyData[]): IDependencyData[] {
+	private initialPrepareNodeModules(opts: INodeModulesBuilderData, productionDependencies: IDependencyData[]): void {
 		const { nodeModulesData, release } = opts;
 
 		if (!this.$fs.exists(nodeModulesData.absoluteOutputPath)) {
@@ -44,16 +37,11 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 			nodeModulesData.lastModifiedTime = null;
 		}
 
-		if (!nodeModulesData.appFilesUpdaterOptions.bundle) {
-			const tnsModulesCopy: TnsModulesCopy = this.$injector.resolve(TnsModulesCopy, {
-				outputRoot: nodeModulesData.absoluteOutputPath
-			});
-			tnsModulesCopy.copyModules({ dependencies: productionDependencies, release });
-		} else {
-			this.cleanNodeModules(nodeModulesData.absoluteOutputPath);
-		}
+		const tnsModulesCopy: TnsModulesCopy = this.$injector.resolve(TnsModulesCopy, {
+			outputRoot: nodeModulesData.absoluteOutputPath
+		});
 
-		return productionDependencies;
+		tnsModulesCopy.copyModules({ dependencies: productionDependencies, release });
 	}
 }
 

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -294,28 +294,6 @@ describe("Npm support tests", () => {
 
 		assert.isTrue(filteredResults.length === 1);
 	});
-
-	it("Ensures that tns_modules absent when bundling", async () => {
-		const fs = testInjector.resolve("fs");
-		const options = testInjector.resolve("options");
-		const tnsModulesFolderPath = path.join(appDestinationFolderPath, "app", "tns_modules");
-
-		try {
-			options.bundle = false;
-			await preparePlatform(testInjector);
-			assert.isTrue(fs.exists(tnsModulesFolderPath), "tns_modules created first");
-
-			options.bundle = true;
-			await preparePlatform(testInjector);
-			assert.isFalse(fs.exists(tnsModulesFolderPath), "tns_modules deleted when bundling");
-
-			options.bundle = false;
-			await preparePlatform(testInjector);
-			assert.isTrue(fs.exists(tnsModulesFolderPath), "tns_modules recreated");
-		} finally {
-			options.bundle = false;
-		}
-	});
 });
 
 describe("Flatten npm modules tests", () => {


### PR DESCRIPTION
In case `--bundle` is passed CLI tries to clean the `tns_modules` directory produced from previous prepare operations. However, this is not required in latest versions as webpack cleans the directory on its own.
The current clean was required for Webpack before 0.14.0, particularly the one used with 3.x versions of NativeScript.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
CLI tries to clean `tns_modules` dir when `tns prepare <platform> --bundle` is executed.

## What is the new behavior?
Logic for cleaning `tns_modules` dir is executed in `nativescript-dev-webpack` plugin.
