### PR TITLE
fix: change ksplay to kspreview schema

### DIFF
--- a/lib/services/livesync/playground/preview-qr-code-service.ts
+++ b/lib/services/livesync/playground/preview-qr-code-service.ts
@@ -16,7 +16,7 @@ export class PreviewQrCodeService implements IPreviewQrCodeService {
 
 	@exported("previewQrCodeService")
 	public async getPlaygroundAppQrCode(options?: IPlaygroundAppQrCodeOptions): Promise<IDictionary<IQrCodeImageData>> {
-		const { projectDir } = options;
+		const { projectDir } = options || <any>{ };
 		const result = Object.create(null);
 
 		if (!options || !options.platform || this.$mobileHelper.isAndroidPlatform(options.platform)) {

--- a/lib/services/livesync/playground/preview-schema-service.ts
+++ b/lib/services/livesync/playground/preview-schema-service.ts
@@ -13,8 +13,8 @@ export class PreviewSchemaService implements IPreviewSchemaService {
 			subscribeKey: PubnubKeys.SUBSCRIBE_KEY,
 			default: true
 		},
-		"ksplay": {
-			name: "ksplay",
+		"kspreview": {
+			name: "kspreview",
 			scannerAppId: "com.kinvey.scanner",
 			scannerAppStoreId: "1263543946",
 			previewAppId: "com.kinvey.preview",

--- a/test/services/playground/preview-schema-service.ts
+++ b/test/services/playground/preview-schema-service.ts
@@ -24,8 +24,8 @@ const nsPlaySchema = {
 	default: true
 };
 
-const ksPlaySchema = {
-	name: 'ksplay',
+const ksPreviewSchema = {
+	name: 'kspreview',
 	scannerAppId: 'com.kinvey.scanner',
 	scannerAppStoreId: '1263543946',
 	previewAppId: 'com.kinvey.preview',
@@ -56,9 +56,9 @@ describe("PreviewSchemaService", () => {
 			expectedSchema: nsPlaySchema
 		},
 		{
-			name: "should return ksplay schema when { 'previewAppSchema': 'ksplay' } in nsconfig",
-			previewAppSchema: "ksplay",
-			expectedSchema: ksPlaySchema
+			name: "should return kspreview schema when { 'previewAppSchema': 'kspreview' } in nsconfig",
+			previewAppSchema: "kspreview",
+			expectedSchema: ksPreviewSchema
 		},
 		{
 			name: "should throw an error when invalid previewAppSchema is specified in nsconfig",

--- a/test/services/preview-sdk-service.ts
+++ b/test/services/preview-sdk-service.ts
@@ -54,8 +54,8 @@ describe('PreviewSdkService', () => {
 				},
 				{
 					name: "should return the schema from nsconfig",
-					schemaFromNsConfig: "ksplay",
-					expectedSchemaName: "ksplay"
+					schemaFromNsConfig: "kspreview",
+					expectedSchemaName: "kspreview"
 				},
 				{
 					name: "should return the default schema",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
