### PR TITLE
fix: fix the order of applying Podfiles

### DIFF
--- a/lib/services/cocoapods-platform-manager.ts
+++ b/lib/services/cocoapods-platform-manager.ts
@@ -13,10 +13,10 @@ export class CocoaPodsPlatformManager implements ICocoaPodsPlatformManager {
 			if (shouldReplacePlatformSection) {
 				this.$logger.warn(`Multiple identical platforms with different versions have been detected during the processing of podfiles. The current platform's content "${platformSectionData.podfilePlatformData.content}" from ${platformSectionData.podfilePlatformData.path} will be replaced with "${podfilePlatformData.content}" from ${podfilePlatformData.path}`);
 				const newSection = this.buildPlatformSection(podfilePlatformData);
-				projectPodfileContent = projectPodfileContent.replace(platformSectionData.platformSectionContent, newSection);
+				projectPodfileContent = projectPodfileContent.replace(platformSectionData.platformSectionContent, newSection.trim());
 			}
 		} else {
-			projectPodfileContent += this.buildPlatformSection(podfilePlatformData);
+			projectPodfileContent = projectPodfileContent.trim() + EOL + EOL + this.buildPlatformSection(podfilePlatformData);
 		}
 
 		return projectPodfileContent;
@@ -29,7 +29,7 @@ export class CocoaPodsPlatformManager implements ICocoaPodsPlatformManager {
 			const allPodfiles = projectPodfileContent.match(podfileContentRegExp) || [];
 			const selectedPlatformData = this.selectPlatformDataFromProjectPodfile(allPodfiles);
 			const newPlatformSection = selectedPlatformData ? this.buildPlatformSection(selectedPlatformData) : "";
-			const regExp = new RegExp(`\\r?\\n${platformSectionData.platformSectionContent}\\r?\\n`, "mg");
+			const regExp = new RegExp(`${platformSectionData.platformSectionContent}\\r?\\n`, "mg");
 			projectPodfileContent = projectPodfileContent.replace(regExp, newPlatformSection);
 		}
 

--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -1,6 +1,7 @@
 import { EOL } from "os";
 import * as path from "path";
 import { PluginNativeDirNames, PODFILE_NAME, NS_BASE_PODFILE } from "../constants";
+import { regExpEscape } from "../common/helpers";
 
 export class CocoaPodsService implements ICocoaPodsService {
 	private static PODFILE_POST_INSTALL_SECTION_NAME = "post_install";
@@ -100,7 +101,7 @@ export class CocoaPodsService implements ICocoaPodsService {
 				finalPodfileContent = this.$cocoaPodsPlatformManager.addPlatformSection(projectData, podfilePlatformData, finalPodfileContent);
 			}
 
-			finalPodfileContent = `${podfileContent}${EOL}${finalPodfileContent}`;
+			finalPodfileContent = `${finalPodfileContent.trim()}${EOL}${EOL}${podfileContent.trim()}${EOL}`;
 			this.saveProjectPodfile(projectData, finalPodfileContent, nativeProjectPath);
 		}
 	}
