### PR TITLE
fix: errors are shown on postinstall when using sudo

### DIFF
--- a/lib/commands/post-install.ts
+++ b/lib/commands/post-install.ts
@@ -1,3 +1,5 @@
+import { doesCurrentNpmCommandMatch } from "../common/helpers";
+
 export class PostInstallCliCommand implements ICommand {
 	constructor(private $fs: IFileSystem,
 		private $subscriptionService: ISubscriptionService,
@@ -13,24 +15,35 @@ export class PostInstallCliCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public async execute(args: string[]): Promise<void> {
+		const isRunningWithSudoUser = !!process.env.SUDO_USER;
+
 		if (!this.$hostInfo.isWindows) {
 			// when running under 'sudo' we create a working dir with wrong owner (root) and
 			// it is no longer accessible for the user initiating the installation
 			// patch the owner here
-			if (process.env.SUDO_USER) {
+			if (isRunningWithSudoUser) {
 				// TODO: Check if this is the correct place, probably we should set this at the end of the command.
 				await this.$fs.setCurrentUserAsOwner(this.$settingsService.getProfileDir(), process.env.SUDO_USER);
 			}
 		}
 
-		await this.$helpService.generateHtmlPages();
-		// Explicitly ask for confirmation of usage-reporting:
-		await this.$analyticsService.checkConsent();
-		await this.$commandsService.tryExecuteCommand("autocomplete", []);
+		const canExecutePostInstallTask = !isRunningWithSudoUser || doesCurrentNpmCommandMatch([/^--unsafe-perm$/]);
+
+		if (canExecutePostInstallTask) {
+			await this.$helpService.generateHtmlPages();
+
+			// Explicitly ask for confirmation of usage-reporting:
+			await this.$analyticsService.checkConsent();
+			await this.$commandsService.tryExecuteCommand("autocomplete", []);
+		}
+
 		// Make sure the success message is separated with at least one line from all other messages.
 		this.$logger.out();
 		this.$logger.printMarkdown("Installation successful. You are good to go. Connect with us on `http://twitter.com/NativeScript`.");
-		await this.$subscriptionService.subscribeForNewsletter();
+
+		if (canExecutePostInstallTask) {
+			await this.$subscriptionService.subscribeForNewsletter();
+		}
 	}
 
 	public async postCommandAction(args: string[]): Promise<void> {

--- a/test/commands/post-install.ts
+++ b/test/commands/post-install.ts
@@ -49,6 +49,14 @@ const createTestInjector = (): IInjector => {
 };
 
 describe("post-install command", () => {
+	const originalNpmArgv = process.env.npm_config_argv;
+	const originalSudoUser = process.env.SUDO_USER;
+
+	afterEach(() => {
+		process.env.npm_config_argv = originalNpmArgv;
+		process.env.SUDO_USER = originalSudoUser;
+	});
+
 	it("calls subscriptionService.subscribeForNewsletter method", async () => {
 		const testInjector = createTestInjector();
 		const subscriptionService = testInjector.resolve<ISubscriptionService>("subscriptionService");
@@ -60,5 +68,63 @@ describe("post-install command", () => {
 
 		await postInstallCommand.execute([]);
 		assert.isTrue(isSubscribeForNewsletterCalled, "post-install-cli command must call subscriptionService.subscribeForNewsletter");
+	});
+
+	const verifyResult = async (opts: { shouldCallMethod: boolean }): Promise<void> => {
+		const testInjector = createTestInjector();
+		const subscriptionService = testInjector.resolve<ISubscriptionService>("subscriptionService");
+		let isSubscribeForNewsletterCalled = false;
+		subscriptionService.subscribeForNewsletter = async (): Promise<void> => {
+			isSubscribeForNewsletterCalled = true;
+		};
+
+		const helpService = testInjector.resolve<IHelpService>("helpService");
+		let isGenerateHtmlPagesCalled = false;
+		helpService.generateHtmlPages = async (): Promise<void> => {
+			isGenerateHtmlPagesCalled = true;
+		};
+
+		const analyticsService = testInjector.resolve<IAnalyticsService>("analyticsService");
+		let isCheckConsentCalled = false;
+		analyticsService.checkConsent = async (): Promise<void> => {
+			isCheckConsentCalled = true;
+		};
+
+		const commandsService = testInjector.resolve<ICommandsService>("commandsService");
+		let isTryExecuteCommandCalled = false;
+		commandsService.tryExecuteCommand = async (): Promise<void> => {
+			isTryExecuteCommandCalled = true;
+		};
+
+		const postInstallCommand = testInjector.resolveCommand("post-install-cli");
+		await postInstallCommand.execute([]);
+
+		process.env.npm_config_argv = originalNpmArgv;
+		process.env.SUDO_USER = originalSudoUser;
+
+		const hasNotInMsg = opts.shouldCallMethod ? "" : "NOT";
+
+		assert.equal(isSubscribeForNewsletterCalled, opts.shouldCallMethod, `post-install-cli command must ${hasNotInMsg} call subscriptionService.subscribeForNewsletter`);
+		assert.equal(isGenerateHtmlPagesCalled, opts.shouldCallMethod, `post-install-cli command must ${hasNotInMsg} call helpService.generateHtmlPages`);
+		assert.equal(isCheckConsentCalled, opts.shouldCallMethod, `post-install-cli command must ${hasNotInMsg} call analyticsService.checkConsent`);
+		assert.equal(isTryExecuteCommandCalled, opts.shouldCallMethod, `post-install-cli command must ${hasNotInMsg} call commandsService.tryExecuteCommand`);
+	};
+
+	it("does not call specific methods when CLI is installed with sudo without `--unsafe-perm`", () => {
+		process.env.npm_config_argv = JSON.stringify({});
+		process.env.SUDO_USER = "user1";
+		return verifyResult({ shouldCallMethod: false });
+	});
+
+	it("calls specific methods when CLI is installed with sudo with `--unsafe-perm`", async () => {
+		process.env.npm_config_argv = JSON.stringify({ original: ["--unsafe-perm"] });
+		process.env.SUDO_USER = "user1";
+		return verifyResult({ shouldCallMethod: true });
+	});
+
+	it("calls specific methods when CLI is installed without sudo", async () => {
+		process.env.npm_config_argv = JSON.stringify({});
+		delete process.env.SUDO_USER;
+		return verifyResult({ shouldCallMethod: true });
 	});
 });


### PR DESCRIPTION
When `sudo npm i -g nativescript` is used, postinstall tasks produce errors, which confuse the users. CLI is actually installed successfully, but error for EACCESS is often shown.
The problem is that npm executes the postinstall scripts with a special OS user - `nobody`. This user does not have permissions to write in users' directories, so generating html help or writing the user-settings.json file fails.
Npm's solution is to pass `--unsafe-perm` to the `sudo npm install -g nativescript` command, which forces the postinstall to be executed with root user.
Fix CLI's code to skip postinstall tasks in case sudo is used and `--unsafe-perm` is not passed.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
`sudo npm install -g nativescript` fails with EACCESS, but CLI is installed correctly.

## What is the new behavior?
`sudo npm install -g nativescript` executes successfully.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4370

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
