### PR TITLE
fix: ensure analytics and cleanup processes are not leaking

### DIFF
--- a/lib/detached-processes/cleanup-process.ts
+++ b/lib/detached-processes/cleanup-process.ts
@@ -166,6 +166,8 @@ process.on("message", async (cleanupProcessMessage: ICleanupMessageBase) => {
 process.on("disconnect", async () => {
 	fileLogService.logData({ message: "cleanup-process received process.disconnect event" });
 	await executeCleanup();
+	$injector.dispose();
+	process.exit();
 });
 
 fileLogService.logData({ message: `cleanup-process will send ${DetachedProcessMessages.ProcessReadyToReceive} message` });

--- a/lib/services/analytics/analytics-broker-process.ts
+++ b/lib/services/analytics/analytics-broker-process.ts
@@ -29,7 +29,7 @@ const finishTracking = async (data?: ITrackingInformation) => {
 	analyticsLoggingService.logData({ message: `analytics-broker-process finish tracking started` });
 	await trackingQueue;
 	analyticsLoggingService.logData({ message: `analytics-broker-process tracking finished` });
-	process.disconnect();
+	$injector.dispose();
 	process.exit();
 };
 


### PR DESCRIPTION
When CLI dies, the `analyticsBroker` and `cleanupProcess` processes receive disconnect event. At this point they have to finish their work and die silently after that.
However, this does not happen for `analyticsBroker` process as in the `disconnect` handler we call `process.disconnect` method. It fails, as the process is already disconnected. So the process hangs in undefined state and it leaks. The stareted cleanup process from it also leaks.
To fix this remove the disconnect call from the handler.
Also ensure injector is disposed before calling process.exit in the detached process's handler.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4593

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
