### PR TITLE
style: misleading warning message

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -318,12 +318,12 @@ export class PluginsService implements IPluginsService {
 		const installedFrameworkVersion = this.getInstalledFrameworkVersion(platform, projectData);
 		const pluginPlatformsData = pluginData.platformsData;
 		if (pluginPlatformsData) {
-			const pluginVersion = (<any>pluginPlatformsData)[platform];
-			if (!pluginVersion) {
+			const versionRequiredByPlugin = (<any>pluginPlatformsData)[platform];
+			if (!versionRequiredByPlugin) {
 				this.$logger.warn(`${pluginData.name} is not supported for ${platform}.`);
 				isValid = false;
-			} else if (semver.gt(pluginVersion, installedFrameworkVersion)) {
-				this.$logger.warn(`${pluginData.name} ${pluginVersion} for ${platform} is not compatible with the currently installed framework version ${installedFrameworkVersion}.`);
+			} else if (semver.gt(versionRequiredByPlugin, installedFrameworkVersion)) {
+				this.$logger.warn(`${pluginData.name} requires at least version ${versionRequiredByPlugin} of platform ${platform}. Currently installed version is ${installedFrameworkVersion}.`);
 				isValid = false;
 			}
 		}

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -272,7 +272,7 @@ describe("Plugins service", () => {
 			});
 			it("fails when the plugin does not support the installed framework", async () => {
 				let isWarningMessageShown = false;
-				const expectedWarningMessage = "mySamplePlugin 1.5.0 for android is not compatible with the currently installed framework version 1.4.0.";
+				const expectedWarningMessage = "mySamplePlugin requires at least version 1.5.0 of platform android. Currently installed version is 1.4.0.";
 
 				// Creates plugin in temp folder
 				const pluginName = "mySamplePlugin";


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [X] Tests for the changes are included.

## What is the current behavior?
https://github.com/NativeScript/nativescript-cli/issues/4608

## What is the new behavior?
https://github.com/NativeScript/nativescript-cli/issues/4608 is addressed

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->