### PR TITLE
fix: warnings for short imports should not be shown for minified code

### DIFF
--- a/test/services/doctor-service.ts
+++ b/test/services/doctor-service.ts
@@ -41,7 +41,8 @@ describe("doctorService", () => {
 	describe("checkForDeprecatedShortImportsInAppDir", () => {
 		const tnsCoreModulesDirs = [
 			"application",
-			"data"
+			"data",
+			"text"
 		];
 
 		const testData: { filesContents: IStringDictionary, expectedShortImports: any[] }[] = [
@@ -180,14 +181,53 @@ const Observable = require("tns-core-modules-widgets/data/observable").Observabl
 				expectedShortImports: []
 			},
 			{
+				filesContents: {
+					// minified code that has both require and some of the tns-core-modules subdirs (i.e. text)
+					file1: `o.cache&&(r+="&cache="+u(o.cache)),t=["<!DOCTYPE html>","<html>","<head>",'<meta charset="UTF-8" />','<script type="text/javascript">',"   var UWA = {hosts:"+n(e.hosts)+"},",'       curl = {apiName: "require"};`
+				},
+				expectedShortImports: []
+			},
+			{
+				filesContents: {
+					// spaces around require
+					file1: 'const application   = require     (  "application"   ); console.log("application");',
+				},
+				expectedShortImports: [
+					{ file: "file1", line: 'const application   = require     (  "application"   )' }
+				]
+			},
+			{
+				filesContents: {
+					// spaces around require
+					file1: 'const application   = require     (  "tns-core-modules/application"   ); console.log("application");',
+				},
+				expectedShortImports: []
+			},
+			{
+				filesContents: {
+					// spaces in import line
+					file1: "import     { run }       from    'application'       ;",
+				},
+				expectedShortImports: [
+					{ file: "file1", line: "import     { run }       from    'application'       " }
+				]
+			},
+			{
+				filesContents: {
+					// spaces in import line
+					file1: "import     { run }       from    'tns-core-modules/application'       ;",
+				},
+				expectedShortImports: []
+			},
+			{
 				// Incorrect behavior, currently by design
 				// In case you have a multiline string and one of the lines matches our RegExp we'll detect it as short import
 				filesContents: {
-					file1: 'const _ = require("lodash");const application = require("application");console.log("application");console.log(`this is line\nyou should import some long words here "application" module and other words here`)',
+					file1: 'const _ = require("lodash");const application = require("application");console.log("application");console.log(`this is line\nyou should import some long words here require("application") module and other words here`)',
 				},
 				expectedShortImports: [
 					{ file: "file1", line: 'const application = require("application")' },
-					{ file: "file1", line: 'you should import some long words here "application" module and other words here`)' },
+					{ file: "file1", line: 'you should import some long words here require("application") module and other words here`)' },
 				]
 			},
 		];


### PR DESCRIPTION
In some cases when there's minified code, CLI prints warning for short imports, while in fact there's no such thing in the code.
Fix the regular exepression to be more strict.
Also, instead of iterrating over each regular expression for core-modules directories, join them in a single RegExp. This improves the worst case scenario (i.e. when there are short imports for `xml` of `tns-core-modules`) with around 40%.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
CLI prints warnings for short imports when there's `require` and `text/javascript` on one line.

## What is the new behavior?
CLI prints warnings only for actual requires.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

