### PR TITLE
fix: pass correct args when using deprecated logger API

### DIFF
--- a/lib/common/logger/logger.ts
+++ b/lib/common/logger/logger.ts
@@ -199,15 +199,15 @@ export class Logger implements ILogger {
 	 *******************************************************************************************/
 
 	out(...args: any[]): void {
-		this.info(args);
+		this.info(...args);
 	}
 
 	write(...args: any[]): void {
-		this.info(args, { [LoggerConfigData.skipNewLine]: true });
+		this.info(...args, { [LoggerConfigData.skipNewLine]: true });
 	}
 
 	printOnStderr(...args: string[]): void {
-		this.error(args);
+		this.error(...args);
 	}
 
 	printInfoMessageOnSameLine(message: string): void {


### PR DESCRIPTION
Several logger methods have been deprecated, but their usage had been broken. Fix it until we delete them.
The current problem arises when we pass several args to the `logger.out` (or any deprecated method) - instead of passing args directly to `logger.info`, we need to spread them
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns account` command prints incorrect table.

## What is the new behavior?
`tns account` prints correct table.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
