### PR TITLE
fix: save correct .nsprepareinfo file on cloud commands

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -47,7 +47,7 @@ export class PrepareController extends EventEmitter {
 			result = { hasNativeChanges, platform: prepareData.platform.toLowerCase() };
 		}
 
-		this.$projectChangesService.savePrepareInfo(platformData);
+		await this.$projectChangesService.savePrepareInfo(platformData, projectData, prepareData);
 
 		this.$logger.info(`Project successfully prepared (${prepareData.platform.toLowerCase()})`);
 

--- a/lib/services/platform/add-platform-service.ts
+++ b/lib/services/platform/add-platform-service.ts
@@ -61,7 +61,7 @@ export class AddPlatformService implements IAddPlatformService {
 		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
 		await platformData.platformProjectService.interpolateData(projectData);
 		platformData.platformProjectService.afterCreateProject(platformData.projectRoot, projectData);
-		this.$projectChangesService.setNativePlatformStatus(platformData, { nativePlatformStatus: NativePlatformStatus.requiresPrepare });
+		await this.$projectChangesService.setNativePlatformStatus(platformData, projectData, { nativePlatformStatus: NativePlatformStatus.requiresPrepare });
 	}
 }
 $injector.register("addPlatformService", AddPlatformService);

--- a/lib/services/platform/prepare-native-platform-service.ts
+++ b/lib/services/platform/prepare-native-platform-service.ts
@@ -47,7 +47,7 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 		}
 
 		platformData.platformProjectService.interpolateConfigurationFile(projectData);
-		this.$projectChangesService.setNativePlatformStatus(platformData, { nativePlatformStatus: NativePlatformStatus.alreadyPrepared });
+		await this.$projectChangesService.setNativePlatformStatus(platformData, projectData, { nativePlatformStatus: NativePlatformStatus.alreadyPrepared });
 
 		return hasChanges;
 	}

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -136,12 +136,16 @@ export class ProjectChangesService implements IProjectChangesService {
 		return prepareInfo;
 	}
 
