### PR TITLE
fix: use proxy only for remote requests

### DIFF
--- a/lib/common/http-client.ts
+++ b/lib/common/http-client.ts
@@ -289,7 +289,9 @@ private defaultUserAgent: string;
 	 * @param {string} requestProto The protocol used for the current request - http or https.
 	 */
 	private async useProxySettings(proxySettings: IProxySettings, cliProxySettings: IProxySettings, options: any, headers: any, requestProto: string): Promise<void> {
-		if (proxySettings || cliProxySettings) {
+		const isLocalRequest = options.host === "localhost" || options.host === "127.0.0.1";
+		// don't use the proxy for requests to localhost
+		if (!isLocalRequest && (proxySettings || cliProxySettings)) {
 			const proto = (proxySettings && proxySettings.protocol) || cliProxySettings.protocol || "http:";
 			const host = (proxySettings && proxySettings.hostname) || cliProxySettings.hostname;
 			const port = (proxySettings && proxySettings.port) || cliProxySettings.port;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

Since there are no tests for `http-client` yet, it would be quite a lot of work to add them. Also, the method which was changed `useProxySettings` is private and therefore more difficult to test.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With a proxy set according to https://docs.nativescript.org/tooling/docs-cli/general/proxy-set when running unit tests with `tns test android` for example, requests to localhost are being made. Depending on the corporate proxy environment, those requests could be blocked or the proxy can't handle the request, since `localhost` is not a remote target. This makes running unit tests with NativeScript impossible in corporate proxy environments, causing exceptions interrupting the test execution. Also, it doesn't make sense to make requests to `localhost` through a proxy, so this will not have any negative effects.

## What is the new behavior?
<!-- Describe the changes. -->
When requests are being made to localhost or 127.0.0.1, even when a proxy is set, the proxy will not be used. Unit tests can be excecuted successfully in an environment with a corporate proxy.

Partially fixes #2313.
A user-defined NO_PROXY is not implemented, but allows for requests to localhost to work properly. Should there be further need to customize which requests should not use the proxy, this could be implemented in a separate PR, but would require discussion on the implementation details.
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
