### PR TITLE
feat: detect and report short imports used in application

### DIFF
--- a/lib/common/declarations.d.ts
+++ b/lib/common/declarations.d.ts
@@ -1168,6 +1168,13 @@ interface IDoctorService {
 	 * @returns {Promise<boolean>} true if the environment is properly configured for local builds
 	 */
 	canExecuteLocalBuild(platform?: string, projectDir?: string, runtimeVersion?: string): Promise<boolean>;
+
+	/**
+	 * Checks and notifies users for deprecated short imports in their applications.
+	 * @param {string} projectDir Path to the application.
+	 * @returns {void}
+	 */
+	checkForDeprecatedShortImportsInAppDir(projectDir: string): void;
 }
 
 interface IUtils {

--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -8,6 +8,12 @@ import * as crypto from "crypto";
 import * as _ from "lodash";
 
 const Table = require("cli-table");
+const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+
+export function stripComments(content: string): string {
+	const newContent = content.replace(STRIP_COMMENTS, "");
+	return newContent;
+}
 
 export function doesCurrentNpmCommandMatch(patterns?: RegExp[]): boolean {
 	const currentNpmCommandArgv = getCurrentNpmCommandArgv();
@@ -682,7 +688,6 @@ const CONSTRUCTOR_ARGS = /constructor\s*([^\(]*)\(\s*([^\)]*)\)/m;
 const FN_NAME_AND_ARGS = /^(?:function)?\s*([^\(]*)\(\s*([^\)]*)\)\s*(=>)?\s*[{_]/m;
 const FN_ARG_SPLIT = /,/;
 const FN_ARG = /^\s*(_?)(\S+?)\1\s*$/;
-const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 
 export function annotate(fn: any) {
 	let $inject: any,

--- a/lib/common/test/unit-tests/helpers.ts
+++ b/lib/common/test/unit-tests/helpers.ts
@@ -825,4 +825,40 @@ describe("helpers", () => {
 			});
 		});
 	});
+
+	describe("stripComments", () => {
+		const testData: ITestData[] = [
+			{
+				input: `// this is comment,
+const test = require("./test");`,
+				expectedResult: `\nconst test = require("./test");`
+			},
+			{
+				input: `/* this is multiline
+comment */
+const test = require("./test");`,
+				expectedResult: `\nconst test = require("./test");`
+			},
+			{
+				input: `/* this is multiline
+comment
+// with inner one line comment inside it
+the multiline comment finishes here
+*/
+const test = require("./test");`,
+				expectedResult: `\nconst test = require("./test");`
+			},
+
+			{
+				input: `const test /*inline comment*/ = require("./test");`,
+				expectedResult: `const test  = require("./test");`
+			},
+		];
+
+		it("strips comments correctly", () => {
+			testData.forEach(testCase => {
+				assertTestData(testCase, helpers.stripComments);
+			});
+		});
+	});
 });

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -116,6 +116,12 @@ export const NgFlavorName = "Angular";
 export const VueFlavorName = "Vue.js";
 export const TsFlavorName = "Plain TypeScript";
 export const JsFlavorName = "Plain JavaScript";
