### PR TITLE
fix: try HMR refresh only when all emitted files are hot updates

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -93,7 +93,7 @@ export class PrepareController extends EventEmitter {
 		this.isInitialPrepareReady = true;
 
 		if (this.persistedData && this.persistedData.length) {
-			this.emitPrepareEvent({ files: [], hasNativeChanges: result.hasNativeChanges, hmrData: null, platform: platformData.platformNameLowerCase });
+			this.emitPrepareEvent({ files: [], hasOnlyHotUpdateFiles: false, hasNativeChanges: result.hasNativeChanges, hmrData: null, platform: platformData.platformNameLowerCase });
 		}
 
 		return result;
@@ -130,7 +130,7 @@ export class PrepareController extends EventEmitter {
 			.on("all", async (event: string, filePath: string) => {
 				filePath = path.join(projectData.projectDir, filePath);
 				this.$logger.trace(`Chokidar raised event ${event} for ${filePath}.`);
-				this.emitPrepareEvent({ files: [], hmrData: null, hasNativeChanges: true, platform: platformData.platformNameLowerCase });
+				this.emitPrepareEvent({ files: [], hasOnlyHotUpdateFiles: false, hmrData: null, hasNativeChanges: true, platform: platformData.platformNameLowerCase });
 			});
 
 		this.watchersData[projectData.projectDir][platformData.platformNameLowerCase].nativeFilesWatcher = watcher;

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -152,7 +152,7 @@ export class RunController extends EventEmitter implements IRunController {
 		const platformLiveSyncService = this.$liveSyncServiceResolver.resolveLiveSyncService(platform);
 
 		try {
-			let shouldRestart = filesChangeEventData && filesChangeEventData.hasNativeChanges;
+			let shouldRestart = filesChangeEventData && (filesChangeEventData.hasNativeChanges || !filesChangeEventData.hasOnlyHotUpdateFiles);
 			if (!shouldRestart) {
 				shouldRestart = await platformLiveSyncService.shouldRestart(projectData, liveSyncResultInfo);
 			}

--- a/lib/services/webpack/webpack.d.ts
+++ b/lib/services/webpack/webpack.d.ts
@@ -28,7 +28,14 @@ declare global {
 		platform: string;
 		files: string[];
 		hmrData: IPlatformHmrData;
+		hasOnlyHotUpdateFiles: boolean;
 		hasNativeChanges: boolean;
+	}
+
+	interface IWebpackEmitMessage {
+		emittedFiles: string[];
+		webpackRuntimeFiles: string[];
+		entryPointFiles: string[];
 	}
 
 	interface IPlatformProjectService extends NodeJS.EventEmitter, IPlatformProjectServiceBase {

--- a/test/controllers/prepare-controller.ts
+++ b/test/controllers/prepare-controller.ts
@@ -103,7 +103,7 @@ describe("prepareController", () => {
 				assert.lengthOf(emittedEventNames, 1);
 				assert.lengthOf(emittedEventData, 1);
 				assert.deepEqual(emittedEventNames[0], PREPARE_READY_EVENT_NAME);
-				assert.deepEqual(emittedEventData[0], { files: [], hasNativeChanges: true, hmrData: null, platform: platform.toLowerCase() });
+				assert.deepEqual(emittedEventData[0], { files: [], hasNativeChanges: true, hasOnlyHotUpdateFiles: false, hmrData: null, platform: platform.toLowerCase() });
 			});
 		});
 	});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

TODO: rebase onto master, add more description, link issue in Webpack

Related to: https://github.com/NativeScript/nativescript-cli/issues/4607