### PR TITLE
chore: remove projectTemplate logic

### DIFF
--- a/lib/commands/add-platform.ts
+++ b/lib/commands/add-platform.ts
@@ -13,7 +13,7 @@ export class AddPlatformCommand extends ValidatePlatformCommandBase implements I
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.addPlatforms(args, this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
+		await this.$platformService.addPlatforms(args, this.$projectData, this.$options, this.$options.frameworkPath);
 	}
 
 	public async canExecute(args: string[]): Promise<ICanExecuteCommandOutput> {

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -64,7 +64,6 @@ export class PublishIOS implements ICommand {
 			const platformInfo: IPreparePlatformInfo = {
 				platform,
 				appFilesUpdaterOptions,
-				platformTemplate: this.$options.platformTemplate,
 				projectData: this.$projectData,
 				config: this.$options,
 				env: this.$options.env

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -24,7 +24,6 @@ export abstract class BuildCommandBase extends ValidatePlatformCommandBase {
 		const platformInfo: IPreparePlatformInfo = {
 			platform,
 			appFilesUpdaterOptions,
-			platformTemplate: this.$options.platformTemplate,
 			projectData: this.$projectData,
 			config: this.$options,
 			env: this.$options.env

--- a/lib/commands/clean-app.ts
+++ b/lib/commands/clean-app.ts
@@ -25,7 +25,6 @@ export class CleanAppCommandBase extends ValidatePlatformCommandBase implements 
 			appFilesUpdaterOptions,
 			platform: this.platform.toLowerCase(),
 			config: this.$options,
-			platformTemplate: this.$options.platformTemplate,
 			projectData: this.$projectData,
 			env: this.$options.env
 		};

--- a/lib/commands/install.ts
+++ b/lib/commands/install.ts
@@ -34,7 +34,7 @@ export class InstallCommand implements ICommand {
 					const platformProjectService = platformData.platformProjectService;
 					await platformProjectService.validate(this.$projectData, this.$options);
 
-					await this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`], this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
+					await this.$platformService.addPlatforms([`${platform}@${frameworkPackageData.version}`], this.$projectData, this.$options, this.$options.frameworkPath);
 				} catch (err) {
 					error = `${error}${EOL}${err}`;
 				}

--- a/lib/commands/platform-clean.ts
+++ b/lib/commands/platform-clean.ts
@@ -10,7 +10,7 @@ export class CleanCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.cleanPlatforms(args, this.$options.platformTemplate, this.$projectData, this.$options);
+		await this.$platformService.cleanPlatforms(args, this.$projectData, this.$options);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -21,7 +21,6 @@ export class PrepareCommand extends ValidatePlatformCommandBase implements IComm
 		const platformInfo: IPreparePlatformInfo = {
 			platform: args[0],
 			appFilesUpdaterOptions,
-			platformTemplate: this.$options.platformTemplate,
 			projectData: this.$projectData,
 			config: this.$options,
 			env: this.$options.env

--- a/lib/commands/update-platform.ts
+++ b/lib/commands/update-platform.ts
@@ -10,7 +10,7 @@ export class UpdatePlatformCommand implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$platformService.updatePlatforms(args, this.$options.platformTemplate, this.$projectData, this.$options);
+		await this.$platformService.updatePlatforms(args, this.$projectData, this.$options);
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -94,12 +94,12 @@ export class UpdateCommand extends ValidatePlatformCommandBase implements IComma
 
 		if (args.length === 1) {
 			for (const platform of platforms.packagePlatforms) {
-				await this.$platformService.addPlatforms([platform + "@" + args[0]], this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
+				await this.$platformService.addPlatforms([platform + "@" + args[0]], this.$projectData, this.$options, this.$options.frameworkPath);
 			}
 
 			await this.$pluginsService.add(`${constants.TNS_CORE_MODULES_NAME}@${args[0]}`, this.$projectData);
 		} else {
-			await this.$platformService.addPlatforms(platforms.packagePlatforms, this.$options.platformTemplate, this.$projectData, this.$options, this.$options.frameworkPath);
+			await this.$platformService.addPlatforms(platforms.packagePlatforms, this.$projectData, this.$options, this.$options.frameworkPath);
 			await this.$pluginsService.add(constants.TNS_CORE_MODULES_NAME, this.$projectData);
 		}
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -441,11 +441,6 @@ interface IBundleString {
 	bundle: string;
 }
 
-interface IPlatformTemplate {
-	platformTemplate: string;
-}
-
-
 interface IClean {
 	clean: boolean;
 }
@@ -499,7 +494,7 @@ interface IAndroidBundleOptions {
 	aab: boolean;
 }
 
-interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvailableDevices, IProfileDir, IHasEmulatorOption, IBundleString, IPlatformTemplate, IHasEmulatorOption, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, IAndroidBundleOptions, INpmInstallConfigurationOptions, IPort, IEnvOptions, IPluginSeedOptions, IGenerateOptions {
+interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvailableDevices, IProfileDir, IHasEmulatorOption, IBundleString, IHasEmulatorOption, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, IAndroidBundleOptions, INpmInstallConfigurationOptions, IPort, IEnvOptions, IPluginSeedOptions, IGenerateOptions {
 	argv: IYargArgv;
 	validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>): void;
 	options: IDictionary<IDashedOption>;
@@ -589,11 +584,11 @@ interface IDeviceEmulator extends IHasEmulatorOption, IDeviceIdentifier { }
 
 interface IRunPlatformOptions extends IJustLaunch, IDeviceEmulator { }
 
-interface IDeployPlatformOptions extends IAndroidReleaseOptions, IPlatformTemplate, IRelease, IClean, IDeviceEmulator, IProvision, ITeamIdentifier, IProjectDir {
+interface IDeployPlatformOptions extends IAndroidReleaseOptions, IRelease, IClean, IDeviceEmulator, IProvision, ITeamIdentifier, IProjectDir {
 	forceInstall?: boolean;
 }
 
-interface IUpdatePlatformOptions extends IPlatformTemplate {
+interface IUpdatePlatformOptions {
 	currentVersion: string;
 	newVersion: string;
 	canUpdate: boolean;

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -15,9 +15,9 @@ interface IBuildPlatformAction {
 }
 
 interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
-	cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, framework?: string): Promise<void>;
+	cleanPlatforms(platforms: string[], projectData: IProjectData, config: IPlatformOptions, framework?: string): Promise<void>;
 
-	addPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, frameworkPath?: string): Promise<void>;
+	addPlatforms(platforms: string[], projectData: IProjectData, config: IPlatformOptions, frameworkPath?: string): Promise<void>;
 
 	/**
 	 * Gets list of all installed platforms (the ones for which <project dir>/platforms/<platform> exists).
@@ -48,7 +48,7 @@ interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
 	 */
 	removePlatforms(platforms: string[], projectData: IProjectData): Promise<void>;
 
-	updatePlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions): Promise<void>;
+	updatePlatforms(platforms: string[], projectData: IProjectData, config: IPlatformOptions): Promise<void>;
 
 	/**
 	 * Ensures that the specified platform and its dependencies are installed.
@@ -316,7 +316,6 @@ interface IAddPlatformInfo extends IProjectDataComposition, IPlatformDataComposi
 	frameworkDir: string;
 	installedVersion: string;
 	config: IPlatformOptions;
-	platformTemplate?: string;
 }
 
 interface IPreparePlatformJSInfo extends IPreparePlatformCoreInfo, ICopyAppFilesData {
@@ -335,7 +334,7 @@ interface IPreparePlatformCoreInfo extends IPreparePlatformInfoBase, IOptionalPr
 	platformSpecificData: IPlatformSpecificData;
 }
 
-interface IPreparePlatformInfo extends IPreparePlatformInfoBase, IPlatformConfig, IPlatformTemplate, ISkipNativeCheckOptional { }
+interface IPreparePlatformInfo extends IPreparePlatformInfoBase, IPlatformConfig, ISkipNativeCheckOptional { }
 
 interface IPlatformConfig {
 	config: IPlatformOptions;

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -336,10 +336,9 @@ interface ILocalBuildService {
 	 * Builds a project locally.
 	 * @param {string} platform Platform for which to build.
 	 * @param {IPlatformBuildData} platformBuildOptions Additional options for controlling the build.
-	 * @param {string} platformTemplate The name of the template.
 	 * @return {Promise<string>} Path to the build output.
 	 */
-	build(platform: string, platformBuildOptions: IPlatformBuildData, platformTemplate?: string): Promise<string>;
+	build(platform: string, platformBuildOptions: IPlatformBuildData): Promise<string>;
 	/**
 	 * Removes build artifacts specific to the platform
 	 * @param {ICleanNativeAppData} data Data describing the clean app process

--- a/lib/helpers/deploy-command-helper.ts
+++ b/lib/helpers/deploy-command-helper.ts
@@ -17,7 +17,6 @@ export class DeployCommandHelper implements IDeployCommandHelper {
 			device: this.$options.device,
 			projectDir: this.$projectData.projectDir,
 			emulator: this.$options.emulator,
-			platformTemplate: this.$options.platformTemplate,
 			release: this.$options.release,
 			forceInstall: true,
 			provision: this.$options.provision,

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -90,7 +90,6 @@ export class Options {
 			compileSdk: { type: OptionType.Number, hasSensitiveValue: false },
 			port: { type: OptionType.Number, hasSensitiveValue: false },
 			copyTo: { type: OptionType.String, hasSensitiveValue: true },
-			platformTemplate: { type: OptionType.String, hasSensitiveValue: true },
 			js: { type: OptionType.Boolean, hasSensitiveValue: false },
 			javascript: { type: OptionType.Boolean, hasSensitiveValue: false },
 			ng: { type: OptionType.Boolean, hasSensitiveValue: false },

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -429,7 +429,6 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 				nativePrepare: nativePrepare,
 				filesToSync: options.filesToSync,
 				filesToRemove: options.filesToRemove,
-				platformTemplate: null,
 				skipModulesNativeCheck: options.skipModulesNativeCheck,
 				config: platformSpecificOptions
 			};

--- a/lib/services/local-build-service.ts
+++ b/lib/services/local-build-service.ts
@@ -12,7 +12,7 @@ export class LocalBuildService extends EventEmitter implements ILocalBuildServic
 		super();
 	}
 
-	public async build(platform: string, platformBuildOptions: IPlatformBuildData, platformTemplate?: string): Promise<string> {
+	public async build(platform: string, platformBuildOptions: IPlatformBuildData): Promise<string> {
 		if (this.$mobileHelper.isAndroidPlatform(platform) && platformBuildOptions.release && (!platformBuildOptions.keyStorePath || !platformBuildOptions.keyStorePassword || !platformBuildOptions.keyStoreAlias || !platformBuildOptions.keyStoreAliasPassword)) {
 			this.$errors.fail(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
 		}
@@ -21,7 +21,6 @@ export class LocalBuildService extends EventEmitter implements ILocalBuildServic
 		const prepareInfo: IPreparePlatformInfo = {
 			platform,
 			appFilesUpdaterOptions: platformBuildOptions,
-			platformTemplate,
 			projectData: this.$projectData,
 			env: platformBuildOptions.env,
 			config: {

--- a/lib/services/prepare-platform-js-service.ts
+++ b/lib/services/prepare-platform-js-service.ts
@@ -1,5 +1,3 @@
-import * as constants from "../constants";
-import * as path from "path";
 import * as temp from "temp";
 import { hook } from "../common/helpers";
 import { PreparePlatformService } from "./prepare-platform-service";
@@ -12,22 +10,12 @@ export class PreparePlatformJSService extends PreparePlatformService implements 
 	constructor($fs: IFileSystem,
 		$xmlValidator: IXmlValidator,
 		$hooksService: IHooksService,
-		private $errors: IErrors,
-		private $logger: ILogger,
-		private $projectDataService: IProjectDataService,
-		private $packageManager: INodePackageManager) {
+		private $projectDataService: IProjectDataService) {
 		super($fs, $hooksService, $xmlValidator);
 	}
 
 	public async addPlatform(info: IAddPlatformInfo): Promise<void> {
-		const customTemplateOptions = await this.getPathToPlatformTemplate(info.platformTemplate, info.platformData.frameworkPackageName, info.projectData.projectDir);
-		info.config.pathToTemplate = customTemplateOptions && customTemplateOptions.pathToTemplate;
-
 		const frameworkPackageNameData: any = { version: info.installedVersion };
-		if (customTemplateOptions) {
-			frameworkPackageNameData.template = customTemplateOptions.selectedTemplate;
-		}
-
 		this.$projectDataService.setNSValue(info.projectData.projectDir, info.platformData.frameworkPackageName, frameworkPackageNameData);
 	}
 
@@ -35,34 +23,6 @@ export class PreparePlatformJSService extends PreparePlatformService implements 
 	@hook('prepareJSApp')
 	public async preparePlatform(config: IPreparePlatformJSInfo): Promise<void> {
 		// intentionally left blank, keep the support for before-prepareJSApp and after-prepareJSApp hooks
-	}
-
-	private async getPathToPlatformTemplate(selectedTemplate: string, frameworkPackageName: string, projectDir: string): Promise<{ selectedTemplate: string, pathToTemplate: string }> {
-		if (!selectedTemplate) {
-			// read data from package.json's nativescript key
-			// check the nativescript.tns-<platform>.template value
-			const nativescriptPlatformData = this.$projectDataService.getNSValue(projectDir, frameworkPackageName);
-			selectedTemplate = nativescriptPlatformData && nativescriptPlatformData.template;
-		}
-
-		if (selectedTemplate) {
-			const tempDir = temp.mkdirSync("platform-template");
-			this.$fs.writeJson(path.join(tempDir, constants.PACKAGE_JSON_FILE_NAME), {});
-			try {
-				const npmInstallResult = await this.$packageManager.install(selectedTemplate, tempDir, {
-					disableNpmInstall: false,
-					frameworkPath: null,
-					ignoreScripts: false
-				});
-				const pathToTemplate = path.join(tempDir, constants.NODE_MODULES_FOLDER_NAME, npmInstallResult.name);
-				return { selectedTemplate, pathToTemplate };
-			} catch (err) {
-				this.$logger.trace("Error while trying to install specified template: ", err);
-				this.$errors.failWithoutHelp(`Unable to install platform template ${selectedTemplate}. Make sure the specified value is valid.`);
-			}
-		}
-
-		return null;
 	}
 }
 

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -147,22 +147,22 @@ describe('Platform Service Tests', () => {
 				const fs = testInjector.resolve("fs");
 				fs.exists = () => false;
 				const projectData: IProjectData = testInjector.resolve("projectData");
-				await platformService.addPlatforms(["Android"], "", projectData, config);
-				await platformService.addPlatforms(["ANDROID"], "", projectData, config);
-				await platformService.addPlatforms(["AnDrOiD"], "", projectData, config);
-				await platformService.addPlatforms(["androiD"], "", projectData, config);
+				await platformService.addPlatforms(["Android"], projectData, config);
+				await platformService.addPlatforms(["ANDROID"], projectData, config);
+				await platformService.addPlatforms(["AnDrOiD"], projectData, config);
+				await platformService.addPlatforms(["androiD"], projectData, config);
 
-				await platformService.addPlatforms(["iOS"], "", projectData, config);
-				await platformService.addPlatforms(["IOS"], "", projectData, config);
-				await platformService.addPlatforms(["IoS"], "", projectData, config);
-				await platformService.addPlatforms(["iOs"], "", projectData, config);
+				await platformService.addPlatforms(["iOS"], projectData, config);
+				await platformService.addPlatforms(["IOS"], projectData, config);
+				await platformService.addPlatforms(["IoS"], projectData, config);
+				await platformService.addPlatforms(["iOs"], projectData, config);
 			});
 
 			it("should fail if platform is already installed", async () => {
 				const projectData: IProjectData = testInjector.resolve("projectData");
 				// By default fs.exists returns true, so the platforms directory should exists
-				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, config), "Platform android already added");
-				await assert.isRejected(platformService.addPlatforms(["ios"], "", projectData, config), "Platform ios already added");
+				await assert.isRejected(platformService.addPlatforms(["android"], projectData, config), "Platform android already added");
+				await assert.isRejected(platformService.addPlatforms(["ios"], projectData, config), "Platform ios already added");
 			});
 
 			it("should fail if unable to extract runtime package", async () => {
@@ -176,7 +176,7 @@ describe('Platform Service Tests', () => {
 				};
 
 				const projectData: IProjectData = testInjector.resolve("projectData");
-				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, config), errorMessage);
+				await assert.isRejected(platformService.addPlatforms(["android"], projectData, config), errorMessage);
 			});
 
 			it("fails when path passed to frameworkPath does not exist", async () => {
@@ -186,7 +186,7 @@ describe('Platform Service Tests', () => {
 				const projectData: IProjectData = testInjector.resolve("projectData");
 				const frameworkPath = "invalidPath";
 				const errorMessage = format(AddPlaformErrors.InvalidFrameworkPathStringFormat, frameworkPath);
-				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, config, frameworkPath), errorMessage);
+				await assert.isRejected(platformService.addPlatforms(["android"], projectData, config, frameworkPath), errorMessage);
 			});
 
 			const assertCorrectDataIsPassedToPacoteService = async (versionString: string): Promise<void> => {
@@ -217,9 +217,9 @@ describe('Platform Service Tests', () => {
 				};
 				const projectData: IProjectData = testInjector.resolve("projectData");
 
-				await platformService.addPlatforms(["android"], "", projectData, config);
+				await platformService.addPlatforms(["android"], projectData, config);
 				assert.equal(packageNamePassedToPacoteService, `${packageName}@${versionString}`);
-				await platformService.addPlatforms(["ios"], "", projectData, config);
+				await platformService.addPlatforms(["ios"], projectData, config);
 				assert.equal(packageNamePassedToPacoteService, `${packageName}@${versionString}`);
 			};
 			it("should respect platform version in package.json's nativescript key", async () => {
@@ -261,7 +261,7 @@ describe('Platform Service Tests', () => {
 				const preparePlatformNativeService = testInjector.resolve("preparePlatformNativeService");
 				preparePlatformNativeService.addPlatform = async () => isNativePlatformAdded = true;
 
-				await platformService.addPlatforms(["android"], "", projectData, config);
+				await platformService.addPlatforms(["android"], projectData, config);
 
 				assert.isTrue(isJsPlatformAdded);
 				assert.isTrue(isNativePlatformAdded);
@@ -275,7 +275,7 @@ describe('Platform Service Tests', () => {
 				projectChangesService.getPrepareInfo = () => <any>null;
 				const projectData = testInjector.resolve("projectData");
 
-				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, config), "Platform android already added");
+				await assert.isRejected(platformService.addPlatforms(["android"], projectData, config), "Platform android already added");
 			});
 
 			// Workflow: tns run; tns platform add
@@ -286,7 +286,7 @@ describe('Platform Service Tests', () => {
 				projectChangesService.getPrepareInfo = () => ({ nativePlatformStatus: constants.NativePlatformStatus.alreadyPrepared });
 				const projectData = testInjector.resolve("projectData");
 
-				await assert.isRejected(platformService.addPlatforms(["android"], "", projectData, config), "Platform android already added");
+				await assert.isRejected(platformService.addPlatforms(["android"], projectData, config), "Platform android already added");
 			});
 		});
 	});
@@ -315,7 +315,7 @@ describe('Platform Service Tests', () => {
 		it("shouldn't fail when platforms are added", async () => {
 			const projectData: IProjectData = testInjector.resolve("projectData");
 			testInjector.resolve("fs").exists = () => false;
-			await platformService.addPlatforms(["android"], "", projectData, config);
+			await platformService.addPlatforms(["android"], projectData, config);
 
 			testInjector.resolve("fs").exists = () => true;
 			await platformService.removePlatforms(["android"], projectData);
@@ -345,10 +345,10 @@ describe('Platform Service Tests', () => {
 				return Promise.resolve();
 			};
 
-			await platformService.cleanPlatforms(["android"], "", projectData, config);
+			await platformService.cleanPlatforms(["android"], projectData, config);
 
 			nsValueObject[VERSION_STRING] = versionString;
-			await platformService.cleanPlatforms(["ios"], "", projectData, config);
+			await platformService.cleanPlatforms(["ios"], projectData, config);
 		});
 	});
 
@@ -366,7 +366,7 @@ describe('Platform Service Tests', () => {
 				packageInstallationManager.getLatestVersion = async () => "0.2.0";
 				const projectData: IProjectData = testInjector.resolve("projectData");
 
-				await assert.isRejected(platformService.updatePlatforms(["android"], "", projectData, null));
+				await assert.isRejected(platformService.updatePlatforms(["android"], projectData, null));
 			});
 		});
 	});
@@ -1001,7 +1001,6 @@ describe('Platform Service Tests', () => {
 
 	describe("ensurePlatformInstalled", () => {
 		const platform = "android";
-		const platformTemplate = "testPlatformTemplate";
 		const appFilesUpdaterOptions = { bundle: true };
 		let areWebpackFilesPersisted = false;
 
@@ -1079,7 +1078,7 @@ describe('Platform Service Tests', () => {
 				usbLiveSyncService.isInitialized = testCase.isWebpackWatcherStarted === undefined ? true : testCase.isWebpackWatcherStarted;
 				mockPrepareInfo(testCase.prepareInfo);
 
-				await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions, testCase.nativePrepare);
+				await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions, testCase.nativePrepare);
 				assert.deepEqual(areWebpackFilesPersisted, testCase.areWebpackFilesPersisted);
 			});
 		});
@@ -1087,64 +1086,64 @@ describe('Platform Service Tests', () => {
 		it("should not persist webpack files after the second execution of `tns preview --bundle` or `tns cloud run --bundle`", async () => {
 			// First execution of `tns preview --bundle`
 			mockPrepareInfo(null);
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
 			assert.isTrue(areWebpackFilesPersisted);
 
 			// Second execution of `tns preview --bundle`
 			reset();
 			mockPrepareInfo({ nativePlatformStatus: constants.NativePlatformStatus.requiresPlatformAdd });
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
 			assert.isFalse(areWebpackFilesPersisted);
 		});
 
 		it("should not persist webpack files after the second execution of `tns run --bundle`", async () => {
 			// First execution of `tns run --bundle`
 			mockPrepareInfo(null);
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions);
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions);
 			assert.isTrue(areWebpackFilesPersisted);
 
 			// Second execution of `tns run --bundle`
 			reset();
 			mockPrepareInfo({ nativePlatformStatus: constants.NativePlatformStatus.alreadyPrepared });
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions);
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions);
 			assert.isFalse(areWebpackFilesPersisted);
 		});
 
 		it("should handle correctly the following sequence of commands: `tns preview --bundle`, `tns run --bundle` and `tns preview --bundle`", async () => {
 			// First execution of `tns preview --bundle`
 			mockPrepareInfo(null);
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
 			assert.isTrue(areWebpackFilesPersisted);
 
 			// Execution of `tns run --bundle`
 			reset();
 			mockPrepareInfo({ nativePlatformStatus: constants.NativePlatformStatus.requiresPlatformAdd });
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions);
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions);
 			assert.isTrue(areWebpackFilesPersisted);
 
 			// Execution of `tns preview --bundle`
 			reset();
 			mockPrepareInfo({ nativePlatformStatus: constants.NativePlatformStatus.alreadyPrepared });
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
 			assert.isFalse(areWebpackFilesPersisted);
 		});
 
 		it("should handle correctly the following sequence of commands: `tns preview --bundle`, `tns run --bundle` and `tns build --bundle`", async () => {
 			// Execution of `tns preview --bundle`
 			mockPrepareInfo(null);
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions, { skipNativePrepare: true });
 			assert.isTrue(areWebpackFilesPersisted);
 
 			// Execution of `tns run --bundle`
 			reset();
 			mockPrepareInfo({ nativePlatformStatus: constants.NativePlatformStatus.requiresPlatformAdd });
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions);
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions);
 			assert.isTrue(areWebpackFilesPersisted);
 
 			// Execution of `tns build --bundle`
 			reset();
 			mockPrepareInfo({ nativePlatformStatus: constants.NativePlatformStatus.alreadyPrepared });
-			await (<any>platformService).ensurePlatformInstalled(platform, platformTemplate, projectData, config, appFilesUpdaterOptions);
+			await (<any>platformService).ensurePlatformInstalled(platform, projectData, config, appFilesUpdaterOptions);
 			assert.isFalse(areWebpackFilesPersisted);
 		});
 	});


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
