### PR TITLE
fix: hmr for iOS does not work on Windows

### DIFF
--- a/lib/common/mobile/ios/device/ios-device.ts
+++ b/lib/common/mobile/ios/device/ios-device.ts
@@ -18,6 +18,7 @@ export class IOSDevice extends IOSDeviceBase {
 		private $injector: IInjector,
 		protected $iOSDebuggerPortService: IIOSDebuggerPortService,
 		protected $deviceLogProvider: Mobile.IDeviceLogProvider,
+		protected $logger: ILogger,
 		protected $lockService: ILockService,
 		private $iOSSocketRequestExecutor: IiOSSocketRequestExecutor,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,

--- a/lib/common/mobile/ios/ios-device-base.ts
+++ b/lib/common/mobile/ios/ios-device-base.ts
@@ -7,6 +7,7 @@ export abstract class IOSDeviceBase implements Mobile.IiOSDevice {
 	protected abstract $deviceLogProvider: Mobile.IDeviceLogProvider;
 	protected abstract $iOSDebuggerPortService: IIOSDebuggerPortService;
 	protected abstract $lockService: ILockService;
+	protected abstract $logger: ILogger;
 	abstract deviceInfo: Mobile.IDeviceInfo;
 	abstract applicationManager: Mobile.IDeviceApplicationManager;
 	abstract fileSystem: Mobile.IDeviceFileSystem;
@@ -22,8 +23,12 @@ export abstract class IOSDeviceBase implements Mobile.IiOSDevice {
 				}
 
 				await this.attachToDebuggerFoundEvent(appId, projectName);
-				if (ensureAppStarted) {
-					await this.applicationManager.startApplication({ appId, projectName });
+				try {
+					if (ensureAppStarted) {
+						await this.applicationManager.startApplication({ appId, projectName });
+					}
+				} catch (err) {
+					this.$logger.trace(`Unable to start application ${appId} on device ${this.deviceInfo.identifier} in getDebugSocket method. Error is: ${err}`);
 				}
 
 				this.cachedSockets[appId] = await this.getDebugSocketCore(appId);

--- a/lib/common/mobile/ios/simulator/ios-simulator-device.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-device.ts
@@ -22,7 +22,7 @@ export class IOSSimulator extends IOSDeviceBase implements Mobile.IiOSDevice {
 		private $iOSEmulatorServices: Mobile.IiOSSimulatorService,
 		private $iOSNotification: IiOSNotification,
 		private $iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider,
-		private $logger: ILogger) {
+		protected $logger: ILogger) {
 		super();
 		this.applicationManager = this.$injector.resolve(applicationManagerPath.IOSSimulatorApplicationManager, { iosSim: this.$iOSSimResolver.iOSSim, device: this });
 		this.fileSystem = this.$injector.resolve(fileSystemPath.IOSSimulatorFileSystem, { iosSim: this.$iOSSimResolver.iOSSim });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "5.4.1",
+  "version": "5.4.2",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {


### PR DESCRIPTION
With `tns cloud run ...` command (or with NativeScript Sidekick), you can use LiveSync on iOS device from Windows machine (with application built in the cloud). However, this approach does not work when the iOS device does not have developer disk image mounted (i.e. it has not been used on macOS).
The problem is that during establishment of socket connection, CLI tries to start the application. This is a precautions for cases when the application had crashed. In most of the cases when we reach to this code, the application is already up and running. However, calling `startApplication` fails on Windows and we never setup the socket connection.
So the HMR does not work at all.

Fix this by adding a try-catch block around starting of application when trying to setup the socket connection.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
