### PR TITLE
docs: add environment flags in CLI help

### DIFF
--- a/docs/build-jekyll-md.sh
+++ b/docs/build-jekyll-md.sh
@@ -5,5 +5,7 @@ rm -rf docs-cli
 npm install --ignore-scripts
 
 grunt docs-jekyll
-cd docs-cli
-mv index.md start.md
+if [ -d docs-cli ]; then 
+    cd docs-cli
+    mv index.md start.md 
+fi

--- a/docs/man_pages/project/testing/build-android.md
+++ b/docs/man_pages/project/testing/build-android.md
@@ -26,7 +26,13 @@ General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <Fil
 * `--key-store-alias-password` - Provides the password for the alias specified with `--key-store-alias-password`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--copy-to` - Specifies the file path where the built `.apk` will be copied. If it points to a non-existent directory path, it will be created. If the specified value is existing directory, the original file name will be used.
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
-* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. Supported additional flags:
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
+    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
+    *   `--env.uglify` - obfuscates the code with Uglify.js
+    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
 * `--aab` - Specifies that the build will produce an Android App Bundle(`.aab`) file.
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/build-android.md
+++ b/docs/man_pages/project/testing/build-android.md
@@ -27,12 +27,12 @@ General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <Fil
 * `--copy-to` - Specifies the file path where the built `.apk` will be copied. If it points to a non-existent directory path, it will be created. If the specified value is existing directory, the original file name will be used.
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. Supported additional flags:
-    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
-    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
-    *   `--env.uglify` - obfuscates the code with Uglify.js
-    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only).
+    *   `--env.snapshot`- creates [Snapshot](https://docs.nativescript.org/performance-optimizations/bundling-with-webpack#v8-heap-snapshot) (only for release builds on Mac OS & for Android).
+    *   `--env.uglify` - provides basic obfuscation and smaller app size.
+    *   `--env.report` - creates a Webpack report inside a `report` folder in the root folder.
     *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
-    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the build will produce an Android App Bundle(`.aab`) file.
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -28,12 +28,12 @@ General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [-
 * `--provision` - If used without parameter, lists all eligible provisioning profiles. If used with UUID or name of your provisioning profile, it will switch to manual signing mode and configure the .xcodeproj file of your app. In this case xcconfig should not contain any provisioning/team id flags. This provisioning profile will be further used for codesigning the app.
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. Supported additional flags:
-    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
-    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
-    *   `--env.uglify` - obfuscates the code with Uglify.js
-    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only).
+    *   `--env.snapshot`- creates [Snapshot](https://docs.nativescript.org/performance-optimizations/bundling-with-webpack#v8-heap-snapshot) (only for release builds on Mac OS & for Android).
+    *   `--env.uglify` - provides basic obfuscation and smaller app size.
+    *   `--env.report` - creates a Webpack report inside a `report` folder in the root folder.
     *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
-    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 
 <% } %>
 

--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -27,7 +27,13 @@ General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [-
 * `--team-id` - If used without parameter, lists all team names and ids. If used with team name or id, it will switch to automatic signing mode and configure the .xcodeproj file of your app. In this case .xcconfig should not contain any provisioning/team id flags. This team id will be further used for codesigning the app. For Xcode 9.0+, xcodebuild will be allowed to update and modify automatically managed provisioning profiles.
 * `--provision` - If used without parameter, lists all eligible provisioning profiles. If used with UUID or name of your provisioning profile, it will switch to manual signing mode and configure the .xcodeproj file of your app. In this case xcconfig should not contain any provisioning/team id flags. This provisioning profile will be further used for codesigning the app.
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
-* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. Supported additional flags:
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
+    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
+    *   `--env.uglify` - obfuscates the code with Uglify.js
+    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
 
 <% } %>
 

--- a/docs/man_pages/project/testing/build.md
+++ b/docs/man_pages/project/testing/build.md
@@ -22,9 +22,22 @@ Usage | Synopsis
 
 <% if(isHtml) { %>
 
-### Command Limitations
+### Options
 
-* You can run the `$ tns build ios` command only on macOS systems.
+* `--justlaunch` - If set, does not print the application output in the console.
+* `--release` - If set, produces a release build. Otherwise, produces a debug build.
+* `--device` - Specifies a connected device/emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device <Platform> --available-devices` command.
+* `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
+* `--hmr` - (Beta) Enables the hot module replacement (HMR) feature. HMR depends on `webpack` and adding the `--hmr` flag to the command will automatically enable the `--bundle` option as well. <% if(isConsole) { %> The HMR feature is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/NativeScript/issues/6398.<% } %>
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. Supported additional flags:
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
+    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
+    *   `--env.uglify` - obfuscates the code with Uglify.js
+    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
+* `--syncAllFiles` - Watches all production dependencies inside node_modules for changes. Triggers project rebuild if necessary!
+
 
 ### Related Commands
 

--- a/docs/man_pages/project/testing/build.md
+++ b/docs/man_pages/project/testing/build.md
@@ -30,12 +30,12 @@ Usage | Synopsis
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--hmr` - (Beta) Enables the hot module replacement (HMR) feature. HMR depends on `webpack` and adding the `--hmr` flag to the command will automatically enable the `--bundle` option as well. <% if(isConsole) { %> The HMR feature is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/NativeScript/issues/6398.<% } %>
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. Supported additional flags:
-    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
-    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
-    *   `--env.uglify` - obfuscates the code with Uglify.js
-    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only).
+    *   `--env.snapshot`- creates [Snapshot](https://docs.nativescript.org/performance-optimizations/bundling-with-webpack#v8-heap-snapshot) (only for release builds on Mac OS & for Android).
+    *   `--env.uglify` - provides basic obfuscation and smaller app size.
+    *   `--env.report` - creates a Webpack report inside a `report` folder in the root folder.
     *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
-    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--syncAllFiles` - Watches all production dependencies inside node_modules for changes. Triggers project rebuild if necessary!
 
 

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -34,12 +34,12 @@ Start a default emulator if none are running, or run application on all connecte
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--hmr` - (Beta) Enables the hot module replacement (HMR) feature. HMR depends on `webpack` and adding the `--hmr` flag to the command will automatically enable the `--bundle` option as well. <% if(isConsole) { %> The HMR feature is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/NativeScript/issues/6398.<% } %>
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. 
-    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
-    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
-    *   `--env.uglify` - obfuscates the code with Uglify.js
-    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only).
+    *   `--env.snapshot`- creates [Snapshot](https://docs.nativescript.org/performance-optimizations/bundling-with-webpack#v8-heap-snapshot) (only for release builds on Mac OS & for Android).
+    *   `--env.uglify` - provides basic obfuscation and smaller app size.
+    *   `--env.report` - creates a Webpack report inside a `report` folder in the root folder.
     *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
-    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--syncAllFiles` - Watches all production dependencies inside node_modules for changes. Triggers project rebuild if necessary!
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -33,7 +33,13 @@ Start a default emulator if none are running, or run application on all connecte
 * `--key-store-alias-password` - Provides the password for the alias specified with `--key-store-alias-password`. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--hmr` - (Beta) Enables the hot module replacement (HMR) feature. HMR depends on `webpack` and adding the `--hmr` flag to the command will automatically enable the `--bundle` option as well. <% if(isConsole) { %> The HMR feature is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/NativeScript/issues/6398.<% } %>
-* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. 
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
+    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
+    *   `--env.uglify` - obfuscates the code with Uglify.js
+    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
 * `--syncAllFiles` - Watches all production dependencies inside node_modules for changes. Triggers project rebuild if necessary!
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -37,12 +37,12 @@ Start an emulator with specified device identifier and sdk | `$ tns run ios [--d
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--hmr` - (Beta) Enables the hot module replacement (HMR) feature. HMR depends on `webpack` and adding the `--hmr` flag to the command will automatically enable the `--bundle` option as well. <% if(isConsole) { %> The HMR feature is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/NativeScript/issues/6398.<% } %>
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. 
-    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
-    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
-    *   `--env.uglify` - obfuscates the code with Uglify.js
-    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only).
+    *   `--env.snapshot`- creates [Snapshot](https://docs.nativescript.org/performance-optimizations/bundling-with-webpack#v8-heap-snapshot) (only for release builds on Mac OS & for Android).
+    *   `--env.uglify` - provides basic obfuscation and smaller app size.
+    *   `--env.report` - creates a Webpack report inside a `report` folder in the root folder.
     *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
-    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--syncAllFiles` - Watches all production dependencies inside node_modules for changes. Triggers project rebuild if necessary!
 
 <% } %>

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -36,7 +36,13 @@ Start an emulator with specified device identifier and sdk | `$ tns run ios [--d
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--hmr` - (Beta) Enables the hot module replacement (HMR) feature. HMR depends on `webpack` and adding the `--hmr` flag to the command will automatically enable the `--bundle` option as well. <% if(isConsole) { %> The HMR feature is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/NativeScript/issues/6398.<% } %>
-* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. 
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
+    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
+    *   `--env.uglify` - obfuscates the code with Uglify.js
+    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
 * `--syncAllFiles` - Watches all production dependencies inside node_modules for changes. Triggers project rebuild if necessary!
 
 <% } %>

--- a/docs/man_pages/project/testing/run.md
+++ b/docs/man_pages/project/testing/run.md
@@ -24,7 +24,13 @@ Run on a selected connected device or running emulator. Will start emulator with
 * `--device` - Specifies a connected device/emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device <Platform> --available-devices` command.
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--hmr` - (Beta) Enables the hot module replacement (HMR) feature. HMR depends on `webpack` and adding the `--hmr` flag to the command will automatically enable the `--bundle` option as well. <% if(isConsole) { %> The HMR feature is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/NativeScript/issues/6398.<% } %>
-* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. For example: `--env.uglify --env.snapshot`.
+* `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. Supported additional flags:
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
+    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
+    *   `--env.uglify` - obfuscates the code with Uglify.js
+    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
 * `--syncAllFiles` - Watches all production dependencies inside node_modules for changes. Triggers project rebuild if necessary!
 
 

--- a/docs/man_pages/project/testing/run.md
+++ b/docs/man_pages/project/testing/run.md
@@ -25,12 +25,12 @@ Run on a selected connected device or running emulator. Will start emulator with
 * `--bundle` - Specifies that the `webpack` bundler will be used to bundle the application.
 * `--hmr` - (Beta) Enables the hot module replacement (HMR) feature. HMR depends on `webpack` and adding the `--hmr` flag to the command will automatically enable the `--bundle` option as well. <% if(isConsole) { %> The HMR feature is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/NativeScript/issues/6398.<% } %>
 * `--env.*` - Specifies additional flags that the bundler may process. May be passed multiple times. Supported additional flags:
-    *   `--env.aot` - creates Ahead-Of-Time build (Angular only)
-    *   `--env.snapshot`- creates Snapshot (only on Mac OS & only for Android)
-    *   `--env.uglify` - obfuscates the code with Uglify.js
-    *   `--env.report` - creates a report inside a `report` folder in the root folde
+    *   `--env.aot` - creates Ahead-Of-Time build (Angular only).
+    *   `--env.snapshot`- creates [Snapshot](https://docs.nativescript.org/performance-optimizations/bundling-with-webpack#v8-heap-snapshot) (only for release builds on Mac OS & for Android).
+    *   `--env.uglify` - provides basic obfuscation and smaller app size.
+    *   `--env.report` - creates a Webpack report inside a `report` folder in the root folder.
     *   `--env.sourceMap` - creates inline source maps (useful for debbuging bundled app).
-    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release)
+    *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--syncAllFiles` - Watches all production dependencies inside node_modules for changes. Triggers project rebuild if necessary!
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 		"noImplicitAny": true,
 		"experimentalDecorators": true,
 		"alwaysStrict": true,
-		"noUnusedLocals": true
+		"noUnusedLocals": true,
+		"noEmitOnError": false
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
Short descriptions for all supported environment flags (info will be visible at docs.nativescript.org and via `help` command/flag)