### PR TITLE
fix: don't check all node_modules from `checkForChanges` method

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -132,7 +132,7 @@ export class PrepareController extends EventEmitter {
 		const watcher = choki.watch(patterns, watcherOptions)
 			.on("all", async (event: string, filePath: string) => {
 				filePath = path.join(projectData.projectDir, filePath);
-				this.$logger.info(`Chokidar raised event ${event} for ${filePath}.`);
+				this.$logger.trace(`Chokidar raised event ${event} for ${filePath}.`);
 				this.emitPrepareEvent({ files: [], hmrData: null, hasNativeChanges: true, platform: platformData.platformNameLowerCase });
 			});
 

--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -4,7 +4,7 @@ import { hook } from "../common/helpers";
 import { performanceLog } from "../common/decorators";
 import { EventEmitter } from "events";
 import * as path from "path";
-import { PREPARE_READY_EVENT_NAME, WEBPACK_COMPILATION_COMPLETE } from "../constants";
+import { PREPARE_READY_EVENT_NAME, WEBPACK_COMPILATION_COMPLETE, PACKAGE_JSON_FILE_NAME } from "../constants";
 
 interface IPlatformWatcherData {
 	webpackCompilerProcess: child_process.ChildProcess;
@@ -115,6 +115,8 @@ export class PrepareController extends EventEmitter {
 		}
 
 		const patterns = [
+			path.join(projectData.projectDir, PACKAGE_JSON_FILE_NAME),
+			path.join(projectData.getAppDirectoryPath(), PACKAGE_JSON_FILE_NAME),
 			path.join(projectData.getAppResourcesRelativeDirectoryPath(), platformData.normalizedPlatformName),
 			`node_modules/**/platforms/${platformData.platformNameLowerCase}/`
 		];

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -302,8 +302,9 @@ export class RunController extends EventEmitter implements IRunController {
 
 			try {
 				if (data.hasNativeChanges) {
-					await this.$prepareNativePlatformService.prepareNativePlatform(platformData, projectData, prepareData);
-					await deviceDescriptor.buildAction();
+					if (await this.$prepareNativePlatformService.prepareNativePlatform(platformData, projectData, prepareData)) {
+						await deviceDescriptor.buildAction();
+					}
 				}
 
 				const isInHMRMode = liveSyncInfo.useHotModuleReload && data.hmrData && data.hmrData.hash;

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -15,7 +15,6 @@ interface IPrepareInfo extends IAddedNativePlatform, IAppFilesHashes {
 interface IProjectChangesInfo extends IAddedNativePlatform {
 	appResourcesChanged: boolean;
 	configChanged: boolean;
-	packageChanged: boolean;
 	nativeChanged: boolean;
 	signingChanged: boolean;
 

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -14,7 +14,6 @@ interface IPrepareInfo extends IAddedNativePlatform, IAppFilesHashes {
 
 interface IProjectChangesInfo extends IAddedNativePlatform {
 	appResourcesChanged: boolean;
-	modulesChanged: boolean;
 	configChanged: boolean;
 	packageChanged: boolean;
 	nativeChanged: boolean;

--- a/lib/services/platform/prepare-native-platform-service.ts
+++ b/lib/services/platform/prepare-native-platform-service.ts
@@ -21,11 +21,12 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 
 		const changesInfo = await this.$projectChangesService.checkForChanges(platformData, projectData, prepareData);
 
-		const hasModulesChange = !changesInfo || changesInfo.modulesChanged;
+		const hasNativeModulesChange = !changesInfo || changesInfo.nativeChanged;
+		const hasPackageChange = !changesInfo || changesInfo.packageChanged;
 		const hasConfigChange = !changesInfo || changesInfo.configChanged;
 		const hasChangesRequirePrepare = !changesInfo || changesInfo.changesRequirePrepare;
 
-		const hasChanges = hasModulesChange || hasConfigChange || hasChangesRequirePrepare;
+		const hasChanges = hasNativeModulesChange || hasPackageChange || hasConfigChange || hasChangesRequirePrepare;
 
 		if (changesInfo.hasChanges) {
 			await this.cleanProject(platformData, { release });
@@ -37,11 +38,11 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 			await platformData.platformProjectService.prepareProject(projectData, prepareData);
 		}
 
-		if (hasModulesChange) {
+		if (hasNativeModulesChange || hasPackageChange) {
 			await this.$nodeModulesBuilder.prepareNodeModules(platformData, projectData);
 		}
 
-		if (hasModulesChange || hasConfigChange) {
+		if (hasNativeModulesChange || hasPackageChange || hasConfigChange) {
 			await platformData.platformProjectService.processConfigurationFilesFromAppResources(projectData, { release });
 			await platformData.platformProjectService.handleNativeDependenciesChange(projectData, { release });
 		}

--- a/lib/services/platform/prepare-native-platform-service.ts
+++ b/lib/services/platform/prepare-native-platform-service.ts
@@ -22,11 +22,10 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 		const changesInfo = await this.$projectChangesService.checkForChanges(platformData, projectData, prepareData);
 
 		const hasNativeModulesChange = !changesInfo || changesInfo.nativeChanged;
-		const hasPackageChange = !changesInfo || changesInfo.packageChanged;
 		const hasConfigChange = !changesInfo || changesInfo.configChanged;
 		const hasChangesRequirePrepare = !changesInfo || changesInfo.changesRequirePrepare;
 
-		const hasChanges = hasNativeModulesChange || hasPackageChange || hasConfigChange || hasChangesRequirePrepare;
+		const hasChanges = hasNativeModulesChange || hasConfigChange || hasChangesRequirePrepare;
 
 		if (changesInfo.hasChanges) {
 			await this.cleanProject(platformData, { release });
@@ -38,11 +37,11 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 			await platformData.platformProjectService.prepareProject(projectData, prepareData);
 		}
 
-		if (hasNativeModulesChange || hasPackageChange) {
+		if (hasNativeModulesChange) {
 			await this.$nodeModulesBuilder.prepareNodeModules(platformData, projectData);
 		}
 
-		if (hasNativeModulesChange || hasPackageChange || hasConfigChange) {
+		if (hasNativeModulesChange || hasConfigChange) {
 			await platformData.platformProjectService.processConfigurationFilesFromAppResources(projectData, { release });
 			await platformData.platformProjectService.handleNativeDependenciesChange(projectData, { release });
 		}

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -60,16 +60,15 @@ export class ProjectChangesService implements IProjectChangesService {
 
 			this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir)
 				.filter(dep => dep.nativescript && this.$fs.exists(path.join(dep.directory, PLATFORMS_DIR_NAME, platformData.platformNameLowerCase)))
-				.map(dep => {
+				.forEach(dep => {
 					this._changesInfo.nativeChanged = this._changesInfo.nativeChanged ||
 						this.containsNewerFiles(path.join(dep.directory, PLATFORMS_DIR_NAME, platformData.platformNameLowerCase), projectData) ||
 						this.isFileModified(path.join(dep.directory, PACKAGE_JSON_FILE_NAME));
 				});
 
 			if (!this._changesInfo.nativeChanged) {
-				const packageJsonChanged = this.isProjectFileChanged(projectData.projectDir, platformData);
 				this._prepareInfo.projectFileHash = this.getProjectFileStrippedHash(projectData.projectDir, platformData);
-				this._changesInfo.nativeChanged = packageJsonChanged;
+				this._changesInfo.nativeChanged = this.isProjectFileChanged(projectData.projectDir, platformData);
 			}
 
 			this.$logger.trace(`Set nativeChanged to ${this._changesInfo.nativeChanged}.`);

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -68,7 +68,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir)
 				.filter(dep => dep.nativescript && this.$fs.exists(path.join(dep.directory, "platforms", platformData.platformNameLowerCase)))
 				.map(dep => {
-					this._changesInfo.nativeChanged = this.containsNewerFiles(
+					this._changesInfo.nativeChanged = this._changesInfo.nativeChanged || this.containsNewerFiles(
 						path.join(dep.directory, "platforms", platformData.platformNameLowerCase),
 						projectData,
 						this.fileChangeRequiresBuild);

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -8,7 +8,6 @@ const prepareInfoFileName = ".nsprepareinfo";
 class ProjectChangesInfo implements IProjectChangesInfo {
 
 	public appResourcesChanged: boolean;
-	public modulesChanged: boolean;
 	public configChanged: boolean;
 	public packageChanged: boolean;
 	public nativeChanged: boolean;
@@ -18,7 +17,6 @@ class ProjectChangesInfo implements IProjectChangesInfo {
 	public get hasChanges(): boolean {
 		return this.packageChanged ||
 			this.appResourcesChanged ||
-			this.modulesChanged ||
 			this.configChanged ||
 			this.signingChanged;
 	}
@@ -78,11 +76,6 @@ export class ProjectChangesService implements IProjectChangesService {
 
 			this.$logger.trace(`Set nativeChanged to ${this._changesInfo.nativeChanged}.`);
 
-			if (this._newFiles > 0 || this._changesInfo.nativeChanged) {
-				this.$logger.trace(`Setting modulesChanged to true, newFiles: ${this._newFiles}, nativeChanged: ${this._changesInfo.nativeChanged}`);
-				this._changesInfo.modulesChanged = true;
-			}
-
 			if (platformData.platformNameLowerCase === this.$devicePlatformsConstants.iOS.toLowerCase()) {
 				this._changesInfo.configChanged = this.filesChanged([path.join(platformResourcesDir, platformData.configurationFileName),
 				path.join(platformResourcesDir, "LaunchScreen.storyboard"),
@@ -105,16 +98,11 @@ export class ProjectChangesService implements IProjectChangesService {
 		if (prepareData.release !== this._prepareInfo.release) {
 			this.$logger.trace(`Setting all setting to true. Current options are: `, prepareData, " old prepare info is: ", this._prepareInfo);
 			this._changesInfo.appResourcesChanged = true;
-			this._changesInfo.modulesChanged = true;
 			this._changesInfo.configChanged = true;
 			this._prepareInfo.release = prepareData.release;
 		}
-		if (this._changesInfo.packageChanged) {
-			this.$logger.trace("Set modulesChanged to true as packageChanged is true");
-			this._changesInfo.modulesChanged = true;
-		}
-		if (this._changesInfo.modulesChanged || this._changesInfo.appResourcesChanged) {
-			this.$logger.trace(`Set configChanged to true, current value of moduleChanged is: ${this._changesInfo.modulesChanged}, appResourcesChanged is: ${this._changesInfo.appResourcesChanged}`);
+		if (this._changesInfo.appResourcesChanged) {
+			this.$logger.trace(`Set configChanged to true, appResourcesChanged is: ${this._changesInfo.appResourcesChanged}`);
 			this._changesInfo.configChanged = true;
 		}
 		if (this._changesInfo.hasChanges) {
@@ -195,7 +183,6 @@ export class ProjectChangesService implements IProjectChangesService {
 		this._outputProjectCTime = 0;
 		this._changesInfo = this._changesInfo || new ProjectChangesInfo();
 		this._changesInfo.appResourcesChanged = true;
-		this._changesInfo.modulesChanged = true;
 		this._changesInfo.configChanged = true;
 		return true;
 	}

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -36,6 +36,7 @@ class ProjectChangesServiceTest extends BaseServiceTest {
 		});
 		this.injector.register("logger", LoggerStub);
 		this.injector.register("hooksService", HooksServiceStub);
+		this.injector.register("nodeModulesDependenciesBuilder", {});
 
 		const fs = this.injector.resolve<IFileSystem>("fs");
 		fs.writeJson(path.join(this.projectDir, Constants.PACKAGE_JSON_FILE_NAME), {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -506,16 +506,10 @@ export class ProjectDataService implements IProjectDataService {
 	removeDependency(dependencyName: string): void { }
 
 	getProjectData(projectDir: string): IProjectData {
-		return <any>{
-			projectDir: "/path/to/my/projecDir",
-			projectName: "myTestProjectName",
-			platformsDir: "/path/to/my/projecDir/platforms",
-			projectIdentifiers: {
-				ios: "org.nativescript.myiosApp",
-				android: "org.nativescript.myAndroidApp"
-			},
-			getAppResourcesRelativeDirectoryPath: () => "/path/to/my/projecDir/App_Resources"
-		};
+		const projectData = new ProjectDataStub();
+		projectData.initializeProjectData(projectDir);
+
+		return projectData;
 	}
 
 	async getAssetsStructure(opts: IProjectDir): Promise<IAssetsStructure> {


### PR DESCRIPTION
Rel to: https://github.com/NativeScript/nativescript-cli/issues/4647

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
