### PR TITLE
feat: add vue drawer navigation template to create project command

### DIFF
--- a/docs/man_pages/project/creation/create.md
+++ b/docs/man_pages/project/creation/create.md
@@ -51,7 +51,8 @@ Template | Command
 `Angular - Hello World`, `--ng`, `--angular` | tns create tns-template-hello-world-ng
 `Angular - SideDrawer` | tns create tns-template-drawer-navigation-ng
 `Angular - Tabs` | tns create tns-template-tab-navigation-ng
-`Vue.js`, `--vue`, `--vuejs` | tns create tns-template-blank-vue
+`Vue.js - Blank`, `--vue`, `--vuejs` | tns create tns-template-blank-vue
+`Vue.js - SideDrawer`, | tns create tns-template-drawer-navigation-vue
 
 ### Related Commands
 

--- a/lib/commands/create-project.ts
+++ b/lib/commands/create-project.ts
@@ -5,6 +5,8 @@ import { isInteractive } from "../common/helpers";
 export class CreateProjectCommand implements ICommand {
 	public enableHooks = false;
 	public allowedParameters: ICommandParameter[] = [this.$stringParameter];
+	private static BlankTemplateKey = "Blank";
+	private static BlankTemplateDescription = "A blank app";
 	private static HelloWorldTemplateKey = "Hello World";
 	private static HelloWorldTemplateDescription = "A Hello World app";
 	private static DrawerTemplateKey = "SideDrawer";
@@ -109,11 +111,11 @@ or --js flags.)
 		let selectedTemplate: string;
 		switch (flavorSelection) {
 			case constants.NgFlavorName: {
-				selectedFlavorTemplates.push(...this.getNgFlavors());
+				selectedFlavorTemplates.push(...this.getNgTemplates());
 				break;
 			}
 			case constants.VueFlavorName: {
-				selectedFlavorTemplates.push({ value: "tns-template-blank-vue" });
+				selectedFlavorTemplates.push(...this.getVueTemplates());
 				break;
 			}
 			case constants.TsFlavorName: {
@@ -178,7 +180,7 @@ or --js flags.)
 		return templates;
 	}
 
-	private getNgFlavors() {
+	private getNgTemplates() {
 		const templates = [{
 			key: CreateProjectCommand.HelloWorldTemplateKey,
 			value: constants.RESERVED_TEMPLATE_NAMES.angular,
@@ -193,6 +195,21 @@ or --js flags.)
 			key: CreateProjectCommand.TabsTemplateKey,
 			value: "tns-template-tab-navigation-ng",
 			description: CreateProjectCommand.TabsTemplateDescription
+		}];
+
+		return templates;
+	}
+
+	private getVueTemplates() {
+		const templates = [{
+			key: CreateProjectCommand.BlankTemplateKey,
+			value: "tns-template-blank-vue",
+			description: CreateProjectCommand.BlankTemplateDescription
+		},
+		{
+			key: CreateProjectCommand.DrawerTemplateKey,
+			value: "tns-template-drawer-navigation-vue",
+			description: CreateProjectCommand.DrawerTemplateDescription
 		}];
 
 		return templates;

--- a/test/project-commands.ts
+++ b/test/project-commands.ts
@@ -23,6 +23,10 @@ const expectedTemplateChoices = [
 	{ key: "SideDrawer", description: "An app with pre-built pages that uses a drawer for navigation" },
 	{ key: "Tabs", description: "An app with pre-built pages that uses tabs for navigation" }
 ];
+const expectedTemplateChoicesVue = [
+	{ key: "Blank", description: "A blank app" },
+	{ key: "SideDrawer", description: "An app with pre-built pages that uses a drawer for navigation" }
+];
 
 class ProjectServiceMock implements IProjectService {
 	async validateProjectName(opts: { projectName: string, force: boolean, pathToProject: string }): Promise<string> {
@@ -92,7 +96,7 @@ describe("Project commands tests", () => {
 		if (opts.templateAnswer) {
 			const templateQuestion = opts.projectNameAnswer ? "Finally" : "Next, which template would you like to start from:";
 			answers[templateQuestion] = opts.templateAnswer;
-			questionChoices[templateQuestion] = expectedTemplateChoices;
+			questionChoices[templateQuestion] = opts.flavorAnswer === constants.VueFlavorName ? expectedTemplateChoicesVue : expectedTemplateChoices;
 		}
 
 		prompterStub.expect({
@@ -207,12 +211,14 @@ describe("Project commands tests", () => {
 			assert.isTrue(createProjectCalledWithForce);
 		});
 
-		it("should select the default vue template when the vue flavor is selected.", async () => {
-			setupAnswers({ flavorAnswer: constants.VueFlavorName });
+		it("should ask for a template when vue flavor is selected.", async () => {
+			setupAnswers({ flavorAnswer: constants.VueFlavorName, templateAnswer:  "SideDrawer" });
 
 			await createProjectCommand.execute(dummyArgs);
 
-			assert.deepEqual(selectedTemplateName, "tns-template-blank-vue");
+			assert.deepEqual(selectedTemplateName, "tns-template-drawer-navigation-vue");
+			assert.equal(validateProjectCallsCount, 1);
+			assert.isTrue(createProjectCalledWithForce);
 		});
 	});
 });


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
when vue flavor is selected, an app is created with the vue blank template 

## What is the new behavior?
<!-- Describe the changes. -->
when vue flavor is selected, two options are presented - Blank and SideDrawer

Fixes/Implements/Closes #4651.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
