### PR TITLE
fix: fix plugin's development workflow

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -4,7 +4,7 @@ import { hook } from "../common/helpers";
 import { performanceLog } from "../common/decorators";
 import { EventEmitter } from "events";
 import * as path from "path";
-import { PREPARE_READY_EVENT_NAME, WEBPACK_COMPILATION_COMPLETE, PACKAGE_JSON_FILE_NAME } from "../constants";
+import { PREPARE_READY_EVENT_NAME, WEBPACK_COMPILATION_COMPLETE, PACKAGE_JSON_FILE_NAME, PLATFORMS_DIR_NAME } from "../constants";
 
 interface IPlatformWatcherData {
 	webpackCompilerProcess: child_process.ChildProcess;
@@ -144,7 +144,7 @@ export class PrepareController extends EventEmitter {
 	public async getWatcherPatterns(platformData: IPlatformData, projectData: IProjectData): Promise<string[]> {
 		const pluginsNativeDirectories = this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir)
 			.filter(dep => dep.nativescript)
-			.map(dep => path.join(dep.directory, "platforms", "ios"));
+			.map(dep => path.join(dep.directory, PLATFORMS_DIR_NAME, platformData.platformNameLowerCase));
 
 		const patterns = [
 			path.join(projectData.projectDir, PACKAGE_JSON_FILE_NAME),

--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -20,6 +20,7 @@ export class PrepareController extends EventEmitter {
 		private $platformController: IPlatformController,
 		public $hooksService: IHooksService,
 		private $logger: ILogger,
+		private $nodeModulesDependenciesBuilder: INodeModulesDependenciesBuilder,
 		private $platformsDataService: IPlatformsDataService,
 		private $prepareNativePlatformService: IPrepareNativePlatformService,
 		private $projectChangesService: IProjectChangesService,
@@ -141,12 +142,15 @@ export class PrepareController extends EventEmitter {
 
 	@hook('watchPatterns')
 	public async getWatcherPatterns(platformData: IPlatformData, projectData: IProjectData): Promise<string[]> {
+		const pluginsNativeDirectories = this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir)
+			.filter(dep => dep.nativescript)
+			.map(dep => path.join(dep.directory, "platforms", "ios"));
+
 		const patterns = [
 			path.join(projectData.projectDir, PACKAGE_JSON_FILE_NAME),
 			path.join(projectData.getAppDirectoryPath(), PACKAGE_JSON_FILE_NAME),
 			path.join(projectData.getAppResourcesRelativeDirectoryPath(), platformData.normalizedPlatformName),
-			`node_modules/**/platforms/${platformData.platformNameLowerCase}/`
-		];
+		].concat(pluginsNativeDirectories);
 
 		return patterns;
 	}

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -302,9 +302,8 @@ export class RunController extends EventEmitter implements IRunController {
 
 			try {
 				if (data.hasNativeChanges) {
-					if (await this.$prepareNativePlatformService.prepareNativePlatform(platformData, projectData, prepareData)) {
-						await deviceDescriptor.buildAction();
-					}
+					await this.$prepareNativePlatformService.prepareNativePlatform(platformData, projectData, prepareData);
+					await deviceDescriptor.buildAction();
 				}
 
 				const isInHMRMode = liveSyncInfo.useHotModuleReload && data.hmrData && data.hmrData.hash;

--- a/test/controllers/prepare-controller.ts
+++ b/test/controllers/prepare-controller.ts
@@ -45,6 +45,10 @@ function createTestInjector(data: { hasNativeChanges: boolean }): IInjector {
 
 	injector.register("prepareController", PrepareController);
 
+	injector.register("nodeModulesDependenciesBuilder", {
+		getProductionDependencies: () => (<any>[])
+	});
+
 	const prepareController: PrepareController = injector.resolve("prepareController");
 	prepareController.emit = (eventName: string, eventData: any) => {
 		emittedEventNames.push(eventName);


### PR DESCRIPTION
Currently CLI provides the following watch patterns `node_modules/**/platforms/<platform>` to `chokidar`. The plugin developers have `symlinked` plugin's source code inside the plugin's demo projects. When the plugin's demo project is ran and a `.js` or `.ts` file is changed in `src` folder of a plugin, `chokidar` reports it as a changed file. It seems as an issue with the way how `symlinked` files are processed from `chokidar` itself. This led to a problem that when a file from plugin's src folder is changed, CLI receives changed event for this file twice - ones from `chokidar` and ones from `webpack's watcher`. After that CLI restarts the application as a change from "native watcher" is received. In order to fix this issue, we changed the patterns provided to choki as we removed the glob pattern and provides only full paths to all nativescript's plugins of the application.

Also this PR removes the check if a native build should be executed and the project is built every time when chokidar reports changed files. This check was based on the result of `prepareNativePlatform` method. This method checks if there are newer files in nativescript's plugins of the application - it traverses all nativescript's plugins file by file and compares the modify time of each file with the modify time of `.nsprepareinfo` file from `platforms` folder. If a newer files from nativescript's plugins of the application is found, CLI returns that there is a native change. This actually doesn't work in case when a file from plugin's src folder is changed, as CLI checks only files from node_modules/<plugin-name>. In this case CLI reports that there is no native change.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
