### PR TITLE
fix: add preview-sync and watchPatterns hooks

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -114,12 +114,8 @@ export class PrepareController extends EventEmitter {
 			return false;
 		}
 
-		const patterns = [
-			path.join(projectData.projectDir, PACKAGE_JSON_FILE_NAME),
-			path.join(projectData.getAppDirectoryPath(), PACKAGE_JSON_FILE_NAME),
-			path.join(projectData.getAppResourcesRelativeDirectoryPath(), platformData.normalizedPlatformName),
-			`node_modules/**/platforms/${platformData.platformNameLowerCase}/`
-		];
+		const patterns = await this.getWatcherPatterns(platformData, projectData);
+
 		const watcherOptions: choki.WatchOptions = {
 			ignoreInitial: true,
 			cwd: projectData.projectDir,
@@ -141,6 +137,18 @@ export class PrepareController extends EventEmitter {
 		const hasNativeChanges = await this.$prepareNativePlatformService.prepareNativePlatform(platformData, projectData, prepareData);
 
 		return hasNativeChanges;
+	}
+
+	@hook('watchPatterns')
+	public async getWatcherPatterns(platformData: IPlatformData, projectData: IProjectData): Promise<string[]> {
+		const patterns = [
+			path.join(projectData.projectDir, PACKAGE_JSON_FILE_NAME),
+			path.join(projectData.getAppDirectoryPath(), PACKAGE_JSON_FILE_NAME),
+			path.join(projectData.getAppResourcesRelativeDirectoryPath(), platformData.normalizedPlatformName),
+			`node_modules/**/platforms/${platformData.platformNameLowerCase}/`
+		];
+
+		return patterns;
 	}
 
 	private emitPrepareEvent(filesChangeEventData: IFilesChangeEventData) {

--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -2,7 +2,7 @@ import { Device, FilesPayload } from "nativescript-preview-sdk";
 import { TrackActionNames, PREPARE_READY_EVENT_NAME } from "../constants";
 import { PrepareController } from "./prepare-controller";
 import { performanceLog } from "../common/decorators";
-import { stringify } from "../common/helpers";
+import { stringify, hook } from "../common/helpers";
 import { HmrConstants } from "../common/constants";
 import { EventEmitter } from "events";
 import { PrepareDataService } from "../services/prepare-data-service";
@@ -17,6 +17,7 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 		private $errors: IErrors,
 		private $hmrStatusService: IHmrStatusService,
 		private $logger: ILogger,
+		public $hooksService: IHooksService,
 		private $prepareController: PrepareController,
 		private $previewAppFilesService: IPreviewAppFilesService,
 		private $previewAppPluginsService: IPreviewAppPluginsService,
@@ -26,6 +27,7 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 		private $prepareDataService: PrepareDataService
 	) { super(); }
 
+	@hook("preview-sync")
 	public async startPreview(data: IPreviewAppLiveSyncData): Promise<IQrCodeImageData> {
 		await this.previewCore(data);
 

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -180,6 +180,10 @@ function createTestInjector(options?: {
 	injector.register("analyticsService", {
 		trackEventActionInGoogleAnalytics: () => ({})
 	});
+	injector.register("hooksService", {
+		executeBeforeHooks: () => ({}),
+		executeAfterHooks: () => ({})
+	});
 
 	return injector;
 }


### PR DESCRIPTION
Add `preview-sync` and `watchPatterns` hooks as some plugins relies on them.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
