### PR TITLE
fix: fix the workflow warnings on Windows

### DIFF
--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -389,7 +389,7 @@ export function getMessageWithBorders(message: string, spanLength = 3): string {
 		return "";
 	}
 
-	const longestRowLength = message.split(EOL).sort((a, b) => { return b.length - a.length; })[0].length;
+	const longestRowLength = message.split("\n").sort((a, b) => { return b.length - a.length; })[0].length;
 	let border = "*".repeat(longestRowLength + 2 * spanLength); // * 2 for both sides
 	if (border.length % 2 === 0) {
 		border += "*"; // the * should always be an odd number in order to get * in each edge (we will remove the even *s below)
@@ -405,7 +405,7 @@ export function getMessageWithBorders(message: string, spanLength = 3): string {
 		EOL,
 		border + EOL,
 		emptyRow,
-		...message.split(EOL).map(row => formatRow(row)),
+		...message.split("\n").map(row => formatRow(row.trim())),
 		emptyRow,
 		border + EOL,
 		EOL


### PR DESCRIPTION
Always split by "\n" as the string literals are always generating "/n" line terminators based on the below-mentioned ES specification.

More details: http://exploringjs.com/es6/ch_template-literals.html#_line-terminators-in-template-literals-are-always-lf-n
```
8.2.3 Line terminators in template literals are always LF (\n) #
Common ways of terminating lines are:

Line feed (LF, \n, U+000A): used by Unix (incl. current macOS)
Carriage return (CR, \r, U+000D): used by the old Mac OS.
CRLF (\r\n): used by Windows.
`All of these line terminators are normalized to LF in template literals.` That is, the following code logs true on all platforms:

const str = `BEFORE
AFTER`;
console.log(str === 'BEFORE\nAFTER'); // true
```
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

Related to: #4548 