### PR TITLE
fix: debug android --start should allow to debug

### DIFF
--- a/lib/commands/debug.ts
+++ b/lib/commands/debug.ts
@@ -12,6 +12,7 @@ export class DebugPlatformCommand extends ValidatePlatformCommandBase implements
 		$projectData: IProjectData,
 		$options: IOptions,
 		$platformsDataService: IPlatformsDataService,
+		$cleanupService: ICleanupService,
 		protected $logger: ILogger,
 		protected $errors: IErrors,
 		private $debugDataService: IDebugDataService,
@@ -19,6 +20,7 @@ export class DebugPlatformCommand extends ValidatePlatformCommandBase implements
 		private $liveSyncCommandHelper: ILiveSyncCommandHelper,
 		private $androidBundleValidatorHelper: IAndroidBundleValidatorHelper) {
 		super($options, $platformsDataService, $platformValidationService, $projectData);
+		$cleanupService.setShouldDispose(false);
 	}
 
 	public async execute(args: string[]): Promise<void> {
@@ -87,8 +89,7 @@ export class DebugIOSCommand implements ICommand {
 		private $sysInfo: ISysInfo,
 		private $projectData: IProjectData,
 		$iosDeviceOperations: IIOSDeviceOperations,
-		$iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider,
-		$cleanupService: ICleanupService) {
+		$iOSSimulatorLogProvider: Mobile.IiOSSimulatorLogProvider) {
 		this.$projectData.initializeProjectData();
 		// Do not dispose ios-device-lib, so the process will remain alive and the debug application (NativeScript Inspector or Chrome DevTools) will be able to connect to the socket.
 		// In case we dispose ios-device-lib, the socket will be closed and the code will fail when the debug application tries to read/send data to device socket.
@@ -96,7 +97,6 @@ export class DebugIOSCommand implements ICommand {
 		// In case we do not set it to false, the dispose will be called once the command finishes its execution, which will prevent the debugging.
 		$iosDeviceOperations.setShouldDispose(false);
 		$iOSSimulatorLogProvider.setShouldDispose(false);
-		$cleanupService.setShouldDispose(false);
 	}
 
 	public execute(args: string[]): Promise<void> {


### PR DESCRIPTION
`tns debug android --start` should allow you to debug. However, immediately after opening the debug socket we set the cleanupService to clean the forwarded port once CLI process exits. As we have not set the cleanupService in long living mode, CLI calls injector.dispose and this cleans the debug socket.
To handle this, just set the cleanupService in long living mode.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
