### PR TITLE
fix: do not wait 60 seconds for debugger port when the app is crashed

### DIFF
--- a/lib/common/constants.ts
+++ b/lib/common/constants.ts
@@ -54,6 +54,7 @@ export class EmulatorDiscoveryNames {
 
 export const DEVICE_LOG_EVENT_NAME = "deviceLogData";
 export const IOS_LOG_PREDICATE = 'senderImagePath contains "NativeScript" || eventMessage contains[c] "NativeScript"';
+export const IOS_APP_CRASH_LOG_REG_EXP = /Fatal JavaScript exception \- application has been terminated/;
 
 export const TARGET_FRAMEWORK_IDENTIFIERS = {
 	Cordova: "Cordova",

--- a/lib/common/mobile/ios/device/ios-device.ts
+++ b/lib/common/mobile/ios/device/ios-device.ts
@@ -60,8 +60,7 @@ export class IOSDevice extends IOSDeviceBase {
 		}
 	}
 
-	protected async getDebugSocketCore(appId: string, projectName: string): Promise<net.Socket> {
-		await super.attachToDebuggerFoundEvent(projectName);
+	protected async getDebugSocketCore(appId: string): Promise<net.Socket> {
 		await this.$iOSSocketRequestExecutor.executeAttachRequest(this, constants.AWAIT_NOTIFICATION_TIMEOUT_SECONDS, appId);
 		const port = await super.getDebuggerPort(appId);
 		const deviceId = this.deviceInfo.identifier;

--- a/lib/common/mobile/ios/ios-device-base.ts
+++ b/lib/common/mobile/ios/ios-device-base.ts
@@ -22,7 +22,9 @@ export abstract class IOSDeviceBase implements Mobile.IiOSDevice {
 					return this.cachedSockets[appId];
 				}
 
-				this.cachedSockets[appId] = await this.getDebugSocketCore(appId, projectName);
+				await this.attachToDebuggerFoundEvent(appId, projectName);
+				await this.applicationManager.startApplication({ appId, projectName });
+				this.cachedSockets[appId] = await this.getDebugSocketCore(appId);
 
 				if (this.cachedSockets[appId]) {
 					this.cachedSockets[appId].on("close", async () => {
@@ -38,11 +40,11 @@ export abstract class IOSDeviceBase implements Mobile.IiOSDevice {
 		);
 	}
 
-	protected abstract async getDebugSocketCore(appId: string, projectName: string): Promise<net.Socket>;
+	protected abstract async getDebugSocketCore(appId: string): Promise<net.Socket>;
 
-	protected async attachToDebuggerFoundEvent(projectName: string): Promise<void> {
+	protected async attachToDebuggerFoundEvent(appId: string, projectName: string): Promise<void> {
 		await this.startDeviceLogProcess(projectName);
-		await this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent();
+		await this.$iOSDebuggerPortService.attachToDebuggerPortFoundEvent(appId);
 	}
 
 	protected async getDebuggerPort(appId: string): Promise<number> {

--- a/lib/common/mobile/ios/simulator/ios-simulator-device.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-device.ts
@@ -53,9 +53,8 @@ export class IOSSimulator extends IOSDeviceBase implements Mobile.IiOSDevice {
 		return this.$iOSSimulatorLogProvider.startLogProcess(this.simulator.id, options);
 	}
 
-	protected async getDebugSocketCore(appId: string, projectName: string): Promise<net.Socket> {
+	protected async getDebugSocketCore(appId: string): Promise<net.Socket> {
 		let socket: net.Socket;
-		await super.attachToDebuggerFoundEvent(projectName);
 		const attachRequestMessage = this.$iOSNotification.getAttachRequest(appId, this.deviceInfo.identifier);
 		await this.$iOSEmulatorServices.postDarwinNotification(attachRequestMessage, this.deviceInfo.identifier);
 		const port = await super.getDebuggerPort(appId);

--- a/lib/definitions/hmr-status-service.d.ts
+++ b/lib/definitions/hmr-status-service.d.ts
@@ -1,4 +1,5 @@
 interface IHmrStatusService {
+	watchHmrStatus(deviceId: string, operationHash: string): void;
 	getHmrStatus(deviceId: string, operationHash: string): Promise<number>;
 	attachToHmrStatusEvent(): void;
 }

--- a/lib/definitions/ios-debugger-port-service.d.ts
+++ b/lib/definitions/ios-debugger-port-service.d.ts
@@ -12,6 +12,7 @@ interface IIOSDebuggerPortData {
 interface IIOSDebuggerPortStoredData {
 	port: number;
 	timer?: NodeJS.Timer;
+	error?: Error;
 }
 
 interface IIOSDebuggerPortService {
@@ -24,5 +25,5 @@ interface IIOSDebuggerPortService {
 	 * Attaches on DEBUGGER_PORT_FOUND event and stores the port
 	 * @returns {Promise<void>}
 	 */
-	attachToDebuggerPortFoundEvent(): Promise<void>;
+	attachToDebuggerPortFoundEvent(appId: string): Promise<void>;
 }

--- a/lib/services/ios-debugger-port-service.ts
+++ b/lib/services/ios-debugger-port-service.ts
@@ -1,10 +1,9 @@
-import { DEBUGGER_PORT_FOUND_EVENT_NAME, ATTACH_REQUEST_EVENT_NAME } from "../common/constants";
+import { DEBUGGER_PORT_FOUND_EVENT_NAME, ATTACH_REQUEST_EVENT_NAME, IOS_APP_CRASH_LOG_REG_EXP } from "../common/constants";
 import { cache } from "../common/decorators";
 import { APPLICATION_RESPONSE_TIMEOUT_SECONDS } from "../constants";
 
 export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 	public static DEBUG_PORT_LOG_REGEX = /NativeScript debugger has opened inspector socket on port (\d+?) for (.*)[.]/;
-	public static APP_CRASH_LOG_REGEX = /Fatal JavaScript exception \- application has been terminated/;
 	private mapDebuggerPortData: IDictionary<IIOSDebuggerPortStoredData> = {};
 	private currentAppId: string;
 
@@ -51,12 +50,13 @@ export class IOSDebuggerPortService implements IIOSDebuggerPortService {
 			platform: this.$devicePlatformsConstants.iOS.toLowerCase()
 		});
 		this.$logParserService.addParseRule({
-			regex: IOSDebuggerPortService.APP_CRASH_LOG_REGEX,
+			regex: IOS_APP_CRASH_LOG_REG_EXP,
 			handler: this.handleAppCrash.bind(this),
 			name: "appCrash",
 			platform: this.$devicePlatformsConstants.iOS.toLowerCase()
 		});
 	}
+
 	private handleAppCrash(matches: RegExpMatchArray, deviceId: string): void {
 		const data = {
 			port: 0,

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -664,12 +664,17 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 										const service = this.getLiveSyncService(device.deviceInfo.platform);
 
 										const watchAction = async (watchInfo: ILiveSyncWatchInfo): Promise<void> => {
+											const isInHMRMode = liveSyncData.useHotModuleReload && platformHmrData.hash;
+											if (isInHMRMode) {
+												this.$hmrStatusService.watchHmrStatus(device.deviceInfo.identifier, platformHmrData.hash);
+											}
+
 											let liveSyncResultInfo = await service.liveSyncWatchAction(device, watchInfo);
 
 											await this.refreshApplication(projectData, liveSyncResultInfo, deviceBuildInfoDescriptor.debugOptions, deviceBuildInfoDescriptor.outputPath);
 
-											// If didRecover is true, this means we were in ErrorActivity and fallback files were already transfered and app will be restarted.
-											if (!liveSyncResultInfo.didRecover && liveSyncData.useHotModuleReload && platformHmrData.hash) {
+											// If didRecover is true, this means we were in ErrorActivity and fallback files were already transferred and app will be restarted.
+											if (!liveSyncResultInfo.didRecover && isInHMRMode) {
 												const status = await this.$hmrStatusService.getHmrStatus(device.deviceInfo.identifier, platformHmrData.hash);
 												if (status === HmrConstants.HMR_ERROR_STATUS) {
 													watchInfo.filesToSync = platformHmrData.fallbackFiles;

--- a/test/services/ios-debugger-port-service.ts
+++ b/test/services/ios-debugger-port-service.ts
@@ -90,6 +90,48 @@ function getMultilineDebuggerPortMessage(port: number) {
 		2018-04-20 09:45:51.260951+0300  localhost nglog[17917]: NativeScript debugger has opened inspector socket on port ${port} for ${appId}.`;
 }
 
+function getAppCrashMessage() {
+	return `***** Fatal JavaScript exception - application has been terminated. *****`;
+}
+
+function getMultilineAppCrashMessage() {
+	return `Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: ***** Fatal JavaScript exception - application has been terminated. *****
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: Native stack trace:
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 1   0x1013ef370 NativeScript::reportFatalErrorBeforeShutdown(JSC::ExecState*, JSC::Exception*, bool)
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 2   0x10141fdec NativeScript::FFICallback<NativeScript::ObjCMethodCallback>::ffiClosureCallback(ffi_cif*, void*, void**, void*)
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 3   0x101e84494 ffi_closure_SYSV_inner
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 4   0x101e881b4 .Ldo_closure
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 5   0x183760c3c <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 6   0x1837601b8 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 7   0x18375ff14 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 8   0x1837dd84c <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 9   0x183696f38 _CFXNotificationPost
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 10  0x184107bbc <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 11  0x18d3da2f0 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 12  0x18d3a75e0 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 13  0x18d9d7b1c <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 14  0x18d3a6dd0 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 15  0x18d3a6c6c <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 16  0x18d3a5afc <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 17  0x18e03b84c <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 18  0x18d3a51ec <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 19  0x18de20ac8 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 20  0x18df6ebf8 _performActionsWithDelayForTransitionContext
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 21  0x18d3a4c0c <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 22  0x18d3a45a8 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 23  0x18d3a15e0 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 24  0x18d3a1330 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 25  0x185fcf470 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 26  0x185fd7d6c <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 27  0x1830c0a60 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 28  0x1830c8170 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 29  0x186003878 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 30  0x18600351c <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 31  0x186003ab8 <redacted>
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: JavaScript stack trace:
+	Mar 20 15:13:23 iOS-Team-iPad-2-Mini-Black hwJs(NativeScript)[3946] <Notice>: 1   @file:///app/vendor.js:12552:56`;
+}
+
 describe("iOSDebuggerPortService", () => {
 	let injector: IInjector, iOSDebuggerPortService: IIOSDebuggerPortService, deviceLogProvider: Mobile.IDeviceLogProvider;
 	let clock: sinon.SinonFakeTimers = null;
@@ -108,71 +150,63 @@ describe("iOSDebuggerPortService", () => {
 	function emitDeviceLog(message: string) {
 		deviceLogProvider.emit(DEVICE_LOG_EVENT_NAME, message, device.deviceInfo.identifier);
 	}
-
-	function emitStartingIOSApplicationEvent() {
-		device.applicationManager.emit("STARTING_IOS_APPLICATION", {
-			appId: appId,
-			deviceId: device.deviceInfo.identifier
-		});
-	}
-
 	describe("getPort", () => {
-		const testCases = [
+		const testCases: { name: string, emittedPort?: number, crashApp?: boolean, expectedError?: string }[] = [
 			{
 				name: `should return null when ${DEBUGGER_PORT_FOUND_EVENT_NAME} event is not emitted`,
-				emittedPort: null,
-				emitStartingIOSApplicationEvent: false
+				emittedPort: null
 			},
 			{
 				name: `should return default port when ${DEBUGGER_PORT_FOUND_EVENT_NAME} event is emitted`,
-				emittedPort: 18181,
-				emitStartingIOSApplicationEvent: false
+				emittedPort: 18181
 			},
 			{
 				name: `should return random port when ${DEBUGGER_PORT_FOUND_EVENT_NAME} event is emitted`,
-				emittedPort: 65432,
-				emitStartingIOSApplicationEvent: false
+				emittedPort: 65432
 			},
 			{
-				name: `should return default port when ${DEBUGGER_PORT_FOUND_EVENT_NAME} and STARTING_IOS_APPLICATION events are emitted`,
-				emittedPort: 18181,
-				emitStartingIOSApplicationEvent: true
-			},
-			{
-				name: `should return random port when ${DEBUGGER_PORT_FOUND_EVENT_NAME} and STARTING_IOS_APPLICATION events are emitted`,
-				emittedPort: 12345,
-				emitStartingIOSApplicationEvent: true
+				name: `should reject when the app crashes`,
+				expectedError: "The application has been terminated.",
+				crashApp: true
 			}
 		];
 
 		_.each(testCases, testCase => {
 			it(testCase.name, async () => {
-				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent();
-				if (testCase.emitStartingIOSApplicationEvent) {
-					emitStartingIOSApplicationEvent();
-				}
+				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent(appId);
 				if (testCase.emittedPort) {
 					emitDeviceLog(getDebuggerPortMessage(testCase.emittedPort));
+				} else if (testCase.crashApp) {
+					emitDeviceLog(getAppCrashMessage());
 				}
 
 				const promise = iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId });
 				clock.tick(70000);
-				const port = await promise;
-				assert.deepEqual(port, testCase.emittedPort);
+				let port = 0;
+				try {
+					port = await promise;
+					assert.deepEqual(port, testCase.emittedPort);
+				} catch (err) {
+					assert.deepEqual(err.message, testCase.expectedError);
+				}
 			});
 			it(`${testCase.name} for multiline debugger port message.`, async () => {
-				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent();
-				if (testCase.emitStartingIOSApplicationEvent) {
-					emitStartingIOSApplicationEvent();
-				}
+				await iOSDebuggerPortService.attachToDebuggerPortFoundEvent(appId);
 				if (testCase.emittedPort) {
 					emitDeviceLog(getMultilineDebuggerPortMessage(testCase.emittedPort));
+				} else if (testCase.crashApp) {
+					emitDeviceLog(getMultilineAppCrashMessage());
 				}
 
 				const promise = iOSDebuggerPortService.getPort({ deviceId: deviceId, appId: appId });
 				clock.tick(70000);
-				const port = await promise;
-				assert.deepEqual(port, testCase.emittedPort);
+				let port = 0;
+				try {
+					port = await promise;
+					assert.deepEqual(port, testCase.emittedPort);
+				} catch (err) {
+					assert.deepEqual(err.message, testCase.expectedError);
+				}
 			});
 		});
 	});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
If you LiveSync a crashing app, the CLI will wait 60 seconds for its debug port and log a warning for a manual app start.

## What is the new behavior?
If you LiveSync a crashing app, the CLI will start the app and stop looking for its debug port after the crash without logging any warnings.

Related to: https://github.com/NativeScript/nativescript-cli/issues/4441