### PR TITLE
fix: enable passing iOS codesigning options to LiveSync operations

### DIFF
--- a/lib/controllers/debug-controller.ts
+++ b/lib/controllers/debug-controller.ts
@@ -128,7 +128,7 @@ export class DebugController extends EventEmitter implements IDebugController {
 		const attachDebuggerData: IAttachDebuggerData = {
 			deviceIdentifier,
 			isEmulator: currentDeviceInstance.isEmulator,
-			outputPath: deviceDescriptor.outputPath,
+			outputPath: deviceDescriptor.buildData.outputPath,
 			platform: currentDeviceInstance.deviceInfo.platform,
 			projectDir,
 			debugOptions

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -244,9 +244,9 @@ export class RunController extends EventEmitter implements IRunController {
 			const prepareData = this.$prepareDataService.getPrepareData(liveSyncInfo.projectDir, device.deviceInfo.platform,
 				{
 					...liveSyncInfo,
-					watch: !liveSyncInfo.skipWatcher,
-					nativePrepare: { skipNativePrepare: !!deviceDescriptor.skipNativePrepare },
 					...deviceDescriptor.buildData,
+					nativePrepare: { skipNativePrepare: !!deviceDescriptor.skipNativePrepare },
+					watch: !liveSyncInfo.skipWatcher,
 				});
 
 			const prepareResultData = await this.$prepareController.prepare(prepareData);
@@ -321,9 +321,9 @@ export class RunController extends EventEmitter implements IRunController {
 			const prepareData = this.$prepareDataService.getPrepareData(liveSyncInfo.projectDir, device.deviceInfo.platform,
 				{
 					...liveSyncInfo,
-					watch: !liveSyncInfo.skipWatcher,
-					nativePrepare: { skipNativePrepare: !!deviceDescriptor.skipNativePrepare },
 					...deviceDescriptor.buildData,
+					nativePrepare: { skipNativePrepare: !!deviceDescriptor.skipNativePrepare },
+					watch: !liveSyncInfo.skipWatcher,
 				});
 
 			try {

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -335,7 +335,7 @@ export class RunController extends EventEmitter implements IRunController {
 						this.rebuiltInformation[platformData.platformNameLowerCase] = { isEmulator: device.isEmulator, platform: platformData.platformNameLowerCase, packageFilePath: null };
 					}
 
-					this.$deviceInstallAppService.installOnDevice(device, deviceDescriptor.buildData, this.rebuiltInformation[platformData.platformNameLowerCase].packageFilePath);
+					await this.$deviceInstallAppService.installOnDevice(device, deviceDescriptor.buildData, this.rebuiltInformation[platformData.platformNameLowerCase].packageFilePath);
 				}
 
 				const isInHMRMode = liveSyncInfo.useHotModuleReload && data.hmrData && data.hmrData.hash;

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -48,7 +48,7 @@ declare global {
 	/**
 	 * Describes information for LiveSync on a device.
 	 */
-	interface ILiveSyncDeviceDescriptor extends IOptionalOutputPath, IOptionalDebuggingOptions {
+	interface ILiveSyncDeviceDescriptor extends IOptionalDebuggingOptions {
 		/**
 		 * Device identifier.
 		 */
@@ -68,6 +68,11 @@ declare global {
 		 * Whether debugging has been enabled for this device or not
 		 */
 		debuggingEnabled?: boolean;
+
+		/**
+		 * Describes the data used for building the application
+		 */
+		buildData: IBuildData;
 	}
 
 	/**
@@ -80,7 +85,7 @@ declare global {
 		 * Defines if the watcher should be skipped. If not passed, fs.Watcher will be started.
 		 */
 		skipWatcher?: boolean;
-		
+
 		/**
 		 * Forces a build before the initial livesync.
 		 */

--- a/lib/definitions/prepare.d.ts
+++ b/lib/definitions/prepare.d.ts
@@ -9,13 +9,13 @@ declare global {
 		watch?: boolean;
 	}
 
-	interface IiOSPrepareData extends IPrepareData {
+	interface IiOSCodeSigningData {
 		teamId: string;
 		provision: string;
 		mobileProvisionData: any;
 	}
 
-	interface IAndroidPrepareData extends IPrepareData { }
+	interface IiOSPrepareData extends IPrepareData, IiOSCodeSigningData { }
 
 	interface IPrepareDataService {
 		getPrepareData(projectDir: string, platform: string, data: any): IPrepareData;

--- a/lib/helpers/deploy-command-helper.ts
+++ b/lib/helpers/deploy-command-helper.ts
@@ -43,8 +43,8 @@ export class DeployCommandHelper {
 					buildAction,
 					debuggingEnabled: additionalOptions && additionalOptions.deviceDebugMap && additionalOptions.deviceDebugMap[d.deviceInfo.identifier],
 					debugOptions: this.$options,
-					outputPath,
 					skipNativePrepare: additionalOptions && additionalOptions.skipNativePrepare,
+					buildData
 				};
 
 				return info;

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -79,8 +79,8 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 					buildAction,
 					debuggingEnabled: additionalOptions && additionalOptions.deviceDebugMap && additionalOptions.deviceDebugMap[d.deviceInfo.identifier],
 					debugOptions: this.$options,
-					outputPath,
 					skipNativePrepare: additionalOptions && additionalOptions.skipNativePrepare,
+					buildData
 				};
 
 				return info;

--- a/test/controllers/run-controller.ts
+++ b/test/controllers/run-controller.ts
@@ -18,9 +18,9 @@ const projectDir = "/path/to/my/projecDir";
 const buildOutputPath = `${projectDir}/platform/ios/build/myproject.app`;
 
 const iOSDevice = <any>{ deviceInfo: { identifier: "myiOSDevice", platform: "ios" } };
-const iOSDeviceDescriptor = { identifier: "myiOSDevice", buildAction: async () => buildOutputPath };
+const iOSDeviceDescriptor = { identifier: "myiOSDevice", buildAction: async () => buildOutputPath, buildData: <any>{} };
 const androidDevice = <any>{ deviceInfo: { identifier: "myAndroidDevice", platform: "android" } };
-const androidDeviceDescriptor = { identifier: "myAndroidDevice", buildAction: async () => buildOutputPath };
+const androidDeviceDescriptor = { identifier: "myAndroidDevice", buildAction: async () => buildOutputPath, buildData: <any>{} };
 
 const map: IDictionary<{ device: Mobile.IDevice, descriptor: ILiveSyncDeviceDescriptor }> = {
 	myiOSDevice: {


### PR DESCRIPTION
Enable passing iOS Code signing options to operations like run/debug, etc. Currently the provision and teamId options are not passed to the controllers, so we do not use them during project preparation.
To resolve this, include the buildData in the deviceDescriptors - this way we'll have all the codesigning data required for the specific device and we'll also allow having different codesign options for different devices.
Also remove outputPath from deviceDescriptors as we can use it directly from the buildData.
