### PR TITLE
fix: fix "Could not open file Library/Application Support/LiveSync/app/tns_modules/tns-core-modules/inspector_modules.js for writing" error on iOS device when hmr fails

### DIFF
--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -30,12 +30,10 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 
 		temp.track();
 		const tempZip = temp.path({ prefix: "sync", suffix: ".zip" });
-		const tempApp = temp.mkdirSync("app");
 		this.$logger.trace("Creating zip file: " + tempZip);
-		this.$fs.copyFile(path.join(path.dirname(projectFilesPath), `${APP_FOLDER_NAME}/*`), tempApp);
 
-		await this.$fs.zipFiles(tempZip, this.$fs.enumerateFilesInDirectorySync(tempApp), (res) => {
-			return path.join(APP_FOLDER_NAME, path.relative(tempApp, res));
+		await this.$fs.zipFiles(tempZip, this.$fs.enumerateFilesInDirectorySync(projectFilesPath), (res) => {
+			return path.join(APP_FOLDER_NAME, path.relative(projectFilesPath, res));
 		});
 
 		await device.fileSystem.transferFiles(deviceAppData, [{

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -3,7 +3,7 @@ import * as temp from "temp";
 
 import { IOSDeviceLiveSyncService } from "./ios-device-livesync-service";
 import { PlatformLiveSyncServiceBase } from "./platform-livesync-service-base";
-import { APP_FOLDER_NAME, TNS_MODULES_FOLDER_NAME } from "../../constants";
+import { APP_FOLDER_NAME } from "../../constants";
 import { performanceLog } from "../../common/decorators";
 
 export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements IPlatformLiveSyncService {
@@ -33,8 +33,6 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		const tempApp = temp.mkdirSync("app");
 		this.$logger.trace("Creating zip file: " + tempZip);
 		this.$fs.copyFile(path.join(path.dirname(projectFilesPath), `${APP_FOLDER_NAME}/*`), tempApp);
-
-		this.$fs.deleteDirectory(path.join(tempApp, TNS_MODULES_FOLDER_NAME));
 
 		await this.$fs.zipFiles(tempZip, this.$fs.enumerateFilesInDirectorySync(tempApp), (res) => {
 			return path.join(APP_FOLDER_NAME, path.relative(tempApp, res));


### PR DESCRIPTION
NativeScript CLI zips all files from application except the files from tns-modules. When the runtime unzips the uploaded archive on device, it symlinks the tns_modules folder from app's bundle folder. When hmr fails, CLI transfers fallback files on device in order to apply the change. The `inspector_modules.js` file is part of these fallback files which is located in `tns_modules` folder. In this situation CLI tries to write the file inside /Library/Application Support/LiveSync/app/tns_modules which is symlinked to app's bundle folder. As CLI is not able to write directly to app's bundle folder, the above error is thrown.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
