### PR TITLE
fix: detect java correctly

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5329,9 +5329,9 @@
       }
     },
     "nativescript-doctor": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.9.1.tgz",
-      "integrity": "sha512-qdluBILhzAQhnIg8Y83syyjy63rTt5pvx0SFpbtwj7kE+LsXJJRhHNa+1KEtznxh7jcTfdLEZjxxWDTIAIK5oA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/nativescript-doctor/-/nativescript-doctor-1.9.2.tgz",
+      "integrity": "sha512-HEBQS7eqycO3TzY3He94dM0AgPCQy3YMT6ZdHSVGDfxA5DhnhMgB0OWOvHPwR3TyL0BJhtLJnjrW4/hJjUw2SQ==",
       "requires": {
         "osenv": "0.1.3",
         "semver": "5.5.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
     "nativescript-dev-xcode": "0.1.0",
-    "nativescript-doctor": "1.9.1",
+    "nativescript-doctor": "1.9.2",
     "nativescript-preview-sdk": "0.3.3",
     "open": "0.0.5",
     "ora": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3720,10 +3720,10 @@ nativescript-dev-xcode@0.1.0:
     simple-plist "^1.0.0"
     uuid "^3.3.2"
 
-nativescript-doctor@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/nativescript-doctor/-/nativescript-doctor-1.9.1.tgz#42ac6b15f7b1531d2fe07d32a30e50b89cf46bbb"
-  integrity sha512-qdluBILhzAQhnIg8Y83syyjy63rTt5pvx0SFpbtwj7kE+LsXJJRhHNa+1KEtznxh7jcTfdLEZjxxWDTIAIK5oA==
+nativescript-doctor@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/nativescript-doctor/-/nativescript-doctor-1.9.2.tgz#a3b5b06c82bc20bf7bfde04552f3d52739229e85"
+  integrity sha512-HEBQS7eqycO3TzY3He94dM0AgPCQy3YMT6ZdHSVGDfxA5DhnhMgB0OWOvHPwR3TyL0BJhtLJnjrW4/hJjUw2SQ==
   dependencies:
     osenv "0.1.3"
     semver "5.5.1"


### PR DESCRIPTION
In case you have incorrect JAVA_HOME, but you have `javac` in PATH, CLI's doctor checks will allow you to build, but Gradle will fail. Fix the logic to be the same as the one used in Gradle.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
