### PR TITLE
Device/emulator detection fixes

### DIFF
--- a/PublicAPI.md
+++ b/PublicAPI.md
@@ -58,6 +58,10 @@ const tns = require("nativescript");
 * [devicesService](#devicesservice)
 	* [getEmulatorImages](#getemulatorimages)
 	* [startEmulator](#startemulator)
+	* [startDeviceDetectionInterval](#startdevicedetectioninterval)
+	* [stopDeviceDetectionInterval](#stopdevicedetectioninterval)
+	* [startEmulatorDetectionInterval](#startemulatordetectioninterval)
+	* [stopEmulatorDetectionInterval](#stopemulatordetectioninterval)
 * [deviceEmitter](#deviceemitter)
 	* [events](#deviceemitterevents)
 * [previewDevicesService](#previewdevicesservice)
@@ -1285,6 +1289,59 @@ The `startEmulator` method starts the emulator specified by provided options. Re
 ```TypeScript
 tns.devicesService.startEmulator({imageIdentifier: "my emulator imageIdentifier"})
 	.then(errors => { });
+```
+
+### startDeviceDetectionInterval
+Starts device detection interval, which is run on specified number of seconds. This allows detection of new attached devices, started emulators/simulators, detection when device/emulator/simulator is disconnected, etc.
+> NOTE: The interval is started automatically when you call `devicesService.initialize` without passing `skipDeviceDetectionInterval: true`.
+
+> NOTE: iOS Device detection interval cannot be stopped, so once started, it will always report connected/disconnected devices.
+
+* Definition
+```TypeScript
+startDeviceDetectionInterval({ detectionInterval?: number, platform?: string }): void
+```
+
+* Usage
+```JavaScript
+tns.devicesService.startDeviceDetectionInterval({ detectionInterval: 1000 });
+```
+
+### stopDeviceDetectionInterval
+Stops device detection interval started by `devicesService.initialize` or `devicesService.startDeviceDetectionInterval`.
+* Definition
+```TypeScript
+stopDeviceDetectionInterval(): void
+```
+
+* Usage
+```JavaScript
+tns.devicesService.stopDeviceDetectionInterval();
+```
+
+### startEmulatorDetectionInterval
+Starts emulator images detection interval, which is run on specified number of seconds. This allows detection of new installed emulator/simulator images.
+
+* Definition
+```TypeScript
+startEmulatorDetectionInterval({ detectionInterval?: number }): void
+```
+
+* Usage
+```JavaScript
+tns.devicesService.startEmulatorDetectionInterval({ detectionInterval: 1000 });
+```
+
+### stopEmulatorDetectionInterval
+Stops device detection interval started by `devicesService.startEmulatorDetectionInterval`.
+* Definition
+```TypeScript
+stopEmulatorDetectionInterval(): void
+```
+
+* Usage
+```JavaScript
+tns.devicesService.stopEmulatorDetectionInterval();
 ```
 
 ## deviceEmitter

--- a/lib/common/bootstrap.ts
+++ b/lib/common/bootstrap.ts
@@ -6,6 +6,7 @@ $injector.require("errors", "./errors");
 $injector.requirePublic("fs", "./file-system");
 $injector.require("hostInfo", "./host-info");
 $injector.require("osInfo", "./os-info");
+$injector.require("timers", "./timers");
 
 $injector.require("dispatcher", "./dispatchers");
 $injector.require("commandDispatcher", "./dispatchers");

--- a/lib/common/declarations.d.ts
+++ b/lib/common/declarations.d.ts
@@ -993,6 +993,18 @@ interface ISysInfo {
 	getJavaCompilerVersion(): Promise<string>;
 
 	/**
+	 * Gets JAVA version based on the executable in PATH.
+	 * @return {Promise<string>}
+	 */
+	getJavaVersionFromPath(): Promise<string>;
+
+	/**
+	 * Gets JAVA version based on the JAVA from JAVA_HOME.
+	 * @return {Promise<string>}
+	 */
+	getJavaVersionFromJavaHome(): Promise<string>;
+
+	/**
 	 * Gets all global warnings for the current environment, for example Node.js version compatibility, OS compatibility, etc.
 	 * @return {Promise<ISystemWarning[]>} All warnings. Empty array is returned in case the system is setup correctly.
 	 */

--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -387,11 +387,7 @@ declare module Mobile {
 	/**
 	 * Describes options that can be passed to devices service's initialization method.
 	 */
-	interface IDevicesServicesInitializationOptions {
-		/**
-		 * The platform for which to initialize. If passed will detect only devices belonging to said platform.
-		 */
-		platform?: string;
+	interface IDevicesServicesInitializationOptions extends Partial<IDeviceLookingOptions> {
 		/**
 		 * If passed will start an emulator if necesasry.
 		 */
@@ -412,10 +408,6 @@ declare module Mobile {
 		 * Specifies whether we should skip the emulator starting.
 		 */
 		skipEmulatorStart?: boolean;
-		/**
-		 * Defines if the initialization should await the whole iOS detection to finish or it can just start the detection.
-		 */
-		shouldReturnImmediateResult?: boolean;
 		/**
 		 * Currently available only for iOS. Specifies the sdk version of the iOS simulator.
 		 * In case when `tns run ios --device "iPhone 6"` command is executed, the user can specify the sdk of the simulator because it is possible to have more than one device with the same name but with different sdk versions.
@@ -1029,7 +1021,11 @@ declare module Mobile {
 		resolveProductName(deviceType: string): string;
 	}
 
-	interface IDeviceLookingOptions extends IHasEmulatorOption {
+	interface IHasDetectionInterval {
+		detectionInterval?: number;
+	}
+
+	interface IDeviceLookingOptions extends IHasEmulatorOption, IHasDetectionInterval {
 		shouldReturnImmediateResult: boolean;
 		platform: string;
 	}

--- a/lib/common/definitions/timers.d.ts
+++ b/lib/common/definitions/timers.d.ts
@@ -1,3 +1,4 @@
 interface ITimers {
 	setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+	clearInterval(intervalId: NodeJS.Timer): void;
 }

--- a/lib/common/definitions/timers.d.ts
+++ b/lib/common/definitions/timers.d.ts
@@ -1,0 +1,3 @@
+interface ITimers {
+	setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer;
+}

--- a/lib/common/mobile/mobile-core/devices-service.ts
+++ b/lib/common/mobile/mobile-core/devices-service.ts
@@ -10,7 +10,6 @@ import { CONNECTED_STATUS } from "../../constants";
 import { isInteractive } from "../../helpers";
 import { DebugCommandErrors } from "../../../constants";
 import { performanceLog } from "../../decorators";
-import { Timers } from "../../timers";
 
 export class DevicesService extends EventEmitter implements Mobile.IDevicesService {
 	private static DEVICE_LOOKING_INTERVAL = 200;
@@ -44,7 +43,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		private $androidEmulatorDiscovery: Mobile.IDeviceDiscovery,
 		private $emulatorHelper: Mobile.IEmulatorHelper,
 		private $prompter: IPrompter,
-		private $timers: Timers) {
+		private $timers: ITimers) {
 		super();
 		this.attachToKnownDeviceDiscoveryEvents();
 		this.attachToKnownEmulatorDiscoveryEvents();
@@ -337,14 +336,14 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 	@exported("devicesService")
 	public stopDeviceDetectionInterval(): void {
 		if (this.deviceDetectionInterval) {
-			clearInterval(this.deviceDetectionInterval);
+			this.$timers.clearInterval(this.deviceDetectionInterval);
 		}
 	}
 
 	@exported("devicesService")
 	public stopEmulatorDetectionInterval(): void {
 		if (this.emulatorDetectionInterval) {
-			clearInterval(this.emulatorDetectionInterval);
+			this.$timers.clearInterval(this.emulatorDetectionInterval);
 		}
 	}
 

--- a/lib/common/test/unit-tests/mobile/android-virtual-device-service.ts
+++ b/lib/common/test/unit-tests/mobile/android-virtual-device-service.ts
@@ -76,6 +76,10 @@ function createTestInjector(data: { avdManagerOutput?: string, avdManagerError?:
 	testInjector.register("emulatorHelper", EmulatorHelper);
 	testInjector.register("hostInfo", {});
 	testInjector.register("logger", { trace: () => ({}) });
+	testInjector.register("sysInfo", {
+		getJavaVersionFromJavaHome: async () => "1.8.0",
+		getJavaVersionFromPath: async () => "1.8.0"
+	});
 
 	return testInjector;
 }

--- a/lib/common/test/unit-tests/mobile/devices-service.ts
+++ b/lib/common/test/unit-tests/mobile/devices-service.ts
@@ -14,6 +14,7 @@ import { CommonLoggerStub, ErrorsStub } from "../stubs";
 import { Messages } from "../../../messages/messages";
 import * as constants from "../../../constants";
 import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
+import { Timers } from "../../../timers";
 
 const helpers = require("../../../helpers");
 const originalIsInteractive = helpers.isInteractive;
@@ -28,11 +29,11 @@ class DevicesServiceInheritor extends DevicesService {
 		return super.startEmulatorIfNecessary(data);
 	}
 
-	public startDeviceDetectionIntervals(deviceInitOpts: Mobile.IDevicesServicesInitializationOptions = {}): Promise<void> {
-		return super.startDeviceDetectionIntervals(deviceInitOpts);
+	public startDeviceDetectionInterval(deviceInitOpts: Mobile.IDeviceLookingOptions = <any>{}): void {
+		return super.startDeviceDetectionInterval(deviceInitOpts);
 	}
 
-	public detectCurrentlyAttachedDevices(options?: Mobile.IDevicesServicesInitializationOptions): Promise<void> {
+	public detectCurrentlyAttachedDevices(options?: Mobile.IDeviceLookingOptions): Promise<void> {
 		return super.detectCurrentlyAttachedDevices(options);
 	}
 }
@@ -185,6 +186,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("androidProcessService", { /* no implementation required */ });
 	testInjector.register("androidEmulatorDiscovery", AndroidEmulatorDiscoveryStub);
 	testInjector.register("emulatorHelper", {});
+	testInjector.register("timers", Timers);
 
 	return testInjector;
 }
@@ -227,7 +229,10 @@ function mockSetInterval(testCaseCallback?: Function): void {
 
 		};
 
-		process.nextTick(() => execution());
+		/* tslint:disable:no-floating-promises */
+		execution();
+		/* tslint:enable:no-floating-promises */
+
 		return nodeJsTimer;
 	};
 }
@@ -238,10 +243,10 @@ function resetDefaultSetInterval(): void {
 
 async function assertOnNextTick(assertionFunction: Function): Promise<void> {
 	await new Promise(resolve => {
-		process.nextTick(() => {
+		setTimeout(() => {
 			assertionFunction();
 			resolve();
-		});
+		}, 2);
 	});
 }
 
@@ -1193,7 +1198,7 @@ describe("devicesService", () => {
 		});
 	});
 
-	describe("startDeviceDetectionIntervals", () => {
+	describe("startDeviceDetectionInterval", () => {
 		let setIntervalsCalledCount: number;
 
 		beforeEach(() => {
@@ -1212,7 +1217,7 @@ describe("devicesService", () => {
 				hasStartedDeviceDetectionInterval = true;
 			});
 
-			await devicesService.startDeviceDetectionIntervals();
+			devicesService.startDeviceDetectionInterval();
 
 			assert.isTrue(hasStartedDeviceDetectionInterval);
 		});
@@ -1225,7 +1230,9 @@ describe("devicesService", () => {
 					await callback();
 				};
 
-				process.nextTick(execution);
+				/* tslint:disable:no-floating-promises */
+				execution();
+				/* tslint:enable:no-floating-promises */
 
 				return {
 					ref: () => { /* no implementation required */ },
@@ -1236,11 +1243,11 @@ describe("devicesService", () => {
 				};
 			};
 
-			await devicesService.startDeviceDetectionIntervals();
-			await devicesService.startDeviceDetectionIntervals();
-			await devicesService.startDeviceDetectionIntervals();
+			devicesService.startDeviceDetectionInterval();
+			devicesService.startDeviceDetectionInterval();
+			devicesService.startDeviceDetectionInterval();
 
-			assert.deepEqual(setIntervalsCalledCount, 2);
+			assert.deepEqual(setIntervalsCalledCount, 1);
 		});
 
 		describe("ios devices check", () => {
@@ -1257,7 +1264,7 @@ describe("devicesService", () => {
 					hasCheckedForIosDevices = true;
 				};
 
-				await devicesService.startDeviceDetectionIntervals();
+				devicesService.startDeviceDetectionInterval();
 
 				assert.isTrue(hasCheckedForIosDevices);
 			});
@@ -1265,7 +1272,14 @@ describe("devicesService", () => {
 			it("should not throw if ios device check fails throws an exception.", async () => {
 				(<any>$iOSDeviceDiscovery).checkForDevices = throwErrorFunction;
 
-				await assert.isFulfilled(devicesService.startDeviceDetectionIntervals());
+				let hasUnhandledRejection = false;
+				process.on("unhandledRejection", (reason: any, promise: Promise<any>) => {
+					hasUnhandledRejection = true;
+				});
+
+				devicesService.startDeviceDetectionInterval();
+
+				await assertOnNextTick(() => assert.isFalse(hasUnhandledRejection));
 			});
 		});
 
@@ -1284,14 +1298,20 @@ describe("devicesService", () => {
 				};
 
 				mockSetInterval();
-				await devicesService.startDeviceDetectionIntervals();
+				devicesService.startDeviceDetectionInterval();
 				await assertOnNextTick(() => assert.isTrue(hasCheckedForAndroidDevices));
 			});
 
 			it("should not throw if android device check fails throws an exception.", async () => {
 				$androidDeviceDiscovery.startLookingForDevices = throwErrorFunction;
+				let hasUnhandledRejection = false;
+				process.on("unhandledRejection", (reason: any, promise: Promise<any>) => {
+					hasUnhandledRejection = true;
+				});
 
-				await assert.isFulfilled(devicesService.startDeviceDetectionIntervals());
+				devicesService.startDeviceDetectionInterval();
+
+				await assertOnNextTick(() => assert.isFalse(hasUnhandledRejection));
 			});
 		});
 
@@ -1314,7 +1334,14 @@ describe("devicesService", () => {
 			it("should not throw if ios simulator check fails throws an exception.", async () => {
 				(<any>$iOSSimulatorDiscovery).checkForDevices = throwErrorFunction;
 
-				await assert.isFulfilled(devicesService.startDeviceDetectionIntervals());
+				let hasUnhandledRejection = false;
+				process.on("unhandledRejection", (reason: any, promise: Promise<any>) => {
+					hasUnhandledRejection = true;
+				});
+
+				devicesService.startDeviceDetectionInterval();
+
+				await assertOnNextTick(() => assert.isFalse(hasUnhandledRejection));
 			});
 		});
 
@@ -1334,7 +1361,7 @@ describe("devicesService", () => {
 				};
 
 				mockSetInterval();
-				await devicesService.startDeviceDetectionIntervals();
+				devicesService.startDeviceDetectionInterval();
 
 				await assertOnNextTick(() => assert.isTrue(hasCheckedForDevices));
 			});
@@ -1342,7 +1369,14 @@ describe("devicesService", () => {
 			it("should not throw if device check fails throws an exception.", async () => {
 				customDeviceDiscovery.startLookingForDevices = throwErrorFunction;
 
-				await assert.isFulfilled(devicesService.startDeviceDetectionIntervals());
+				let hasUnhandledRejection = false;
+				process.on("unhandledRejection", (reason: any, promise: Promise<any>) => {
+					hasUnhandledRejection = true;
+				});
+
+				devicesService.startDeviceDetectionInterval();
+
+				await assertOnNextTick(() => assert.isFalse(hasUnhandledRejection));
 			});
 		});
 
@@ -1371,7 +1405,7 @@ describe("devicesService", () => {
 			});
 
 			it("should check for application updates for all connected devices.", async () => {
-				await devicesService.startDeviceDetectionIntervals();
+				devicesService.startDeviceDetectionInterval();
 
 				await assertOnNextTick(() => {
 					assert.isTrue(hasCheckedForAndroidAppUpdates);
@@ -1382,14 +1416,14 @@ describe("devicesService", () => {
 			it("should check for application updates if the check on one device throws an exception.", async () => {
 				iOSDevice.applicationManager.checkForApplicationUpdates = throwErrorFunction;
 
-				await devicesService.startDeviceDetectionIntervals();
+				devicesService.startDeviceDetectionInterval();
 
 				await assertOnNextTick(() => assert.isTrue(hasCheckedForAndroidAppUpdates));
 			});
 
 			it("should check for application updates only on devices with status Connected", async () => {
 				androidDevice.deviceInfo.status = constants.UNREACHABLE_STATUS;
-				await devicesService.startDeviceDetectionIntervals();
+				devicesService.startDeviceDetectionInterval();
 
 				await assertOnNextTick(() => {
 					assert.isFalse(hasCheckedForAndroidAppUpdates);
@@ -1402,7 +1436,7 @@ describe("devicesService", () => {
 				androidDevice.applicationManager.checkForApplicationUpdates = throwErrorFunction;
 
 				const callback = () => {
-					devicesService.startDeviceDetectionIntervals.call(devicesService);
+					devicesService.startDeviceDetectionInterval.call(devicesService);
 				};
 
 				assert.doesNotThrow(callback);

--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -1,11 +1,24 @@
 export class Timers implements ITimers {
+	private pendingIntervalIds: NodeJS.Timer[] = [];
+
 	constructor(private $processService: IProcessService) {
+		this.$processService.attachToProcessExitSignals(this, () => {
+			_.each(this.pendingIntervalIds, clearInterval);
+		});
 	}
 
 	public setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer {
 		const timer = setInterval(callback, ms, args);
-		this.$processService.attachToProcessExitSignals(this, () => clearInterval(timer));
+
+		this.pendingIntervalIds.push(timer);
+
 		return timer;
+	}
+
+	public clearInterval(intervalId: NodeJS.Timer): void {
+		clearInterval(intervalId);
+
+		_.remove(this.pendingIntervalIds, id => id === intervalId);
 	}
 }
 

--- a/lib/common/timers.ts
+++ b/lib/common/timers.ts
@@ -1,0 +1,12 @@
+export class Timers implements ITimers {
+	constructor(private $processService: IProcessService) {
+	}
+
+	public setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timer {
+		const timer = setInterval(callback, ms, args);
+		this.$processService.attachToProcessExitSignals(this, () => clearInterval(timer));
+		return timer;
+	}
+}
+
+$injector.register("timers", Timers);

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -34,6 +34,14 @@ export class SysInfo implements ISysInfo {
 		return sysInfo.getJavaCompilerVersion();
 	}
 
+	public getJavaVersionFromPath(): Promise<string> {
+		return sysInfo.getJavaVersionFromPath();
+	}
+
+	public getJavaVersionFromJavaHome(): Promise<string> {
+		return sysInfo.getJavaVersionFromJavaHome();
+	}
+
 	@exported("sysInfo")
 	public async getSystemWarnings(): Promise<ISystemWarning[]> {
 		const warnings: ISystemWarning[] = [];

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5605,9 +5605,9 @@
       }
     },
     "nativescript-doctor": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.8.1.tgz",
-      "integrity": "sha512-Ke19jTb3Gz/3QHF1hE2iFoQ0N0693paEbtNgfeMFszKCJLw0BfOHRwbABjNhb9pxfvvi86fvFexDcmWJWpJo0w==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.9.1.tgz",
+      "integrity": "sha512-qdluBILhzAQhnIg8Y83syyjy63rTt5pvx0SFpbtwj7kE+LsXJJRhHNa+1KEtznxh7jcTfdLEZjxxWDTIAIK5oA==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.5.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
     "nativescript-dev-xcode": "0.1.0",
-    "nativescript-doctor": "1.8.1",
+    "nativescript-doctor": "1.9.1",
     "nativescript-preview-sdk": "0.3.3",
     "open": "0.0.5",
     "ora": "2.0.0",

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -160,6 +160,7 @@ function createTestInjector(projectPath: string, projectName: string, xcode?: IX
 		removeExtensions: () => { /* */ },
 		addExtensionsFromPath: () => Promise.resolve()
 	});
+	testInjector.register("timers", {});
 	return testInjector;
 }
 

--- a/test/nativescript-cli-lib.ts
+++ b/test/nativescript-cli-lib.ts
@@ -37,11 +37,17 @@ describe("nativescript-cli-lib", () => {
 			"getDebuggableApps",
 			"getDebuggableViews",
 			"getDevices",
+			"getEmulatorImages",
 			"getInstalledApplications",
 			"initialize",
 			"isAppInstalledOnDevices",
 			"mapAbstractToTcpPort",
-			"setLogLevel"
+			"setLogLevel",
+			"startDeviceDetectionInterval",
+			"stopDeviceDetectionInterval",
+			"startEmulator",
+			"startEmulatorDetectionInterval",
+			"stopEmulatorDetectionInterval",
 		],
 		assetsGenerationService: [
 			"generateIcons",


### PR DESCRIPTION
### fix: do not start emulator detection interval
The emulator detection interval is not required for CLI and in fact it just uses CPU and memory. Also, it causes some issues when you do not hava JAVA installed.
So remove start of emulator detection interval and allow it to be started from the API, when CLI is used as a library.

### fix: stop executing avdmanager in case java is not available
In case JAVA_HOME is not set and there's no java executable in PATH, calls to `avdmanager` fail with error. However, on macOS this also leads to system prompt to install JAVA.
To handle this, do not execute `avdmanager` in case there's no JAVA_HOME or java in PATH.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
