### PR TITLE
fix: cloud run command does not respect useLegacyWorkflow flag

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -503,7 +503,7 @@ interface IAndroidBundleOptions {
 
 interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvailableDevices, IProfileDir, IHasEmulatorOption, IBundleString, IPlatformTemplate, IHasEmulatorOption, IClean, IProvision, ITeamIdentifier, IAndroidReleaseOptions, IAndroidBundleOptions, INpmInstallConfigurationOptions, IPort, IEnvOptions, IPluginSeedOptions, IGenerateOptions {
 	argv: IYargArgv;
-	validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>): void;
+	validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>, projectData?: IProjectData): void;
 	options: IDictionary<IDashedOption>;
 	shorthands: string[];
 	/**
@@ -573,7 +573,6 @@ interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvai
 	performance: Object;
 	cleanupLogFile: string;
 	workflow: any;
-	setupOptions(projectData: IProjectData): void;
 	printMessagesForDeprecatedOptions(logger: ILogger): void;
 }
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -21,7 +21,12 @@ export class Options {
 
 	public options: IDictionary<IDashedOption>;
 
-	public setupOptions(projectData: IProjectData): void {
+	public setupOptions(projectData: IProjectData, commandSpecificDashedOptions?: IDictionary<IDashedOption>): void {
+		if (commandSpecificDashedOptions) {
+			_.extend(this.options, commandSpecificDashedOptions);
+			this.setArgv();
+		}
+
 		if (this.argv.release && this.argv.hmr) {
 			this.$errors.failWithoutHelp("The options --release and --hmr cannot be used simultaneously.");
 		}
@@ -173,12 +178,8 @@ export class Options {
 		return this.argv[optionName];
 	}
 
-	public validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>): void {
-		if (commandSpecificDashedOptions) {
-			_.extend(this.options, commandSpecificDashedOptions);
-			this.setArgv();
-		}
-
+	public validateOptions(commandSpecificDashedOptions?: IDictionary<IDashedOption>, projectData?: IProjectData): void {
+		this.setupOptions(projectData, commandSpecificDashedOptions);
 		const parsed = Object.create(null);
 		// DO NOT REMOVE { } as when they are missing and some of the option values is false, the each stops as it thinks we have set "return false".
 		_.each(_.keys(this.argv), optionName => {

--- a/test/options.ts
+++ b/test/options.ts
@@ -325,7 +325,7 @@ describe("options", () => {
 				it(`should pass correctly when ${testCase.name} and useLegacyWorkflow is ${useLegacyWorkflow}`, () => {
 					(testCase.args || []).forEach(arg => process.argv.push(arg));
 
-					const options = createOptions(testInjector);
+					const options: any = createOptions(testInjector);
 					const projectData = <IProjectData>{ useLegacyWorkflow };
 					options.setupOptions(projectData);
 
@@ -359,7 +359,7 @@ describe("options", () => {
 				errors.failWithoutHelp = (error: string) => actualError = error;
 				(testCase.args || []).forEach(arg => process.argv.push(arg));
 
-				const options = createOptions(testInjector);
+				const options: any = createOptions(testInjector);
 				options.setupOptions(null);
 
 				(testCase.args || []).forEach(arg => process.argv.pop());


### PR DESCRIPTION
Currently when you run `tns cloud run ...` the command executes local prepare without taking into account the value of `useLegacyWorkflow` value in nsconfig.json file.
The problem is that cloud commands have specific `--` options, which are set as `dashedOptions` on command level. During command execution the following actions happen:
1. CLI starts its execution and via `$injector` constructs new instance of `$options`.
2. In the constructor of `$options` we call `this.setArgv()`, which calls `yargs` package and constructs values based on the user input of `--` options.
3. `$injector` resolves `$commandsService` and constructs new object from it.
4. In the constructor of `CommandsService`, we call `$options.setupOptions` and pass the current projectData. `setupOptions` takes into account the projectData and again calls `this.setArgv()`. After that it overwrites some of the values set by yargs based on the projectData.
5. `CommandsService` starts execution of the command by resolving new instance of it and calling its own `tryExecuteCommandAction` method.
6. `tryExecuteCommandAction` method internally calls `this.$options.validateOptions` by passing the command specific options(`dashedOptions`). The `validateOptions` method modifies the internal structure based on which yargs constructs the passed options and calls `this.setArgv()` again.

At this point we overwrite the internal values of `$options` based on the user's input and taking into account the command's `dashedOptions`. However, this way we've overwritten the values set by `setupOptions` in step 4 which are based on the current project dir.

To fix the behavior, make `setupOptions` private in `$options` and call it internally in the `validateOptions` method. So the new workflow is:
1. CLI starts its execution and via `$injector` constructs new instance of `$options`.
2. In the constructor of `$options` we call `this.setArgv()`, which calls `yargs` package and constructs values based on the user input of `--` options.
3. `$injector` resolves `$commandsService` and constructs new object from it.
4. `CommandsService` starts execution of the command by resolving new instance of it and calling its own `tryExecuteCommandAction` method.
5. `tryExecuteCommandAction` method internally calls `this.$options.validateOptions` by passing the command specific options(`dashedOptions`). The `validateOptions` method calls `this.setupOptions` and pass the current projectData and command specific options. After that it calls `this.setArgv()` and the internal structure that contains the passed options is overwritten based on the command specific options. After that the method overwrites some of the values based on the passed projectData.
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
