### PR TITLE
Add time(hours, minutes and seconds) to cli version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ branches:
 env:
   global:
   - DATE=$(date +%Y-%m-%d)
-  - PACKAGE_VERSION=$DATE-$TRAVIS_BUILD_NUMBER
+  - TIME=$(date +%H%M%S)
+  - PACKAGE_VERSION=$DATE-$TIME-$TRAVIS_BUILD_NUMBER
   - NATIVESCRIPT_SKIP_POSTINSTALL_TASKS=1
 language: node_js
 node_js:


### PR DESCRIPTION
All other packages in Nativescript(e.g. Runtime, Angular...) have time in their version. We are using the time in the version to determine if we need to run tests. We run tests if the package has been released  within the 24 hours period since running the triggering job.