### PR TITLE
fix: pass the max_old_space_size option to nodejs, not webpack

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -117,7 +117,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 		];
 
 		if (process.arch === "x64") {
-			args.push("--max_old_space_size=4096");
+			args.unshift("--max_old_space_size=4096");
 		}
 
 		if (prepareData.watch) {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The memory of the Webpack process it not really increased.

## What is the new behavior?
The memory of the Webpack process is properly increased.