### PR TITLE
chore: update nativescript-dev-xcode to 0.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5316,8 +5316,9 @@
       }
     },
     "nativescript-dev-xcode": {
-      "version": "https://github.com/NativeScript/nativescript-dev-xcode/tarball/ec70f5d6032a72b65298ad56fa6ec0c4b2ef03a3",
-      "integrity": "sha512-CIZGo20Mulu/0u5Im6MYfh/gt2jldK3zt/HtWjUBogV/0QVQNKry2ewC6BudpjetUw4otjmqTRlUhY6wXpZ9Bg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nativescript-dev-xcode/-/nativescript-dev-xcode-0.2.0.tgz",
+      "integrity": "sha512-UKX+AS3rF/HNQ7777GunT9SaVQJXmcYnol9yKxVXWM1uRNXiQUgLaUmhjYUkHw7voqNN+FCqqRZQlB8mHUPA9g==",
       "requires": {
         "simple-plist": "^1.0.0",
         "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "minimatch": "3.0.2",
     "mkdirp": "0.5.1",
     "mute-stream": "0.0.5",
-    "nativescript-dev-xcode": "https://github.com/NativeScript/nativescript-dev-xcode/tarball/ec70f5d6032a72b65298ad56fa6ec0c4b2ef03a3",
+    "nativescript-dev-xcode": "0.2.0",
     "nativescript-doctor": "1.9.2",
     "nativescript-preview-sdk": "0.3.4",
     "open": "0.0.5",


### PR DESCRIPTION
Update to `nativescript-dev-xcode` dependency. Previously the dependency was targeted to the last commit in the development repository.