### PR TITLE
fix: fix release run for android

### DIFF
--- a/lib/controllers/build-controller.ts
+++ b/lib/controllers/build-controller.ts
@@ -47,7 +47,7 @@ export class BuildController extends EventEmitter implements IBuildController {
 		});
 
 		if (buildData.clean) {
-			await platformData.platformProjectService.cleanProject(platformData.projectRoot, projectData);
+			await platformData.platformProjectService.cleanProject(platformData.projectRoot);
 		}
 
 		const handler = (data: any) => {

--- a/lib/controllers/deploy-controller.ts
+++ b/lib/controllers/deploy-controller.ts
@@ -1,18 +1,15 @@
 export class DeployController {
 
 	constructor(
-		private $buildDataService: IBuildDataService,
 		private $buildController: IBuildController,
 		private $deviceInstallAppService: IDeviceInstallAppService,
 		private $devicesService: Mobile.IDevicesService
 	) { }
 
-	public async deploy(data: IRunData): Promise<void> {
-		const { liveSyncInfo, deviceDescriptors } = data;
+	public async deploy(data: IDeployData): Promise<void> {
+		const { buildData, deviceDescriptors } = data;
 
 		const executeAction = async (device: Mobile.IDevice) => {
-			const options = { ...liveSyncInfo, buildForDevice: !device.isEmulator };
-			const buildData = this.$buildDataService.getBuildData(liveSyncInfo.projectDir, device.deviceInfo.platform, options);
 			await this.$buildController.prepareAndBuild(buildData);
 			await this.$deviceInstallAppService.installOnDevice(device, buildData);
 		};

--- a/lib/definitions/gradle.d.ts
+++ b/lib/definitions/gradle.d.ts
@@ -9,16 +9,12 @@ interface IGradleCommandOptions {
 	spawnOptions?: ISpawnFromEventOptions;
 }
 
-interface IAndroidBuildConfig extends IRelease, IAndroidReleaseOptions, IHasAndroidBundle {
-	buildOutputStdio?: string;
-}
-
 interface IGradleBuildService {
-	buildProject(projectRoot: string, buildConfig: IAndroidBuildConfig): Promise<void>;
-	cleanProject(projectRoot: string, buildConfig: IAndroidBuildConfig): Promise<void>;
+	buildProject(projectRoot: string, buildData: IAndroidBuildData): Promise<void>;
+	cleanProject(projectRoot: string, buildData: IAndroidBuildData): Promise<void>;
 }
 
 interface IGradleBuildArgsService {
-	getBuildTaskArgs(buildConfig: IAndroidBuildConfig): string[];
-	getCleanTaskArgs(buildConfig: IAndroidBuildConfig): string[];
+	getBuildTaskArgs(buildData: IAndroidBuildData): string[];
+	getCleanTaskArgs(buildData: IAndroidBuildData): string[];
 }

--- a/lib/definitions/run.d.ts
+++ b/lib/definitions/run.d.ts
@@ -7,6 +7,11 @@ declare global {
 		deviceDescriptors: ILiveSyncDeviceDescriptor[];
 	}
 
+	interface IDeployData {
+		buildData: IBuildData;
+		deviceDescriptors: ILiveSyncDeviceDescriptor[];
+	}
+
 	interface IStopRunData {
 		projectDir: string;
 		deviceIdentifiers?: string[];

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -233,16 +233,16 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	@performanceLog()
-	public async buildProject(projectRoot: string, projectData: IProjectData, buildConfig: IBuildConfig): Promise<void> {
+	public async buildProject(projectRoot: string, projectData: IProjectData, buildData: IAndroidBuildData): Promise<void> {
 		const platformData = this.getPlatformData(projectData);
-		await this.$gradleBuildService.buildProject(platformData.projectRoot, buildConfig);
+		await this.$gradleBuildService.buildProject(platformData.projectRoot, buildData);
 
-		const outputPath = platformData.getBuildOutputPath(buildConfig);
+		const outputPath = platformData.getBuildOutputPath(buildData);
 		await this.$filesHashService.saveHashesForProject(this._platformData, outputPath);
 	}
 
-	public async buildForDeploy(projectRoot: string, projectData: IProjectData, buildConfig?: IBuildConfig): Promise<void> {
-		return this.buildProject(projectRoot, projectData, buildConfig);
+	public async buildForDeploy(projectRoot: string, projectData: IProjectData, buildData?: IAndroidBuildData): Promise<void> {
+		return this.buildProject(projectRoot, projectData, buildData);
 	}
 
 	public isPlatformPrepared(projectRoot: string, projectData: IProjectData): boolean {
@@ -376,8 +376,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		return result;
 	}
 
-	public async cleanProject(projectRoot: string, projectData: IProjectData): Promise<void> {
-		await this.$gradleBuildService.cleanProject(projectRoot, { release: false });
+	public async cleanProject(projectRoot: string): Promise<void> {
+		await this.$gradleBuildService.cleanProject(projectRoot, <any>{ release: false });
 	}
 
 	public async cleanDeviceTempFolder(deviceIdentifier: string, projectData: IProjectData): Promise<void> {

--- a/lib/services/android/gradle-build-args-service.ts
+++ b/lib/services/android/gradle-build-args-service.ts
@@ -5,21 +5,21 @@ export class GradleBuildArgsService implements IGradleBuildArgsService {
 	constructor(private $androidToolsInfo: IAndroidToolsInfo,
 		private $logger: ILogger) { }
 
-	public getBuildTaskArgs(buildConfig: IAndroidBuildConfig): string[] {
-		const args = this.getBaseTaskArgs(buildConfig);
-		args.unshift(this.getBuildTaskName(buildConfig));
+	public getBuildTaskArgs(buildData: IAndroidBuildData): string[] {
+		const args = this.getBaseTaskArgs(buildData);
+		args.unshift(this.getBuildTaskName(buildData));
 
 		return args;
 	}
 
-	public getCleanTaskArgs(buildConfig: IAndroidBuildConfig): string[] {
-		const args = this.getBaseTaskArgs(buildConfig);
+	public getCleanTaskArgs(buildData: IAndroidBuildData): string[] {
+		const args = this.getBaseTaskArgs(buildData);
 		args.unshift("clean");
 
 		return args;
 	}
 
-	private getBaseTaskArgs(buildConfig: IAndroidBuildConfig): string[] {
+	private getBaseTaskArgs(buildData: IAndroidBuildData): string[] {
 		const args = this.getBuildLoggingArgs();
 
 		const toolsInfo = this.$androidToolsInfo.getToolsInfo();
@@ -30,13 +30,13 @@ export class GradleBuildArgsService implements IGradleBuildArgsService {
 			`-PgenerateTypings=${toolsInfo.generateTypings}`
 		);
 
-		if (buildConfig.release) {
+		if (buildData.release) {
 			args.push(
 				"-Prelease",
-				`-PksPath=${path.resolve(buildConfig.keyStorePath)}`,
-				`-Palias=${buildConfig.keyStoreAlias}`,
-				`-Ppassword=${buildConfig.keyStoreAliasPassword}`,
-				`-PksPassword=${buildConfig.keyStorePassword}`
+				`-PksPath=${path.resolve(buildData.keyStorePath)}`,
+				`-Palias=${buildData.keyStoreAlias}`,
+				`-Ppassword=${buildData.keyStoreAliasPassword}`,
+				`-PksPassword=${buildData.keyStorePassword}`
 			);
 		}
 
@@ -56,9 +56,9 @@ export class GradleBuildArgsService implements IGradleBuildArgsService {
 		return args;
 	}
 
-	private getBuildTaskName(buildConfig: IAndroidBuildConfig): string {
-		const baseTaskName = buildConfig.androidBundle ? "bundle" : "assemble";
-		const buildTaskName = buildConfig.release ? `${baseTaskName}${Configurations.Release}` : `${baseTaskName}${Configurations.Debug}`;
+	private getBuildTaskName(buildData: IAndroidBuildData): string {
+		const baseTaskName = buildData.androidBundle ? "bundle" : "assemble";
+		const buildTaskName = buildData.release ? `${baseTaskName}${Configurations.Release}` : `${baseTaskName}${Configurations.Debug}`;
 
 		return buildTaskName;
 	}

--- a/lib/services/android/gradle-build-service.ts
+++ b/lib/services/android/gradle-build-service.ts
@@ -9,10 +9,10 @@ export class GradleBuildService extends EventEmitter implements IGradleBuildServ
 		private $gradleCommandService: IGradleCommandService,
 	) { super(); }
 
-	public async buildProject(projectRoot: string, buildConfig: IAndroidBuildConfig): Promise<void> {
-		const buildTaskArgs = this.$gradleBuildArgsService.getBuildTaskArgs(buildConfig);
+	public async buildProject(projectRoot: string, buildData: IAndroidBuildData): Promise<void> {
+		const buildTaskArgs = this.$gradleBuildArgsService.getBuildTaskArgs(buildData);
 		const spawnOptions = { emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: true };
-		const gradleCommandOptions = { cwd: projectRoot, message: "Gradle build...", stdio: buildConfig.buildOutputStdio, spawnOptions };
+		const gradleCommandOptions = { cwd: projectRoot, message: "Gradle build...", stdio: buildData.buildOutputStdio, spawnOptions };
 
 		await attachAwaitDetach(constants.BUILD_OUTPUT_EVENT_NAME,
 			this.$childProcess,
@@ -21,8 +21,8 @@ export class GradleBuildService extends EventEmitter implements IGradleBuildServ
 		);
 	}
 
-	public async cleanProject(projectRoot: string, buildConfig: IAndroidBuildConfig): Promise<void> {
-		const cleanTaskArgs = this.$gradleBuildArgsService.getCleanTaskArgs(buildConfig);
+	public async cleanProject(projectRoot: string, buildData: IAndroidBuildData): Promise<void> {
+		const cleanTaskArgs = this.$gradleBuildArgsService.getCleanTaskArgs(buildData);
 		const gradleCommandOptions = { cwd: projectRoot, message: "Gradle clean..." };
 		await this.$gradleCommandService.executeCommand(cleanTaskArgs, gradleCommandOptions);
 	}

--- a/lib/services/platform/prepare-native-platform-service.ts
+++ b/lib/services/platform/prepare-native-platform-service.ts
@@ -28,7 +28,7 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 		const hasChanges = hasModulesChange || hasConfigChange || hasChangesRequirePrepare;
 
 		if (changesInfo.hasChanges) {
-			await this.cleanProject(platformData, projectData, { release });
+			await this.cleanProject(platformData, { release });
 		}
 
 		platformData.platformProjectService.prepareAppResources(projectData);
@@ -52,7 +52,7 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 		return hasChanges;
 	}
 
-	private async cleanProject(platformData: IPlatformData, projectData: IProjectData, options: { release: boolean }): Promise<void> {
+	private async cleanProject(platformData: IPlatformData, options: { release: boolean }): Promise<void> {
 		// android build artifacts need to be cleaned up
 		// when switching between debug, release and webpack builds
 		if (platformData.platformNameLowerCase !== "android") {
@@ -67,7 +67,7 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 		const { release: previousWasRelease } = previousPrepareInfo;
 		const { release: currentIsRelease } = options;
 		if (previousWasRelease !== currentIsRelease) {
-			await platformData.platformProjectService.cleanProject(platformData.projectRoot, projectData);
+			await platformData.platformProjectService.cleanProject(platformData.projectRoot);
 		}
 	}
 }

--- a/lib/services/webpack/webpack.d.ts
+++ b/lib/services/webpack/webpack.d.ts
@@ -129,10 +129,9 @@ declare global {
 		/**
 		 * Removes build artifacts specific to the platform
 		 * @param {string} projectRoot The root directory of the native project.
-		 * @param {IProjectData} projectData DTO with information about the project.
 		 * @returns {void}
 		 */
-		cleanProject?(projectRoot: string, projectData: IProjectData): Promise<void>
+		cleanProject?(projectRoot: string): Promise<void>
 
 		/**
 		 * Check the current state of the project, and validate against the options.

--- a/test/services/android/gradle-build-args-service.ts
+++ b/test/services/android/gradle-build-args-service.ts
@@ -18,7 +18,7 @@ function createTestInjector(): IInjector {
 	return injector;
 }
 
-function executeTests(testCases: any[], testFunction: (gradleBuildArgsService: IGradleBuildArgsService, buildConfig: IAndroidBuildConfig) => string[]) {
+function executeTests(testCases: any[], testFunction: (gradleBuildArgsService: IGradleBuildArgsService, buildData: IAndroidBuildData) => string[]) {
 	_.each(testCases, testCase => {
 		it(testCase.name, () => {
 			const injector = createTestInjector();
@@ -102,7 +102,7 @@ describe("GradleBuildArgsService", () => {
 			}
 		];
 
-		executeTests(testCases, (gradleBuildArgsService: IGradleBuildArgsService, buildConfig: IAndroidBuildConfig) => gradleBuildArgsService.getBuildTaskArgs(buildConfig));
+		executeTests(testCases, (gradleBuildArgsService: IGradleBuildArgsService, buildData: IAndroidBuildData) => gradleBuildArgsService.getBuildTaskArgs(buildData));
 	});
 
 	describe("getCleanTaskArgs", () => {
@@ -157,6 +157,6 @@ describe("GradleBuildArgsService", () => {
 			}
 		];
 
-		executeTests(testCases, (gradleBuildArgsService: IGradleBuildArgsService, buildConfig: IAndroidBuildConfig) => gradleBuildArgsService.getCleanTaskArgs(buildConfig));
+		executeTests(testCases, (gradleBuildArgsService: IGradleBuildArgsService, buildData: IAndroidBuildData) => gradleBuildArgsService.getCleanTaskArgs(buildData));
 	});
 });

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -453,7 +453,7 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 	async stopServices(): Promise<ISpawnResult> {
 		return Promise.resolve({ stderr: "", stdout: "", exitCode: 0 });
 	}
-	async cleanProject(projectRoot: string, projectData: IProjectData): Promise<void> {
+	async cleanProject(projectRoot: string): Promise<void> {
 		return Promise.resolve();
 	}
 	async checkForChanges(changesInfo: IProjectChangesInfo, options: any, projectData: IProjectData): Promise<void> {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns run android --emulator --release --key-store-path <pathToKeyStoreFile> --key-store-password <keyStorePassword> --key-store-alias <keyStoreAlias> --key-store-alias-password <keyStoreAliasPassword> ` throws an error `The "path" argument must be of type string. Received type undefined `

## What is the new behavior?
`tns run android --emulator --release --key-store-path <pathToKeyStoreFile> --key-store-password <keyStorePassword> --key-store-alias <keyStoreAlias> --key-store-alias-password <keyStoreAliasPassword>` works correctly

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
