### PR TITLE
fix: fix multiple installation on android device

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -223,4 +223,6 @@ $injector.require("applePortalSessionService", "./services/apple-portal/apple-po
 $injector.require("applePortalCookieService", "./services/apple-portal/apple-portal-cookie-service");
 $injector.require("applePortalApplicationService", "./services/apple-portal/apple-portal-application-service");
 
+$injector.require("watchIgnoreListService", "./services/watch-ignore-list-service");
+
 $injector.requirePublicClass("initializeService", "./services/initialize-service");

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -1050,3 +1050,9 @@ interface IPlatformCommandHelper {
 	getPreparedPlatforms(projectData: IProjectData): string[];
 	getCurrentPlatformVersion(platform: string, projectData: IProjectData): string;
 }
+
+interface IWatchIgnoreListService {
+	addFileToIgnoreList(filePath: string): void;
+	removeFileFromIgnoreList(filePath: string): void;
+	isFileInIgnoreList(filePath: string): boolean;
+}

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -20,7 +20,8 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		private $errors: IErrors,
 		private $filesHashService: IFilesHashService,
 		public $hooksService: IHooksService,
-		private $injector: IInjector
+		private $injector: IInjector,
+		private $watchIgnoreListService: IWatchIgnoreListService
 	) { }
 
 	private static MANIFEST_ROOT = {
@@ -189,6 +190,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			this.copySourceSetDirectories(androidSourceDirectories, pluginTempMainSrcDir);
 			await this.setupGradle(pluginTempDir, options.platformsAndroidDirPath, options.projectDir);
 			await this.buildPlugin({ pluginDir: pluginTempDir, pluginName: options.pluginName });
+			this.$watchIgnoreListService.addFileToIgnoreList(path.join(options.aarOutputDir, `${shortPluginName}.aar`));
 			this.copyAar(shortPluginName, pluginTempDir, options.aarOutputDir);
 			this.writePluginHashInfo(pluginSourceFileHashesInfo, pluginTempDir);
 		}

--- a/lib/services/watch-ignore-list-service.ts
+++ b/lib/services/watch-ignore-list-service.ts
@@ -1,0 +1,16 @@
+export class WatchIgnoreListService implements IWatchIgnoreListService {
+	private ignoreMap: IDictionary<boolean> = {};
+
+	public addFileToIgnoreList(filePath: string): void {
+		this.ignoreMap[filePath] = true;
+	}
+
+	public removeFileFromIgnoreList(filePath: string): void {
+		this.ignoreMap[filePath] = false;
+	}
+
+	public isFileInIgnoreList(filePath: string): boolean {
+		return !!this.ignoreMap[filePath];
+	}
+}
+$injector.register("watchIgnoreListService", WatchIgnoreListService);

--- a/test/controllers/prepare-controller.ts
+++ b/test/controllers/prepare-controller.ts
@@ -49,6 +49,11 @@ function createTestInjector(data: { hasNativeChanges: boolean }): IInjector {
 		getProductionDependencies: () => (<any>[])
 	});
 
+	injector.register("watchIgnoreListService", {
+		addFileToIgnoreList: () => ({}),
+		isFileInIgnoreList: () => false
+	});
+
 	const prepareController: PrepareController = injector.resolve("prepareController");
 	prepareController.emit = (eventName: string, eventData: any) => {
 		emittedEventNames.push(eventName);

--- a/test/services/android-plugin-build-service.ts
+++ b/test/services/android-plugin-build-service.ts
@@ -75,6 +75,10 @@ describe('androidPluginBuildService', () => {
 			hasChangesInShasums: (oldHashes: IStringDictionary, newHashes: IStringDictionary): boolean => !!options.hasChangesInShasums
 		});
 
+		testInjector.register("watchIgnoreListService", {
+			addFileToIgnoreList: () => ({})
+		});
+
 		fs = testInjector.resolve("fs");
 		androidBuildPluginService = testInjector.resolve<AndroidPluginBuildService>(AndroidPluginBuildService);
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
