### PR TITLE
fix: hmr is working slowly

### DIFF
--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -358,6 +358,7 @@ export class RunController extends EventEmitter implements IRunController {
 					}
 
 					let liveSyncResultInfo = await platformLiveSyncService.liveSyncWatchAction(device, watchInfo);
+					await this.refreshApplication(projectData, liveSyncResultInfo, data, deviceDescriptor);
 
 					if (!liveSyncResultInfo.didRecover && isInHMRMode) {
 						const status = await this.$hmrStatusService.getHmrStatus(device.deviceInfo.identifier, data.hmrData.hash);
@@ -369,8 +370,6 @@ export class RunController extends EventEmitter implements IRunController {
 							await this.refreshApplication(projectData, liveSyncResultInfo, data, deviceDescriptor);
 						}
 					}
-
-					await this.refreshApplication(projectData, liveSyncResultInfo, data, deviceDescriptor);
 				}
 
 				this.$logger.info(`Successfully synced application ${deviceAppData.appIdentifier} on device ${device.deviceInfo.identifier}.`);


### PR DESCRIPTION
In recent changes we've broken HMR - in order to get its status on device, we need to call refresh application and monitor the logs. However, the logic at the moment is - wait for logs and call refresh application after that. This leads to very slow hmr. Also this way application will not be restarted when the HMR fails as we do not monitor the logs at the point when the hmr cannot be applied.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
