### PR TITLE
fix: fix native change during livesync

### DIFF
--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -352,6 +352,7 @@ export class RunController extends EventEmitter implements IRunController {
 					}
 
 					await this.$deviceInstallAppService.installOnDevice(device, deviceDescriptor.buildData, this.rebuiltInformation[platformData.platformNameLowerCase].packageFilePath);
+					await platformLiveSyncService.syncAfterInstall(device, watchInfo);
 					await platformLiveSyncService.restartApplication(projectData, { deviceAppData, modifiedFilesData: [], isFullSync: false, useHotModuleReload: liveSyncInfo.useHotModuleReload });
 				} else {
 					const isInHMRMode = liveSyncInfo.useHotModuleReload && data.hmrData && data.hmrData.hash;

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -124,6 +124,16 @@ export class RunController extends EventEmitter implements IRunController {
 			await this.refreshApplicationWithDebug(projectData, liveSyncResultInfo, filesChangeEventData, deviceDescriptor, settings) :
 			await this.refreshApplicationWithoutDebug(projectData, liveSyncResultInfo, filesChangeEventData, deviceDescriptor, settings);
 
+		const device = liveSyncResultInfo.deviceAppData.device;
+
+		this.emitCore(RunOnDeviceEvents.runOnDeviceExecuted, {
+			projectDir: projectData.projectDir,
+			deviceIdentifier: device.deviceInfo.identifier,
+			applicationIdentifier: projectData.projectIdentifiers[device.deviceInfo.platform.toLowerCase()],
+			syncedFiles: liveSyncResultInfo.modifiedFilesData.map(m => m.getLocalPath()),
+			isFullSync: liveSyncResultInfo.isFullSync
+		});
+
 		return result;
 	}
 
@@ -282,14 +292,6 @@ export class RunController extends EventEmitter implements IRunController {
 
 				await this.refreshApplication(projectData, liveSyncResultInfo, null, deviceDescriptor);
 
-				this.emitCore(RunOnDeviceEvents.runOnDeviceExecuted, {
-					projectDir: projectData.projectDir,
-					deviceIdentifier: device.deviceInfo.identifier,
-					applicationIdentifier: projectData.projectIdentifiers[device.deviceInfo.platform.toLowerCase()],
-					syncedFiles: liveSyncResultInfo.modifiedFilesData.map(m => m.getLocalPath()),
-					isFullSync: liveSyncResultInfo.isFullSync
-				});
-
 				this.$logger.info(`Successfully synced application ${liveSyncResultInfo.deviceAppData.appIdentifier} on device ${liveSyncResultInfo.deviceAppData.device.deviceInfo.identifier}.`);
 
 				this.emitCore(RunOnDeviceEvents.runOnDeviceStarted, {
@@ -327,22 +329,6 @@ export class RunController extends EventEmitter implements IRunController {
 				});
 
 			try {
-				if (data.hasNativeChanges) {
-					const rebuiltInfo = this.rebuiltInformation[platformData.platformNameLowerCase] && (this.$mobileHelper.isAndroidPlatform(platformData.platformNameLowerCase) || this.rebuiltInformation[platformData.platformNameLowerCase].isEmulator === device.isEmulator);
-					if (!rebuiltInfo) {
-						await this.$prepareNativePlatformService.prepareNativePlatform(platformData, projectData, prepareData);
-						await deviceDescriptor.buildAction();
-						this.rebuiltInformation[platformData.platformNameLowerCase] = { isEmulator: device.isEmulator, platform: platformData.platformNameLowerCase, packageFilePath: null };
-					}
-
-					await this.$deviceInstallAppService.installOnDevice(device, deviceDescriptor.buildData, this.rebuiltInformation[platformData.platformNameLowerCase].packageFilePath);
-				}
-
-				const isInHMRMode = liveSyncInfo.useHotModuleReload && data.hmrData && data.hmrData.hash;
-				if (isInHMRMode) {
-					this.$hmrStatusService.watchHmrStatus(device.deviceInfo.identifier, data.hmrData.hash);
-				}
-
 				const platformLiveSyncService = this.$liveSyncServiceResolver.resolveLiveSyncService(device.deviceInfo.platform);
 				const watchInfo = {
 					liveSyncDeviceData: deviceDescriptor,
@@ -355,53 +341,52 @@ export class RunController extends EventEmitter implements IRunController {
 					force: liveSyncInfo.force,
 					connectTimeout: 1000
 				};
-				let liveSyncResultInfo = await platformLiveSyncService.liveSyncWatchAction(device, watchInfo);
+				const deviceAppData = await platformLiveSyncService.getAppData(_.merge({ device, watch: true }, watchInfo));
 
-				await this.refreshApplication(projectData, liveSyncResultInfo, data, deviceDescriptor);
+				if (data.hasNativeChanges) {
+					const rebuiltInfo = this.rebuiltInformation[platformData.platformNameLowerCase] && (this.$mobileHelper.isAndroidPlatform(platformData.platformNameLowerCase) || this.rebuiltInformation[platformData.platformNameLowerCase].isEmulator === device.isEmulator);
+					if (!rebuiltInfo) {
+						await this.$prepareNativePlatformService.prepareNativePlatform(platformData, projectData, prepareData);
+						await deviceDescriptor.buildAction();
+						this.rebuiltInformation[platformData.platformNameLowerCase] = { isEmulator: device.isEmulator, platform: platformData.platformNameLowerCase, packageFilePath: null };
+					}
 
-				this.emitCore(RunOnDeviceEvents.runOnDeviceExecuted, {
+					await this.$deviceInstallAppService.installOnDevice(device, deviceDescriptor.buildData, this.rebuiltInformation[platformData.platformNameLowerCase].packageFilePath);
+					await platformLiveSyncService.restartApplication(projectData, { deviceAppData, modifiedFilesData: [], isFullSync: false, useHotModuleReload: liveSyncInfo.useHotModuleReload });
+				} else {
+					const isInHMRMode = liveSyncInfo.useHotModuleReload && data.hmrData && data.hmrData.hash;
+					if (isInHMRMode) {
+						this.$hmrStatusService.watchHmrStatus(device.deviceInfo.identifier, data.hmrData.hash);
+					}
+
+					let liveSyncResultInfo = await platformLiveSyncService.liveSyncWatchAction(device, watchInfo);
+
+					if (!liveSyncResultInfo.didRecover && isInHMRMode) {
+						const status = await this.$hmrStatusService.getHmrStatus(device.deviceInfo.identifier, data.hmrData.hash);
+						if (status === HmrConstants.HMR_ERROR_STATUS) {
+							watchInfo.filesToSync = data.hmrData.fallbackFiles;
+							liveSyncResultInfo = await platformLiveSyncService.liveSyncWatchAction(device, watchInfo);
+							// We want to force a restart of the application.
+							liveSyncResultInfo.isFullSync = true;
+							await this.refreshApplication(projectData, liveSyncResultInfo, data, deviceDescriptor);
+						}
+					}
+
+					await this.refreshApplication(projectData, liveSyncResultInfo, data, deviceDescriptor);
+				}
+
+				this.$logger.info(`Successfully synced application ${deviceAppData.appIdentifier} on device ${device.deviceInfo.identifier}.`);
+			} catch (err) {
+				this.$logger.warn(`Unable to apply changes for device: ${device.deviceInfo.identifier}. Error is: ${err && err.message}.`);
+
+				this.emitCore(RunOnDeviceEvents.runOnDeviceError, {
 					projectDir: projectData.projectDir,
 					deviceIdentifier: device.deviceInfo.identifier,
 					applicationIdentifier: projectData.projectIdentifiers[device.deviceInfo.platform.toLowerCase()],
-					syncedFiles: liveSyncResultInfo.modifiedFilesData.map(m => m.getLocalPath()),
-					isFullSync: liveSyncResultInfo.isFullSync
+					error: err,
 				});
 
-				if (!liveSyncResultInfo.didRecover && isInHMRMode) {
-					const status = await this.$hmrStatusService.getHmrStatus(device.deviceInfo.identifier, data.hmrData.hash);
-					if (status === HmrConstants.HMR_ERROR_STATUS) {
-						watchInfo.filesToSync = data.hmrData.fallbackFiles;
-						liveSyncResultInfo = await platformLiveSyncService.liveSyncWatchAction(device, watchInfo);
-						// We want to force a restart of the application.
-						liveSyncResultInfo.isFullSync = true;
-						await this.refreshApplication(projectData, liveSyncResultInfo, data, deviceDescriptor);
-
-						this.emitCore(RunOnDeviceEvents.runOnDeviceExecuted, {
-							projectDir: projectData.projectDir,
-							deviceIdentifier: device.deviceInfo.identifier,
-							applicationIdentifier: projectData.projectIdentifiers[device.deviceInfo.platform.toLowerCase()],
-							syncedFiles: liveSyncResultInfo.modifiedFilesData.map(m => m.getLocalPath()),
-							isFullSync: liveSyncResultInfo.isFullSync
-						});
-					}
-				}
-
-				this.$logger.info(`Successfully synced application ${liveSyncResultInfo.deviceAppData.appIdentifier} on device ${liveSyncResultInfo.deviceAppData.device.deviceInfo.identifier}.`);
-			} catch (err) {
-				const allErrors = (<Mobile.IDevicesOperationError>err).allErrors;
-
-				if (allErrors && _.isArray(allErrors)) {
-					for (const deviceError of allErrors) {
-						this.$logger.warn(`Unable to apply changes for device: ${deviceError.deviceIdentifier}. Error is: ${deviceError.message}.`);
-
-						this.emitCore(RunOnDeviceEvents.runOnDeviceError, {
-							projectDir: projectData.projectDir,
-							deviceIdentifier: device.deviceInfo.identifier,
-							applicationIdentifier: projectData.projectIdentifiers[device.deviceInfo.platform.toLowerCase()],
-							error: err,
-						});
-					}
-				}
+				await this.stop({ projectDir: projectData.projectDir, deviceIdentifiers: [device.deviceInfo.identifier] });
 			}
 		};
 

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -335,7 +335,6 @@ export class RunController extends EventEmitter implements IRunController {
 					projectData,
 					filesToRemove: <any>[],
 					filesToSync: data.files,
-					isReinstalled: false,
 					hmrData: data.hmrData,
 					useHotModuleReload: liveSyncInfo.useHotModuleReload,
 					force: liveSyncInfo.force,

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -250,6 +250,7 @@ declare global {
 		restartApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void>;
 		shouldRestart(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<boolean>;
 		getDeviceLiveSyncService(device: Mobile.IDevice, projectData: IProjectData): INativeScriptDeviceLiveSyncService;
+		getAppData(syncInfo: IFullSyncInfo): Promise<Mobile.IDeviceAppData>;
 	}
 
 	interface IRestartApplicationInfo {

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -251,6 +251,7 @@ declare global {
 		shouldRestart(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<boolean>;
 		getDeviceLiveSyncService(device: Mobile.IDevice, projectData: IProjectData): INativeScriptDeviceLiveSyncService;
 		getAppData(syncInfo: IFullSyncInfo): Promise<Mobile.IDeviceAppData>;
+		syncAfterInstall(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<void>;
 	}
 
 	interface IRestartApplicationInfo {

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -210,7 +210,6 @@ declare global {
 	interface ILiveSyncWatchInfo extends IProjectDataComposition, IHasUseHotModuleReloadOption, IConnectTimeoutOption {
 		filesToRemove: string[];
 		filesToSync: string[];
-		isReinstalled: boolean;
 		liveSyncDeviceData: ILiveSyncDeviceDescriptor;
 		hmrData: IPlatformHmrData;
 		force?: boolean;

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -55,19 +55,16 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		};
 	}
 
-	@performanceLog()
-	public liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<ILiveSyncResultInfo> {
-		if (liveSyncInfo.isReinstalled) {
+	public async syncAfterInstall(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<void> {
+		if (!device.isEmulator) {
 			// In this case we should execute fullsync because iOS Runtime requires the full content of app dir to be extracted in the root of sync dir.
-			return this.fullSync({
+			await this.fullSync({
 				projectData: liveSyncInfo.projectData,
 				device,
 				liveSyncDeviceData: liveSyncInfo.liveSyncDeviceData,
 				watch: true,
 				useHotModuleReload: liveSyncInfo.useHotModuleReload
 			});
-		} else {
-			return super.liveSyncWatchAction(device, liveSyncInfo);
 		}
 	}
 

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -141,7 +141,7 @@ export abstract class PlatformLiveSyncServiceBase {
 		return transferredFiles;
 	}
 
-	protected async getAppData(syncInfo: IFullSyncInfo): Promise<Mobile.IDeviceAppData> {
+	public async getAppData(syncInfo: IFullSyncInfo): Promise<Mobile.IDeviceAppData> {
 		const platform = syncInfo.device.deviceInfo.platform.toLowerCase();
 		const appIdentifier = syncInfo.projectData.projectIdentifiers[platform];
 		const deviceProjectRootOptions: IDeviceProjectRootOptions = _.assign({ appIdentifier }, syncInfo);

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -126,7 +126,7 @@ export abstract class PlatformLiveSyncServiceBase {
 
 		return {
 			modifiedFilesData: modifiedLocalToDevicePaths,
-			isFullSync: liveSyncInfo.isReinstalled,
+			isFullSync: false,
 			deviceAppData,
 			useHotModuleReload: liveSyncInfo.useHotModuleReload
 		};

--- a/lib/services/livesync/platform-livesync-service-base.ts
+++ b/lib/services/livesync/platform-livesync-service-base.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as util from "util";
 import { APP_FOLDER_NAME } from "../../constants";
 import { getHash } from "../../common/helpers";
+import { performanceLog } from "../../common/decorators";
 
 export abstract class PlatformLiveSyncServiceBase {
 	private _deviceLiveSyncServicesCache: IDictionary<INativeScriptDeviceLiveSyncService> = {};
@@ -31,6 +32,8 @@ export abstract class PlatformLiveSyncServiceBase {
 		const shouldRestart = await deviceLiveSyncService.shouldRestart(projectData, liveSyncInfo);
 		return shouldRestart;
 	}
+
+	public async syncAfterInstall(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<void> { /* intentionally left blank */ }
 
 	public async restartApplication(projectData: IProjectData, liveSyncInfo: ILiveSyncResultInfo): Promise<void> {
 		const deviceLiveSyncService = this.getDeviceLiveSyncService(liveSyncInfo.deviceAppData.device, projectData);
@@ -72,6 +75,7 @@ export abstract class PlatformLiveSyncServiceBase {
 		};
 	}
 
+	@performanceLog()
 	public async liveSyncWatchAction(device: Mobile.IDevice, liveSyncInfo: ILiveSyncWatchInfo): Promise<ILiveSyncResultInfo> {
 		const projectData = liveSyncInfo.projectData;
 		const deviceLiveSyncService = this.getDeviceLiveSyncService(device, projectData);


### PR DESCRIPTION
Currently when a native file is changed during livesync on android, NativeScript CLI doesn't show the "Successfully synced application" message. This is due to the reason that NativeScript CLI tries to transfer native file on device (for example AndroidManifest.xml). After timeout of 30seconds, the socket on android device throws "Socket connection timeout" error but CLI doesn't show it as the parsing of received errors is not correct. This PR fixes the followings:
* the behavior when native file is changed during liveSync
* the parsing of errors during livesync
* stops livesync process when an error occurs during livesync

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
