### PR TITLE
feat: add ability to pass schema to preview app from nsconfig file

### DIFF
--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -29,7 +29,11 @@ export class PreviewCommand implements ICommand {
 			env: this.$options.env
 		});
 
-		await this.$previewQrCodeService.printLiveSyncQrCode({ useHotModuleReload: this.$options.hmr, link: this.$options.link });
+		await this.$previewQrCodeService.printLiveSyncQrCode({
+			nsConfigPreviewAppSchema: this.$projectData.previewAppSchema,
+			useHotModuleReload: this.$options.hmr,
+			link: this.$options.link
+		});
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -30,7 +30,7 @@ export class PreviewCommand implements ICommand {
 		});
 
 		await this.$previewQrCodeService.printLiveSyncQrCode({
-			nsConfigPreviewAppSchema: this.$projectData.previewAppSchema,
+			projectDir: this.$projectData.projectDir,
 			useHotModuleReload: this.$options.hmr,
 			link: this.$options.link
 		});

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -18,13 +18,26 @@ declare global {
 		filesToRemove?: string[];
 	}
 
-	interface IPreviewAppLiveSyncData extends IProjectDir, IHasUseHotModuleReloadOption, IBundle, IEnvOptions { }
+	interface IPreviewAppLiveSyncData extends IProjectDir, IHasUseHotModuleReloadOption, IBundle, IEnvOptions {
+		qrCodeData?: IPreviewAppQrCodeData;
+	}
+
+	interface IPreviewAppQrCodeData {
+		publishKey?: string;
+		subscribeKey?: string;
+		schemaName?: string;
+	}
 
 	interface IPreviewSdkService extends EventEmitter {
-		getQrCodeUrl(options: IHasUseHotModuleReloadOption): string;
+		getQrCodeUrl(options: IGetQrCodeUrlOptions): string;
 		initialize(getInitialFiles: (device: Device) => Promise<FilesPayload>): void;
 		applyChanges(filesPayload: FilesPayload): Promise<void>;
 		stop(): void;
+	}
+
+	interface IGetQrCodeUrlOptions extends IHasUseHotModuleReloadOption {
+		nsConfigPreviewAppSchema?: string;
+		qrCodeData?: IPreviewAppQrCodeData;
 	}
 
 	interface IPreviewAppPluginsService {
@@ -48,6 +61,7 @@ declare global {
 	}
 
 	interface IPrintLiveSyncOptions extends IHasUseHotModuleReloadOption {
+		nsConfigPreviewAppSchema?: string;
 		/**
 		 * If set to true, a link will be shown on console instead of QR code
 		 * Default value is false.

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -18,15 +18,7 @@ declare global {
 		filesToRemove?: string[];
 	}
 
-	interface IPreviewAppLiveSyncData extends IProjectDir, IHasUseHotModuleReloadOption, IBundle, IEnvOptions {
-		qrCodeData?: IPreviewAppQrCodeData;
-	}
-
-	interface IPreviewAppQrCodeData {
-		publishKey?: string;
-		subscribeKey?: string;
-		schemaName?: string;
-	}
+	interface IPreviewAppLiveSyncData extends IProjectDir, IHasUseHotModuleReloadOption, IBundle, IEnvOptions { }
 
 	interface IPreviewSdkService extends EventEmitter {
 		getQrCodeUrl(options: IGetQrCodeUrlOptions): string;
@@ -35,10 +27,7 @@ declare global {
 		stop(): void;
 	}
 
-	interface IGetQrCodeUrlOptions extends IHasUseHotModuleReloadOption {
-		nsConfigPreviewAppSchema?: string;
-		qrCodeData?: IPreviewAppQrCodeData;
-	}
+	interface IGetQrCodeUrlOptions extends IHasUseHotModuleReloadOption, IProjectDir { }
 
 	interface IPreviewAppPluginsService {
 		getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[];
@@ -60,8 +49,7 @@ declare global {
 		platform?: string;
 	}
 
-	interface IPrintLiveSyncOptions extends IHasUseHotModuleReloadOption {
-		nsConfigPreviewAppSchema?: string;
+	interface IPrintLiveSyncOptions extends IGetQrCodeUrlOptions {
 		/**
 		 * If set to true, a link will be shown on console instead of QR code
 		 * Default value is false.

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -75,6 +75,7 @@ interface INsConfig {
 	appResourcesPath?: string;
 	shared?: boolean;
 	useLegacyWorkflow?: boolean;
+	previewAppSchema?: string;
 }
 
 interface IProjectData extends ICreateProjectData {
@@ -104,6 +105,11 @@ interface IProjectData extends ICreateProjectData {
 	 * Defines if the project has hmr enabled by default
 	 */
 	useLegacyWorkflow: boolean;
+
+	/**
+	 * Defines the schema for the preview app
+	 */
+	previewAppSchema: string;
 
 	/**
 	 * Initializes project data with the given project directory. If none supplied defaults to --path option or cwd.

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -62,6 +62,7 @@ export class ProjectData implements IProjectData {
 	public podfilePath: string;
 	public isShared: boolean;
 	public useLegacyWorkflow: boolean;
+	public previewAppSchema: string;
 
 	constructor(private $fs: IFileSystem,
 		private $errors: IErrors,
@@ -137,6 +138,7 @@ export class ProjectData implements IProjectData {
 			this.podfilePath = path.join(this.appResourcesDirectoryPath, this.$devicePlatformsConstants.iOS, constants.PODFILE_NAME);
 			this.isShared = !!(this.nsConfig && this.nsConfig.shared);
 			this.useLegacyWorkflow = this.nsConfig && this.nsConfig.useLegacyWorkflow;
+			this.previewAppSchema = this.nsConfig && this.nsConfig.previewAppSchema;
 			return;
 		}
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -66,12 +66,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 			env: data.env,
 		});
 
-		const projectData = this.$projectDataService.getProjectData(data.projectDir);
-		const url = this.$previewSdkService.getQrCodeUrl({
-			nsConfigPreviewAppSchema: projectData.previewAppSchema,
-			qrCodeData: data.qrCodeData,
-			useHotModuleReload: data.useHotModuleReload
-		});
+		const url = this.$previewSdkService.getQrCodeUrl({ projectDir: data.projectDir, useHotModuleReload: data.useHotModuleReload });
 		const result = await this.$previewQrCodeService.getLiveSyncQrCode(url);
 		return result;
 	}

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -66,7 +66,12 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 			env: data.env,
 		});
 
-		const url = this.$previewSdkService.getQrCodeUrl({ useHotModuleReload: data.useHotModuleReload });
+		const projectData = this.$projectDataService.getProjectData(data.projectDir);
+		const url = this.$previewSdkService.getQrCodeUrl({
+			nsConfigPreviewAppSchema: projectData.previewAppSchema,
+			qrCodeData: data.qrCodeData,
+			useHotModuleReload: data.useHotModuleReload
+		});
 		const result = await this.$previewQrCodeService.getLiveSyncQrCode(url);
 		return result;
 	}

--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -12,17 +12,21 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 		private $httpClient: Server.IHttpClient,
 		private $logger: ILogger,
 		private $previewDevicesService: IPreviewDevicesService,
-		private $previewAppLogProvider: IPreviewAppLogProvider) {
+		private $previewAppLogProvider: IPreviewAppLogProvider,
+		private $projectDataService: IProjectDataService) {
 			super();
 	}
 
 	public getQrCodeUrl(options: IGetQrCodeUrlOptions): string {
-		const { nsConfigPreviewAppSchema, qrCodeData = { }, useHotModuleReload } = options;
-		const schema = qrCodeData.schemaName || nsConfigPreviewAppSchema || "nsplay";
-		const publishKey = qrCodeData.publishKey || PubnubKeys.PUBLISH_KEY;
-		const subscribeKey = qrCodeData.subscribeKey || PubnubKeys.SUBSCRIBE_KEY;
+		const { projectDir, useHotModuleReload } = options;
+		const projectData = this.$projectDataService.getProjectData(projectDir);
+		const schema = projectData.previewAppSchema || "nsplay";
+		// TODO: Use the correct keys for the schema
+		const publishKey = PubnubKeys.PUBLISH_KEY;
+		const subscribeKey = PubnubKeys.SUBSCRIBE_KEY;
 		const hmrValue = useHotModuleReload ? "1" : "0";
-		return `${schema}://boot?instanceId=${this.instanceId}&pKey=${publishKey}&sKey=${subscribeKey}&template=play-ng&hmr=${hmrValue}`;
+		const result = `${schema}://boot?instanceId=${this.instanceId}&pKey=${publishKey}&sKey=${subscribeKey}&template=play-ng&hmr=${hmrValue}`;
+		return result;
 	}
 
 	public async initialize(getInitialFiles: (device: Device) => Promise<FilesPayload>): Promise<void> {

--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -16,9 +16,13 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 			super();
 	}
 
-	public getQrCodeUrl(options: IHasUseHotModuleReloadOption): string {
-		const hmrValue = options.useHotModuleReload ? "1" : "0";
-		return `nsplay://boot?instanceId=${this.instanceId}&pKey=${PubnubKeys.PUBLISH_KEY}&sKey=${PubnubKeys.SUBSCRIBE_KEY}&template=play-ng&hmr=${hmrValue}`;
+	public getQrCodeUrl(options: IGetQrCodeUrlOptions): string {
+		const { nsConfigPreviewAppSchema, qrCodeData = { }, useHotModuleReload } = options;
+		const schema = qrCodeData.schemaName || nsConfigPreviewAppSchema || "nsplay";
+		const publishKey = qrCodeData.publishKey || PubnubKeys.PUBLISH_KEY;
+		const subscribeKey = qrCodeData.subscribeKey || PubnubKeys.SUBSCRIBE_KEY;
+		const hmrValue = useHotModuleReload ? "1" : "0";
+		return `${schema}://boot?instanceId=${this.instanceId}&pKey=${publishKey}&sKey=${subscribeKey}&template=play-ng&hmr=${hmrValue}`;
 	}
 
 	public async initialize(getInitialFiles: (device: Device) => Promise<FilesPayload>): Promise<void> {

--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -194,7 +194,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 				useHotModuleReload: options.hmr
 			});
 
-			await this.$previewQrCodeService.printLiveSyncQrCode({ useHotModuleReload: options.hmr, link: options.link });
+			await this.$previewQrCodeService.printLiveSyncQrCode({ projectDir, useHotModuleReload: options.hmr, link: options.link });
 		}
 	}
 

--- a/test/services/preview-sdk-service.ts
+++ b/test/services/preview-sdk-service.ts
@@ -2,6 +2,7 @@ import { PreviewSdkService } from "../../lib/services/livesync/playground/previe
 import { Yok } from "../../lib/common/yok";
 import { assert } from "chai";
 import { LoggerStub } from "../stubs";
+import { PubnubKeys } from "../../lib/services/livesync/playground/preview-app-constants";
 
 const getPreviewSdkService = (): IPreviewSdkService => {
 	const testInjector = new Yok();
@@ -19,20 +20,108 @@ const getPreviewSdkService = (): IPreviewSdkService => {
 
 describe('PreviewSdkService', () => {
 	describe('getQrCodeUrl', () => {
-		it('sets hmr to 1 when useHotModuleReload is true', async () => {
-			const sdk = getPreviewSdkService();
+		describe("hmr", () => {
+			it('sets hmr to 1 when useHotModuleReload is true', async () => {
+				const sdk = getPreviewSdkService();
 
-			const previewUrl = sdk.getQrCodeUrl({ useHotModuleReload: true });
+				const previewUrl = sdk.getQrCodeUrl({ useHotModuleReload: true });
 
-			assert.isTrue(previewUrl.indexOf("hmr=1") > -1);
+				assert.isTrue(previewUrl.indexOf("hmr=1") > -1);
+			});
+			it('sets hmr to 0 when useHotModuleReload is false', async () => {
+				const sdk = getPreviewSdkService();
+
+				const previewUrl = sdk.getQrCodeUrl({ useHotModuleReload: false });
+
+				assert.isTrue(previewUrl.indexOf("hmr=0") > -1);
+			});
 		});
-	});
 
-	it('sets hmr to 0 when useHotModuleReload is false', async () => {
-		const sdk = getPreviewSdkService();
+		describe("schema", () => {
+			const testCases: [{ name: string, schemaFromApi: string, schemaFromNsConfig: string, expectedSchemaName: string }] = [
+				{
+					name: "should return the schema from api",
+					schemaFromApi: "ksplay",
+					schemaFromNsConfig: null,
+					expectedSchemaName: "ksplay"
+				},
+				{
+					name: "should return the schema from nsconfig",
+					schemaFromApi: null,
+					schemaFromNsConfig: "ksplay",
+					expectedSchemaName: "ksplay"
+				},
+				{
+					name: "should return the default schema",
+					schemaFromApi: null,
+					schemaFromNsConfig: null,
+					expectedSchemaName: "nsplay"
+				}
+			];
 
-		const previewUrl = sdk.getQrCodeUrl({ useHotModuleReload: false });
+			_.each(testCases, testCase => {
+				it(`${testCase.name}`, () => {
+					const qrCodeData = { schemaName: testCase.schemaFromApi };
+					const qrCodeOptions = { nsConfigPreviewAppSchema: testCase.schemaFromNsConfig, qrCodeData, useHotModuleReload: true };
+					const previewSdkService = getPreviewSdkService();
 
-		assert.isTrue(previewUrl.indexOf("hmr=0") > -1);
+					const qrCodeUrl = previewSdkService.getQrCodeUrl(qrCodeOptions);
+
+					assert.deepEqual(qrCodeUrl.split(":")[0], testCase.expectedSchemaName);
+				});
+			});
+		});
+
+		describe("publishKey", () => {
+			const testCases = [
+				{
+					name: "should return the provided key from api",
+					publishKeyFromApi: "myTestPublishKey",
+					expectedPublishKey: "myTestPublishKey"
+				},
+				{
+					name: "should return the default key",
+					publishKeyFromApi: null,
+					expectedPublishKey: PubnubKeys.PUBLISH_KEY
+				}
+			];
+
+			_.each(testCases, testCase => {
+				it(`${testCase.name}`, () => {
+					const qrCodeOptions = { projectData: <any>{}, qrCodeData: <any>{ publishKey: testCase.publishKeyFromApi }, useHotModuleReload: true };
+					const previewSdkService = getPreviewSdkService();
+
+					const qrCodeUrl = previewSdkService.getQrCodeUrl(qrCodeOptions);
+
+					assert.isTrue(qrCodeUrl.indexOf(`&pKey=${testCase.expectedPublishKey}`) > -1);
+				});
+			});
+		});
+
+		describe("subscribeKey", () => {
+			const testCases = [
+				{
+					name: "should return the provided key from api",
+					subscribeKeyFromApi: "myTestSubscribeKey",
+					expectedSubscribeKey: "myTestSubscribeKey"
+				},
+				{
+					name: "should return the default key",
+					subscribeKeyFromApi: null,
+					expectedSubscribeKey: PubnubKeys.SUBSCRIBE_KEY
+				}
+			];
+
+			_.each(testCases, testCase => {
+				it(`${testCase.name}`, () => {
+					const qrCodeOptions = { projectData: <any>{}, qrCodeData: <any>{ subscribeKey: testCase.subscribeKeyFromApi }, useHotModuleReload: true };
+					const previewSdkService = getPreviewSdkService();
+
+					const qrCodeUrl = previewSdkService.getQrCodeUrl(qrCodeOptions);
+
+					assert.isTrue(qrCodeUrl.indexOf(`&sKey=${testCase.expectedSubscribeKey}`) > -1);
+				});
+			});
+		});
 	});
 });

--- a/test/services/preview-sdk-service.ts
+++ b/test/services/preview-sdk-service.ts
@@ -2,9 +2,8 @@ import { PreviewSdkService } from "../../lib/services/livesync/playground/previe
 import { Yok } from "../../lib/common/yok";
 import { assert } from "chai";
 import { LoggerStub } from "../stubs";
-import { PubnubKeys } from "../../lib/services/livesync/playground/preview-app-constants";
 
-const getPreviewSdkService = (): IPreviewSdkService => {
+const createTestInjector = (): IInjector => {
 	const testInjector = new Yok();
 	testInjector.register("logger", LoggerStub);
 	testInjector.register("config", {});
@@ -14,46 +13,49 @@ const getPreviewSdkService = (): IPreviewSdkService => {
 	testInjector.register("httpClient", {
 		httpRequest: async (options: any, proxySettings?: IProxySettings): Promise<Server.IResponse> => undefined
 	});
+	testInjector.register("projectDataService", {
+		getProjectData: () => ({})
+	});
 
-	return testInjector.resolve("previewSdkService");
+	return testInjector;
 };
 
 describe('PreviewSdkService', () => {
+	let injector: IInjector, previewSdkService: IPreviewSdkService;
+
+	beforeEach(() => {
+		injector = createTestInjector();
+		previewSdkService = injector.resolve("previewSdkService");
+	});
+
 	describe('getQrCodeUrl', () => {
 		describe("hmr", () => {
 			it('sets hmr to 1 when useHotModuleReload is true', async () => {
-				const sdk = getPreviewSdkService();
-
-				const previewUrl = sdk.getQrCodeUrl({ useHotModuleReload: true });
+				const previewUrl = previewSdkService.getQrCodeUrl({ projectDir: "", useHotModuleReload: true });
 
 				assert.isTrue(previewUrl.indexOf("hmr=1") > -1);
 			});
 			it('sets hmr to 0 when useHotModuleReload is false', async () => {
-				const sdk = getPreviewSdkService();
-
-				const previewUrl = sdk.getQrCodeUrl({ useHotModuleReload: false });
+				const previewUrl = previewSdkService.getQrCodeUrl({ projectDir: "", useHotModuleReload: false });
 
 				assert.isTrue(previewUrl.indexOf("hmr=0") > -1);
 			});
 		});
 
 		describe("schema", () => {
-			const testCases: [{ name: string, schemaFromApi: string, schemaFromNsConfig: string, expectedSchemaName: string }] = [
+			const testCases = [
 				{
 					name: "should return the schema from api",
-					schemaFromApi: "ksplay",
-					schemaFromNsConfig: null,
-					expectedSchemaName: "ksplay"
+					schemaFromNsConfig: "nsplay",
+					expectedSchemaName: "nsplay"
 				},
 				{
 					name: "should return the schema from nsconfig",
-					schemaFromApi: null,
 					schemaFromNsConfig: "ksplay",
 					expectedSchemaName: "ksplay"
 				},
 				{
 					name: "should return the default schema",
-					schemaFromApi: null,
 					schemaFromNsConfig: null,
 					expectedSchemaName: "nsplay"
 				}
@@ -61,65 +63,13 @@ describe('PreviewSdkService', () => {
 
 			_.each(testCases, testCase => {
 				it(`${testCase.name}`, () => {
-					const qrCodeData = { schemaName: testCase.schemaFromApi };
-					const qrCodeOptions = { nsConfigPreviewAppSchema: testCase.schemaFromNsConfig, qrCodeData, useHotModuleReload: true };
-					const previewSdkService = getPreviewSdkService();
+					const qrCodeOptions = { projectDir: "myTestDir", useHotModuleReload: true };
+					const projectDataService = injector.resolve("projectDataService");
+					projectDataService.getProjectData = () => ({ previewAppSchema: testCase.schemaFromNsConfig });
 
 					const qrCodeUrl = previewSdkService.getQrCodeUrl(qrCodeOptions);
 
 					assert.deepEqual(qrCodeUrl.split(":")[0], testCase.expectedSchemaName);
-				});
-			});
-		});
-
-		describe("publishKey", () => {
-			const testCases = [
-				{
-					name: "should return the provided key from api",
-					publishKeyFromApi: "myTestPublishKey",
-					expectedPublishKey: "myTestPublishKey"
-				},
-				{
-					name: "should return the default key",
-					publishKeyFromApi: null,
-					expectedPublishKey: PubnubKeys.PUBLISH_KEY
-				}
-			];
-
-			_.each(testCases, testCase => {
-				it(`${testCase.name}`, () => {
-					const qrCodeOptions = { projectData: <any>{}, qrCodeData: <any>{ publishKey: testCase.publishKeyFromApi }, useHotModuleReload: true };
-					const previewSdkService = getPreviewSdkService();
-
-					const qrCodeUrl = previewSdkService.getQrCodeUrl(qrCodeOptions);
-
-					assert.isTrue(qrCodeUrl.indexOf(`&pKey=${testCase.expectedPublishKey}`) > -1);
-				});
-			});
-		});
-
-		describe("subscribeKey", () => {
-			const testCases = [
-				{
-					name: "should return the provided key from api",
-					subscribeKeyFromApi: "myTestSubscribeKey",
-					expectedSubscribeKey: "myTestSubscribeKey"
-				},
-				{
-					name: "should return the default key",
-					subscribeKeyFromApi: null,
-					expectedSubscribeKey: PubnubKeys.SUBSCRIBE_KEY
-				}
-			];
-
-			_.each(testCases, testCase => {
-				it(`${testCase.name}`, () => {
-					const qrCodeOptions = { projectData: <any>{}, qrCodeData: <any>{ subscribeKey: testCase.subscribeKeyFromApi }, useHotModuleReload: true };
-					const previewSdkService = getPreviewSdkService();
-
-					const qrCodeUrl = previewSdkService.getQrCodeUrl(qrCodeOptions);
-
-					assert.isTrue(qrCodeUrl.indexOf(`&sKey=${testCase.expectedSubscribeKey}`) > -1);
 				});
 			});
 		});

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -332,6 +332,7 @@ export class ProjectDataStub implements IProjectData {
 	public podfilePath: string;
 	public isShared: boolean;
 	public useLegacyWorkflow: boolean;
+	public previewAppSchema: string;
 
 	public initializeProjectData(projectDir?: string): void {
 		this.projectDir = this.projectDir || projectDir;


### PR DESCRIPTION
Currently the schema is hardcoded to `nsplay`. This PR adds support for passing schema and keys from the public api when livesyncing to `preview app`. If no schema is provided, {N} CLI checks if the `previewAppSchema` is added to `nsconfig.json`. If there is no `previewAppSchema` property in `nsconfig`, {N} CLI fallbacks to `nsplay`.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
