### PR TITLE
feat: add iCloudContainerEnvironment build option

### DIFF
--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -23,6 +23,7 @@ General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [-
 
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 * `--for-device` - If set, produces an application package that you can deploy on device. Otherwise, produces a build that you can run only in the native iOS Simulator.
+* `--i-cloud-container-environment` - If set, adds the passed `iCloudContainerEnvironment` when exporting an application package with the `--for-device` option.
 * `--copy-to` - Specifies the file path where the built `.ipa` will be copied. If it points to a non-existent directory path, it will be created. If the specified value is existing directory, the original file name will be used.
 * `--team-id` - If used without parameter, lists all team names and ids. If used with team name or id, it will switch to automatic signing mode and configure the .xcodeproj file of your app. In this case .xcconfig should not contain any provisioning/team id flags. This team id will be further used for codesigning the app. For Xcode 9.0+, xcodebuild will be allowed to update and modify automatically managed provisioning profiles.
 * `--provision` - If used without parameter, lists all eligible provisioning profiles. If used with UUID or name of your provisioning profile, it will switch to manual signing mode and configure the .xcodeproj file of your app. In this case xcconfig should not contain any provisioning/team id flags. This provisioning profile will be further used for codesigning the app.

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -78,6 +78,7 @@ export class PublishIOS implements ICommand {
 					provision: this.$options.provision,
 					teamId: this.$options.teamId,
 					buildForDevice: true,
+					iCloudContainerEnvironment: this.$options.iCloudContainerEnvironment,
 					mobileProvisionIdentifier,
 					codeSignIdentity
 				};

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -33,6 +33,7 @@ export abstract class BuildCommandBase extends ValidatePlatformCommandBase {
 		await this.$platformService.preparePlatform(platformInfo);
 		const buildConfig: IBuildConfig = {
 			buildForDevice: this.$options.forDevice,
+			iCloudContainerEnvironment: this.$options.iCloudContainerEnvironment,
 			projectDir: this.$options.path,
 			clean: this.$options.clean,
 			teamId: this.$options.teamId,

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -544,6 +544,7 @@ interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvai
 	copyTo: string;
 	debugTransport: boolean;
 	forDevice: boolean;
+	iCloudContainerEnvironment: string;
 	framework: string;
 	frameworkName: string;
 	frameworkVersion: string;

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -304,6 +304,10 @@ interface IBuildForDevice {
 	buildForDevice: boolean;
 }
 
+interface IiCloudContainerEnvironment {
+	iCloudContainerEnvironment: string;
+}
+
 interface INativePrepare {
 	skipNativePrepare: boolean;
 }
@@ -317,7 +321,7 @@ interface IBuildConfig extends IAndroidBuildOptionsSettings, IiOSBuildConfig, IP
 /**
  * Describes iOS-specific build configuration properties
  */
-interface IiOSBuildConfig extends IBuildForDevice, IDeviceIdentifier, IProvision, ITeamIdentifier, IRelease {
+interface IiOSBuildConfig extends IBuildForDevice, IiCloudContainerEnvironment, IDeviceIdentifier, IProvision, ITeamIdentifier, IRelease {
 	/**
 	 * Identifier of the mobile provision which will be used for the build. If not set a provision will be selected automatically if possible.
 	 */

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -76,6 +76,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 
 				const buildConfig: IBuildConfig = {
 					buildForDevice: !d.isEmulator,
+					iCloudContainerEnvironment: this.$options.iCloudContainerEnvironment,
 					projectDir: this.$options.path,
 					clean: this.$options.clean,
 					teamId: this.$options.teamId,

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -76,6 +76,7 @@ export class Options {
 			framework: { type: OptionType.String, hasSensitiveValue: false },
 			frameworkVersion: { type: OptionType.String, hasSensitiveValue: false },
 			forDevice: { type: OptionType.Boolean, hasSensitiveValue: false },
+			iCloudContainerEnvironment: { type: OptionType.String, hasSensitiveValue: false },
 			provision: { type: OptionType.Object, hasSensitiveValue: true },
 			client: { type: OptionType.Boolean, default: true, hasSensitiveValue: false },
 			env: { type: OptionType.Object, hasSensitiveValue: false },

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -279,6 +279,10 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		return exportFile;
 	}
 
+	private iCloudContainerEnvironment(buildConfig: IBuildConfig): string {
+		return buildConfig && buildConfig.iCloudContainerEnvironment ? buildConfig.iCloudContainerEnvironment : null;
+	}
+
 	/**
 	 * Exports .xcarchive for a development device.
 	 */
@@ -287,6 +291,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		const projectRoot = platformData.projectRoot;
 		const archivePath = options.archivePath;
 		const exportOptionsMethod = await this.getExportOptionsMethod(projectData, archivePath);
+		const iCloudContainerEnvironment = this.iCloudContainerEnvironment(buildConfig);
 		let plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -304,7 +309,13 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
     <key>uploadBitcode</key>
     <false/>
     <key>compileBitcode</key>
-    <false/>
+    <false/>`;
+		if (iCloudContainerEnvironment) {
+			plistTemplate += `
+    <key>iCloudContainerEnvironment</key>
+    <string>${iCloudContainerEnvironment}</string>`;
+		}
+		plistTemplate += `
 </dict>
 </plist>`;
 

--- a/lib/services/livesync/livesync-service.ts
+++ b/lib/services/livesync/livesync-service.ts
@@ -858,6 +858,7 @@ export class LiveSyncService extends EventEmitter implements IDebugLiveSyncServi
 	private getInstallApplicationBuildConfig(deviceIdentifier: string, projectDir: string, opts: { isEmulator: boolean }): IBuildConfig {
 		const buildConfig: IBuildConfig = {
 			buildForDevice: !opts.isEmulator,
+			iCloudContainerEnvironment: null,
 			release: false,
 			device: deviceIdentifier,
 			provision: null,

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -548,6 +548,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		const action = async (device: Mobile.IDevice): Promise<void> => {
 			const buildConfig: IBuildConfig = {
 				buildForDevice: !this.$devicesService.isiOSSimulator(device),
+				iCloudContainerEnvironment: null,
 				projectDir: deployInfo.deployOptions.projectDir,
 				release: deployInfo.deployOptions.release,
 				device: deployInfo.deployOptions.device,

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -84,6 +84,7 @@ export class TestExecutionService implements ITestExecutionService {
 							buildAction: async (): Promise<string> => {
 								const buildConfig: IBuildConfig = {
 									buildForDevice: !d.isEmulator,
+									iCloudContainerEnvironment: this.$options.iCloudContainerEnvironment,
 									projectDir: this.$options.path,
 									clean: this.$options.clean,
 									teamId: this.$options.teamId,

--- a/test/services/android-project-service.ts
+++ b/test/services/android-project-service.ts
@@ -43,6 +43,7 @@ const getDefautlBuildConfig = (): IBuildConfig => {
 	return {
 		release: true,
 		buildForDevice: false,
+		iCloudContainerEnvironment: null,
 		device: "testDevice",
 		provision: null,
 		teamId: "",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Enterprise applications that use iCloud fail to build in 5.x. 
(This was not an issue in prior versions.)

The error message is: 
```
error: exportArchive: exportOptionsPlist error for key 'iCloudContainerEnvironment': expected one of {Development, Production}, but no value was provided
```

## What is the new behavior?
<!-- Describe the changes. -->
Allow the user to pass a new `--i-cloud-container-environment` option (while doing a `--for-device` build), that accepts an environment string.

Fixes/Implements/Closes #4374.