+export class ProjectTypes {
+	public static NgFlavorName = NgFlavorName;
+	public static VueFlavorName = VueFlavorName;
+	public static TsFlavorName = "Pure TypeScript";
+	public static JsFlavorName = "Pure JavaScript";
+}
 export const BUILD_OUTPUT_EVENT_NAME = "buildOutput";
 export const CONNECTION_ERROR_EVENT_NAME = "connectionError";
 export const USER_INTERACTION_NEEDED_EVENT_NAME = "userInteractionNeeded";

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -172,6 +172,13 @@ interface IProjectDataService {
 	 * @returns {Promise<IAssetGroup>} An object describing the current asset structure for Android.
 	 */
 	getAndroidAssetsStructure(opts: IProjectDir): Promise<IAssetGroup>;
+
+	/**
+	 * Returns array with paths to all `.js` or `.ts` files in application's app directory.
+	 * @param {string} projectDir Path to application.
+	 * @returns {string[]} Array of paths to `.js` or `.ts` files.
+	 */
+	getAppExecutableFiles(projectDir: string): string[];
 }
 
 interface IAssetItem {
@@ -535,9 +542,9 @@ interface ICocoaPodsService {
 
 	/**
 	 * Merges pod's xcconfig file into project's xcconfig file
-	 * @param projectData 
-	 * @param platformData 
-	 * @param opts 
+	 * @param projectData
+	 * @param platformData
+	 * @param opts
 	 */
 	mergePodXcconfigFile(projectData: IProjectData, platformData: IPlatformData, opts: IRelease): Promise<void>;
 }

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -16,19 +16,19 @@ export class ProjectData implements IProjectData {
 	 */
 	private static PROJECT_TYPES: IProjectType[] = [
 		{
-			type: "Pure JavaScript",
+			type: constants.ProjectTypes.JsFlavorName,
 			isDefaultProjectType: true
 		},
 		{
-			type: constants.NgFlavorName,
+			type: constants.ProjectTypes.NgFlavorName,
 			requiredDependencies: ["@angular/core", "nativescript-angular"]
 		},
 		{
-			type: constants.VueFlavorName,
+			type: constants.ProjectTypes.VueFlavorName,
 			requiredDependencies: ["nativescript-vue"]
 		},
 		{
-			type: "Pure TypeScript",
+			type: constants.ProjectTypes.TsFlavorName,
 			requiredDependencies: ["typescript", "nativescript-dev-typescript"]
 		}
 	];

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -27,6 +27,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		private $errors: IErrors,
 		private $fs: IFileSystem,
 		private $logger: ILogger,
+		private $doctorService: IDoctorService,
 		private $packageInstallationManager: IPackageInstallationManager,
 		private $platformsData: IPlatformsData,
 		private $projectDataService: IProjectDataService,
@@ -236,6 +237,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			if (changesInfo.bundleChanged) {
 				await this.cleanDestinationApp(platformInfo);
 			}
+
+			this.$doctorService.checkForDeprecatedShortImportsInAppDir(platformInfo.projectData.projectDir);
 
 			await this.preparePlatformCore(
 				platformInfo.platform,

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import { ProjectData } from "../project-data";
 import { exported } from "../common/decorators";
-import { NATIVESCRIPT_PROPS_INTERNAL_DELIMITER, AssetConstants, SRC_DIR, RESOURCES_DIR, MAIN_DIR, CLI_RESOURCES_DIR_NAME } from "../constants";
+import { NATIVESCRIPT_PROPS_INTERNAL_DELIMITER, AssetConstants, SRC_DIR, RESOURCES_DIR, MAIN_DIR, CLI_RESOURCES_DIR_NAME, ProjectTypes } from "../constants";
 
 interface IProjectFileData {
 	projectData: any;
@@ -114,6 +114,32 @@ export class ProjectDataService implements IProjectDataService {
 			splashCenterImages: this.getAndroidAssetSubGroup(content.splashCenterImages, currentStructure),
 			splashImages: null
 		};
+	}
+
+	public getAppExecutableFiles(projectDir: string): string[] {
+		const projectData = this.getProjectData(projectDir);
+
+		let supportedFileExtension = ".js";
+		if (projectData.projectType === ProjectTypes.NgFlavorName || projectData.projectType === ProjectTypes.TsFlavorName) {
+			supportedFileExtension = ".ts";
+		}
+
+		const files = this.$fs.enumerateFilesInDirectorySync(
+			projectData.appDirectoryPath,
+			(filePath, fstat) => {
+				if (filePath.indexOf(projectData.appResourcesDirectoryPath) !== -1) {
+					return false;
+				}
+
+				if (fstat.isDirectory()) {
+					return true;
+				}
+
+				return path.extname(filePath) === supportedFileExtension;
+			}
+		);
+
+		return files;
 	}
 
 	private getImageDefinitions(): IImageDefinitionsStructure {

--- a/test/npm-support.ts
+++ b/test/npm-support.ts
@@ -107,6 +107,9 @@ function createTestInjector(): IInjector {
 		extractPackage: async (packageName: string, destinationDirectory: string, options?: IPacoteExtractOptions): Promise<void> => undefined
 	});
 	testInjector.register("usbLiveSyncService", () => ({}));
+	testInjector.register("doctorService", {
+		checkForDeprecatedShortImportsInAppDir: (projectDir: string): void => undefined
+	});
 
 	return testInjector;
 }

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -176,6 +176,9 @@ function createTestInjector() {
 		trackOptions: () => Promise.resolve(null)
 	});
 	testInjector.register("usbLiveSyncService", ({}));
+	testInjector.register("doctorService", {
+		checkForDeprecatedShortImportsInAppDir: (projectDir: string): void => undefined
+	});
 
 	return testInjector;
 }

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -118,6 +118,9 @@ function createTestInjector() {
 		}
 	});
 	testInjector.register("usbLiveSyncService", () => ({}));
