### PR TITLE
fix: get Xcode version correctly

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -28,7 +28,6 @@ const getPlatformSdkName = (forDevice: boolean): string => forDevice ? DevicePla
 const getConfigurationName = (release: boolean): string => release ? Configurations.Release : Configurations.Debug;
 
 export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServiceBase implements IPlatformProjectService {
-	private static XCODEBUILD_MIN_VERSION = "6.0";
 	private static IOS_PROJECT_NAME_PLACEHOLDER = "__PROJECT_NAME__";
 	private static IOS_PLATFORM_NAME = "ios";
 
@@ -144,11 +143,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			options,
 			notConfiguredEnvOptions
 		});
-
-		const xcodeBuildVersion = await this.getXcodeVersion();
-		if (helpers.versionCompare(xcodeBuildVersion, IOSProjectService.XCODEBUILD_MIN_VERSION) < 0) {
-			this.$errors.fail("NativeScript can only run in Xcode version %s or greater", IOSProjectService.XCODEBUILD_MIN_VERSION);
-		}
 
 		return {
 			checkEnvironmentRequirementsOutput
@@ -353,13 +347,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		if (semver.lt(frameworkVersion, "1.4.0")) {
 			basicArgs.push("-xcconfig", path.join(projectRoot, projectData.projectName, BUILD_XCCONFIG_FILE_NAME));
 		}
-
-		// if (this.$logger.getLevel() === "INFO") {
-		// 	let xcodeBuildVersion = this.getXcodeVersion();
-		// 	if (helpers.versionCompare(xcodeBuildVersion, "8.0") >= 0) {
-		// 		basicArgs.push("-quiet");
-		// 	}
-		// }
 
 		const handler = (data: any) => {
 			this.emit(constants.BUILD_OUTPUT_EVENT_NAME, data);
@@ -1238,7 +1225,7 @@ We will now place an empty obsolete compatability white screen LauncScreen.xib f
 		let xcodeBuildVersion = "";
 
 		try {
-			xcodeBuildVersion = await this.$childProcess.exec("xcodebuild -version | head -n 1 | sed -e 's/Xcode //'");
+			xcodeBuildVersion = await this.$sysInfo.getXcodeVersion();
 		} catch (error) {
 			this.$errors.fail("xcodebuild execution failed. Make sure that you have latest Xcode and tools installed.");
 		}

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -118,7 +118,9 @@ function createTestInjector(projectPath: string, projectName: string, xcode?: IX
 	testInjector.register("pluginsService", PluginsService);
 	testInjector.register("androidProcessService", {});
 	testInjector.register("processService", {});
-	testInjector.register("sysInfo", {});
+	testInjector.register("sysInfo", {
+		getXcodeVersion: async () => ""
+	});
 	testInjector.register("pbxprojDomXcode", {});
 	testInjector.register("xcode", xcode || {
 		project: class {


### PR DESCRIPTION
In some cases NativeScript CLI fails on all iOS related commands (build, run, debug, etc.) with error: `NativeScript can only run in Xcode version 6 or greater`.
This happens when user has correct Xcode version, i.e. 9 or greater, but the `head` command on their machine does not support `-n` flag. This happens when the `head` command is overwritten by some tool, so the `head` executable is not the original one used by macOS.
CLI has some obsolete code to check the Xcode version AFTER it has verified it in the doctorService. Delete this code and use sysInfo's getXcodeVersion, which does not rely on `head` command.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
CLI fails to execute iOS related commands when the `head` command is not the original one from macOS.

## What is the new behavior?
CLI is able to execute iOS related commands when the `head` command is not the original one.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4440
