### PR TITLE
fix: disable the Webpack plugins which require the files from the file system

### DIFF
--- a/resources/test/karma.conf.js
+++ b/resources/test/karma.conf.js
@@ -102,5 +102,7 @@ function setWebpack(config, options) {
     options.webpack = require('./webpack.config')(env);
     delete options.webpack.entry;
     delete options.webpack.output.libraryTarget;
+    const invalidPluginsForUnitTesting = ["GenerateBundleStarterPlugin", "GenerateNativeScriptEntryPointsPlugin"];
+    options.webpack.plugins = options.webpack.plugins.filter(p => !invalidPluginsForUnitTesting.includes(p.constructor.name));
   }
 }


### PR DESCRIPTION
(Karma is compiling only in memory)

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The unit testing command with `bundle` is failing when the `GenerateNativeScriptEntryPointsPlugin` plugin is used.

## What is the new behavior?
The Webpack plugins which require the files from the file system are removed when compiling in Karma.