+	testInjector.register("doctorService", {
+		checkForDeprecatedShortImportsInAppDir: (projectDir: string): void => undefined
+	});
 
 	return testInjector;
 }

--- a/test/services/doctor-service.ts
+++ b/test/services/doctor-service.ts
@@ -1,0 +1,190 @@
+import { DoctorService } from "../../lib/services/doctor-service";
+import { Yok } from "../../lib/common/yok";
+import { LoggerStub } from "../stubs";
+import { assert } from "chai";
+import * as path from "path";
+
+class DoctorServiceInheritor extends DoctorService {
+	constructor($analyticsService: IAnalyticsService,
+		$hostInfo: IHostInfo,
+		$logger: ILogger,
+		$childProcess: IChildProcess,
+		$injector: IInjector,
+		$projectDataService: IProjectDataService,
+		$fs: IFileSystem,
+		$terminalSpinnerService: ITerminalSpinnerService,
+		$versionsService: IVersionsService) {
+		super($analyticsService, $hostInfo, $logger, $childProcess, $injector, $projectDataService, $fs, $terminalSpinnerService, $versionsService);
+	}
+
+	public getDeprecatedShortImportsInFiles(files: string[], projectDir: string): { file: string, line: string }[] {
+		return super.getDeprecatedShortImportsInFiles(files, projectDir);
+	}
+}
+
+describe("doctorService", () => {
+	const createTestInjector = (): IInjector => {
+		const testInjector = new Yok();
+		testInjector.register("doctorService", DoctorServiceInheritor);
+		testInjector.register("analyticsService", {});
+		testInjector.register("hostInfo", {});
+		testInjector.register("logger", LoggerStub);
+		testInjector.register("childProcess", {});
+		testInjector.register("projectDataService", {});
+		testInjector.register("fs", {});
+		testInjector.register("terminalSpinnerService", {});
+		testInjector.register("versionsService", {});
+
+		return testInjector;
+	};
+
+	describe("checkForDeprecatedShortImportsInAppDir", () => {
+		const tnsCoreModulesDirs = [
+			"application",
+			"data"
+		];
+
+		const testData: { filesContents: IStringDictionary, expectedShortImports: any[] }[] = [
+			{
+				filesContents: {
+					file1: 'const application = require("application");'
+				},
+				expectedShortImports: [{ file: "file1", line: 'const application = require("application");' }]
+			},
+			{
+				filesContents: {
+					file1: 'const application = require("tns-core-modules/application");'
+				},
+				expectedShortImports: []
+			},
+			{
+				filesContents: {
+					file1: 'const Observable = require("data/observable").Observable;'
+				},
+				expectedShortImports: [{ file: "file1", line: 'const Observable = require("data/observable").Observable;' }]
+			},
+			{
+				filesContents: {
+					file1: 'const Observable = require("tns-core-modules/data/observable").Observable;'
+				},
+				expectedShortImports: []
+			},
+			{
+				filesContents: {
+					file1: 'import * as application from "application";'
+				},
+				expectedShortImports: [{ file: "file1", line: 'import * as application from "application";' }]
+			},
+			{
+				filesContents: {
+					file1: 'import * as application from "tns-core-modules/application";'
+				},
+				expectedShortImports: []
+			},
+			{
+				filesContents: {
+					file1: 'import { run } from "application";'
+				},
+				expectedShortImports: [{ file: "file1", line: 'import { run } from "application";' }]
+			},
+			{
+				filesContents: {
+					file1: 'import { run } from "tns-core-modules/application";'
+				},
+				expectedShortImports: []
+			},
+			{
+				// Using single quotes
+				filesContents: {
+					file1: "import { run } from 'application';"
+				},
+				expectedShortImports: [{ file: "file1", line: "import { run } from 'application';" }]
+			},
+			{
+				// Using single quotes
+				filesContents: {
+					file1: "import { run } from 'tns-core-modules/application';"
+				},
+				expectedShortImports: []
+			},
+			{
+				filesContents: {
+					file1: `const application = require("application");
+const Observable = require("data/observable").Observable;
+`
+				},
+				expectedShortImports: [
+					{ file: "file1", line: 'const application = require("application");' },
+					{ file: "file1", line: 'const Observable = require("data/observable").Observable;' },
+				]
+			},
+			{
+				filesContents: {
+					file1: `const application = require("application");
+const Observable = require("data/observable").Observable;
+`
+				},
+				expectedShortImports: [
+					{ file: "file1", line: 'const application = require("application");' },
+					{ file: "file1", line: 'const Observable = require("data/observable").Observable;' },
+				]
+			},
+			{
+				filesContents: {
+					file1: `const application = require("application");
+const Observable = require("tns-core-modules/data/observable").Observable;
+`
+				},
+				expectedShortImports: [
+					{ file: "file1", line: 'const application = require("application");' },
+				]
+			},
+			{
+				filesContents: {
+					file1: `const application = require("application");
+const Observable = require("tns-core-modules/data/observable").Observable;
+`,
+					file2: `const application = require("tns-core-modules/application");
+const Observable = require("data/observable").Observable;`
+				},
+				expectedShortImports: [
+					{ file: "file1", line: 'const application = require("application");' },
+					{ file: "file2", line: 'const Observable = require("data/observable").Observable;'  },
+				]
+			},
+			{
+				filesContents: {
+					// this is not from tns-core-modules
+					file1: `const application = require("application1");
+const Observable = require("tns-core-modules/data/observable").Observable;
+`,
+					file2: `const application = require("some-name-tns-core-modules-widgets/application");
+const Observable = require("tns-core-modules-widgets/data/observable").Observable;`
+				},
+				expectedShortImports: [ ]
+			},
+		];
+
+		it("getDeprecatedShortImportsInFiles returns correct results", () => {
+			const testInjector = createTestInjector();
+			const doctorService = testInjector.resolve<DoctorServiceInheritor>("doctorService");
+			const fs = testInjector.resolve<IFileSystem>("fs");
+			fs.getFsStats = (file) => <any>({
+				isDirectory: () => true
+			});
+
+			fs.readDirectory = (dirPath) => {
+				if (dirPath.indexOf(path.join("node_modules", "tns-core-modules"))) {
+					return tnsCoreModulesDirs;
+				}
+			};
+
+			testData.forEach(({ filesContents, expectedShortImports }) => {
+				fs.readText = (filePath) => filesContents[filePath];
+
+				const shortImports = doctorService.getDeprecatedShortImportsInFiles(_.keys(filesContents), "projectDir");
+				assert.deepEqual(shortImports, expectedShortImports);
+			});
+		});
+	});
+});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -527,6 +527,10 @@ export class ProjectDataService implements IProjectDataService {
 	async getAndroidAssetsStructure(opts: IProjectDir): Promise<IAssetGroup> {
 		return null;
 	}
+
+	getAppExecutableFiles(projectDir: string): string[] {
+		return [];
+	}
 }
 
 export class ProjectHelperStub implements IProjectHelper {
@@ -913,7 +917,7 @@ export class AndroidBundleValidatorHelper implements IAndroidBundleValidatorHelp
 
 export class PerformanceService implements IPerformanceService {
 	now(): number { return 10; }
-	processExecutionData() {}
+	processExecutionData() { }
 }
 
 export class InjectorStub extends Yok implements IInjector {


### PR DESCRIPTION
In NativeScript 5.2.0 we've deprecated support for short imports. Add ability in CLI to check if there are such imports in the application's code and report them to users. The logic will be executed whenever application is prepared for build/livesync or when `tns doctor` is executed inside project dir.
Create class with static variables for ProjectTypes. These values must not be changed as they are used in Analytics, so changing them will break the current reports.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Users should search their own code for short imports.

## What is the new behavior?
CLI warns users for used short imports in the application when `tns run <platform>` or `tns doctor` is executed.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4375