### PR TITLE
fix: handle correctly runtime files

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -37,7 +37,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 						return;
 					}
 
-					const result = this.getUpdatedEmittedFiles(message.emittedFiles);
+					const result = this.getUpdatedEmittedFiles(message.emittedFiles, message.webpackRuntimeFiles);
 
 					const files = result.emittedFiles
 						.filter((file: string) => file.indexOf("App_Resources") === -1)
@@ -173,7 +173,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 		return args;
 	}
 
-	private getUpdatedEmittedFiles(emittedFiles: string[]) {
+	private getUpdatedEmittedFiles(emittedFiles: string[], webpackRuntimeFiles: string[]) {
 		let fallbackFiles: string[] = [];
 		let hotHash;
 		if (emittedFiles.some(x => x.endsWith('.hot-update.json'))) {
@@ -184,6 +184,10 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 				hotHash = hash;
 				// remove bundle/vendor.js files if there's a bundle.XXX.hot-update.js or vendor.XXX.hot-update.js
 				result = result.filter(file => file !== `${name}.js`);
+				if (webpackRuntimeFiles && webpackRuntimeFiles.length) {
+					// remove files containing only the Webpack runtime (e.g. runtime.js)
+					result = result.filter(file => webpackRuntimeFiles.indexOf(file) === -1);
+				}
 			});
 			//if applying of hot update fails, we must fallback to the full files
 			fallbackFiles = emittedFiles.filter(file => result.indexOf(file) === -1);


### PR DESCRIPTION
As we have an issue that the hmr changes are not applied after restarting the application, we  need to skip webpack's runtime chunks when sending files for the HMR updates.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
