### PR TITLE
feat: deprecate the legacy workflow and recommend the new one

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -190,6 +190,7 @@ $injector.require("hmrStatusService", "./services/hmr-status-service");
 $injector.require("pacoteService", "./services/pacote-service");
 $injector.require("qrCodeTerminalService", "./services/qr-code-terminal-service");
 $injector.require("testInitializationService", "./services/test-initialization-service");
+$injector.require("workflowService", "./services/workflow-service");
 
 $injector.require("networkConnectivityValidator", "./helpers/network-connectivity-validator");
 $injector.requirePublic("cleanupService", "./services/cleanup-service");

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -9,12 +9,14 @@ export abstract class BuildCommandBase extends ValidatePlatformCommandBase {
 		protected $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$platformService: IPlatformService,
 		private $bundleValidatorHelper: IBundleValidatorHelper,
-		protected $logger: ILogger) {
-			super($options, $platformsData, $platformService, $projectData);
-			this.$projectData.initializeProjectData();
+		protected $logger: ILogger,
+		protected $workflowService: IWorkflowService) {
+		super($options, $platformsData, $platformService, $projectData);
+		this.$projectData.initializeProjectData();
 	}
 
 	public async executeCore(args: string[]): Promise<string> {
+		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
 		const platform = args[0].toLowerCase();
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = {
 			bundle: !!this.$options.bundle,
@@ -94,8 +96,9 @@ export class BuildIosCommand extends BuildCommandBase implements ICommand {
 		$devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		$platformService: IPlatformService,
 		$bundleValidatorHelper: IBundleValidatorHelper,
-		$logger: ILogger) {
-			super($options, $errors, $projectData, $platformsData, $devicePlatformsConstants, $platformService, $bundleValidatorHelper, $logger);
+		$logger: ILogger,
+		$workflowService: IWorkflowService) {
+		super($options, $errors, $projectData, $platformsData, $devicePlatformsConstants, $platformService, $bundleValidatorHelper, $logger, $workflowService);
 	}
 
 	public async execute(args: string[]): Promise<void> {
@@ -107,7 +110,7 @@ export class BuildIosCommand extends BuildCommandBase implements ICommand {
 
 		super.validatePlatform(platform);
 
-		let result = await super.canExecuteCommandBase(platform, { notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true }});
+		let result = await super.canExecuteCommandBase(platform, { notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true } });
 		if (result.canExecute) {
 			result = await super.validateArgs(args, platform);
 		}
@@ -129,8 +132,9 @@ export class BuildAndroidCommand extends BuildCommandBase implements ICommand {
 		$platformService: IPlatformService,
 		$bundleValidatorHelper: IBundleValidatorHelper,
 		protected $androidBundleValidatorHelper: IAndroidBundleValidatorHelper,
-		protected $logger: ILogger) {
-			super($options, $errors, $projectData, $platformsData, $devicePlatformsConstants, $platformService, $bundleValidatorHelper, $logger);
+		protected $logger: ILogger,
+		$workflowService: IWorkflowService) {
+		super($options, $errors, $projectData, $platformsData, $devicePlatformsConstants, $platformService, $bundleValidatorHelper, $logger, $workflowService);
 	}
 
 	public async execute(args: string[]): Promise<void> {
@@ -149,7 +153,7 @@ export class BuildAndroidCommand extends BuildCommandBase implements ICommand {
 		const platform = this.$devicePlatformsConstants.Android;
 		super.validatePlatform(platform);
 		this.$androidBundleValidatorHelper.validateRuntimeVersion(this.$projectData);
-		let result = await super.canExecuteCommandBase(platform, { notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true }});
+		let result = await super.canExecuteCommandBase(platform, { notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true } });
 		if (result.canExecute) {
 			if (this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
 				this.$errors.fail(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -65,7 +65,7 @@ export abstract class BuildCommandBase extends ValidatePlatformCommandBase {
 			this.$errors.fail(`Applications for platform ${platform} can not be built on this OS`);
 		}
 
-		this.$bundleValidatorHelper.validate();
+		this.$bundleValidatorHelper.validate(this.$projectData);
 	}
 
 	protected async validateArgs(args: string[], platform: string): Promise<ICanExecuteCommandOutput> {

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -16,7 +16,7 @@ export abstract class BuildCommandBase extends ValidatePlatformCommandBase {
 	}
 
 	public async executeCore(args: string[]): Promise<string> {
-		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
+		await this.$workflowService.handleLegacyWorkflow({ projectDir: this.$projectData.projectDir, settings: this.$options, skipWarnings: true });
 		const platform = args[0].toLowerCase();
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = {
 			bundle: !!this.$options.bundle,

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -69,7 +69,7 @@ export class DebugPlatformCommand extends ValidatePlatformCommandBase implements
 		}
 
 		const minSupportedWebpackVersion = this.$options.hmr ? LiveSyncCommandHelper.MIN_SUPPORTED_WEBPACK_VERSION_WITH_HMR : null;
-		this.$bundleValidatorHelper.validate(minSupportedWebpackVersion);
+		this.$bundleValidatorHelper.validate(this.$projectData, minSupportedWebpackVersion);
 
 		const result = await super.canExecuteCommandBase(this.platform, { validateOptions: true, notConfiguredEnvOptions: { hideCloudBuildOption: true, hideSyncToPreviewAppOption: true } });
 		return result;

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -24,7 +24,7 @@ export class DebugPlatformCommand extends ValidatePlatformCommandBase implements
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
+		await this.$workflowService.handleLegacyWorkflow({ projectDir: this.$projectData.projectDir, settings: this.$options, skipWarnings: true });
 		await this.$devicesService.initialize({
 			platform: this.platform,
 			deviceId: this.$options.device,

--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -18,11 +18,13 @@ export class DebugPlatformCommand extends ValidatePlatformCommandBase implements
 		private $debugDataService: IDebugDataService,
 		private $liveSyncService: IDebugLiveSyncService,
 		private $liveSyncCommandHelper: ILiveSyncCommandHelper,
-		private $androidBundleValidatorHelper: IAndroidBundleValidatorHelper) {
+		private $androidBundleValidatorHelper: IAndroidBundleValidatorHelper,
+		private $workflowService: IWorkflowService) {
 		super($options, $platformsData, $platformService, $projectData);
 	}
 
 	public async execute(args: string[]): Promise<void> {
+		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
 		await this.$devicesService.initialize({
 			platform: this.platform,
 			deviceId: this.$options.device,

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -14,8 +14,8 @@ export class DeployOnDeviceCommand extends ValidatePlatformCommandBase implement
 		$platformsData: IPlatformsData,
 		private $bundleValidatorHelper: IBundleValidatorHelper,
 		private $androidBundleValidatorHelper: IAndroidBundleValidatorHelper) {
-			super($options, $platformsData, $platformService, $projectData);
-			this.$projectData.initializeProjectData();
+		super($options, $platformsData, $platformService, $projectData);
+		this.$projectData.initializeProjectData();
 	}
 
 	public async execute(args: string[]): Promise<void> {
@@ -26,7 +26,7 @@ export class DeployOnDeviceCommand extends ValidatePlatformCommandBase implement
 
 	public async canExecute(args: string[]): Promise<boolean | ICanExecuteCommandOutput> {
 		this.$androidBundleValidatorHelper.validateNoAab();
-		this.$bundleValidatorHelper.validate();
+		this.$bundleValidatorHelper.validate(this.$projectData);
 		if (!args || !args.length || args.length > 1) {
 			return false;
 		}

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -7,12 +7,14 @@ export class PrepareCommand extends ValidatePlatformCommandBase implements IComm
 		$platformService: IPlatformService,
 		$projectData: IProjectData,
 		private $platformCommandParameter: ICommandParameter,
-		$platformsData: IPlatformsData) {
-			super($options, $platformsData, $platformService, $projectData);
-			this.$projectData.initializeProjectData();
+		$platformsData: IPlatformsData,
+		private $workflowService: IWorkflowService) {
+		super($options, $platformsData, $platformService, $projectData);
+		this.$projectData.initializeProjectData();
 	}
 
 	public async execute(args: string[]): Promise<void> {
+		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = {
 			bundle: !!this.$options.bundle,
 			release: this.$options.release,

--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -14,7 +14,7 @@ export class PrepareCommand extends ValidatePlatformCommandBase implements IComm
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
+		await this.$workflowService.handleLegacyWorkflow({ projectDir: this.$projectData.projectDir, settings: this.$options, skipWarnings: true });
 		const appFilesUpdaterOptions: IAppFilesUpdaterOptions = {
 			bundle: !!this.$options.bundle,
 			release: this.$options.release,

--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -46,7 +46,7 @@ export class PreviewCommand implements ICommand {
 		}
 
 		await this.$networkConnectivityValidator.validate();
-		this.$bundleValidatorHelper.validate(PreviewCommand.MIN_SUPPORTED_WEBPACK_VERSION);
+		this.$bundleValidatorHelper.validate(this.$projectData, PreviewCommand.MIN_SUPPORTED_WEBPACK_VERSION);
 		return true;
 	}
 }

--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -21,7 +21,7 @@ export class PreviewCommand implements ICommand {
 	}
 
 	public async execute(): Promise<void> {
-		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
+		await this.$workflowService.handleLegacyWorkflow({ projectDir: this.$projectData.projectDir, settings: this.$options, skipWarnings: true });
 		this.$previewAppLogProvider.on(DEVICE_LOG_EVENT_NAME, (deviceId: string, message: string) => {
 			this.$logger.info(message);
 		});

--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -21,7 +21,7 @@ export class PreviewCommand implements ICommand {
 	}
 
 	public async execute(): Promise<void> {
-		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options);
+		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
 		this.$previewAppLogProvider.on(DEVICE_LOG_EVENT_NAME, (deviceId: string, message: string) => {
 			this.$logger.info(message);
 		});

--- a/lib/commands/preview.ts
+++ b/lib/commands/preview.ts
@@ -14,12 +14,14 @@ export class PreviewCommand implements ICommand {
 		private $options: IOptions,
 		private $previewAppLogProvider: IPreviewAppLogProvider,
 		private $previewQrCodeService: IPreviewQrCodeService,
+		protected $workflowService: IWorkflowService,
 		$cleanupService: ICleanupService) {
-			this.$analyticsService.setShouldDispose(false);
-			$cleanupService.setShouldDispose(false);
-		}
+		this.$analyticsService.setShouldDispose(false);
+		$cleanupService.setShouldDispose(false);
+	}
 
 	public async execute(): Promise<void> {
+		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options);
 		this.$previewAppLogProvider.on(DEVICE_LOG_EVENT_NAME, (deviceId: string, message: string) => {
 			this.$logger.info(message);
 		});

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -13,10 +13,13 @@ export class RunCommandBase implements ICommand {
 		private $errors: IErrors,
 		private $hostInfo: IHostInfo,
 		private $liveSyncCommandHelper: ILiveSyncCommandHelper,
-		private $androidBundleValidatorHelper: IAndroidBundleValidatorHelper) { }
+		private $androidBundleValidatorHelper: IAndroidBundleValidatorHelper,
+		private $options: IOptions,
+		private $workflowService: IWorkflowService) { }
 
 	public allowedParameters: ICommandParameter[] = [];
 	public async execute(args: string[]): Promise<void> {
+		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
 		await this.$analyticsService.trackPreviewAppData(this.platform, this.$projectData.projectDir);
 		return this.$liveSyncCommandHelper.executeCommandLiveSync(this.platform, this.liveSyncCommandHelperAdditionalOptions);
 	}

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -19,7 +19,7 @@ export class RunCommandBase implements ICommand {
 
 	public allowedParameters: ICommandParameter[] = [];
 	public async execute(args: string[]): Promise<void> {
-		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
+		await this.$workflowService.handleLegacyWorkflow({ projectDir: this.$projectData.projectDir, settings: this.$options, skipWarnings: true });
 		await this.$analyticsService.trackPreviewAppData(this.platform, this.$projectData.projectDir);
 		return this.$liveSyncCommandHelper.executeCommandLiveSync(this.platform, this.liveSyncCommandHelperAdditionalOptions);
 	}

--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -14,7 +14,7 @@ abstract class TestCommandBase {
 	protected abstract $workflowService: IWorkflowService;
 
 	async execute(args: string[]): Promise<void> {
-		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
+		await this.$workflowService.handleLegacyWorkflow({ projectDir: this.$projectData.projectDir, settings: this.$options, skipWarnings: true });
 		await this.$testExecutionService.startKarmaServer(this.platform, this.$projectData, this.projectFilesConfig);
 	}
 

--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -11,8 +11,10 @@ abstract class TestCommandBase {
 	protected abstract $platformEnvironmentRequirements: IPlatformEnvironmentRequirements;
 	protected abstract $errors: IErrors;
 	protected abstract $cleanupService: ICleanupService;
+	protected abstract $workflowService: IWorkflowService;
 
 	async execute(args: string[]): Promise<void> {
+		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options);
 		await this.$testExecutionService.startKarmaServer(this.platform, this.$projectData, this.projectFilesConfig);
 	}
 
@@ -54,7 +56,8 @@ class TestAndroidCommand extends TestCommandBase implements ICommand {
 		protected $options: IOptions,
 		protected $platformEnvironmentRequirements: IPlatformEnvironmentRequirements,
 		protected $errors: IErrors,
-		protected $cleanupService: ICleanupService) {
+		protected $cleanupService: ICleanupService,
+		protected $workflowService: IWorkflowService) {
 		super();
 	}
 
@@ -69,7 +72,8 @@ class TestIosCommand extends TestCommandBase implements ICommand {
 		protected $options: IOptions,
 		protected $platformEnvironmentRequirements: IPlatformEnvironmentRequirements,
 		protected $errors: IErrors,
-		protected $cleanupService: ICleanupService) {
+		protected $cleanupService: ICleanupService,
+		protected $workflowService: IWorkflowService) {
 		super();
 	}
 

--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -14,7 +14,7 @@ abstract class TestCommandBase {
 	protected abstract $workflowService: IWorkflowService;
 
 	async execute(args: string[]): Promise<void> {
-		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options);
+		await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, true);
 		await this.$testExecutionService.startKarmaServer(this.platform, this.$projectData, this.projectFilesConfig);
 	}
 

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -12,7 +12,8 @@ export class UpdateCommand extends ValidatePlatformCommandBase implements IComma
 		private $pluginsService: IPluginsService,
 		private $projectDataService: IProjectDataService,
 		private $fs: IFileSystem,
-		private $logger: ILogger) {
+		private $logger: ILogger,
+		private $workflowService: IWorkflowService) {
 		super($options, $platformsData, $platformService, $projectData);
 		this.$projectData.initializeProjectData();
 	}
@@ -28,6 +29,12 @@ export class UpdateCommand extends ValidatePlatformCommandBase implements IComma
 	static readonly backupFailMessage: string = "Could not backup project folders!";
 
 	public async execute(args: string[]): Promise<void> {
+		if (this.$options.workflow) {
+			const forceWebpackWorkflow = true;
+			await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, forceWebpackWorkflow);
+			return;
+		}
+
 		const tmpDir = path.join(this.$projectData.projectDir, UpdateCommand.tempFolder);
 
 		try {

--- a/lib/commands/update.ts
+++ b/lib/commands/update.ts
@@ -30,8 +30,7 @@ export class UpdateCommand extends ValidatePlatformCommandBase implements IComma
 
 	public async execute(args: string[]): Promise<void> {
 		if (this.$options.workflow) {
-			const forceWebpackWorkflow = true;
-			await this.$workflowService.handleLegacyWorkflow(this.$projectData.projectDir, this.$options, forceWebpackWorkflow);
+			await this.$workflowService.handleLegacyWorkflow({ projectDir: this.$projectData.projectDir, settings: this.$options, force: true });
 			return;
 		}
 

--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -385,7 +385,11 @@ export function createTable(headers: string[], data: string[][]): any {
 }
 
 export function getMessageWithBorders(message: string, spanLength = 3): string {
-	const longestRowLength = message.split(EOL).sort(function (a, b) { return b.length - a.length; })[0].length;
+	if (!message) {
+		return "";
+	}
+
+	const longestRowLength = message.split(EOL).sort((a, b) => { return b.length - a.length; })[0].length;
 	let border = "*".repeat(longestRowLength + 2 * spanLength); // * 2 for both sides
 	if (border.length % 2 === 0) {
 		border += "*"; // the * should always be an odd number in order to get * in each edge (we will remove the even *s below)

--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -384,6 +384,31 @@ export function createTable(headers: string[], data: string[][]): any {
 	return table;
 }
 
+export function getMessageWithBorders(message: string, spanLength = 3): string {
+	const longestRowLength = message.split(EOL).sort(function (a, b) { return b.length - a.length; })[0].length;
+	let border = "*".repeat(longestRowLength + 2 * spanLength); // * 2 for both sides
+	if (border.length % 2 === 0) {
+		border += "*"; // the * should always be an odd number in order to get * in each edge (we will remove the even *s below)
+	}
+	border = border.replace(/\*\*/g, "* "); // ***** => * * * in order to have similar padding to the side borders
+	const formatRow = function (row: string) {
+		return _.padEnd("*", spanLength) + _.padEnd(row, border.length - (2 * spanLength)) + _.padStart("*", spanLength) + EOL;
+	};
+	const emptyRow = formatRow("");
+
+	const messageWithBorders = [];
+	messageWithBorders.push(
+		EOL,
+		border + EOL,
+		emptyRow,
+		...message.split(EOL).map(row => formatRow(row)),
+		emptyRow,
+		border + EOL,
+		EOL
+	);
+	return messageWithBorders.join("");
+}
+
 export function remove<T>(array: T[], predicate: (element: T) => boolean, numberOfElements?: number): T[] {
 	numberOfElements = numberOfElements || 1;
 	const index = _.findIndex(array, predicate);

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -940,13 +940,13 @@ interface IBundleValidatorHelper {
 	 * @param {string} minSupportedVersion the minimum supported version of nativescript-dev-webpack
 	 * @return {void}
 	 */
-	validate(minSupportedVersion?: string): void;
+	validate(projectData: IProjectData, minSupportedVersion?: string): void;
 
 	/**
 	 * Returns the installed bundler version.
 	 * @return {string}
 	 */
-	getBundlerDependencyVersion(bundlerName?: string): string;
+	getBundlerDependencyVersion(projectData: IProjectData, bundlerName?: string): string;
 }
 
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -571,6 +571,7 @@ interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvai
 	performance: Object;
 	setupOptions(projectData: IProjectData): void;
 	cleanupLogFile: string;
+	workflow: boolean;
 }
 
 interface IEnvOptions {
@@ -940,6 +941,12 @@ interface IBundleValidatorHelper {
 	 * @return {void}
 	 */
 	validate(minSupportedVersion?: string): void;
+
+	/**
+	 * Returns the installed bundler version.
+	 * @return {string}
+	 */
+	getBundlerDependencyVersion(bundlerName?: string): string;
 }
 
 

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -15,7 +15,7 @@ interface IBuildPlatformAction {
 }
 
 interface IWorkflowService {
-	handleLegacyWorkflow(projectDir: string, settings: IWebpackWorkflowSettings, force?: boolean): Promise<void>;
+	handleLegacyWorkflow(projectDir: string, settings: IWebpackWorkflowSettings, skipWarnings?: boolean, force?: boolean): Promise<void>;
 }
 
 interface IWebpackWorkflowSettings {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -15,7 +15,14 @@ interface IBuildPlatformAction {
 }
 
 interface IWorkflowService {
-	handleLegacyWorkflow(projectDir: string, settings: IWebpackWorkflowSettings, skipWarnings?: boolean, force?: boolean): Promise<void>;
+	handleLegacyWorkflow(options: IHandleLegacyWorkflowOptions): Promise<void>;
+}
+
+interface IHandleLegacyWorkflowOptions {
+	projectDir: string;
+	settings: IWebpackWorkflowSettings;
+	skipWarnings?: boolean;
+	force?: boolean;
 }
 
 interface IWebpackWorkflowSettings {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -14,6 +14,16 @@ interface IBuildPlatformAction {
 	buildPlatform(platform: string, buildConfig: IBuildConfig, projectData: IProjectData): Promise<string>;
 }
 
+interface IWorkflowService {
+	handleLegacyWorkflow(projectDir: string, settings: IWebpackWorkflowSettings, force?: boolean): Promise<void>;
+}
+
+interface IWebpackWorkflowSettings {
+	bundle?: boolean | string;
+	useHotModuleReload?: boolean;
+	release?: boolean;
+}
+
 interface IPlatformService extends IBuildPlatformAction, NodeJS.EventEmitter {
 	cleanPlatforms(platforms: string[], platformTemplate: string, projectData: IProjectData, config: IPlatformOptions, framework?: string): Promise<void>;
 

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -143,6 +143,14 @@ interface IProjectDataService {
 	setNSValue(projectDir: string, key: string, value: any): void;
 
 	/**
+	 * Sets a value in the `useLegacyWorkflow` key in a project's nsconfig.json.
+	 * @param {string} projectDir The project directory - the place where the root package.json is located.
+	 * @param {any} value Value of the key to be set to `useLegacyWorkflow` key in project's nsconfig.json.
+	 * @returns {void}
+	 */
+	setUseLegacyWorkflow(projectDir: string, value: any): void;
+
+	/**
 	 * Removes a property from `nativescript` key in project's package.json.
 	 * @param {string} projectDir The project directory - the place where the root package.json is located.
 	 * @param {string} propertyName The name of the property to be removed from `nativescript` key.
@@ -584,7 +592,7 @@ interface IIOSExtensionsService {
 	removeExtensions(options: IRemoveExtensionsOptions): void;
 }
 
-interface IAddExtensionsFromPathOptions{
+interface IAddExtensionsFromPathOptions {
 	extensionsFolderPath: string;
 	projectData: IProjectData;
 	platformData: IPlatformData;

--- a/lib/helpers/bundle-validator-helper.ts
+++ b/lib/helpers/bundle-validator-helper.ts
@@ -7,16 +7,14 @@ export class BundleValidatorHelper extends VersionValidatorHelper implements IBu
 		webpack: "nativescript-dev-webpack"
 	};
 
-	constructor(protected $projectData: IProjectData,
-		protected $errors: IErrors,
+	constructor(protected $errors: IErrors,
 		protected $options: IOptions) {
 		super();
-		this.$projectData.initializeProjectData();
 	}
 
-	public validate(minSupportedVersion?: string): void {
+	public validate(projectData: IProjectData, minSupportedVersion?: string): void {
 		if (this.$options.bundle) {
-			const currentVersion = this.getBundlerDependencyVersion();
+			const currentVersion = this.getBundlerDependencyVersion(projectData);
 			if (!currentVersion) {
 				this.$errors.failWithoutHelp(BundleValidatorMessages.MissingBundlePlugin);
 			}
@@ -28,11 +26,11 @@ export class BundleValidatorHelper extends VersionValidatorHelper implements IBu
 		}
 	}
 
-	public getBundlerDependencyVersion(bundlerName?: string): string {
+	public getBundlerDependencyVersion(projectData: IProjectData, bundlerName?: string): string {
 		let dependencyVersion = null;
 		const bundlePluginName = bundlerName || this.bundlersMap[this.$options.bundle];
-		const bundlerVersionInDependencies = this.$projectData.dependencies && this.$projectData.dependencies[bundlePluginName];
-		const bundlerVersionInDevDependencies = this.$projectData.devDependencies && this.$projectData.devDependencies[bundlePluginName];
+		const bundlerVersionInDependencies = projectData.dependencies && projectData.dependencies[bundlePluginName];
+		const bundlerVersionInDevDependencies = projectData.devDependencies && projectData.devDependencies[bundlePluginName];
 		dependencyVersion = bundlerVersionInDependencies || bundlerVersionInDevDependencies;
 
 		return dependencyVersion;

--- a/lib/helpers/bundle-validator-helper.ts
+++ b/lib/helpers/bundle-validator-helper.ts
@@ -16,19 +16,27 @@ export class BundleValidatorHelper extends VersionValidatorHelper implements IBu
 
 	public validate(minSupportedVersion?: string): void {
 		if (this.$options.bundle) {
-			const bundlePluginName = this.bundlersMap[this.$options.bundle];
-			const bundlerVersionInDependencies = this.$projectData.dependencies && this.$projectData.dependencies[bundlePluginName];
-			const bundlerVersionInDevDependencies = this.$projectData.devDependencies && this.$projectData.devDependencies[bundlePluginName];
-			if (!bundlePluginName || (!bundlerVersionInDependencies && !bundlerVersionInDevDependencies)) {
+			const currentVersion = this.getBundlerDependencyVersion();
+			if (!currentVersion) {
 				this.$errors.failWithoutHelp(BundleValidatorMessages.MissingBundlePlugin);
 			}
 
-			const currentVersion = bundlerVersionInDependencies || bundlerVersionInDevDependencies;
 			const shouldThrowError = minSupportedVersion && this.isValidVersion(currentVersion) && this.isVersionLowerThan(currentVersion, minSupportedVersion);
 			if (shouldThrowError) {
-					this.$errors.failWithoutHelp(util.format(BundleValidatorMessages.NotSupportedVersion, minSupportedVersion));
+				this.$errors.failWithoutHelp(util.format(BundleValidatorMessages.NotSupportedVersion, minSupportedVersion));
 			}
 		}
+	}
+
+	public getBundlerDependencyVersion(bundlerName?: string): string {
+		let dependencyVersion = null;
+		const bundlePluginName = bundlerName || this.bundlersMap[this.$options.bundle];
+		const bundlerVersionInDependencies = this.$projectData.dependencies && this.$projectData.dependencies[bundlePluginName];
+		const bundlerVersionInDevDependencies = this.$projectData.devDependencies && this.$projectData.devDependencies[bundlePluginName];
+		dependencyVersion = bundlerVersionInDependencies || bundlerVersionInDevDependencies;
+
+		return dependencyVersion;
+
 	}
 }
 

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -152,7 +152,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 		}
 
 		const minSupportedWebpackVersion = this.$options.hmr ? LiveSyncCommandHelper.MIN_SUPPORTED_WEBPACK_VERSION_WITH_HMR : null;
-		this.$bundleValidatorHelper.validate(minSupportedWebpackVersion);
+		this.$bundleValidatorHelper.validate(this.$projectData, minSupportedWebpackVersion);
 
 		return result;
 	}

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -136,6 +136,7 @@ export class Options {
 			file: { type: OptionType.String, hasSensitiveValue: true },
 			force: { type: OptionType.Boolean, alias: "f", hasSensitiveValue: false },
 			// remove legacy
+			workflow: { type: OptionType.Boolean, hasSensitiveValue: false },
 			companion: { type: OptionType.Boolean, hasSensitiveValue: false },
 			emulator: { type: OptionType.Boolean, hasSensitiveValue: false },
 			sdk: { type: OptionType.String, hasSensitiveValue: false },

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -263,4 +263,4 @@ export class ProjectData implements IProjectData {
 		this.$logger.warnWithLabel("IProjectData.projectId is deprecated. Please use IProjectData.projectIdentifiers[platform].");
 	}
 }
-$injector.register("projectData", ProjectData);
+$injector.register("projectData", ProjectData, true);

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -30,7 +30,7 @@ export class PreviewAppLiveSyncService extends EventEmitter implements IPreviewA
 	@performanceLog()
 	public async initialize(data: IPreviewAppLiveSyncData): Promise<void> {
 		await this.$previewSdkService.initialize(data.projectDir, async (device: Device) => {
-			await this.$workflowService.handleLegacyWorkflow(data.projectDir, data);
+			await this.$workflowService.handleLegacyWorkflow({ projectDir: data.projectDir, settings: data });
 			try {
 				if (!device) {
 					this.$errors.failWithoutHelp("Sending initial preview files without a specified device is not supported.");

--- a/lib/services/livesync/playground/preview-app-livesync-service.ts
+++ b/lib/services/livesync/playground/preview-app-livesync-service.ts
@@ -22,13 +22,15 @@ export class PreviewAppLiveSyncService extends EventEmitter implements IPreviewA
 		private $previewAppFilesService: IPreviewAppFilesService,
 		private $previewAppPluginsService: IPreviewAppPluginsService,
 		private $previewDevicesService: IPreviewDevicesService,
-		private $hmrStatusService: IHmrStatusService) {
-			super();
-		}
+		private $hmrStatusService: IHmrStatusService,
+		protected $workflowService: IWorkflowService) {
+		super();
+	}
 
 	@performanceLog()
 	public async initialize(data: IPreviewAppLiveSyncData): Promise<void> {
 		await this.$previewSdkService.initialize(data.projectDir, async (device: Device) => {
+			await this.$workflowService.handleLegacyWorkflow(data.projectDir, data);
 			try {
 				if (!device) {
 					this.$errors.failWithoutHelp("Sending initial preview files without a specified device is not supported.");
@@ -177,7 +179,7 @@ export class PreviewAppLiveSyncService extends EventEmitter implements IPreviewA
 						if (status === HmrConstants.HMR_ERROR_STATUS) {
 							const originalUseHotModuleReload = data.useHotModuleReload;
 							data.useHotModuleReload = false;
-							await this.syncFilesForPlatformSafe(data, { filesToSync: platformHmrData.fallbackFiles }, platform, previewDevice.id );
+							await this.syncFilesForPlatformSafe(data, { filesToSync: platformHmrData.fallbackFiles }, platform, previewDevice.id);
 							data.useHotModuleReload = originalUseHotModuleReload;
 						}
 					}));

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -36,7 +36,8 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 		private $terminalSpinnerService: ITerminalSpinnerService,
 		private $pacoteService: IPacoteService,
 		private $usbLiveSyncService: any,
-		public $hooksService: IHooksService
+		public $hooksService: IHooksService,
+		public $workflowService: IWorkflowService
 	) {
 		super();
 	}
@@ -221,6 +222,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	@performanceLog()
 	public async preparePlatform(platformInfo: IPreparePlatformInfo): Promise<boolean> {
+		await this.$workflowService.handleLegacyWorkflow(platformInfo.projectData.projectDir, platformInfo.appFilesUpdaterOptions);
 		const changesInfo = await this.getChangesInfo(platformInfo);
 		const shouldPrepare = await this.shouldPrepare({ platformInfo, changesInfo });
 

--- a/lib/services/platform-service.ts
+++ b/lib/services/platform-service.ts
@@ -222,7 +222,7 @@ export class PlatformService extends EventEmitter implements IPlatformService {
 
 	@performanceLog()
 	public async preparePlatform(platformInfo: IPreparePlatformInfo): Promise<boolean> {
-		await this.$workflowService.handleLegacyWorkflow(platformInfo.projectData.projectDir, platformInfo.appFilesUpdaterOptions);
+		await this.$workflowService.handleLegacyWorkflow({ projectDir: platformInfo.projectData.projectDir, settings: platformInfo.appFilesUpdaterOptions });
 		const changesInfo = await this.getChangesInfo(platformInfo);
 		const shouldPrepare = await this.shouldPrepare({ platformInfo, changesInfo });
 

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -1,7 +1,6 @@
 import * as path from "path";
 import * as constants from "../constants";
 import { ProjectData } from "../project-data";
-import { parseJson } from "../common/helpers";
 import { exported } from "../common/decorators";
 import {
 	NATIVESCRIPT_PROPS_INTERNAL_DELIMITER,
@@ -197,9 +196,8 @@ export class ProjectDataService implements IProjectDataService {
 	private getNsConfig(nsConfigPath: string): INsConfig {
 		let result = this.getNsConfigDefaultObject();
 		if (this.$fs.exists(nsConfigPath)) {
-			const nsConfigContent = this.$fs.readText(nsConfigPath);
 			try {
-				result = <INsConfig>parseJson(nsConfigContent);
+				result = <INsConfig>this.$fs.readJson(nsConfigPath);
 			} catch (e) {
 				// default
 			}

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -19,7 +19,7 @@ interface IProjectFileData {
 }
 
 export class ProjectDataService implements IProjectDataService {
-	private defaultProjectDir = "";
+	private defaultProjectDir: string;
 	private static DEPENDENCIES_KEY_NAME = "dependencies";
 	private projectDataCache: IDictionary<IProjectData> = {};
 
@@ -28,12 +28,16 @@ export class ProjectDataService implements IProjectDataService {
 		private $logger: ILogger,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $androidResourcesMigrationService: IAndroidResourcesMigrationService,
-		private $injector: IInjector,
-		$projectData: IProjectData) {
-		// add the ProjectData of the default projectDir to the projectData cache
-		$projectData.initializeProjectData();
-		this.defaultProjectDir = $projectData.projectDir;
-		this.projectDataCache[this.defaultProjectDir] = $projectData;
+		private $injector: IInjector) {
+		try {
+			// add the ProjectData of the default projectDir to the projectData cache
+			const projectData = this.$injector.resolve("projectData");
+			projectData.initializeProjectData();
+			this.defaultProjectDir = projectData.projectDir;
+			this.projectDataCache[this.defaultProjectDir] = projectData;
+		} catch (e) {
+			// the CLI is required as a lib from a non-project folder
+		}
 	}
 
 	public getNSValue(projectDir: string, propertyName: string): any {

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -137,11 +137,10 @@ export class ProjectDataService implements IProjectDataService {
 	}
 
 	public setUseLegacyWorkflow(projectDir: string, value: any): void {
-		// TODO: use trace
-		this.$logger.info(`useLegacyWorkflow will be set to ${value}`);
+		this.$logger.trace(`useLegacyWorkflow will be set to ${value}`);
 		this.updateNsConfigValue(projectDir, { useLegacyWorkflow: value });
 		this.refreshProjectData(projectDir);
-		this.$logger.info(`useLegacyWorkflow was set to ${value}`);
+		this.$logger.trace(`useLegacyWorkflow was set to ${value}`);
 	}
 
 	public getAppExecutableFiles(projectDir: string): string[] {

--- a/lib/services/workflow-service.ts
+++ b/lib/services/workflow-service.ts
@@ -68,7 +68,7 @@ export class WorkflowService implements IWorkflowService {
 		const validWebpackPluginTags = ["*", "latest", "next", "rc"];
 
 		let isInstalledVersionSupported = true;
-		const installedVersion = this.$bundleValidatorHelper.getBundlerDependencyVersion(webpackPluginName);
+		const installedVersion = this.$bundleValidatorHelper.getBundlerDependencyVersion(projectData, webpackPluginName);
 		this.$logger.trace(`Updating to webpack workflow: Found ${webpackPluginName} v${installedVersion}`);
 		if (validWebpackPluginTags.indexOf(installedVersion) === -1) {
 			const isInstalledVersionValid = !!semver.valid(installedVersion) || !!semver.coerce(installedVersion);

--- a/lib/services/workflow-service.ts
+++ b/lib/services/workflow-service.ts
@@ -1,0 +1,102 @@
+import * as helpers from "../common/helpers";
+import * as path from "path";
+import * as semver from "semver";
+
+export class WorkflowService implements IWorkflowService {
+	constructor(private $bundleValidatorHelper: IBundleValidatorHelper,
+		private $fs: IFileSystem,
+		private $logger: ILogger,
+		private $packageManager: INodePackageManager,
+		private $projectDataService: IProjectDataService,
+		private $prompter: IPrompter,
+		private $options: IOptions
+	) {
+	}
+
+	public async handleLegacyWorkflow(projectDir: string, settings: IWebpackWorkflowSettings, force?: boolean): Promise<void> {
+		if (!settings.bundle || force) {
+			const projectData = this.$projectDataService.getProjectData(projectDir);
+			if (projectData.useLegacyWorkflow === null || projectData.useLegacyWorkflow === undefined || force) {
+				const hasSwitched = await this.handleWebpackWorkflowSwitch(projectData, force);
+				if (hasSwitched) {
+					this.$options.bundle = "webpack";
+					this.$options.hmr = !settings.release;
+					if (typeof (settings.bundle) === "boolean") {
+						settings.bundle = true;
+					} else {
+						settings.bundle = this.$options.bundle;
+					}
+					settings.useHotModuleReload = this.$options.hmr;
+				}
+			} else if (projectData.useLegacyWorkflow === true) {
+				this.showLegacyWorkflowWarning();
+			} else {
+				this.showNoBundleWarning();
+			}
+		}
+	}
+
+	private async handleWebpackWorkflowSwitch(projectData: IProjectData, force: boolean): Promise<boolean> {
+		let hasSwitched = false;
+		if (force || helpers.isInteractive()) {
+			hasSwitched = force || await this.$prompter.confirm("Please use webpack!", () => true);
+			if (hasSwitched) {
+				this.$projectDataService.setUseLegacyWorkflow(projectData.projectDir, false);
+				await this.ensureWebpackPluginInstalled(projectData);
+			} else {
+				this.$projectDataService.setUseLegacyWorkflow(projectData.projectDir, true);
+				await this.showLegacyWorkflowWarning();
+			}
+		} else {
+			await this.showLegacyWorkflowWarning();
+		}
+
+		return hasSwitched;
+	}
+
+	private async showLegacyWorkflowWarning() {
+		this.$logger.warn("WARNINGGGGG LEGACY TRUE!!!");
+	}
+
+	private showNoBundleWarning() {
+		this.$logger.warn("WARNINGGGGG NO BUNDLE!!!");
+	}
+
+	private async ensureWebpackPluginInstalled(projectData: IProjectData) {
+		const hmrOutOfBetaWebpackPluginVersion = "0.21.0";
+		const webpackPluginName = "nativescript-dev-webpack";
+		const webpackConfigFileName = "webpack.config.js";
+		const validWebpackPluginTags = ["*", "latest", "next", "rc"];
+
+		let isInstalledVersionSupported = true;
+		const installedVersion = this.$bundleValidatorHelper.getBundlerDependencyVersion(webpackPluginName);
+		// TODO: use trace
+		this.$logger.info(`Updating to webpack workflow: Found ${webpackPluginName} v${installedVersion}`);
+		if (validWebpackPluginTags.indexOf(installedVersion) === -1) {
+			const isInstalledVersionValid = !!semver.valid(installedVersion) || !!semver.coerce(installedVersion);
+			isInstalledVersionSupported =
+				isInstalledVersionValid && semver.gte(semver.coerce(installedVersion), hmrOutOfBetaWebpackPluginVersion);
+			this.$logger.info(`Updating to webpack workflow: Is installedVersion valid: ${isInstalledVersionValid}`);
+		}
+
+		this.$logger.info(`Updating to webpack workflow: Is installedVersion supported: ${isInstalledVersionSupported}`);
+		if (!isInstalledVersionSupported) {
+			const webpackConfigPath = path.join(projectData.projectDir, webpackConfigFileName);
+			if (this.$fs.exists(webpackConfigPath)) {
+				this.$logger.info(`Your Webpack config was stored to .bak!!`);
+				this.$fs.rename(webpackConfigPath, `${webpackConfigPath}.bak`);
+			}
+
+			const installResult = await this.$packageManager.install(`${webpackPluginName}@latest`, projectData.projectDir, {
+				'save-dev': true,
+				'save-exact': true,
+				disableNpmInstall: false,
+				frameworkPath: null,
+				ignoreScripts: false,
+			});
+			this.$logger.info(`Updating to webpack workflow: The ${webpackPluginName} was updated to v${installResult.version}`);
+		}
+	}
+}
+
+$injector.register("workflowService", WorkflowService);

--- a/lib/services/workflow-service.ts
+++ b/lib/services/workflow-service.ts
@@ -4,8 +4,8 @@ import * as semver from "semver";
 import { EOL } from "os";
 
 export class WorkflowService implements IWorkflowService {
-	private legacyWorkflowDeprecationMessage = `With the upcoming NativeScript 6.0 the Webpack workflow will become the only way of build apps.
-More info about the reason for this change and how to migrate your project can be found in the link below:
+	private legacyWorkflowDeprecationMessage = `With the upcoming NativeScript 6.0 the Webpack workflow will become the only way of building apps.
+More info about the reasons for this change and how to migrate your project can be found in the link below:
 <TODO: add link here>`;
 	private webpackWorkflowConfirmMessage = `Do you want to switch your app to the Webpack workflow?`;
 
@@ -19,7 +19,8 @@ More info about the reason for this change and how to migrate your project can b
 	) {
 	}
 
-	public async handleLegacyWorkflow(projectDir: string, settings: IWebpackWorkflowSettings, skipWarnings?: boolean, force?: boolean): Promise<void> {
+	public async handleLegacyWorkflow(options: IHandleLegacyWorkflowOptions): Promise<void> {
+		const { projectDir, settings, skipWarnings, force } = options;
 		if (!settings.bundle || force) {
 			const projectData = this.$projectDataService.getProjectData(projectDir);
 			if (typeof (projectData.useLegacyWorkflow) !== "boolean" || force) {

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -15,6 +15,7 @@ import { SettingsService } from "../lib/common/test/unit-tests/stubs";
 function createTestInjector(): IInjector {
 	const testInjector: IInjector = new yok.Yok();
 
+	testInjector.register("workflowService", stubs.WorkflowServiceStub);
 	testInjector.register("debug|android", DebugAndroidCommand);
 	testInjector.register("config", Configuration);
 	testInjector.register("staticConfig", StaticConfig);

--- a/test/helpers/bundle-validator-helper.ts
+++ b/test/helpers/bundle-validator-helper.ts
@@ -90,17 +90,18 @@ describe("BundleValidatorHelper", () => {
 			]);
 		});
 
-		_.each(testCases, (testCase: any) => {
-			const deps = {
-				"nativescript-dev-webpack": testCase.currentWebpackVersion
-			};
+	_.each(testCases, (testCase: any) => {
+		const deps = {
+			"nativescript-dev-webpack": testCase.currentWebpackVersion
+		};
 
-			it(`${testCase.name}`, async () => {
-				const injector = createTestInjector({ dependencies: testCase.isDependency ? deps : null, devDependencies: !testCase.isDependency ? deps : null });
-				const bundleValidatorHelper = injector.resolve("bundleValidatorHelper");
-				bundleValidatorHelper.validate(testCase.minSupportedWebpackVersion);
+		it(`${testCase.name}`, async () => {
+			const injector = createTestInjector({ dependencies: testCase.isDependency ? deps : null, devDependencies: !testCase.isDependency ? deps : null });
+			const bundleValidatorHelper = injector.resolve("bundleValidatorHelper");
+			const projectData = injector.resolve("projectData");
+			bundleValidatorHelper.validate(projectData, testCase.minSupportedWebpackVersion);
 
-				assert.deepEqual(error, testCase.expectedError);
-			});
+			assert.deepEqual(error, testCase.expectedError);
 		});
+	});
 });

--- a/test/package-installation-manager.ts
+++ b/test/package-installation-manager.ts
@@ -14,10 +14,13 @@ import * as yok from "../lib/common/yok";
 import ChildProcessLib = require("../lib/common/child-process");
 import { SettingsService } from "../lib/common/test/unit-tests/stubs";
 import { ProjectDataService } from "../lib/services/project-data-service";
+import { WorkflowServiceStub, ProjectDataStub } from "./stubs";
 
 function createTestInjector(): IInjector {
 	const testInjector = new yok.Yok();
 
+	testInjector.register("workflowService", WorkflowServiceStub);
+	testInjector.register("projectData", ProjectDataStub);
 	testInjector.register("config", ConfigLib.Configuration);
 	testInjector.register("logger", LoggerLib.Logger);
 	testInjector.register("errors", ErrorsLib.Errors);

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -20,6 +20,7 @@ import * as ChildProcessLib from "../lib/common/child-process";
 import ProjectChangesLib = require("../lib/services/project-changes-service");
 import { Messages } from "../lib/common/messages/messages";
 import { SettingsService } from "../lib/common/test/unit-tests/stubs";
+import { WorkflowServiceStub } from "./stubs";
 
 let isCommandExecuted = true;
 
@@ -97,6 +98,7 @@ function createTestInjector() {
 	const testInjector = new yok.Yok();
 
 	testInjector.register("injector", testInjector);
+	testInjector.register("workflowService", WorkflowServiceStub);
 	testInjector.register("hooksService", stubs.HooksServiceStub);
 	testInjector.register("staticConfig", StaticConfigLib.StaticConfig);
 	testInjector.register("nodeModulesDependenciesBuilder", {});

--- a/test/platform-service.ts
+++ b/test/platform-service.ts
@@ -32,6 +32,7 @@ temp.track();
 function createTestInjector() {
 	const testInjector = new yok.Yok();
 
+	testInjector.register("workflowService", stubs.WorkflowServiceStub);
 	testInjector.register('platformService', PlatformServiceLib.PlatformService);
 	testInjector.register('errors', stubs.ErrorsStub);
 	testInjector.register('logger', stubs.LoggerStub);

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -1,6 +1,6 @@
 import { Yok } from "../../../lib/common/yok";
 import * as _ from 'lodash';
-import { LoggerStub, ErrorsStub } from "../../stubs";
+import { LoggerStub, ErrorsStub, WorkflowServiceStub } from "../../stubs";
 import { FilePayload, Device, FilesPayload } from "nativescript-preview-sdk";
 import { PreviewAppLiveSyncService } from "../../../lib/services/livesync/playground/preview-app-livesync-service";
 import * as chai from "chai";
@@ -101,6 +101,7 @@ function createTestInjector(options?: {
 	options = options || {};
 
 	const injector = new Yok();
+	injector.register("workflowService", WorkflowServiceStub);
 	injector.register("logger", LoggerMock);
 	injector.register("hmrStatusService", {});
 	injector.register("errors", ErrorsStub);

--- a/test/services/project-data-service.ts
+++ b/test/services/project-data-service.ts
@@ -1,7 +1,7 @@
 import { Yok } from "../../lib/common/yok";
 import { assert } from "chai";
 import { ProjectDataService } from "../../lib/services/project-data-service";
-import { LoggerStub } from "../stubs";
+import { LoggerStub, WorkflowServiceStub, ProjectDataStub } from "../stubs";
 import { NATIVESCRIPT_PROPS_INTERNAL_DELIMITER, PACKAGE_JSON_FILE_NAME, AssetConstants, ProjectTypes } from '../../lib/constants';
 import { DevicePlatformsConstants } from "../../lib/common/mobile/device-platforms-constants";
 import { basename, join } from "path";
@@ -43,6 +43,8 @@ const testData: any = [
 
 const createTestInjector = (readTextData?: string): IInjector => {
 	const testInjector = new Yok();
+	testInjector.register("workflowService", WorkflowServiceStub);
+	testInjector.register("projectData", ProjectDataStub);
 	testInjector.register("staticConfig", {
 		CLIENT_NAME_KEY_IN_PROJECT_FILE: CLIENT_NAME_KEY_IN_PROJECT_FILE,
 		PROJECT_FILE_NAME: "package.json"

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -497,6 +497,9 @@ export class PlatformsDataStub extends EventEmitter implements IPlatformsData {
 }
 
 export class ProjectDataService implements IProjectDataService {
+	setUseLegacyWorkflow(projectDir: string, value: any): Promise<void> {
+		return;
+	}
 	getNSValue(propertyName: string): any {
 		return {};
 	}

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -916,6 +916,12 @@ export class PerformanceService implements IPerformanceService {
 	processExecutionData() { }
 }
 
+export class WorkflowServiceStub implements IWorkflowService {
+	handleLegacyWorkflow(projectDir: string, settings: IWebpackWorkflowSettings, skipWarnings?: boolean, force?: boolean): Promise<void> {
+		return;
+	}
+}
+
 export class InjectorStub extends Yok implements IInjector {
 	constructor() {
 		super();
@@ -954,5 +960,6 @@ export class InjectorStub extends Yok implements IInjector {
 			getDevice: (): Mobile.IDevice => undefined,
 			getDeviceByIdentifier: (): Mobile.IDevice => undefined
 		});
+		this.register("workflowService", WorkflowServiceStub);
 	}
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -917,7 +917,7 @@ export class PerformanceService implements IPerformanceService {
 }
 
 export class WorkflowServiceStub implements IWorkflowService {
-	handleLegacyWorkflow(projectDir: string, settings: IWebpackWorkflowSettings, skipWarnings?: boolean, force?: boolean): Promise<void> {
+	handleLegacyWorkflow(options: IHandleLegacyWorkflowOptions): Promise<void> {
 		return;
 	}
 }

--- a/test/update.ts
+++ b/test/update.ts
@@ -25,6 +25,7 @@ function createTestInjector(
 ): IInjector {
 	const testInjector: IInjector = new yok.Yok();
 	testInjector.register("logger", stubs.LoggerStub);
+	testInjector.register("workflowService", stubs.WorkflowServiceStub);
 	testInjector.register("options", Options);
 	testInjector.register('fs', stubs.FileSystemStub);
 	testInjector.register("analyticsService", {
@@ -49,10 +50,10 @@ function createTestInjector(
 	});
 	testInjector.register("pluginVariablesService", {});
 	testInjector.register("platformService", {
-		getInstalledPlatforms: function(): string[] {
+		getInstalledPlatforms: function (): string[] {
 			return installedPlatforms;
 		},
-		getAvailablePlatforms: function(): string[] {
+		getAvailablePlatforms: function (): string[] {
 			return availablePlatforms;
 		},
 		removePlatforms: async (): Promise<void> => undefined,
@@ -66,9 +67,9 @@ function createTestInjector(
 		getPlatformData: () => {
 			return {
 				platformProjectService: {
-						validate
-					}
-				};
+					validate
+				}
+			};
 		}
 	});
 	testInjector.register("settingsService", SettingsService);
@@ -161,7 +162,7 @@ describe("update command method tests", () => {
 			const fs = testInjector.resolve("fs");
 			const copyFileStub = sandbox.stub(fs, "copyFile");
 			const updateCommand = testInjector.resolve<UpdateCommand>(UpdateCommand);
-			return updateCommand.execute(["3.3.0"]).then( () => {
+			return updateCommand.execute(["3.3.0"]).then(() => {
 				assert.isTrue(copyFileStub.calledWith(path.join(projectFolder, "package.json")));
 				for (const folder of UpdateCommand.folders) {
 					assert.isTrue(copyFileStub.calledWith(path.join(projectFolder, folder)));


### PR DESCRIPTION
These changes are fully deprecating the Legacy Development Workflow and preparing the users for removing the its support in NativeScript 6.0.0.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
We are fully supporting both the legacy prepare (copying the whole app folder and post-processing it with nativescript-dev-typescript, nativescript-dev-sass, etc.) and the webpack approach (using nativescript-dev-webpack and its plugins/loaders).

## What is the new behavior?
We are deprecating the legacy workflow as shown on the charts below:

![WebpackLegacyWorkflowHandlingDetailed](https://user-images.githubusercontent.com/1865068/56367331-b3a3fe00-61fd-11e9-89b2-8005f493faee.png)

Related to: https://github.com/NativeScript/nativescript-cli/issues/4548