### PR TITLE
fix: restore application when the broken xml file is fixed

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -42,12 +42,14 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 
 					const files = result.emittedFiles
 						.map((file: string) => path.join(platformData.appDestinationDirectoryPath, "app", file));
+					const fallbackFiles = result.fallbackFiles
+						.map((file: string) => path.join(platformData.appDestinationDirectoryPath, "app", file));
 
 					const data = {
 						files,
 						hmrData: {
 							hash: result.hash,
-							fallbackFiles: result.fallbackFiles
+							fallbackFiles
 						}
 					};
 


### PR DESCRIPTION
The files on android device are transferred through socket. When the application is in errorActivity, the runtime reports to the CLI that the application is in broken state (e.g. didRefresh property). In this case NativeScript CLI transfers all fallback files (bundle.js and runtime.js). CLI has a logic to ignore all non-existing files when transferring them on the device. As the fallback files are reported with relative paths, CLI consider them as non-existing and doesn't transfer them on device. So in order to fix this issue, we need to make fallbackFiles with absolute paths.

To reproduce:
1. tns run android
2. Broke some xml file from the application
3. Fix the broken xml file

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
