### PR TITLE
fix: debugging on iOS Device is very slow

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3919,9 +3919,9 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ios-device-lib": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.5.1.tgz",
-      "integrity": "sha512-HW96QpgGCCtg5E8rz+758FrieUbwqHFC7c2g6Al2kTIF2iaKBeVXZhONE8PoQPtpm+PrFBBkA9i4ZlyntS2FoA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.5.2.tgz",
+      "integrity": "sha512-OSUcEkyS5AnoLs9g+oONIyPUOFHJNaSR93aep9QeLN6xkaY+fNqfUIIj45AQZDaFUpDcWiqiWr7gMOImqNcoYQ==",
       "requires": {
         "bufferpack": "0.0.6",
         "node-uuid": "1.4.7"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "esprima": "2.7.0",
     "iconv-lite": "0.4.11",
     "inquirer": "6.2.0",
-    "ios-device-lib": "0.5.1",
+    "ios-device-lib": "0.5.2",
     "ios-mobileprovision-finder": "1.0.10",
     "ios-sim-portable": "4.0.9",
     "istextorbinary": "2.2.1",


### PR DESCRIPTION
Debugging on iOS Device is very slow with bundle workflow. The problem is in the way ios-device-lib handles the huge messages. Update the library to its latest version where this issue is resolved.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4226

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
