### PR TITLE
fix: unable to start iOS simulator when Android is not setup

### DIFF
--- a/lib/common/mobile/mobile-core/devices-service.ts
+++ b/lib/common/mobile/mobile-core/devices-service.ts
@@ -128,9 +128,6 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		const availableEmulatorsOutput = await this.getEmulatorImages({ platform: options.platform });
 		const emulators = this.$emulatorHelper.getEmulatorsFromAvailableEmulatorsOutput(availableEmulatorsOutput);
 		const errors = this.$emulatorHelper.getErrorsFromAvailableEmulatorsOutput(availableEmulatorsOutput);
-		if (errors.length) {
-			return errors;
-		}
 
 		let emulator = null;
 		if (options.imageIdentifier) {
@@ -140,7 +137,8 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 		}
 
 		if (!emulator) {
-			return [`Unable to find emulator with provided options: ${options}`];
+			const additionalErrors = errors && errors.length ? errors : [];
+			return [`Unable to find emulator with provided options: ${options}`, ...additionalErrors];
 		}
 
 		// emulator is already running


### PR DESCRIPTION
In case CLI is used as a library, you need both Android and iOS to be setup in order to start simulator/emulator. The problem is that we check for errors in the setup before actually checking if we have found simulator/emulator with the specified name.
Change the logic and do not raise errors in case the specified name/id is found. This way you can start iOS Simulator without having any Android setup on local machine.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
