### PR TITLE
fix: start iOS simulator logs before starting the app

### DIFF
--- a/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -58,9 +58,10 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 			waitForDebugger: true,
 			args: "--nativescript-debug-brk",
 		} : {};
+		await this.setDeviceLogData(appData);
 		const launchResult = await this.iosSim.startApplication(this.device.deviceInfo.identifier, appData.appId, options);
 		const pid = getPidFromiOSSimulatorLogs(appData.appId, launchResult);
-		await this.setDeviceLogData(appData, pid);
+		this.$deviceLogProvider.setApplicationPidForDevice(this.device.deviceInfo.identifier, pid);
 		if (appData.waitForDebugger) {
 			this.attachNativeDebugger(appData.appId, pid);
 		}
@@ -114,8 +115,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		}
 	}
 
-	private async setDeviceLogData(appData: Mobile.IApplicationData, pid: string): Promise<void> {
-		this.$deviceLogProvider.setApplicationPidForDevice(this.device.deviceInfo.identifier, pid);
+	private async setDeviceLogData(appData: Mobile.IApplicationData): Promise<void> {
 		this.$deviceLogProvider.setProjectNameForDevice(this.device.deviceInfo.identifier, appData.projectName);
 
 		if (!this.$options.justlaunch) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The Simulator logs in your app entry point might not be shown in the CLI output.

## What is the new behavior?
We listen for Simulator logs before we start the app and we won't miss any of them.
