### PR TITLE
fix: incorrect error for non-supported Node.js version

### DIFF
--- a/lib/common/verify-node-version.ts
+++ b/lib/common/verify-node-version.ts
@@ -49,7 +49,7 @@ export function verifyNodeVersion(): void {
 
 	var nodeWarning = getNodeWarning();
 	if (nodeWarning && nodeWarning.message) {
-		console.warn((`${os.EOL}${nodeWarning.message}${os.EOL}`).yellow.bold);
+		console.warn((os.EOL + nodeWarning.message + os.EOL).yellow.bold);
 	}
 }
 


### PR DESCRIPTION
In case you are using unsupported Node.js version CLI must show you error that this version is not supported and to inform you which is the supported range. Currently this is not working and CLI shows error for `Unexpected token`.
The problem is that CLI has some specific logic to check the Node.js version and the code should be pure ES5 syntax in order to work with old Node.js versions (by default CLI's code is ES6).
The current issue is caused by using string interpolation in the mentioned code. Fix the message to fix the problem.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?


## What is the new behavior?
<!-- Describe the changes. -->

Fixes https://github.com/NativeScript/nativescript-cli/issues/4665
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
