### PR TITLE
fix: emit only `bundle.<hash>.hot-update.js` and `<hash>.hot-update.json` files when `--hmr` is provided

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -37,10 +37,9 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 						return;
 					}
 
-					const result = this.getUpdatedEmittedFiles(message.emittedFiles, message.webpackRuntimeFiles);
+					const result = this.getUpdatedEmittedFiles(message.emittedFiles, message.webpackRuntimeFiles, message.entryPointFiles);
 
 					const files = result.emittedFiles
-						.filter((file: string) => file.indexOf("App_Resources") === -1)
 						.map((file: string) => path.join(platformData.appDestinationDirectoryPath, "app", file));
 
 					const data = {
@@ -173,23 +172,25 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 		return args;
 	}
 
-	private getUpdatedEmittedFiles(emittedFiles: string[], webpackRuntimeFiles: string[]) {
+	private getUpdatedEmittedFiles(emittedFiles: string[], webpackRuntimeFiles: string[], entryPointFiles: string[]) {
 		let fallbackFiles: string[] = [];
 		let hotHash;
 		if (emittedFiles.some(x => x.endsWith('.hot-update.json'))) {
 			let result = emittedFiles.slice();
 			const hotUpdateScripts = emittedFiles.filter(x => x.endsWith('.hot-update.js'));
+			if (webpackRuntimeFiles && webpackRuntimeFiles.length) {
+				result = result.filter(file => webpackRuntimeFiles.indexOf(file) === -1);
+			}
+			if (entryPointFiles && entryPointFiles.length) {
+				result = result.filter(file => entryPointFiles.indexOf(file) === -1);
+			}
 			hotUpdateScripts.forEach(hotUpdateScript => {
 				const { name, hash } = this.parseHotUpdateChunkName(hotUpdateScript);
 				hotHash = hash;
 				// remove bundle/vendor.js files if there's a bundle.XXX.hot-update.js or vendor.XXX.hot-update.js
 				result = result.filter(file => file !== `${name}.js`);
-				if (webpackRuntimeFiles && webpackRuntimeFiles.length) {
-					// remove files containing only the Webpack runtime (e.g. runtime.js)
-					result = result.filter(file => webpackRuntimeFiles.indexOf(file) === -1);
-				}
 			});
-			//if applying of hot update fails, we must fallback to the full files
+			// if applying of hot update fails, we must fallback to the full files
 			fallbackFiles = emittedFiles.filter(file => result.indexOf(file) === -1);
 			return { emittedFiles: result, fallbackFiles, hash: hotHash };
 		}


### PR DESCRIPTION


Currently `inspector.modules.js` file is reported on change and this led to the problem that `inspcector-modules.js` file is transferred on every sync. As we need to transfer only `.hot-update` files when `--hmr` is provided, we should exclude all other files.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