-	public savePrepareInfo(platformData: IPlatformData): void {
+	public async savePrepareInfo(platformData: IPlatformData, projectData: IProjectData, prepareData: IPrepareData): Promise<void> {
+		if (!this._prepareInfo) {
+			await this.ensurePrepareInfo(platformData, projectData, prepareData);
+		}
+
 		const prepareInfoFilePath = this.getPrepareInfoFilePath(platformData);
 		this.$fs.writeJson(prepareInfoFilePath, this._prepareInfo);
 	}
 
-	public setNativePlatformStatus(platformData: IPlatformData, addedPlatform: IAddedNativePlatform): void {
+	public async setNativePlatformStatus(platformData: IPlatformData, projectData: IProjectData, addedPlatform: IAddedNativePlatform): Promise<void> {
 		this._prepareInfo = this._prepareInfo || this.getPrepareInfo(platformData);
 		if (this._prepareInfo && addedPlatform.nativePlatformStatus === NativePlatformStatus.alreadyPrepared) {
 			this._prepareInfo.nativePlatformStatus = addedPlatform.nativePlatformStatus;
@@ -151,7 +155,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			};
 		}
 
-		this.savePrepareInfo(platformData);
+		await this.savePrepareInfo(platformData, projectData, null);
 	}
 
 	private async ensurePrepareInfo(platformData: IPlatformData, projectData: IProjectData, prepareData: PrepareData): Promise<boolean> {

--- a/lib/services/webpack/webpack.d.ts
+++ b/lib/services/webpack/webpack.d.ts
@@ -19,8 +19,8 @@ declare global {
 		checkForChanges(platformData: IPlatformData, projectData: IProjectData, prepareData: IPrepareData): Promise<IProjectChangesInfo>;
 		getPrepareInfoFilePath(platformData: IPlatformData): string;
 		getPrepareInfo(platformData: IPlatformData): IPrepareInfo;
-		savePrepareInfo(platformData: IPlatformData): void;
-		setNativePlatformStatus(platformData: IPlatformData, addedPlatform: IAddedNativePlatform): void;
+		savePrepareInfo(platformData: IPlatformData, projectData: IProjectData, prepareData: IPrepareData): Promise<void>;
+		setNativePlatformStatus(platformData: IPlatformData, projectData: IProjectData, addedPlatform: IAddedNativePlatform): void;
 		currentChanges: IProjectChangesInfo;
 	}
 

--- a/test/project-changes-service.ts
+++ b/test/project-changes-service.ts
@@ -170,9 +170,9 @@ describe("Project Changes Service Tests", () => {
 	});
 
 	describe("setNativePlatformStatus", () => {
-		it("creates prepare info and sets only the native platform status when there isn't an existing prepare info", () => {
+		it("creates prepare info and sets only the native platform status when there isn't an existing prepare info", async () => {
 			for (const platform of ["ios", "android"]) {
-				serviceTest.projectChangesService.setNativePlatformStatus(serviceTest.getPlatformData(platform), { nativePlatformStatus: Constants.NativePlatformStatus.requiresPrepare });
+				await serviceTest.projectChangesService.setNativePlatformStatus(serviceTest.getPlatformData(platform), serviceTest.projectData, { nativePlatformStatus: Constants.NativePlatformStatus.requiresPrepare });
 
 				const actualPrepareInfo = serviceTest.projectChangesService.getPrepareInfo(serviceTest.getPlatformData(platform));
 
@@ -183,10 +183,10 @@ describe("Project Changes Service Tests", () => {
 		it(`shouldn't reset prepare info when native platform status is ${Constants.NativePlatformStatus.alreadyPrepared} and there is existing prepare info`, async () => {
 			for (const platform of ["ios", "android"]) {
 				await serviceTest.projectChangesService.checkForChanges(serviceTest.getPlatformData(platform), serviceTest.projectData, <any>{});
-				serviceTest.projectChangesService.savePrepareInfo(serviceTest.getPlatformData(platform));
+				await serviceTest.projectChangesService.savePrepareInfo(serviceTest.getPlatformData(platform), serviceTest.projectData, null);
 				const prepareInfo = serviceTest.projectChangesService.getPrepareInfo(serviceTest.getPlatformData(platform));
 
-				serviceTest.projectChangesService.setNativePlatformStatus(serviceTest.getPlatformData(platform), { nativePlatformStatus: Constants.NativePlatformStatus.alreadyPrepared });
+				await serviceTest.projectChangesService.setNativePlatformStatus(serviceTest.getPlatformData(platform), serviceTest.projectData, { nativePlatformStatus: Constants.NativePlatformStatus.alreadyPrepared });
 
 				const actualPrepareInfo = serviceTest.projectChangesService.getPrepareInfo(serviceTest.getPlatformData(platform));
 				prepareInfo.nativePlatformStatus = Constants.NativePlatformStatus.alreadyPrepared;
@@ -198,7 +198,7 @@ describe("Project Changes Service Tests", () => {
 			it(`should reset prepare info when native platform status is ${nativePlatformStatus} and there is existing prepare info`, async () => {
 				for (const platform of ["ios", "android"]) {
 					await serviceTest.projectChangesService.checkForChanges(serviceTest.getPlatformData(platform), serviceTest.projectData, <any>{});
-					serviceTest.projectChangesService.setNativePlatformStatus(serviceTest.getPlatformData(platform), { nativePlatformStatus: nativePlatformStatus });
+					await serviceTest.projectChangesService.setNativePlatformStatus(serviceTest.getPlatformData(platform), serviceTest.projectData, { nativePlatformStatus: nativePlatformStatus });
 
 					const actualPrepareInfo = serviceTest.projectChangesService.getPrepareInfo(serviceTest.getPlatformData(platform));
 					assert.deepEqual(actualPrepareInfo, { nativePlatformStatus: nativePlatformStatus });

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -749,7 +749,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		return null;
 	}
 
-	public savePrepareInfo(platformData: IPlatformData): void {
+	public async savePrepareInfo(platformData: IPlatformData, projectData: IProjectData, prepareData: IPrepareData): Promise<void> {
 	}
 
 	public getPrepareInfoFilePath(platformData: IPlatformData): string {
@@ -760,7 +760,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		return <IProjectChangesInfo>{};
 	}
 
-	public setNativePlatformStatus(platformData: IPlatformData, addedPlatform: IAddedNativePlatform): void {
+	public async setNativePlatformStatus(platformData: IPlatformData, projectData: IProjectData, addedPlatform: IAddedNativePlatform): Promise<void> {
 		return;
 	}
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
