### PR TITLE
fix: fix `tns platform list` and `tns platform clean` commands

### DIFF
--- a/lib/helpers/platform-command-helper.ts
+++ b/lib/helpers/platform-command-helper.ts
@@ -43,9 +43,10 @@ export class PlatformCommandHelper implements IPlatformCommandHelper {
 
 	public async cleanPlatforms(platforms: string[], projectData: IProjectData, framworkPath: string): Promise<void> {
 		for (const platform of platforms) {
+			const version: string = this.getCurrentPlatformVersion(platform, projectData);
+
 			await this.removePlatforms([platform], projectData);
 
-			const version: string = this.getCurrentPlatformVersion(platform, projectData);
 			const platformParam = version ? `${platform}@${version}` : platform;
 			await this.addPlatforms([platformParam], projectData, framworkPath);
 		}

--- a/lib/helpers/platform-command-helper.ts
+++ b/lib/helpers/platform-command-helper.ts
@@ -104,7 +104,8 @@ export class PlatformCommandHelper implements IPlatformCommandHelper {
 		}
 
 		const subDirs = this.$fs.readDirectory(projectData.platformsDir);
-		return _.filter(subDirs, p => this.$mobileHelper.platformNames.indexOf(p) > -1);
+		const platforms = this.$mobileHelper.platformNames.map(p => p.toLowerCase());
+		return _.filter(subDirs, p => platforms.indexOf(p) > -1);
 	}
 
 	public getAvailablePlatforms(projectData: IProjectData): string[] {


### PR DESCRIPTION
This PR fixes 2 issues:
 
###  clean command 
`tns clean` command doesn't add the correct platform.
To reproduce:
1. `tns platform add ios@5.1.0`
2. `tns clean` 
Expected: The steps above should delete `ios@5.1.0` and install again `ios@5.1.0`
Actual:  The platform `ios@5.1.0` is deleted but `ios@5.4.0` is added instead.

### platform list
`tns platform list` command doesn't work when there is already added platform. This is due to the fact that NativeScript CLI makes case sensitive comparison when getting already installed platforms.


## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
