### PR TITLE
fix: support custom tagged android runtime versions

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -16,6 +16,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	private static MIN_RUNTIME_VERSION_WITH_GRADLE = "1.5.0";
 	private static MIN_RUNTIME_VERSION_WITHOUT_DEPS = "4.2.0-2018-06-29-02";
 
+	private isAndroidStudioTemplate: boolean;
+
 	constructor(private $androidToolsInfo: IAndroidToolsInfo,
 		private $childProcess: IChildProcess,
 		private $errors: IErrors,
@@ -32,6 +34,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		private $androidResourcesMigrationService: IAndroidResourcesMigrationService,
 		private $filesHashService: IFilesHashService) {
 		super($fs, $projectDataService);
+		this.isAndroidStudioTemplate = false;
 	}
 
 	private _platformData: IPlatformData = null;
@@ -41,10 +44,27 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		}
 		if (projectData && projectData.platformsDir) {
 			const projectRoot = path.join(projectData.platformsDir, AndroidProjectService.ANDROID_PLATFORM_NAME);
+			if (this.isAndroidStudioCompatibleTemplate(projectData)) {
+				this.isAndroidStudioTemplate = true;
+			}
 
-			const appDestinationDirectoryArr = [projectRoot, constants.APP_FOLDER_NAME, constants.SRC_DIR, constants.MAIN_DIR, constants.ASSETS_DIR];
-			const configurationsDirectoryArr = [projectRoot, constants.APP_FOLDER_NAME, constants.SRC_DIR, constants.MAIN_DIR, constants.MANIFEST_FILE_NAME];
-			const deviceBuildOutputArr = [projectRoot, constants.APP_FOLDER_NAME, constants.BUILD_DIR, constants.OUTPUTS_DIR, constants.APK_DIR];
+			const appDestinationDirectoryArr = [projectRoot];
+			if (this.isAndroidStudioTemplate) {
+				appDestinationDirectoryArr.push(constants.APP_FOLDER_NAME);
+			}
+			appDestinationDirectoryArr.push(constants.SRC_DIR, constants.MAIN_DIR, constants.ASSETS_DIR);
+
+			const configurationsDirectoryArr = [projectRoot];
+			if (this.isAndroidStudioTemplate) {
+				configurationsDirectoryArr.push(constants.APP_FOLDER_NAME);
+			}
+			configurationsDirectoryArr.push(constants.SRC_DIR, constants.MAIN_DIR, constants.MANIFEST_FILE_NAME);
+
+			const deviceBuildOutputArr = [projectRoot];
+			if (this.isAndroidStudioTemplate) {
+				deviceBuildOutputArr.push(constants.APP_FOLDER_NAME);
+			}
+			deviceBuildOutputArr.push(constants.BUILD_DIR, constants.OUTPUTS_DIR, constants.APK_DIR);
 
 			const packageName = this.getProjectNameFromId(projectData);
 
@@ -140,7 +160,30 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		const targetSdkVersion = androidToolsInfo && androidToolsInfo.targetSdkVersion;
 		this.$logger.trace(`Using Android SDK '${targetSdkVersion}'.`);
 
-		this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "*", "-R");
+		this.isAndroidStudioTemplate = this.isAndroidStudioCompatibleTemplate(projectData, frameworkVersion);
+		if (this.isAndroidStudioTemplate) {
+			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "*", "-R");
+		} else {
+			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "libs", "-R");
+
+			if (config.pathToTemplate) {
+				const mainPath = path.join(this.getPlatformData(projectData).projectRoot, constants.SRC_DIR, constants.MAIN_DIR);
+				this.$fs.createDirectory(mainPath);
+				shell.cp("-R", path.join(path.resolve(config.pathToTemplate), "*"), mainPath);
+			} else {
+				this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, constants.SRC_DIR, "-R");
+			}
+			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "build.gradle settings.gradle build-tools", "-Rf");
+
+			try {
+				this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "gradle.properties", "-Rf");
+			} catch (e) {
+				this.$logger.warn(`\n${e}\nIt's possible, the final .apk file will contain all architectures instead of the ones described in the abiFilters!\nYou can fix this by using the latest android platform.`);
+			}
+
+			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "gradle", "-R");
+			this.copy(this.getPlatformData(projectData).projectRoot, frameworkDir, "gradlew gradlew.bat", "-f");
+		}
 
 		this.cleanResValues(targetSdkVersion, projectData);
 
@@ -702,6 +745,24 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		}
 	}
 
+	private isAndroidStudioCompatibleTemplate(projectData: IProjectData, frameworkVersion?: string): boolean {
+		const currentPlatformData: IDictionary<any> = this.$projectDataService.getNSValue(projectData.projectDir, constants.TNS_ANDROID_RUNTIME_NAME);
+		const platformVersion = (currentPlatformData && currentPlatformData[constants.VERSION_STRING]) || frameworkVersion;
+
+		if (!platformVersion) {
+			return true;
+		}
+
+		if (platformVersion === constants.PackageVersion.NEXT || platformVersion === constants.PackageVersion.LATEST || platformVersion === constants.PackageVersion.RC) {
+			return true;
+		}
+
+		const androidStudioCompatibleTemplate = "3.4.0";
+		const normalizedPlatformVersion = `${semver.major(platformVersion)}.${semver.minor(platformVersion)}.0`;
+
+		return semver.gte(normalizedPlatformVersion, androidStudioCompatibleTemplate);
+	}
+
 	private runtimeVersionIsGreaterThanOrEquals(projectData: IProjectData, versionString: string): boolean {
 		const platformVersion = this.getCurrentPlatformVersion(this.getPlatformData(projectData), projectData);
 
@@ -714,12 +775,20 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	private getLegacyAppResourcesDestinationDirPath(projectData: IProjectData): string {
-		const resourcePath: string[] = [constants.APP_FOLDER_NAME, constants.SRC_DIR, constants.MAIN_DIR, constants.RESOURCES_DIR];
+		const resourcePath: string[] = [constants.SRC_DIR, constants.MAIN_DIR, constants.RESOURCES_DIR];
+		if (this.isAndroidStudioTemplate) {
+			resourcePath.unshift(constants.APP_FOLDER_NAME);
+		}
+
 		return path.join(this.getPlatformData(projectData).projectRoot, ...resourcePath);
 	}
 
 	private getUpdatedAppResourcesDestinationDirPath(projectData: IProjectData): string {
-		const resourcePath: string[] = [constants.APP_FOLDER_NAME, constants.SRC_DIR];
+		const resourcePath: string[] = [constants.SRC_DIR];
+		if (this.isAndroidStudioTemplate) {
+			resourcePath.unshift(constants.APP_FOLDER_NAME);
+		}
+
 		return path.join(this.getPlatformData(projectData).projectRoot, ...resourcePath);
 	}
 

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -753,7 +753,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			return true;
 		}
 
-		if (platformVersion === constants.PackageVersion.NEXT || platformVersion === constants.PackageVersion.LATEST || platformVersion === constants.PackageVersion.RC) {
+		if (!semver.valid(platformVersion)) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->

Rel to: https://github.com/NativeScript/nativescript-cli/issues/4504
