### PR TITLE
Kddimitrov/fix hanging webpack process

### DIFF
--- a/lib/bash-scripts/terminateProcess.sh
+++ b/lib/bash-scripts/terminateProcess.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+terminateTree() {
+	for cpid in $(/usr/bin/pgrep -P $1); do
+		terminateTree $cpid
+	done
+	kill -9 $1 > /dev/null 2>&1
+}
+
+for pid in $*; do
+	terminateTree $pid
+done

--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -54,7 +54,7 @@ export class PrepareController extends EventEmitter {
 		return result;
 	}
 
-	public stopWatchers(projectDir: string, platform: string): void {
+	public async stopWatchers(projectDir: string, platform: string): Promise<void> {
 		const platformLowerCase = platform.toLowerCase();
 
 		if (this.watchersData && this.watchersData[projectDir] && this.watchersData[projectDir][platformLowerCase] && this.watchersData[projectDir][platformLowerCase].nativeFilesWatcher) {
@@ -63,7 +63,7 @@ export class PrepareController extends EventEmitter {
 		}
 
 		if (this.watchersData && this.watchersData[projectDir] && this.watchersData[projectDir][platformLowerCase] && this.watchersData[projectDir][platformLowerCase].webpackCompilerProcess) {
-			this.$webpackCompilerService.stopWebpackCompiler(platform);
+			await this.$webpackCompilerService.stopWebpackCompiler(platform);
 			this.watchersData[projectDir][platformLowerCase].webpackCompilerProcess = null;
 		}
 	}

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -70,12 +70,13 @@ export class RunController extends EventEmitter implements IRunController {
 				.map(descriptor => descriptor.identifier);
 
 			// Handle the case when no more devices left for any of the persisted platforms
-			_.each(liveSyncProcessInfo.platforms, platform => {
+			for (let i = 0; i < liveSyncProcessInfo.platforms.length; i++) {
+				const platform = liveSyncProcessInfo.platforms[i];
 				const devices = this.$devicesService.getDevicesForPlatform(platform);
 				if (!devices || !devices.length) {
-					this.$prepareController.stopWatchers(projectDir, platform);
+					await this.$prepareController.stopWatchers(projectDir, platform);
 				}
-			});
+			}
 
 			// In case deviceIdentifiers are not passed, we should stop the whole LiveSync.
 			if (!deviceIdentifiers || !deviceIdentifiers.length || !liveSyncProcessInfo.deviceDescriptors || !liveSyncProcessInfo.deviceDescriptors.length) {
@@ -83,9 +84,9 @@ export class RunController extends EventEmitter implements IRunController {
 					clearTimeout(liveSyncProcessInfo.timer);
 				}
 
-				_.each(liveSyncProcessInfo.platforms, platform => {
-					this.$prepareController.stopWatchers(projectDir, platform);
-				});
+				for (let k = 0; k < liveSyncProcessInfo.platforms.length; k++) {
+					await this.$prepareController.stopWatchers(projectDir, liveSyncProcessInfo.platforms[k]);
+				}
 
 				liveSyncProcessInfo.isStopped = true;
 

--- a/lib/definitions/cleanup-service.d.ts
+++ b/lib/definitions/cleanup-service.d.ts
@@ -56,4 +56,18 @@ interface ICleanupService extends IShouldDispose, IDisposable {
 	 * @returns {Promise<void>}
 	 */
 	removeCleanupJS(jsCommand: IJSCommand): Promise<void>;
+
+	/**
+	 * Adds a kill action for the process
+	 * @param pid the pid of the process to be killed
+	 * @returns {Promise<void>}
+	 */
+	addKillProcess(pid: string): Promise<void>;
+
+	/**
+	 * Removes the kill action for the process
+	 * @param pid the pid of the process to be killed
+	 * @returns {Promise<void>}
+	 */
+	removeKillProcess(pid: string): Promise<void>;
 }

--- a/lib/definitions/prepare.d.ts
+++ b/lib/definitions/prepare.d.ts
@@ -23,7 +23,7 @@ declare global {
 
 	interface IPrepareController extends EventEmitter {
 		prepare(prepareData: IPrepareData): Promise<IPrepareResultData>;
-		stopWatchers(projectDir: string, platform: string): void;
+		stopWatchers(projectDir: string, platform: string): Promise<void>;
 	}
 
 	interface IPrepareResultData {

--- a/lib/services/cleanup-service.ts
+++ b/lib/services/cleanup-service.ts
@@ -45,6 +45,16 @@ export class CleanupService implements ICleanupService {
 		cleanupProcess.send(<IJSCleanupMessage>{ messageType: CleanupProcessMessage.RemoveJSFileToRequire, jsCommand});
 	}
 
+	public async addKillProcess(pid: string): Promise<void> {
+		const killSpawnCommandInfo = this.getKillProcesSpawnInfo(pid);
+		await this.addCleanupCommand(killSpawnCommandInfo);
+	}
+
+	public async removeKillProcess(pid: string): Promise<void> {
+		const killSpawnCommandInfo = this.getKillProcesSpawnInfo(pid);
+		await this.removeCleanupCommand(killSpawnCommandInfo);
+	}
+
 	@exported("cleanupService")
 	public setCleanupLogFile(filePath: string): void {
 		this.pathToCleanupLogFile = filePath;
@@ -120,6 +130,27 @@ export class CleanupService implements ICleanupService {
 		}
 
 		return cleanupProcessArgs;
+	}
+
+	private getKillProcesSpawnInfo(pid: string): ISpawnCommandInfo {
+		let command;
+		let args;
+		switch (process.platform) {
+			case 'win32':
+				command = "taskkill";
+				args = ["/pid", pid, "/T", "/F"];
+				break;
+
+			default:
+				command = path.join(__dirname, '../bash-scripts/terminateProcess.sh');
+				args = [pid];
+				break;
+		}
+
+		return {
+			command,
+			args
+		};
 	}
 }
 

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -71,7 +71,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 				}
 			});
 
-			childProcess.on("close", (arg: any) => {
+			childProcess.on("close", async (arg: any) => {
 				const exitCode = typeof arg === "number" ? arg : arg && arg.code;
 				if (exitCode === 0) {
 					resolve(childProcess);
@@ -80,6 +80,8 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 					error.code = exitCode;
 					reject(error);
 				}
+
+				await this.$cleanupService.removeKillProcess(childProcess.pid.toString());
 			});
 		});
 	}
@@ -92,7 +94,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 			}
 
 			const childProcess = await this.startWebpackProcess(platformData, projectData, prepareData);
