### PR TITLE
fix: fix the "cannot read property imageIdentifier of undefined" error

### DIFF
--- a/lib/common/mobile/android/android-emulator-services.ts
+++ b/lib/common/mobile/android/android-emulator-services.ts
@@ -15,9 +15,11 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 		const adbDevicesOutput = await this.$adb.getDevicesSafe();
 		const avdAvailableEmulatorsOutput = await this.$androidVirtualDeviceService.getEmulatorImages(adbDevicesOutput);
 		const genyAvailableDevicesOutput = await this.$androidGenymotionService.getEmulatorImages(adbDevicesOutput);
+		const devices = _.concat(avdAvailableEmulatorsOutput.devices, genyAvailableDevicesOutput.devices)
+			.filter(item => !!item);
 
 		return {
-			devices: avdAvailableEmulatorsOutput.devices.concat(genyAvailableDevicesOutput.devices),
+			devices,
 			errors: avdAvailableEmulatorsOutput.errors.concat(genyAvailableDevicesOutput.errors)
 		};
 	}
@@ -97,10 +99,10 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 
 		while (hasTimeLeft || isInfiniteWait) {
 			const emulators = (await this.getEmulatorImages()).devices;
-			emulator = _.find(emulators, e => e.imageIdentifier === emulator.imageIdentifier);
-			if (emulator && this.$emulatorHelper.isEmulatorRunning(emulator)) {
+			const newEmulator = _.find(emulators, e => e.imageIdentifier === emulator.imageIdentifier);
+			if (newEmulator && this.$emulatorHelper.isEmulatorRunning(newEmulator)) {
 				return {
-					runningEmulator: emulator,
+					runningEmulator: newEmulator,
 					errors: [],
 					endTimeEpoch
 				};


### PR DESCRIPTION
Sometimes when an emulator is started from sidekick, the error "cannot read property imageIdentifier of undefined" is thrown.
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

