### PR TITLE
fix: show warning when --env.snapshot is provided for debug builds

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -1,6 +1,5 @@
 import * as path from "path";
 import * as child_process from "child_process";
-import * as os from "os";
 import { EventEmitter } from "events";
 import { performanceLog } from "../../common/decorators";
 import { hook } from "../../common/helpers";
@@ -12,6 +11,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 	constructor(
 		private $childProcess: IChildProcess,
 		public $hooksService: IHooksService,
+		public $hostInfo: IHostInfo,
 		private $logger: ILogger,
 		private $pluginsService: IPluginsService,
 		private $mobileHelper: Mobile.IMobileHelper
@@ -160,13 +160,12 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 
 	private buildEnvCommandLineParams(envData: any, platformData: IPlatformData, prepareData: IPrepareData) {
 		const envFlagNames = Object.keys(envData);
-		const snapshotEnvIndex = envFlagNames.indexOf("snapshot");
-		const shouldSnapshot = prepareData.release && os.type() !== "Windows_NT" && this.$mobileHelper.isAndroidPlatform(platformData.normalizedPlatformName);
-		if (snapshotEnvIndex > -1 && !shouldSnapshot) {
+		const shouldSnapshot = prepareData.release && !this.$hostInfo.isWindows && this.$mobileHelper.isAndroidPlatform(platformData.normalizedPlatformName);
+		if (envData && envData.snapshot && !shouldSnapshot) {
 			this.$logger.warn("Stripping the snapshot flag. " +
 				"Bear in mind that snapshot is only available in release builds and " +
 				"is NOT available on Windows systems.");
-			envFlagNames.splice(snapshotEnvIndex, 1);
+			envFlagNames.splice(envFlagNames.indexOf("snapshot"), 1);
 		}
 
 		const args: any[] = [];


### PR DESCRIPTION
NativeScript CLI v5.4.0 shows an warning when `--env.snapshot` is provided for debug builds. This PR keeps the same behavior for NativeScript v6.0.0.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
