### PR TITLE
fix: make logger backwards compatible

### DIFF
--- a/lib/common/definitions/logger.d.ts
+++ b/lib/common/definitions/logger.d.ts
@@ -25,6 +25,36 @@ declare global {
 		trace(formatStr?: any, ...args: any[]): void;
 		printMarkdown(...args: any[]): void;
 		prepare(item: any): string;
+
+		/**
+		 * DEPRECATED
+		 * Do not use it.
+		 */
+		out(formatStr?: any, ...args: any[]): void;
+
+		/**
+		 * DEPRECATED
+		 * Do not use it.
+		 */
+		write(...args: any[]): void;
+
+		/**
+		 * DEPRECATED
+		 * Do not use it.
+		 */
+		printInfoMessageOnSameLine(message: string): void;
+
+		/**
+		 * DEPRECATED
+		 * Do not use it.
+		 */
+		printMsgWithTimeout(message: string, timeout: number): Promise<void>;
+
+		/**
+		 * DEPRECATED
+		 * Do not use it.
+		 */
+		printOnStderr(formatStr?: any, ...args: any[]): void;
 	}
 
 	interface Log4JSAppenderConfiguration extends Configuration {

--- a/lib/common/logger/logger.ts
+++ b/lib/common/logger/logger.ts
@@ -81,15 +81,6 @@ export class Logger implements ILogger {
 		this.logMessage(args, LoggerLevel.INFO);
 	}
 
-	/**
-	 * DEPRECATED
-	 * Present only for backwards compatibility as some plugins (nativescript-plugin-firebase)
-	 * use $logger.out in their hooks
-	 */
-	out(...args: any[]): void {
-		this.info(args);
-	}
-
 	debug(...args: any[]): void {
 		const encodedArgs: string[] = this.getPasswordEncodedArguments(args);
 		this.logMessage(encodedArgs, LoggerLevel.DEBUG);
@@ -198,6 +189,37 @@ export class Logger implements ILogger {
 			}
 
 			return argument;
+		});
+	}
+
+	/*******************************************************************************************
+	 * Metods below are deprecated. Delete them in 6.0.0 release:                              *
+	 * Present only for backwards compatibility as some plugins (nativescript-plugin-firebase) *
+	 * use these methods in their hooks                                                          *
+	 *******************************************************************************************/
+
+	out(...args: any[]): void {
+		this.info(args);
+	}
+
+	write(...args: any[]): void {
+		this.info(args, { [LoggerConfigData.skipNewLine]: true });
+	}
+
+	printOnStderr(...args: string[]): void {
+		this.error(args);
+	}
+
+	printInfoMessageOnSameLine(message: string): void {
+		this.info(message, { [LoggerConfigData.skipNewLine]: true });
+	}
+
+	printMsgWithTimeout(message: string, timeout: number): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			setTimeout(() => {
+				this.printInfoMessageOnSameLine(message);
+				resolve();
+			}, timeout);
 		});
 	}
 }

--- a/lib/common/test/unit-tests/stubs.ts
+++ b/lib/common/test/unit-tests/stubs.ts
@@ -45,6 +45,12 @@ export class CommonLoggerStub implements ILogger {
 	printMarkdown(message: string): void {
 		this.output += message;
 	}
+
+	out(formatStr?: any, ...args: any[]): void { }
+	write(...args: any[]): void { }
+	printInfoMessageOnSameLine(message: string): void { }
+	async printMsgWithTimeout(message: string, timeout: number): Promise<void> { }
+	printOnStderr(formatStr?: any, ...args: any[]): void { }
 }
 
 export class ErrorsStub implements IErrors {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -570,7 +570,7 @@ interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvai
 	analyticsLogFile: string;
 	performance: Object;
 	cleanupLogFile: string;
-	workflow: boolean;
+	workflow: any;
 	setupOptions(projectData: IProjectData): void;
 	printMessagesForDeprecatedOptions(logger: ILogger): void;
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -34,6 +34,12 @@ export class LoggerStub implements ILogger {
 	}
 
 	printMarkdown(message: string): void { }
+
+	out(formatStr?: any, ...args: any[]): void { }
+	write(...args: any[]): void { }
+	printInfoMessageOnSameLine(message: string): void { }
+	async printMsgWithTimeout(message: string, timeout: number): Promise<void> { }
+	printOnStderr(formatStr?: any, ...args: any[]): void { }
 }
 
 export class FileSystemStub implements IFileSystem {


### PR DESCRIPTION
Several plugin use deleted logger methods in their hooks. Same is valid for `nativescript-cloud` extension.
To resolve this, get back the deleted methods, we'll delete them in 6.0.0 release.

Also, `nativescript-cloud` has an option `--workflow`, that is an object, while ours is boolean. This breaks its transpilation, so set ours to `any`.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
