### PR TITLE
feat: migrate unit test related dependencies so `tns test` command can work out of the box with CLI v6.0

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -28,6 +28,7 @@ export const PLATFORMS_DIR_NAME = "platforms";
 export const HOOKS_DIR_NAME = "hooks";
 export const WEBPACK_CONFIG_NAME = "webpack.config.js";
 export const TSCCONFIG_TNS_JSON_NAME = "tsconfig.tns.json";
+export const KARMA_CONFIG_NAME = "karma.conf.js";
 export const LIB_DIR_NAME = "lib";
 export const CODE_SIGN_ENTITLEMENTS = "CODE_SIGN_ENTITLEMENTS";
 export const AWAIT_NOTIFICATION_TIMEOUT_SECONDS = 9;

--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -225,9 +225,9 @@ export class MigrateController extends UpdateControllerBase implements IMigrateC
 		// Migrate karma.conf.js
 		const oldKarmaContent = this.$fs.readText(path.join(migrationBackupDirPath, constants.KARMA_CONFIG_NAME));
 
-		const regExp = /frameworks:\s+\[(\S+)\]\,/g;
+		const regExp = /frameworks:\s+\[([\S\s]*?)\]/g;
 		const matches = regExp.exec(oldKarmaContent);
-		const frameworks = (matches && matches[1]) || '["jasmine"]';
+		const frameworks = (matches && matches[1] && matches[1].trim()) || '["jasmine"]';
 
 		const testsDir = path.join(projectData.appDirectoryPath, 'tests');
 		const relativeTestsDir = path.relative(projectData.projectDir, testsDir);

--- a/lib/controllers/update-controller-base.ts
+++ b/lib/controllers/update-controller-base.ts
@@ -34,18 +34,13 @@ export class UpdateControllerBase {
 
 	protected hasDependency(dependency: IDependency, projectData: IProjectData): boolean {
 		const collection = dependency.isDev ? projectData.devDependencies : projectData.dependencies;
-		if (collection && collection[dependency.packageName]) {
-			return true;
-		}
+		return collection && collection[dependency.packageName];
 	}
 
 	protected hasRuntimeDependency({platform, projectData}: {platform: string, projectData: IProjectData}): boolean {
 		const lowercasePlatform = platform.toLowerCase();
 		const currentPlatformVersion = this.$platformCommandHelper.getCurrentPlatformVersion(lowercasePlatform, projectData);
-
-		if (currentPlatformVersion) {
-			return true;
-		}
+		return !!currentPlatformVersion;
 	}
 
 	protected async getMaxRuntimeVersion({platform, projectData}: {platform: string, projectData: IProjectData}) {

--- a/lib/definitions/migrate.d.ts
+++ b/lib/definitions/migrate.d.ts
@@ -13,4 +13,6 @@ interface IMigrationDependency extends IDependency {
 	replaceWith?: string;
 	verifiedVersion?: string;
 	shouldAddIfMissing?: boolean;
+	shouldMigrateAction?: (projectData: IProjectData) => boolean;
+	migrateAction?: (projectData: IProjectData, migrationBackupDirPath: string) => Promise<IMigrationDependency[]>;
 }


### PR DESCRIPTION
This PR makes the following changes:
* install the latest nativescript-unit-test-runner
* install the latest karma-webpack
* update karma
* update karma.conf.js
* update karma-* plugins

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
