### PR TITLE
fix: add new line at the end of the platform's section in order to remove it correctly

### DIFF
--- a/lib/services/cocoapods-platform-manager.ts
+++ b/lib/services/cocoapods-platform-manager.ts
@@ -118,7 +118,7 @@ export class CocoaPodsPlatformManager implements ICocoaPodsPlatformManager {
 			result += ` ${podfilePlatformData.version}`;
 		}
 
-		result += `${EOL}${podfilePlatformData.content}${EOL}${this.getPlatformSectionFooter()}`;
+		result += `${EOL}${podfilePlatformData.content}${EOL}${this.getPlatformSectionFooter()}${EOL}`;
 		return result;
 	}
 


### PR DESCRIPTION

Steps to reproduce:
1. `tns create myApp --js`
2. `tns plugin add nativescript-imagepicker` && `tns plugin add nativescript-facebook`
3. Replace the content of `./node_modules/nativescript-imagepicker/platforms/ios/Podfile` with `platform: ios, '9.0'`
4. Replace the content of `./node_modules/nativescript-facebook/platforms/ios/Podfile` with `platform: ios, '10.0'`
5. Add Podfile in `./app/App_Resources/iOS` with the following content `platform: ios: '8.0'`
6. Execute `tns prepare ios`
7. Remove `./app/App_Resources/iOS/Podfile`
8. Execute `tns prepare ios`

Expected behavior: It should pass correctly and the content of `platforms/ios/Podfile` should be
```
...
# NativeScriptPlatformSection /node_modules/nativescript-facebook/platforms/ios/Podfile with 10.0
       platform :ios, '10.0'
# End NativeScriptPlatformSection
end
```

Actual behavior: It fails with `[!] Invalid `Podfile` file: syntax error, unexpected end-of-input, expecting keyword_end.` error and the the content of `platforms/ios/Podfile` is:
```
...
# NativeScriptPlatformSection /node_modules/nativescript-facebook/platforms/ios/Podfile with 10.0
       platform :ios, '10.0'
# End NativeScriptPlatformSectionend
```

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

Fixes/Implements/Closes #[Issue Number].

Rel to: https://github.com/NativeScript/nativescript-cli/issues/3604

