### PR TITLE
 fix: debugging clients are now able to debug with debug-brk

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -66,10 +66,6 @@ export class DebugPlatformCommand extends ValidatePlatformCommandBase implements
 			this.$errors.fail("--release flag is not applicable to this command");
 		}
 
-		if (this.$options.hmr && this.$options.debugBrk) {
-			this.$errors.fail("--debug-brk and --hmr flags cannot be combined");
-		}
-
 		const minSupportedWebpackVersion = this.$options.hmr ? LiveSyncCommandHelper.MIN_SUPPORTED_WEBPACK_VERSION_WITH_HMR : null;
 		this.$bundleValidatorHelper.validate(minSupportedWebpackVersion);
 

--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -106,7 +106,7 @@ declare module Mobile {
 	}
 
 	interface IiOSDevice extends IDevice {
-		getDebugSocket(appId: string, projectName: string): Promise<any>;
+		getDebugSocket(appId: string, projectName: string, ensureAppStarted?: boolean): Promise<any>;
 		destroyDebugSocket(appId: string): Promise<void>;
 		openDeviceLogStream(options?: IiOSLogStreamOptions): Promise<void>;
 		destroyAllSockets(): Promise<void>;

--- a/lib/common/mobile/ios/ios-device-base.ts
+++ b/lib/common/mobile/ios/ios-device-base.ts
@@ -15,7 +15,7 @@ export abstract class IOSDeviceBase implements Mobile.IiOSDevice {
 	abstract openDeviceLogStream(options?: Mobile.IiOSLogStreamOptions): Promise<void>;
 
 	@performanceLog()
-	public async getDebugSocket(appId: string, projectName: string): Promise<net.Socket> {
+	public async getDebugSocket(appId: string, projectName: string, ensureAppStarted: boolean = false): Promise<net.Socket> {
 		return this.$lockService.executeActionWithLock(
 			async () => {
 				if (this.cachedSockets[appId]) {
@@ -23,7 +23,10 @@ export abstract class IOSDeviceBase implements Mobile.IiOSDevice {
 				}
 
 				await this.attachToDebuggerFoundEvent(appId, projectName);
-				await this.applicationManager.startApplication({ appId, projectName });
+				if (ensureAppStarted) {
+					await this.applicationManager.startApplication({ appId, projectName });
+				}
+
 				this.cachedSockets[appId] = await this.getDebugSocketCore(appId);
 
 				if (this.cachedSockets[appId]) {

--- a/lib/services/livesync/ios-device-livesync-service.ts
+++ b/lib/services/livesync/ios-device-livesync-service.ts
@@ -25,7 +25,9 @@ export class IOSDeviceLiveSyncService extends DeviceLiveSyncServiceBase implemen
 
 		const appId = projectData.projectIdentifiers.ios;
 		try {
-			this.socket = await this.device.getDebugSocket(appId, projectData.projectName);
+			// TODO: temp workaround till we setup the sockets along with the app start
+			const ensureAppStarted = true;
+			this.socket = await this.device.getDebugSocket(appId, projectData.projectName, ensureAppStarted);
 		} catch (err) {
 			this.$logger.trace(`Error while connecting to the debug socket. Error is:`, err);
 		}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When we try to get debug socket in `tns debug ios --debug-brk`, an additional app start is resuming the app and we are not able to debug the app start.

## What is the new behavior?
We are making an additional app start call only during LiveSync.

<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
