### PR TITLE
fix: dependency won't be migrated if in devDependencies

### DIFF
--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -189,7 +189,7 @@ export class MigrateController extends UpdateControllerBase implements IMigrateC
 		const hasDependency = this.hasDependency(dependency, projectData);
 
 		if (hasDependency && dependency.replaceWith) {
-			this.$pluginsService.removeFromPackageJson(dependency.packageName, dependency.isDev, projectData.projectDir);
+			this.$pluginsService.removeFromPackageJson(dependency.packageName, projectData.projectDir);
 			const replacementDep = _.find(this.migrationDependencies, migrationPackage => migrationPackage.packageName === dependency.replaceWith);
 			if (!replacementDep) {
 				this.$errors.failWithoutHelp("Failed to find replacement dependency.");
@@ -212,8 +212,11 @@ export class MigrateController extends UpdateControllerBase implements IMigrateC
 	}
 
 	private async shouldMigrateDependencyVersion(dependency: IMigrationDependency, projectData: IProjectData): Promise<boolean> {
-		const collection = dependency.isDev ? projectData.devDependencies : projectData.dependencies;
-		const maxSatisfyingVersion = await this.getMaxDependencyVersion(dependency.packageName, collection[dependency.packageName]);
+		const devDependencies = projectData.devDependencies || {};
+		const dependencies = projectData.dependencies || {};
+		const packageName = dependency.packageName;
+		const version = dependencies[packageName] || devDependencies[packageName];
+		const maxSatisfyingVersion = await this.getMaxDependencyVersion(dependency.packageName, version);
 
 		return !(maxSatisfyingVersion && semver.gte(maxSatisfyingVersion, dependency.verifiedVersion));
 	}

--- a/lib/controllers/update-controller-base.ts
+++ b/lib/controllers/update-controller-base.ts
@@ -33,8 +33,10 @@ export class UpdateControllerBase {
 	}
 
 	protected hasDependency(dependency: IDependency, projectData: IProjectData): boolean {
-		const collection = dependency.isDev ? projectData.devDependencies : projectData.dependencies;
-		return collection && collection[dependency.packageName];
+		const devDependencies = projectData.devDependencies;
+		const dependencies = projectData.dependencies;
+
+		return (dependencies && dependencies[dependency.packageName]) || (devDependencies && devDependencies[dependency.packageName]);
 	}
 
 	protected hasRuntimeDependency({platform, projectData}: {platform: string, projectData: IProjectData}): boolean {

--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -121,16 +121,17 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 				continue;
 			}
 
-			if (await this.shouldUpdateDependency(dependency, templateVersion, areDev, projectData)) {
+			if (await this.shouldUpdateDependency(dependency, templateVersion, projectData)) {
 				this.$logger.info(`Updating '${dependency}' to version '${templateVersion}'.`);
 				this.$pluginsService.addToPackageJson(dependency, templateVersion, areDev, projectData.projectDir);
 			}
 		}
 	}
 
-	private async shouldUpdateDependency(dependency: string, targetVersion: string, isDev: boolean, projectData: IProjectData) {
-		const collection = isDev ? projectData.devDependencies : projectData.dependencies;
-		const projectVersion = collection[dependency];
+	private async shouldUpdateDependency(dependency: string, targetVersion: string, projectData: IProjectData) {
+		const devDependencies = projectData.devDependencies || {};
+		const dependencies = projectData.dependencies || {};
+		const projectVersion = dependencies[dependency] || devDependencies[dependency];
 		const maxSatisfyingTargetVersion = await this.getMaxDependencyVersion(dependency, targetVersion);
 		const maxSatisfyingProjectVersion = await this.getMaxDependencyVersion(dependency, projectVersion);
 
@@ -144,7 +145,7 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 				continue;
 			}
 
-			if (await this.shouldUpdateDependency(dependency, templateVersion, areDev, projectData)) {
+			if (await this.shouldUpdateDependency(dependency, templateVersion, projectData)) {
 				return true;
 			}
 		}

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -2,7 +2,7 @@ interface IPluginsService {
 	add(plugin: string, projectData: IProjectData): Promise<void>; // adds plugin by name, github url, local path and et.
 	remove(pluginName: string, projectData: IProjectData): Promise<void>; // removes plugin only by name
 	addToPackageJson(plugin: string, version: string, isDev: boolean, projectDir: string): void;
-	removeFromPackageJson(plugin: string, isDev: boolean, projectDir: string): void;
+	removeFromPackageJson(plugin: string, projectDir: string): void;
 	getAllInstalledPlugins(projectData: IProjectData): Promise<IPluginData[]>;
 	ensureAllDependenciesAreInstalled(projectData: IProjectData): Promise<void>;
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
