### PR TITLE
fix: respect App_Resources directly from project

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -335,20 +335,23 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		}
 	}
 
-	public prepareAppResources(appResourcesDirectoryPath: string, projectData: IProjectData): void {
-		const platformFolder = path.join(appResourcesDirectoryPath, this.getPlatformData(projectData).normalizedPlatformName);
-		const filterFile = (filename: string) => this.$fs.deleteFile(path.join(platformFolder, filename));
+	public prepareAppResources(projectData: IProjectData): void {
+		const platformData = this.getPlatformData(projectData);
+		const projectAppResourcesPath = projectData.getAppResourcesDirectoryPath(projectData.projectDir);
+		const platformsAppResourcesPath = this.getAppResourcesDestinationDirectoryPath(projectData);
 
-		filterFile(this.getPlatformData(projectData).configurationFileName);
-		filterFile(constants.PODFILE_NAME);
+		this.$fs.deleteDirectory(platformsAppResourcesPath);
+		this.$fs.ensureDirectoryExists(platformsAppResourcesPath);
 
-		// src folder should not be copied as the pbxproject will have references to its files
-		this.$fs.deleteDirectory(path.join(appResourcesDirectoryPath, this.getPlatformData(projectData).normalizedPlatformName, constants.NATIVE_SOURCE_FOLDER));
-		this.$fs.deleteDirectory(path.join(appResourcesDirectoryPath, this.getPlatformData(projectData).normalizedPlatformName, constants.NATIVE_EXTENSION_FOLDER));
-		this.$fs.deleteDirectory(path.join(appResourcesDirectoryPath, this.getPlatformData(projectData).normalizedPlatformName, "watchapp"));
-		this.$fs.deleteDirectory(path.join(appResourcesDirectoryPath, this.getPlatformData(projectData).normalizedPlatformName, "watchextension"));
+		this.$fs.copyFile(path.join(projectAppResourcesPath, platformData.normalizedPlatformName, "*"), platformsAppResourcesPath);
 
-		this.$fs.deleteDirectory(this.getAppResourcesDestinationDirectoryPath(projectData));
+		this.$fs.deleteFile(path.join(platformsAppResourcesPath, platformData.configurationFileName));
+		this.$fs.deleteFile(path.join(platformsAppResourcesPath, constants.PODFILE_NAME));
+
+		this.$fs.deleteDirectory(path.join(platformsAppResourcesPath, constants.NATIVE_SOURCE_FOLDER));
+		this.$fs.deleteDirectory(path.join(platformsAppResourcesPath, constants.NATIVE_EXTENSION_FOLDER));
+		this.$fs.deleteDirectory(path.join(platformsAppResourcesPath, "watchapp"));
+		this.$fs.deleteDirectory(path.join(platformsAppResourcesPath, "watchextension"));
 	}
 
 	public async processConfigurationFilesFromAppResources(projectData: IProjectData, opts: IRelease): Promise<void> {

--- a/lib/services/webpack/webpack.d.ts
+++ b/lib/services/webpack/webpack.d.ts
@@ -78,7 +78,7 @@ declare global {
 		 * @param {IProjectData} projectData DTO with information about the project.
 		 * @returns {void}
 		 */
-		prepareAppResources(appResourcesDirectoryPath: string, projectData: IProjectData): void;
+		prepareAppResources(projectData: IProjectData): void;
 
 		/**
 		 * Defines if current platform is prepared (i.e. if <project dir>/platforms/<platform> dir exists).

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -425,7 +425,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	async updatePlatform(currentVersion: string, newVersion: string, canUpdate: boolean): Promise<boolean> {
 		return Promise.resolve(true);
 	}
-	prepareAppResources(appResourcesDirectoryPath: string): void { }
+	prepareAppResources(projectData: IProjectData): void { }
 
 	async preparePluginNativeCode(pluginData: IPluginData): Promise<void> {
 		return Promise.resolve();


### PR DESCRIPTION
Currently App_Resources are copied to platforms folder and after that NativeScript CLI  moves them to the correct places in native project and deletes the App_Resources folder in platforms. On the other side, nativescript-dev-webpack plugin copies the App_Resources to platforms folder only on initial start (not when some file is changed). This led to the problem that when native file is changed, NativeScript CLI moves App_Resources to the correct places in native project and deletes App_Resources folder inside platforms (the one that nativescript-dev-webpack plugin has previously copied on initial webpack's compilation). On the next native file change, NativeScript CLI tries to move the platforms/App_Resources to the correct places inside native project, but this directory doesn't exist. So `cp unable to find source directory` error is thrown.

Fixes: https://github.com/NativeScript/nativescript-cli/issues/4377

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
