### PR TITLE
fix: process correctly podfiles without platform's version

### DIFF
--- a/lib/services/cocoapods-platform-manager.ts
+++ b/lib/services/cocoapods-platform-manager.ts
@@ -45,7 +45,7 @@ export class CocoaPodsPlatformManager implements ICocoaPodsPlatformManager {
 	}
 
 	private getPlatformSectionData(projectPodfileContent: string): { podfilePlatformData: IPodfilePlatformData, platformSectionContent: string } {
-		const platformSectionRegExp = new RegExp(`${this.getPlatformSectionHeader()} ([\\s\\S]*?)with (.*)[\\s\\S]*?${this.getPlatformSectionFooter()}`, "m");
+		const platformSectionRegExp = new RegExp(`${this.getPlatformSectionHeader()} ([\\s\\S]*?)with[\\s\\S]*?\\n([\\s\\S]*?(?:,\\s*?['"](.+)['"])?)\\n${this.getPlatformSectionFooter()}`, "m");
 		const match = platformSectionRegExp.exec(projectPodfileContent);
 		let result = null;
 		if (match && match[0]) {
@@ -53,8 +53,8 @@ export class CocoaPodsPlatformManager implements ICocoaPodsPlatformManager {
 				platformSectionContent: match[0],
 				podfilePlatformData: {
 					path: match[1].trim(),
-					content: "",
-					version: match[2]
+					content: match[2],
+					version: match[3]
 				}
 			};
 		}
@@ -104,7 +104,7 @@ export class CocoaPodsPlatformManager implements ICocoaPodsPlatformManager {
 		const appResourcesPodfilePath = path.join(projectData.getAppResourcesDirectoryPath(), "iOS", PODFILE_NAME);
 		const isFromAppResources = oldPodfilePlatformData.path !== appResourcesPodfilePath && currentPodfilePlatformData.path === appResourcesPodfilePath;
 		const isFromAppResourcesWithGreaterPlatformVersion = oldPodfilePlatformData.path === appResourcesPodfilePath && currentPodfilePlatformData.path === appResourcesPodfilePath && semver.gt(semver.coerce(currentPodfilePlatformData.version), semver.coerce(oldPodfilePlatformData.version));
-		const isPodfileWithGreaterPlatformVersion = !currentPodfilePlatformData.version || semver.gt(semver.coerce(currentPodfilePlatformData.version), semver.coerce(oldPodfilePlatformData.version));
+		const isPodfileWithGreaterPlatformVersion = !currentPodfilePlatformData.version || (oldPodfilePlatformData.version && semver.gt(semver.coerce(currentPodfilePlatformData.version), semver.coerce(oldPodfilePlatformData.version)));
 		const result = isFromAppResources || isFromAppResourcesWithGreaterPlatformVersion || isPodfileWithGreaterPlatformVersion;
 		return result;
 	}

--- a/test/cocoapods-service.ts
+++ b/test/cocoapods-service.ts
@@ -1052,6 +1052,39 @@ platform :ios
 end`
 			},
 			{
+				name: "shouldn't replace the platform without version when no Podfile in App_Resources",
+				pods: [{
+					name: 'myPluginWithoutPlatform',
+					path: 'node_modules/myPluginWithoutPlatform/Podfile',
+					content: `pod 'myPod' ~> 0.3.4`
+				}, {
+					name: 'myFirstPluginWithPlatform',
+					path: 'node_modules/myFirstPluginWithPlatform/Podfile',
+					content: `platform :ios`
+				}, {
+					name: 'mySecondPluginWithPlatform',
+					path: 'node_modules/mySecondPluginWithPlatform/Podfile',
+					content: `platform :ios, '10.0'`
+				}],
+				expectedProjectPodfileContent: `use_frameworks!
+
+target "projectName" do
+# Begin Podfile - node_modules/mySecondPluginWithPlatform/Podfile
+# platform :ios, '10.0'
+# End Podfile
+
+# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
+# platform :ios
+# End Podfile
+
+# Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
+pod 'myPod' ~> 0.3.4
+# End Podfile# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with
+platform :ios
+# End NativeScriptPlatformSection
+end`
+			},
+			{
 				name: "should select platform from plugins when the podfile in App_Resources/iOS/Podfile has no platform",
 				pods: [{
 					name: "mySecondPluginWithPlatform",


### PR DESCRIPTION
Steps to reproduce:
1. `tns create myPodApp --js`
2. `tns plugin add nativescript-imagepicker`
3. `tns plugin add nativescript-facebook`
4. Open `node_modules/nativescript-facebook/platforms/ios/Podfile` and replace the file's content with `platform :ios`
5. Open `node_modules/nativescript-imagepicker/platforms/ios/Podfile` and replace the file's content with `platform :ios, '9.0'`

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].
Rel to: https://github.com/NativeScript/nativescript-cli/issues/3604

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

