### PR TITLE
fix: pass --env.verbose to webpack compiler

### DIFF
--- a/lib/common/definitions/logger.d.ts
+++ b/lib/common/definitions/logger.d.ts
@@ -25,6 +25,7 @@ declare global {
 		trace(formatStr?: any, ...args: any[]): void;
 		printMarkdown(...args: any[]): void;
 		prepare(item: any): string;
+		isVerbose(): boolean;
 	}
 
 	interface Log4JSAppenderConfiguration extends Configuration {

--- a/lib/common/logger/logger.ts
+++ b/lib/common/logger/logger.ts
@@ -135,6 +135,10 @@ export class Logger implements ILogger {
 		this.info(formattedMessage, { [LoggerConfigData.skipNewLine]: true });
 	}
 
+	public isVerbose(): boolean {
+		return log4js.levels.DEBUG.isGreaterThanOrEqualTo(this.getLevel());
+	}
+
 	private logMessage(inputData: any[], logMethod: string): void {
 		this.initialize();
 

--- a/lib/common/test/unit-tests/stubs.ts
+++ b/lib/common/test/unit-tests/stubs.ts
@@ -51,6 +51,7 @@ export class CommonLoggerStub implements ILogger {
 	printInfoMessageOnSameLine(message: string): void { }
 	async printMsgWithTimeout(message: string, timeout: number): Promise<void> { }
 	printOnStderr(formatStr?: any, ...args: any[]): void { }
+	isVerbose(): boolean { return false; }
 }
 
 export class ErrorsStub implements IErrors {

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -133,8 +133,10 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 		const appResourcesPath = this.$projectData.getAppResourcesRelativeDirectoryPath();
 		Object.assign(envData,
 			appPath && { appPath },
-			appResourcesPath && { appResourcesPath }
+			appResourcesPath && { appResourcesPath },
 		);
+
+		envData.verbose = this.$logger.isVerbose();
 
 		return envData;
 	}

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -41,6 +41,8 @@ export class LoggerStub implements ILogger {
 	printInfoMessageOnSameLine(message: string): void { }
 	async printMsgWithTimeout(message: string, timeout: number): Promise<void> { }
 	printOnStderr(formatStr?: any, ...args: any[]): void { }
+
+	isVerbose(): boolean { return false; }
 }
 
 export class FileSystemStub implements IFileSystem {


### PR DESCRIPTION
`copy-webpack` plugin prints its info messages on `stderr` by default. This led to the problem that these messages are shown in errors tab in Sidekick.
When `{ verbose: false }` is provided as option to `copy-webpack` plugin, it doesn't print any information. So when `tns run android` is executed, no messages will be shown from `copy-webpack` plugin and thus no errors will be shown from Sidekick.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