-			childProcess.on("close", (arg: any) => {
+			childProcess.on("close", async (arg: any) => {
 				const exitCode = typeof arg === "number" ? arg : arg && arg.code;
 				if (exitCode === 0) {
 					resolve();
@@ -101,6 +103,8 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 					error.code = exitCode;
 					reject(error);
 				}
+
+				await this.$cleanupService.removeKillProcess(childProcess.pid.toString());
 			});
 		});
 	}

--- a/lib/services/webpack/webpack.d.ts
+++ b/lib/services/webpack/webpack.d.ts
@@ -6,7 +6,7 @@ declare global {
 	interface IWebpackCompilerService extends EventEmitter {
 		compileWithWatch(platformData: IPlatformData, projectData: IProjectData, prepareData: IPrepareData): Promise<any>;
 		compileWithoutWatch(platformData: IPlatformData, projectData: IProjectData, prepareData: IPrepareData): Promise<void>;
-		stopWebpackCompiler(platform: string): void;
+		stopWebpackCompiler(platform: string): Promise<void>;
 	}
 
 	interface IWebpackEnvOptions {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are cases when the CLI exits, but the webpack process stays alive. Most probably reproducible with **TypeScript project**.

## What is the new behavior?
<!-- Describe the changes. -->
The CLI makes shure that the webpack process is killed when the `celeanupService` is disposed.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
