### PR TITLE
fix: handle HTTP 304 response status code

### DIFF
--- a/lib/common/constants.ts
+++ b/lib/common/constants.ts
@@ -92,6 +92,7 @@ export class Proxy {
  */
 export class HttpStatusCodes {
 	static SEE_OTHER = 303;
+	static NOT_MODIFIED = 304;
 	static PAYMENT_REQUIRED = 402;
 	static PROXY_AUTHENTICATION_REQUIRED = 407;
 }

--- a/lib/common/http-client.ts
+++ b/lib/common/http-client.ts
@@ -168,7 +168,7 @@ export class HttpClient implements Server.IHttpClient {
 							this.setResponseResult(promiseActions, cleanupRequestData, { err: new Error(HttpClient.STUCK_RESPONSE_ERROR_MESSAGE) });
 						}
 					}, HttpClient.STUCK_RESPONSE_CHECK_INTERVAL);
-					const successful = helpers.isRequestSuccessful(responseData);
+					const successful = helpers.isRequestSuccessful(responseData) || responseData.statusCode === HttpStatusCodes.NOT_MODIFIED;
 					if (!successful) {
 						pipeTo = undefined;
 					}


### PR DESCRIPTION
In case 304 is returned, the cached version of the result should be used, so consider this response as success. NOTE: It can be returned only when specific header is sent in the request, so the caller actually expects to receive either 304 or 200 with new content.


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Http requests returning 304 are considered as failed.

## What is the new behavior?
Http requests returning 304 are considered as successful.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
