### PR TITLE
fix: show warning when the platform's version in project's podfile will be replaced with another platform's version

### DIFF
--- a/lib/services/cocoapods-platform-manager.ts
+++ b/lib/services/cocoapods-platform-manager.ts
@@ -4,11 +4,14 @@ import * as semver from "semver";
 import { PODFILE_NAME } from "../constants";
 
 export class CocoaPodsPlatformManager implements ICocoaPodsPlatformManager {
+	constructor(private $logger: ILogger) { }
+
 	public addPlatformSection(projectData: IProjectData, podfilePlatformData: IPodfilePlatformData, projectPodfileContent: string): string {
 		const platformSectionData = this.getPlatformSectionData(projectPodfileContent);
 		if (platformSectionData && platformSectionData.podfilePlatformData) {
 			const shouldReplacePlatformSection = this.shouldReplacePlatformSection(projectData, platformSectionData.podfilePlatformData, podfilePlatformData);
 			if (shouldReplacePlatformSection) {
+				this.$logger.warn(`Multiple identical platforms with different versions have been detected during the processing of podfiles. The current platform's content "${platformSectionData.podfilePlatformData.content}" from ${platformSectionData.podfilePlatformData.path} will be replaced with "${podfilePlatformData.content}" from ${podfilePlatformData.path}`);
 				const newSection = this.buildPlatformSection(podfilePlatformData);
 				projectPodfileContent = projectPodfileContent.replace(platformSectionData.platformSectionContent, newSection);
 			}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
No warning is shown when platform's version in project's podfile is replaced with another platform's version

## What is the new behavior?
Warning is shown when platform's version in project's podfile is replaced with another platform's version

Fixes/Implements/Closes #[Issue Number].

Rel to: #3604


