### PR TITLE
Shows an appropriate message while trying to run the app in a non-project folder

### DIFF
--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -66,7 +66,7 @@ export class RunIosCommand implements ICommand {
 		private $errors: IErrors,
 		private $injector: IInjector,
 		private $platformService: IPlatformService,
-		private $projectData: IProjectData,
+		private $projectDataService: IProjectDataService,
 		private $options: IOptions) {
 	}
 
@@ -75,11 +75,11 @@ export class RunIosCommand implements ICommand {
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
-		if (!this.$platformService.isPlatformSupportedForOS(this.$devicePlatformsConstants.iOS, this.$projectData)) {
+		if (!this.$platformService.isPlatformSupportedForOS(this.$devicePlatformsConstants.iOS, projectData)) {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.iOS} can not be built on this OS`);
 		}
 
-		const result = await this.runCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$platformsData.availablePlatforms.iOS);
+		const result = await this.runCommand.canExecute(args) && await this.$platformService.validateOptions(this.$options.provision, this.$options.teamId, projectData, this.$platformsData.availablePlatforms.iOS);
 		return result;
 	}
 }

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -75,6 +75,8 @@ export class RunIosCommand implements ICommand {
 	}
 
 	public async canExecute(args: string[]): Promise<boolean> {
+		const projectData = this.$projectDataService.getProjectData();
+		
 		if (!this.$platformService.isPlatformSupportedForOS(this.$devicePlatformsConstants.iOS, projectData)) {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.iOS} can not be built on this OS`);
 		}

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -76,7 +76,7 @@ export class RunIosCommand implements ICommand {
 
 	public async canExecute(args: string[]): Promise<boolean> {
 		const projectData = this.$projectDataService.getProjectData();
-		
+
 		if (!this.$platformService.isPlatformSupportedForOS(this.$devicePlatformsConstants.iOS, projectData)) {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.iOS} can not be built on this OS`);
 		}


### PR DESCRIPTION
Shows up an appropriate message while trying to run app in non-project directory

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you try to run app in non-project folder with --path in command without existing folder, you will see exception and you couldn't understand what is the problem.

## What is the new behavior?
<!-- Describe the changes. -->
correct error for non existing folder

Closes #4280 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
