### PR TITLE
fix: remove the logic for skipCopyTnsModules and skipCopyAppResourcesFiles

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -350,9 +350,7 @@ interface IOptionalFilesToRemove {
 	filesToRemove?: string[];
 }
 
-interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync, IOptionalFilesToRemove, IOptionalNativePrepareComposition {
-	skipCopyTnsModules?: boolean;
-}
+interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync, IOptionalFilesToRemove, IOptionalNativePrepareComposition { }
 
 interface IOptionalNativePrepareComposition {
 	nativePrepare?: INativePrepare;

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -352,7 +352,6 @@ interface IOptionalFilesToRemove {
 
 interface IPreparePlatformInfoBase extends IPlatform, IAppFilesUpdaterOptionsComposition, IProjectDataComposition, IEnvOptions, IOptionalFilesToSync, IOptionalFilesToRemove, IOptionalNativePrepareComposition {
 	skipCopyTnsModules?: boolean;
-	skipCopyAppResourcesFiles?: boolean;
 }
 
 interface IOptionalNativePrepareComposition {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -249,8 +249,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				changesInfo,
 				platformInfo.filesToSync,
 				platformInfo.filesToRemove,
-				platformInfo.nativePrepare,
-				platformInfo.skipCopyTnsModules
+				platformInfo.nativePrepare
 			);
 			this.$projectChangesService.savePrepareInfo(platformInfo.platform, platformInfo.projectData);
 		} else {
@@ -319,8 +318,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		changesInfo?: IProjectChangesInfo,
 		filesToSync?: string[],
 		filesToRemove?: string[],
-		nativePrepare?: INativePrepare,
-		skipCopyTnsModules?: boolean): Promise<void> {
+		nativePrepare?: INativePrepare): Promise<void> {
 
 		this.$logger.out("Preparing project...");
 
@@ -336,8 +334,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			changesInfo,
 			filesToSync,
 			filesToRemove,
-			env,
-			skipCopyTnsModules
+			env
 		});
 
 		if (!nativePrepare || !nativePrepare.skipNativePrepare) {

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -250,7 +250,6 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 				platformInfo.filesToSync,
 				platformInfo.filesToRemove,
 				platformInfo.nativePrepare,
-				platformInfo.skipCopyAppResourcesFiles,
 				platformInfo.skipCopyTnsModules
 			);
 			this.$projectChangesService.savePrepareInfo(platformInfo.platform, platformInfo.projectData);
@@ -321,7 +320,6 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		filesToSync?: string[],
 		filesToRemove?: string[],
 		nativePrepare?: INativePrepare,
-		skipCopyAppResourcesFiles?: boolean,
 		skipCopyTnsModules?: boolean): Promise<void> {
 
 		this.$logger.out("Preparing project...");
@@ -339,7 +337,6 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 			filesToSync,
 			filesToRemove,
 			env,
-			skipCopyAppResourcesFiles,
 			skipCopyTnsModules
 		});
 

--- a/lib/services/prepare-platform-js-service.ts
+++ b/lib/services/prepare-platform-js-service.ts
@@ -51,12 +51,6 @@ export class PreparePlatformJSService extends PreparePlatformService implements 
 		}
 
 		if (!config.changesInfo || config.changesInfo.modulesChanged) {
-			if (!config.skipCopyTnsModules) {
-				await this.copyTnsModules(config.platform, config.platformData, config.projectData, config.appFilesUpdaterOptions, config.projectFilesConfig);
-			}
-		}
-
-		if (!config.skipCopyTnsModules && !this.$fs.exists(path.join(config.platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME, constants.TNS_MODULES_FOLDER_NAME, constants.TNS_CORE_MODULES_NAME))) {
 			await this.copyTnsModules(config.platform, config.platformData, config.projectData, config.appFilesUpdaterOptions, config.projectFilesConfig);
 		}
 	}

--- a/lib/services/prepare-platform-js-service.ts
+++ b/lib/services/prepare-platform-js-service.ts
@@ -38,12 +38,6 @@ export class PreparePlatformJSService extends PreparePlatformService implements 
 	public async preparePlatform(config: IPreparePlatformJSInfo): Promise<void> {
 		if (!config.changesInfo || config.changesInfo.appFilesChanged || config.changesInfo.changesRequirePrepare) {
 			await this.copyAppFiles(config);
-			if (!config.skipCopyAppResourcesFiles) {
-				this.copyAppResourcesFiles(config);
-			}
-		}
-
-		if (!config.skipCopyAppResourcesFiles && !this.$fs.exists(path.join(config.platformData.appDestinationDirectoryPath, constants.APP_FOLDER_NAME, constants.APP_RESOURCES_FOLDER_NAME))) {
 			this.copyAppResourcesFiles(config);
 		}
 


### PR DESCRIPTION
`skipCopyTnsModules` and `skipCopyAppResourcesFiles` were introduced in order to satisfy the needs of preview app. As the preview doesn't prepare the project anymore, we don't need this logic.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
There is logic for `skipCopyTnsModules` and `skipCopyAppResourcesFiles`.

## What is the new behavior?
There is no logic for `skipCopyTnsModules` and `skipCopyAppResourcesFiles`.

Introduced here https://github.com/NativeScript/nativescript-cli/commit/5986b60a0be8e5208426d9b7fc72b63f4f981869