### PR TITLE
fix: logcat process is not restarted in some cases

### DIFF
--- a/lib/common/mobile/android/logcat-helper.ts
+++ b/lib/common/mobile/android/logcat-helper.ts
@@ -39,7 +39,8 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 
 			logcatStream.on("close", (code: number) => {
 				try {
-					this.stop(deviceIdentifier);
+					this.forceStop(deviceIdentifier);
+
 					if (code !== 0) {
 						this.$logger.trace("ADB process exited with code " + code.toString());
 					}
@@ -76,11 +77,15 @@ export class LogcatHelper implements Mobile.ILogcatHelper {
 	 */
 	public stop(deviceIdentifier: string): void {
 		if (this.mapDevicesLoggingData[deviceIdentifier] && !this.mapDevicesLoggingData[deviceIdentifier].keepSingleProcess) {
-			this.mapDevicesLoggingData[deviceIdentifier].loggingProcess.removeAllListeners();
-			this.mapDevicesLoggingData[deviceIdentifier].loggingProcess.kill("SIGINT");
-			this.mapDevicesLoggingData[deviceIdentifier].lineStream.removeAllListeners();
-			delete this.mapDevicesLoggingData[deviceIdentifier];
+			this.forceStop(deviceIdentifier);
 		}
+	}
+
+	private forceStop(deviceIdentifier: string): void {
+		this.mapDevicesLoggingData[deviceIdentifier].loggingProcess.removeAllListeners();
+		this.mapDevicesLoggingData[deviceIdentifier].loggingProcess.kill("SIGINT");
+		this.mapDevicesLoggingData[deviceIdentifier].lineStream.removeAllListeners();
+		delete this.mapDevicesLoggingData[deviceIdentifier];
 	}
 
 	private async getLogcatStream(deviceIdentifier: string, pid?: string) {


### PR DESCRIPTION
In case you have `keepSingleProcess` passed to logcat Stream (this option is passed when using CLI as a library - in this case we keep a long living logcat process alive and change only the filter for it by specifying different PIDs), in case the logcat process dies (for example device is disconnected), the process is not cleaned from CLI's internal cache.
This way, in case you try to start the logs again (in the example above - just attach the device again), they are not started as CLI thinks it has a process for this case. So, in case the logcat stream process dies, ensure we clean all the resources related to it.
Add unit tests for this case and remove calls to `type`/`cat` from the tests - there's no need to spawn actual child process in the tests.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
When using CLI as a library attaching Android device, disconnecting it after that and reconnecting it does not show any logs for this device.

## What is the new behavior?
Logs from Android devices are properly shown.

Fixes issue in Sidekick (logged in JIRA)
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
