### PR TITLE
feat(kinvey): provide correct data to preview-sdk based on the schema

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -140,6 +140,7 @@ $injector.require("previewAppLiveSyncService", "./services/livesync/playground/p
 $injector.require("previewAppLogProvider", "./services/livesync/playground/preview-app-log-provider");
 $injector.require("previewAppPluginsService", "./services/livesync/playground/preview-app-plugins-service");
 $injector.require("previewSdkService", "./services/livesync/playground/preview-sdk-service");
+$injector.require("previewSchemaService", "./services/livesync/playground/preview-schema-service");
 $injector.requirePublicClass("previewDevicesService", "./services/livesync/playground/devices/preview-devices-service");
 $injector.requirePublic("previewQrCodeService", "./services/livesync/playground/preview-qr-code-service");
 $injector.requirePublic("sysInfo", "./sys-info");

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -45,7 +45,7 @@ declare global {
 		printLiveSyncQrCode(options: IPrintLiveSyncOptions): Promise<void>;
 	}
 
-	interface IPlaygroundAppQrCodeOptions {
+	interface IPlaygroundAppQrCodeOptions extends IProjectDir {
 		platform?: string;
 	}
 
@@ -71,8 +71,10 @@ declare global {
 
 	interface IPreviewSchemaData {
 		name: string;
-		previewAppId: string;
 		scannerAppId: string;
+		scannerAppStoreId: string;
+		previewAppId: string;
+		previewAppStoreId: string;
 		msvKey: string;
 		publishKey: string;
 		subscribeKey: string;

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -22,7 +22,7 @@ declare global {
 
 	interface IPreviewSdkService extends EventEmitter {
 		getQrCodeUrl(options: IGetQrCodeUrlOptions): string;
-		initialize(getInitialFiles: (device: Device) => Promise<FilesPayload>): void;
+		initialize(projectDir: string, getInitialFiles: (device: Device) => Promise<FilesPayload>): void;
 		applyChanges(filesPayload: FilesPayload): Promise<void>;
 		stop(): void;
 	}
@@ -63,5 +63,19 @@ declare global {
 		getDeviceById(id: string): Device;
 		getDevicesForPlatform(platform: string): Device[];
 		getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[];
+	}
+
+	interface IPreviewSchemaService {
+		getSchemaData(projectDir: string): IPreviewSchemaData;
+	}
+
+	interface IPreviewSchemaData {
+		name: string;
+		previewAppId: string;
+		scannerAppId: string;
+		msvKey: string;
+		publishKey: string;
+		subscribeKey: string;
+		default?: boolean;
 	}
 }

--- a/lib/services/livesync/playground/preview-app-constants.ts
+++ b/lib/services/livesync/playground/preview-app-constants.ts
@@ -8,11 +8,6 @@ export class PubnubKeys {
 	public static SUBSCRIBE_KEY = "sub-c-3dad1ebe-aaa3-11e8-8027-363023237e0b";
 }
 
-export class PlaygroundStoreUrls {
-	public static GOOGLE_PLAY_URL = "https://play.google.com/store/apps/details?id=org.nativescript.play";
-	public static APP_STORE_URL = "https://itunes.apple.com/us/app/nativescript-playground/id1263543946?mt=8&ls=1";
-}
-
 export class PluginComparisonMessages {
 	public static PLUGIN_NOT_INCLUDED_IN_PREVIEW_APP = "Plugin %s is not included in preview app on device %s and will not work.";
 	public static LOCAL_PLUGIN_WITH_DIFFERENCE_IN_MAJOR_VERSION = "Local plugin %s differs in major version from plugin in preview app. The local plugin has version %s and the plugin in preview app has version %s. Some features might not work as expected.";

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -28,7 +28,7 @@ export class PreviewAppLiveSyncService extends EventEmitter implements IPreviewA
 
 	@performanceLog()
 	public async initialize(data: IPreviewAppLiveSyncData): Promise<void> {
-		await this.$previewSdkService.initialize(async (device: Device) => {
+		await this.$previewSdkService.initialize(data.projectDir, async (device: Device) => {
 			try {
 				if (!device) {
 					this.$errors.failWithoutHelp("Sending initial preview files without a specified device is not supported.");

--- a/lib/services/livesync/playground/preview-qr-code-service.ts
+++ b/lib/services/livesync/playground/preview-qr-code-service.ts
@@ -1,6 +1,5 @@
 import * as util from "util";
 import { EOL } from "os";
-import { PlaygroundStoreUrls } from "./preview-app-constants";
 import { exported } from "../../../common/decorators";
 
 export class PreviewQrCodeService implements IPreviewQrCodeService {
@@ -10,20 +9,22 @@ export class PreviewQrCodeService implements IPreviewQrCodeService {
 		private $logger: ILogger,
 		private $mobileHelper: Mobile.IMobileHelper,
 		private $previewSdkService: IPreviewSdkService,
+		private $previewSchemaService: IPreviewSchemaService,
 		private $qrCodeTerminalService: IQrCodeTerminalService,
 		private $qr: IQrCodeGenerator
 	) { }
 
 	@exported("previewQrCodeService")
 	public async getPlaygroundAppQrCode(options?: IPlaygroundAppQrCodeOptions): Promise<IDictionary<IQrCodeImageData>> {
+		const { projectDir } = options;
 		const result = Object.create(null);
 
 		if (!options || !options.platform || this.$mobileHelper.isAndroidPlatform(options.platform)) {
-			result.android = await this.getLiveSyncQrCode(PlaygroundStoreUrls.GOOGLE_PLAY_URL);
+			result.android = await this.getLiveSyncQrCode(this.getGooglePlayUrl(projectDir));
 		}
 
 		if (!options || !options.platform || this.$mobileHelper.isiOSPlatform(options.platform)) {
-			result.ios = await this.getLiveSyncQrCode(PlaygroundStoreUrls.APP_STORE_URL);
+			result.ios = await this.getLiveSyncQrCode(this.getAppStoreUrl(projectDir));
 		}
 
 		return result;
@@ -56,8 +57,8 @@ export class PreviewQrCodeService implements IPreviewQrCodeService {
 			this.$logger.printMarkdown(`# Use \`NativeScript Playground app\` and scan the \`QR code\` above to preview the application on your device.`);
 			this.$logger.printMarkdown(`
 To scan the QR code and deploy your app on a device, you need to have the \`NativeScript Playground app\`:
-	App Store (iOS): ${PlaygroundStoreUrls.APP_STORE_URL}
-	Google Play (Android): ${PlaygroundStoreUrls.GOOGLE_PLAY_URL}`);
+	App Store (iOS): ${this.getAppStoreUrl(options.projectDir)}
+	Google Play (Android): ${this.getGooglePlayUrl(options.projectDir)}`);
 		}
 	}
 
@@ -72,6 +73,16 @@ To scan the QR code and deploy your app on a device, you need to have the \`Nati
 		}
 
 		return url;
+	}
+
+	private getGooglePlayUrl(projectDir: string): string {
+		const schema = this.$previewSchemaService.getSchemaData(projectDir);
+		return `https://play.google.com/store/apps/details?id=${schema.scannerAppId}`;
+	}
+
+	private getAppStoreUrl(projectDir: string): string {
+		const schema = this.$previewSchemaService.getSchemaData(projectDir);
+		return `https://itunes.apple.com/us/app/nativescript-playground/id${schema.scannerAppStoreId}?mt=8&ls=1`;
 	}
 }
 $injector.register("previewQrCodeService", PreviewQrCodeService);

--- a/lib/services/livesync/playground/preview-schema-service.ts
+++ b/lib/services/livesync/playground/preview-schema-service.ts
@@ -4,8 +4,10 @@ export class PreviewSchemaService implements IPreviewSchemaService {
 	private previewSchemas: IDictionary<IPreviewSchemaData> = {
 		"nsplay": {
 			name: "nsplay",
-			previewAppId: "org.nativescript.preview",
 			scannerAppId: "org.nativescript.play",
+			scannerAppStoreId: "1263543946",
+			previewAppId: "org.nativescript.preview",
+			previewAppStoreId: "1264484702",
 			msvKey: "cli",
 			publishKey: PubnubKeys.PUBLISH_KEY,
 			subscribeKey: PubnubKeys.SUBSCRIBE_KEY,
@@ -13,8 +15,10 @@ export class PreviewSchemaService implements IPreviewSchemaService {
 		},
 		"ksplay": {
 			name: "ksplay",
-			previewAppId: "com.kinvey.preview",
 			scannerAppId: "com.kinvey.scanner",
+			scannerAppStoreId: "1263543946",
+			previewAppId: "com.kinvey.preview",
+			previewAppStoreId: "1264484702",
 			msvKey: "kinveyStudio",
 			publishKey: PubnubKeys.PUBLISH_KEY,
 			subscribeKey: PubnubKeys.SUBSCRIBE_KEY
@@ -25,9 +29,7 @@ export class PreviewSchemaService implements IPreviewSchemaService {
 		private $projectDataService: IProjectDataService) { }
 
 	public getSchemaData(projectDir: string): IPreviewSchemaData {
-		const projectData = this.$projectDataService.getProjectData(projectDir);
-
-		let schemaName = projectData.previewAppSchema;
+		let schemaName = this.getSchemaNameFromProject(projectDir);
 		if (!schemaName) {
 			schemaName = _.findKey(this.previewSchemas, previewSchema => previewSchema.default);
 		}
@@ -38,6 +40,15 @@ export class PreviewSchemaService implements IPreviewSchemaService {
 		}
 
 		return result;
+	}
+
+	private getSchemaNameFromProject(projectDir: string): string {
+		try {
+			const projectData = this.$projectDataService.getProjectData(projectDir);
+			return projectData.previewAppSchema;
+		} catch (err) { /* ignore the error */ }
+
+		return null;
 	}
 }
 $injector.register("previewSchemaService", PreviewSchemaService);

--- a/lib/services/livesync/playground/preview-schema-service.ts
+++ b/lib/services/livesync/playground/preview-schema-service.ts
@@ -1,0 +1,43 @@
+import { PubnubKeys } from "./preview-app-constants";
+
+export class PreviewSchemaService implements IPreviewSchemaService {
+	private previewSchemas: IDictionary<IPreviewSchemaData> = {
+		"nsplay": {
+			name: "nsplay",
+			previewAppId: "org.nativescript.preview",
+			scannerAppId: "org.nativescript.play",
+			msvKey: "cli",
+			publishKey: PubnubKeys.PUBLISH_KEY,
+			subscribeKey: PubnubKeys.SUBSCRIBE_KEY,
+			default: true
+		},
+		"ksplay": {
+			name: "ksplay",
+			previewAppId: "com.kinvey.preview",
+			scannerAppId: "com.kinvey.scanner",
+			msvKey: "kinveyStudio",
+			publishKey: PubnubKeys.PUBLISH_KEY,
+			subscribeKey: PubnubKeys.SUBSCRIBE_KEY
+		}
+	};
+
+	constructor(private $errors: IErrors,
+		private $projectDataService: IProjectDataService) { }
+
+	public getSchemaData(projectDir: string): IPreviewSchemaData {
+		const projectData = this.$projectDataService.getProjectData(projectDir);
+
+		let schemaName = projectData.previewAppSchema;
+		if (!schemaName) {
+			schemaName = _.findKey(this.previewSchemas, previewSchema => previewSchema.default);
+		}
+
+		const result = this.previewSchemas[schemaName];
+		if (!result) {
+			this.$errors.failWithoutHelp(`Invalid schema. The valid schemas are ${_.keys(this.previewSchemas)}.`);
+		}
+
+		return result;
+	}
+}
+$injector.register("previewSchemaService", PreviewSchemaService);

--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -54,7 +54,6 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 			pubnubSubscribeKey: schema.subscribeKey,
 			msvKey: schema.msvKey,
 			msvEnv: this.$config.PREVIEW_APP_ENVIRONMENT,
-			showLoadingPage: false,
 			callbacks: this.getCallbacks(),
 			getInitialFiles,
 			previewAppStoreId: schema.previewAppStoreId,

--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -1,5 +1,4 @@
 import { MessagingService, Config, Device, DeviceConnectedMessage, SdkCallbacks, ConnectedDevices, FilesPayload } from "nativescript-preview-sdk";
-import { PubnubKeys } from "./preview-app-constants";
 import { EventEmitter } from "events";
 const pako = require("pako");
 
@@ -13,24 +12,20 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 		private $logger: ILogger,
 		private $previewDevicesService: IPreviewDevicesService,
 		private $previewAppLogProvider: IPreviewAppLogProvider,
-		private $projectDataService: IProjectDataService) {
+		private $previewSchemaService: IPreviewSchemaService) {
 			super();
 	}
 
 	public getQrCodeUrl(options: IGetQrCodeUrlOptions): string {
 		const { projectDir, useHotModuleReload } = options;
-		const projectData = this.$projectDataService.getProjectData(projectDir);
-		const schema = projectData.previewAppSchema || "nsplay";
-		// TODO: Use the correct keys for the schema
-		const publishKey = PubnubKeys.PUBLISH_KEY;
-		const subscribeKey = PubnubKeys.SUBSCRIBE_KEY;
+		const schema = this.$previewSchemaService.getSchemaData(projectDir);
 		const hmrValue = useHotModuleReload ? "1" : "0";
-		const result = `${schema}://boot?instanceId=${this.instanceId}&pKey=${publishKey}&sKey=${subscribeKey}&template=play-ng&hmr=${hmrValue}`;
+		const result = `${schema.name}://boot?instanceId=${this.instanceId}&pKey=${schema.publishKey}&sKey=${schema.subscribeKey}&template=play-ng&hmr=${hmrValue}`;
 		return result;
 	}
 
-	public async initialize(getInitialFiles: (device: Device) => Promise<FilesPayload>): Promise<void> {
-		const initConfig = this.getInitConfig(getInitialFiles);
+	public async initialize(projectDir: string, getInitialFiles: (device: Device) => Promise<FilesPayload>): Promise<void> {
+		const initConfig = this.getInitConfig(projectDir, getInitialFiles);
 		this.messagingService = new MessagingService();
 		this.instanceId = await this.messagingService.initialize(initConfig);
 	}
@@ -51,11 +46,13 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 		this.messagingService.stop();
 	}
 
-	private getInitConfig(getInitialFiles: (device: Device) => Promise<FilesPayload>): Config {
+	private getInitConfig(projectDir: string, getInitialFiles: (device: Device) => Promise<FilesPayload>): Config {
+		const schema = this.$previewSchemaService.getSchemaData(projectDir);
+
 		return {
-			pubnubPublishKey: PubnubKeys.PUBLISH_KEY,
-			pubnubSubscribeKey: PubnubKeys.SUBSCRIBE_KEY,
-			msvKey: "cli",
+			pubnubPublishKey: schema.publishKey,
+			pubnubSubscribeKey: schema.subscribeKey,
+			msvKey: schema.msvKey,
 			msvEnv: this.$config.PREVIEW_APP_ENVIRONMENT,
 			showLoadingPage: false,
 			callbacks: this.getCallbacks(),

--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -56,7 +56,9 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 			msvEnv: this.$config.PREVIEW_APP_ENVIRONMENT,
 			showLoadingPage: false,
 			callbacks: this.getCallbacks(),
-			getInitialFiles
+			getInitialFiles,
+			previewAppStoreId: schema.previewAppStoreId,
+			previewAppGooglePlayId: schema.previewAppId
 		};
 	}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -141,8 +141,7 @@
     "@types/node": {
       "version": "8.10.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.30.tgz",
-      "integrity": "sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q==",
-      "dev": true
+      "integrity": "sha512-Le8HGMI5gjFSBqcCuKP/wfHC19oURzkU2D+ERIescUoJd+CmNEMYBib9LQ4zj1HHEZOJQWhw2ZTnbD8weASh/Q=="
     },
     "@types/ora": {
       "version": "1.3.3",
@@ -1450,13 +1449,6 @@
       "integrity": "sha512-YbKCNLPPP4inc0E5If4OaalBc7gpaM2MRv77Pv2VThVComLKfbGYtJcdDCViDyp1Wd4SebhHLz94vp91zbK6bw==",
       "requires": {
         "@types/node": "^8.0.7"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.45.tgz",
-          "integrity": "sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ=="
-        }
       }
     },
     "date-format": {
@@ -5353,9 +5345,9 @@
       }
     },
     "nativescript-preview-sdk": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/nativescript-preview-sdk/-/nativescript-preview-sdk-0.3.3.tgz",
-      "integrity": "sha512-QHi4SbDblN+dSZCIztx1xVdrB4cP911OXV92REIVOqDHXyAFYUZeWu5DH0/3IHdC9fnMgXMeJ0WZEpgGgieqtQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/nativescript-preview-sdk/-/nativescript-preview-sdk-0.3.4.tgz",
+      "integrity": "sha512-Dw4Nn6MXbZMW8dkQIf1NfXSSNtu3rDOw0z1KE159lwPEVMM8F7qxrqqT57XTiQP5pnqXMARhoQvkgW55qTVx6Q==",
       "requires": {
         "@types/axios": "0.14.0",
         "@types/pubnub": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "mute-stream": "0.0.5",
     "nativescript-dev-xcode": "0.1.0",
     "nativescript-doctor": "1.9.2",
-    "nativescript-preview-sdk": "0.3.3",
+    "nativescript-preview-sdk": "0.3.4",
     "open": "0.0.5",
     "ora": "2.0.0",
     "osenv": "0.1.3",

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -73,7 +73,7 @@ class PreviewSdkServiceMock extends EventEmitter implements IPreviewSdkService {
 		return "my_cool_qr_code_url";
 	}
 
-	public initialize(getInitialFiles: (device: Device) => Promise<FilesPayload>) {
+	public initialize(projectDir: string, getInitialFiles: (device: Device) => Promise<FilesPayload>) {
 		this.getInitialFiles = async (device) => {
 			const filesPayload = await getInitialFiles(device);
 			initialFiles.push(...filesPayload.files);

--- a/test/services/playground/preview-schema-service.ts
+++ b/test/services/playground/preview-schema-service.ts
@@ -1,0 +1,89 @@
+import { Yok } from "../../../lib/common/yok";
+import { PreviewSchemaService } from "../../../lib/services/livesync/playground/preview-schema-service";
+import { PubnubKeys } from "../../../lib/services/livesync/playground/preview-app-constants";
+import { assert } from "chai";
+
+function createTestInjector(): IInjector {
+	const injector = new Yok();
+	injector.register("previewSchemaService", PreviewSchemaService);
+	injector.register("projectDataService", () => ({}));
+	injector.register("errors", () => ({}));
+
+	return injector;
+}
+
+const nsPlaySchema = {
+	name: 'nsplay',
+	scannerAppId: 'org.nativescript.play',
+	scannerAppStoreId: '1263543946',
+	previewAppId: 'org.nativescript.preview',
+	previewAppStoreId: '1264484702',
+	msvKey: 'cli',
+	publishKey: PubnubKeys.PUBLISH_KEY,
+	subscribeKey: PubnubKeys.SUBSCRIBE_KEY,
+	default: true
+};
+
+const ksPlaySchema = {
+	name: 'ksplay',
+	scannerAppId: 'com.kinvey.scanner',
+	scannerAppStoreId: '1263543946',
+	previewAppId: 'com.kinvey.preview',
+	previewAppStoreId: '1264484702',
+	msvKey: 'kinveyStudio',
+	publishKey: PubnubKeys.PUBLISH_KEY,
+	subscribeKey: PubnubKeys.SUBSCRIBE_KEY
+};
+
+describe.only("PreviewSchemaService", () => {
+	let injector: IInjector;
+	let previewSchemaService: IPreviewSchemaService;
+
+	beforeEach(() => {
+		injector = createTestInjector();
+		previewSchemaService = injector.resolve("previewSchemaService");
+	});
+
+	const testCases = [
+		{
+			name: "should return default nsplay schema when no previewAppSchema in nsconfig",
+			previewAppSchema: <any>null,
+			expectedSchema: nsPlaySchema
+		},
+		{
+			name: "should return nsplay schema when { 'previewAppSchema': 'nsplay' } in nsconfig",
+			previewAppSchema: "nsplay",
+			expectedSchema: nsPlaySchema
+		},
+		{
+			name: "should return ksplay schema when { 'previewAppSchema': 'ksplay' } in nsconfig",
+			previewAppSchema: "ksplay",
+			expectedSchema: ksPlaySchema
+		},
+		{
+			name: "should throw an error when invalid previewAppSchema is specified in nsconfig",
+			previewAppSchema: "someInvalidSchema",
+			expectedToThrow: true
+		}
+	];
+
+	_.each(testCases, testCase => {
+		it(`${testCase.name}`, () => {
+			const projectDataService = injector.resolve("projectDataService");
+			projectDataService.getProjectData = () => ({ previewAppSchema: testCase.previewAppSchema });
+
+			let actualError = null;
+			if (testCase.expectedToThrow) {
+				const errors = injector.resolve("errors");
+				errors.failWithoutHelp = (err: string) => actualError = err;
+			}
+
+			const schemaData = previewSchemaService.getSchemaData("someTestProjectDir");
+
+			assert.deepEqual(schemaData, testCase.expectedSchema);
+			if (testCase.expectedToThrow) {
+				assert.isNotNull(actualError);
+			}
+		});
+	});
+});

--- a/test/services/playground/preview-schema-service.ts
+++ b/test/services/playground/preview-schema-service.ts
@@ -35,7 +35,7 @@ const ksPlaySchema = {
 	subscribeKey: PubnubKeys.SUBSCRIBE_KEY
 };
 
-describe.only("PreviewSchemaService", () => {
+describe("PreviewSchemaService", () => {
 	let injector: IInjector;
 	let previewSchemaService: IPreviewSchemaService;
 

--- a/test/services/preview-sdk-service.ts
+++ b/test/services/preview-sdk-service.ts
@@ -2,6 +2,7 @@ import { PreviewSdkService } from "../../lib/services/livesync/playground/previe
 import { Yok } from "../../lib/common/yok";
 import { assert } from "chai";
 import { LoggerStub } from "../stubs";
+import { PreviewSchemaService } from "../../lib/services/livesync/playground/preview-schema-service";
 
 const createTestInjector = (): IInjector => {
 	const testInjector = new Yok();
@@ -9,6 +10,7 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("config", {});
 	testInjector.register("previewSdkService", PreviewSdkService);
 	testInjector.register("previewDevicesService", {});
+	testInjector.register("previewSchemaService", PreviewSchemaService);
 	testInjector.register("previewAppLogProvider", {});
 	testInjector.register("httpClient", {
 		httpRequest: async (options: any, proxySettings?: IProxySettings): Promise<Server.IResponse> => undefined
@@ -16,6 +18,7 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("projectDataService", {
 		getProjectData: () => ({})
 	});
+	testInjector.register("errors", {});
 
 	return testInjector;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3731,10 +3731,10 @@ nativescript-doctor@1.9.2:
     winreg "1.2.2"
     yauzl "2.10.0"
 
-nativescript-preview-sdk@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/nativescript-preview-sdk/-/nativescript-preview-sdk-0.3.3.tgz#0e95e5a92db8d4566d9bb9767a2a849217574787"
-  integrity sha512-QHi4SbDblN+dSZCIztx1xVdrB4cP911OXV92REIVOqDHXyAFYUZeWu5DH0/3IHdC9fnMgXMeJ0WZEpgGgieqtQ==
+nativescript-preview-sdk@0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/nativescript-preview-sdk/-/nativescript-preview-sdk-0.3.4.tgz#bb0dc3ce7da2be7e1e91cd2836b61b3699555f95"
+  integrity sha512-Dw4Nn6MXbZMW8dkQIf1NfXSSNtu3rDOw0z1KE159lwPEVMM8F7qxrqqT57XTiQP5pnqXMARhoQvkgW55qTVx6Q==
   dependencies:
     "@types/axios" "0.14.0"
     "@types/pubnub" "4.0.2"


### PR DESCRIPTION
* Respect the correct min supported versions from https://github.com/telerik/nativescript-preview-sdk/blob/master/src/preview-app-versions.js
* Fix exported getPlaygroundAppQrCode method to return correct data based on the schema
* Provide previewAppStoreId and previewAppGoogledPlayId to preview-sdk in order to show correct data on deprecated page from kinvey's preview app

Should be merged after this PR https://github.com/telerik/nativescript-preview-sdk/pull/30

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