@@ -115,8 +116,8 @@ export class CocoaPodsService implements ICocoaPodsService {
 			projectPodFileContent = this.$cocoaPodsPlatformManager.removePlatformSection(moduleName, projectPodFileContent, podfilePath);
 
 			const defaultPodfileBeginning = this.getPodfileHeader(projectData.projectName);
-			const defaultContentWithPostInstallHook = `${defaultPodfileBeginning}${EOL}${this.getPostInstallHookHeader()}end${EOL}end`;
-			const defaultContentWithoutPostInstallHook = `${defaultPodfileBeginning}end`;
+			const defaultContentWithPostInstallHook = `${defaultPodfileBeginning}${this.getPostInstallHookHeader()}end${EOL}end`;
+			const defaultContentWithoutPostInstallHook = `${defaultPodfileBeginning}${EOL}end`;
 			const trimmedProjectPodFileContent = projectPodFileContent.trim();
 			if (!trimmedProjectPodFileContent || trimmedProjectPodFileContent === defaultContentWithPostInstallHook || trimmedProjectPodFileContent === defaultContentWithoutPostInstallHook) {
 				this.$fs.deleteFile(this.getProjectPodfilePath(projectRoot));
@@ -147,7 +148,9 @@ export class CocoaPodsService implements ICocoaPodsService {
 		if (postInstallHookContent) {
 			const index = finalPodfileContent.indexOf(postInstallHookStart);
 			if (index !== -1) {
-				finalPodfileContent = finalPodfileContent.replace(postInstallHookStart, `${postInstallHookStart}${postInstallHookContent}`);
+				const regExp = new RegExp(`(${regExpEscape(postInstallHookStart)}[\\s\\S]*?)(\\bend\\b)`, "m");
+				finalPodfileContent = finalPodfileContent.replace(regExp, `$1${postInstallHookContent.trimRight()}${EOL}$2`);
+
 			} else {
 				if (finalPodfileContent.length > 0) {
 					finalPodfileContent += `${EOL}${EOL}`;

--- a/test/cocoapods-service.ts
+++ b/test/cocoapods-service.ts
@@ -119,6 +119,10 @@ end`,
 				output: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+  post_installplugin1_with_special_symbols_0 installer
+end
+
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -135,10 +139,6 @@ def post_installplugin1_with_special_symbols_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-  post_installplugin1_with_special_symbols_0 installer
-end
 end`,
 				projectPodfileContent: "",
 				pluginData: <any>{
@@ -165,6 +165,10 @@ end`,
 				output: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+  post_installplugin1_with_special_symbols___and___underscore_0 installer
+end
+
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -181,10 +185,6 @@ def post_installplugin1_with_special_symbols___and___underscore_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-  post_installplugin1_with_special_symbols___and___underscore_0 installer
-end
 end`,
 				projectPodfileContent: "",
 				pluginData: <any>{
@@ -207,6 +207,10 @@ end`,
 				output: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+  post_installplugin1___plugin_0 installer
+end
+
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -219,14 +223,13 @@ def post_installplugin1___plugin_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-  post_installplugin1___plugin_0 installer
-end
 end`,
 				projectPodfileContent: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+  post_installplugin1___plugin_0 installer
+end
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -239,10 +242,6 @@ def post_installplugin1___plugin_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-  post_installplugin1___plugin_0 installer
-end
 end`,
 				pluginData: <any>{
 					name: "plugin1_plugin",
@@ -268,6 +267,10 @@ end`,
 				output: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+  post_installplugin1_0 installer
+end
+
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -284,14 +287,13 @@ def post_installplugin1_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-  post_installplugin1_0 installer
-end
 end`,
 				projectPodfileContent: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+	post_installplugin1_0 installer
+end
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -308,10 +310,6 @@ def post_installplugin1_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-	post_installplugin1_0 installer
-end
 end`,
 			},
 			{
@@ -329,6 +327,14 @@ end`,
 				output: `use_frameworks!
 
 target "projectName" do
+# Begin Podfile - secondPluginPlatformsFolderPath/Podfile
+pod 'OCMock', '~> 2.0.1'
+# End Podfile
+
+post_install do |installer|
+  post_installplugin1_0 installer
+end
+
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -341,14 +347,6 @@ def post_installplugin1_0 (installer)
 	end
 end
 # End Podfile
-
-# Begin Podfile - secondPluginPlatformsFolderPath/Podfile
-pod 'OCMock', '~> 2.0.1'
-# End Podfile
-
-post_install do |installer|
-  post_installplugin1_0 installer
-end
 end`,
 				projectPodfileContent: `use_frameworks!
 
@@ -387,6 +385,12 @@ end`,
 				output: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+  post_installplugin1_0 installer
+  post_installplugin1_1 installer
+  post_installplugin1_2 installer
+end
+
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -413,12 +417,6 @@ def post_installplugin1_2 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-  post_installplugin1_0 installer
-  post_installplugin1_1 installer
-  post_installplugin1_2 installer
-end
 end`,
 			},
 			{
@@ -443,6 +441,11 @@ end`,
 				output: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+  post_installplugin1_0 installer
+  post_installplugin1_1
+end
+
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -462,11 +465,6 @@ target 'MyApp' do
 	end
 end
 # End Podfile
-
-post_install do |installer|
-  post_installplugin1_0 installer
-  post_installplugin1_1
-end
 end`,
 			},
 			{
@@ -489,6 +487,10 @@ end`,
 				projectPodfileContent: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+  post_installplugin1_0 installer
+end
+
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -505,10 +507,6 @@ def post_installplugin1_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-  post_installplugin1_0 installer
-end
 end`,
 			}
 		];
@@ -540,6 +538,7 @@ target "projectName" do
 pod 'GoogleAnalytics', '~> 3.1'
 
 # End Podfile
+
 end`
 			},
 			{
@@ -562,6 +561,9 @@ end`,
 				projectPodfileContent: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+post_installplugin1_0 installer
+end
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -578,10 +580,6 @@ def post_installplugin1_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-post_installplugin1_0 installer
-end
 end`
 			},
 			{
@@ -614,6 +612,11 @@ end`,
 				projectPodfileContent: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+	post_installplugin1_0 installer
+	post_installplugin1_1 installer
+	post_installplugin1_2 installer
+end
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -640,12 +643,6 @@ def post_installplugin1_2 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-	post_installplugin1_0 installer
-	post_installplugin1_1 installer
-	post_installplugin1_2 installer
-end
 end`
 			},
 			{
@@ -667,6 +664,9 @@ end`,
 				output: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+	post_installplugin2_0 installer
+end
 
 # Begin Podfile - pluginPlatformsFolderPath1/Podfile
 
@@ -678,14 +678,14 @@ def post_installplugin2_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-post_installplugin2_0 installer
-end
 end`,
 				projectPodfileContent: `use_frameworks!
 
 target "projectName" do
+post_install do |installer|
+	post_installplugin1_0 installer
+	post_installplugin2_0 installer
+end
 # Begin Podfile - pluginPlatformsFolderPath/Podfile
 
 target 'MyApp' do
@@ -713,11 +713,6 @@ def post_installplugin2_0 (installer)
 	end
 end
 # End Podfile
-
-post_install do |installer|
-post_installplugin1_0 installer
-post_installplugin2_0 installer
-end
 end`
 			}
 		];
@@ -975,44 +970,45 @@ end`
 				expectedProjectPodfileContentAfterApply: `use_frameworks!
 
 target "projectName" do
-# Begin Podfile - my/full/path/to/app/App_Resources/iOS/Podfile
-# platform :ios, '8.0'
-# End Podfile
+# NativeScriptPlatformSection my/full/path/to/app/App_Resources/iOS/Podfile with 8.0
+platform :ios, '8.0'
+# End NativeScriptPlatformSection
 
-# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
-# platform :ios, '11.0'
+# Begin Podfile - node_modules/  mypath  with spaces/mySecondPluginWithPlatform/Podfile
+# platform :ios, '10.0'
 # End Podfile
 
 # Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
 pod 'myPod' ~> 0.3.4
 # End Podfile
 
-# Begin Podfile - node_modules/  mypath  with spaces/mySecondPluginWithPlatform/Podfile
-# platform :ios, '10.0'
+# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
+# platform :ios, '11.0'
 # End Podfile
 
-# NativeScriptPlatformSection my/full/path/to/app/App_Resources/iOS/Podfile with 8.0
-platform :ios, '8.0'
-# End NativeScriptPlatformSection
+# Begin Podfile - my/full/path/to/app/App_Resources/iOS/Podfile
+# platform :ios, '8.0'
+# End Podfile
 end`,
 				expectedProjectPodfileContentAfterRemove: `use_frameworks!
 
 target "projectName" do
+# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with 11.0
+platform :ios, '11.0'
+# End NativeScriptPlatformSection
 
-# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
-# platform :ios, '11.0'
+# Begin Podfile - node_modules/  mypath  with spaces/mySecondPluginWithPlatform/Podfile
+# platform :ios, '10.0'
 # End Podfile
 
 # Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
 pod 'myPod' ~> 0.3.4
 # End Podfile
 
-# Begin Podfile - node_modules/  mypath  with spaces/mySecondPluginWithPlatform/Podfile
-# platform :ios, '10.0'
+# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
+# platform :ios, '11.0'
 # End Podfile
-# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with 11.0
-platform :ios, '11.0'
-# End NativeScriptPlatformSection
+
 end`
 			}
 		];
@@ -1061,13 +1057,13 @@ end`
 				expectedProjectPodfileContent: `use_frameworks!
 
 target "projectName" do
-# Begin Podfile - path/to/my/plugin2/platforms/ios/Podfile
-# platform :ios, '9.0'
-# End Podfile
-
 # NativeScriptPlatformSection path/to/my/plugin2/platforms/ios/Podfile with 9.0
 platform :ios, '9.0'
 # End NativeScriptPlatformSection
+
+# Begin Podfile - path/to/my/plugin2/platforms/ios/Podfile
+# platform :ios, '9.0'
+# End Podfile
 end`
 			},
 			{
@@ -1088,21 +1084,21 @@ end`
 				expectedProjectPodfileContent: `use_frameworks!
 
 target "projectName" do
-# Begin Podfile - my/full/path/to/app/App_Resources/iOS/Podfile
-# platform :ios, '9.0'
+# NativeScriptPlatformSection my/full/path/to/app/App_Resources/iOS/Podfile with 9.0
+platform :ios, '9.0'
+# End NativeScriptPlatformSection
+
+# Begin Podfile - my/full/path/to/plugin1/platforms/ios/Podfile
+# platform :ios, '10.0'
 # End Podfile
 
 # Begin Podfile - my/full/path/to/plugin2/platforms/ios/Podfile
 pod 'myPod' ~> 0.3.4
 # End Podfile
 
-# Begin Podfile - my/full/path/to/plugin1/platforms/ios/Podfile
-# platform :ios, '10.0'
+# Begin Podfile - my/full/path/to/app/App_Resources/iOS/Podfile
+# platform :ios, '9.0'
 # End Podfile
-
-# NativeScriptPlatformSection my/full/path/to/app/App_Resources/iOS/Podfile with 9.0
-platform :ios, '9.0'
-# End NativeScriptPlatformSection
 end`
 			},
 			{
@@ -1123,21 +1119,21 @@ end`
 				expectedProjectPodfileContent: `use_frameworks!
 
 target "projectName" do
-# Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
-pod 'myPod' ~> 0.3.4
+# NativeScriptPlatformSection node_modules/mySecondPluginWithPlatform/Podfile with 10.0
+platform :ios, '10.0'
+# End NativeScriptPlatformSection
+
+# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
+# platform :ios, '9.0'
 # End Podfile
 
 # Begin Podfile - node_modules/mySecondPluginWithPlatform/Podfile
 # platform :ios, '10.0'
 # End Podfile
 
-# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
-# platform :ios, '9.0'
+# Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
+pod 'myPod' ~> 0.3.4
 # End Podfile
-
-# NativeScriptPlatformSection node_modules/mySecondPluginWithPlatform/Podfile with 10.0
-platform :ios, '10.0'
-# End NativeScriptPlatformSection
 end`
 			},
 			{
@@ -1158,19 +1154,21 @@ end`
 				expectedProjectPodfileContent: `use_frameworks!
 
 target "projectName" do
-# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
-# platform :ios
+# Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
+pod 'myPod' ~> 0.3.4
 # End Podfile
+
+# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with
+platform :ios
+# End NativeScriptPlatformSection
 
 # Begin Podfile - node_modules/mySecondPluginWithPlatform/Podfile
 # platform :ios, '10.0'
 # End Podfile
 
-# Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
-pod 'myPod' ~> 0.3.4
-# End Podfile# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with
-platform :ios
-# End NativeScriptPlatformSection
+# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
+# platform :ios
+# End Podfile
 end`
 			},
 			{
@@ -1191,19 +1189,21 @@ end`
 				expectedProjectPodfileContent: `use_frameworks!
 
 target "projectName" do
-# Begin Podfile - node_modules/mySecondPluginWithPlatform/Podfile
-# platform :ios, '10.0'
+# Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
+pod 'myPod' ~> 0.3.4
 # End Podfile
+
+# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with
+platform :ios
+# End NativeScriptPlatformSection
 
 # Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
 # platform :ios
 # End Podfile
 
-# Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
-pod 'myPod' ~> 0.3.4
-# End Podfile# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with
-platform :ios
-# End NativeScriptPlatformSection
+# Begin Podfile - node_modules/mySecondPluginWithPlatform/Podfile
+# platform :ios, '10.0'
+# End Podfile
 end`
 			},
 			{
@@ -1228,26 +1228,26 @@ end`
 				expectedProjectPodfileContent: `use_frameworks!
 
 target "projectName" do
-# Begin Podfile - my/full/path/to/app/App_Resources/iOS/Podfile
-pod: 'mySecondPlatformPod' ~> 2.0.0
-pod: 'platformKit' ~> 1.0
-# End Podfile
+# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with 11.0
+platform :ios, '11.0'
+# End NativeScriptPlatformSection
 
-# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
-# platform :ios, '11.0'
+# Begin Podfile - node_modules/  mypath  with spaces/mySecondPluginWithPlatform/Podfile
+# platform :ios, '10.0'
 # End Podfile
 
 # Begin Podfile - node_modules/myPluginWithoutPlatform/Podfile
 pod 'myPod' ~> 0.3.4
 # End Podfile
 
-# Begin Podfile - node_modules/  mypath  with spaces/mySecondPluginWithPlatform/Podfile
-# platform :ios, '10.0'
+# Begin Podfile - node_modules/myFirstPluginWithPlatform/Podfile
+# platform :ios, '11.0'
 # End Podfile
 
-# NativeScriptPlatformSection node_modules/myFirstPluginWithPlatform/Podfile with 11.0
-platform :ios, '11.0'
-# End NativeScriptPlatformSection
+# Begin Podfile - my/full/path/to/app/App_Resources/iOS/Podfile
+pod: 'mySecondPlatformPod' ~> 2.0.0
+pod: 'platformKit' ~> 1.0
+# End Podfile
 end`
 			}
 		];

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -405,14 +405,14 @@ describe("Cocoapods support", () => {
 			const expectedPlatformSection = [
 				`# NativeScriptPlatformSection ${basePodfilePath} with 8.1`,
 				"platform :ios, '8.1'",
-				"# End NativeScriptPlatformSection",
+				"# End NativeScriptPlatformSection\n"
 			].join("\n");
 			const expectedProjectPodfileContent = ["use_frameworks!\n",
 				`target "${projectName}" do`,
+				expectedPlatformSection,
 				`# Begin Podfile - ${basePodfilePath}`,
 				expectedPluginPodfileContent,
-				"# End Podfile\n",
-				expectedPlatformSection,
+				"# End Podfile",
 				"end"]
 				.join("\n");
 			assert.equal(actualProjectPodfileContent, expectedProjectPodfileContent);
@@ -483,14 +483,14 @@ describe("Cocoapods support", () => {
 			const expectedPlatformSection = [
 				`# NativeScriptPlatformSection ${pluginPodfilePath} with 8.1`,
 				"platform :ios, '8.1'",
-				"# End NativeScriptPlatformSection",
+				"# End NativeScriptPlatformSection\n",
 			].join("\n");
 			const expectedProjectPodfileContent = ["use_frameworks!\n",
 				`target "${projectName}" do`,
+				expectedPlatformSection,
 				`# Begin Podfile - ${pluginPodfilePath}`,
 				expectedPluginPodfileContent,
-				"# End Podfile\n",
-				expectedPlatformSection,
+				"# End Podfile",
 				"end"]
 				.join("\n");
 			assert.equal(actualProjectPodfileContent, expectedProjectPodfileContent);
@@ -565,14 +565,14 @@ describe("Cocoapods support", () => {
 			const expectedPlatformSection = [
 				`# NativeScriptPlatformSection ${pluginPodfilePath} with 8.1`,
 				"platform :ios, '8.1'",
-				"# End NativeScriptPlatformSection",
+				"# End NativeScriptPlatformSection\n",
 			].join("\n");
 			const expectedProjectPodfileContent = ["use_frameworks!\n",
 				`target "${projectName}" do`,
+				expectedPlatformSection,
 				`# Begin Podfile - ${pluginPodfilePath}`,
 				expectedPluginPodfileContent,
-				"# End Podfile\n",
-				expectedPlatformSection,
+				"# End Podfile",
 				"end"]
 				.join("\n");
 			assert.equal(actualProjectPodfileContent, expectedProjectPodfileContent);
@@ -1246,7 +1246,7 @@ describe("Merge Project XCConfig files", () => {
 		const destinationFilePaths = xcconfigService.getPluginsXcconfigFilePaths(projectRoot);
 
 		_.each(destinationFilePaths, destinationFilePath => {
-			assert.isTrue(fs.exists(destinationFilePath), `Target build xcconfig ${destinationFilePath} is missing.` );
+			assert.isTrue(fs.exists(destinationFilePath), `Target build xcconfig ${destinationFilePath} is missing.`);
 			const content = fs.readFile(destinationFilePath).toString();
 			assert.equal(content, "");
 		});


### PR DESCRIPTION
Currently when CLI adds plugin's Podfile, it places its content at the top of the newly generated Podfile. Same happens for the post_install hook of the plugin. The last Podfile that is applied, is the one from App_Resources/iOS, but its content is also placed at the top of the merged Podfile and its post_install action (in case it has such) is executed first.
The idea of having Podfile in App_Resources/iOS was to be able to overwrite some settings from plugins Podfiles, for example SWIFT_VERSION.
To handle this, append each Podfile at the end of the merged Podfile. Same is valid for the post_install hook coming from a Podfile - it will be appended at end of the merged post_install function.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
