### PR TITLE
fix: don't restart application when lazy loaded code is changed in angular app with uglify option

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -45,7 +45,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 					let result;
 
 					if (prepareData.hmr) {
-						result = this.getUpdatedEmittedFiles(message.emittedFiles, message.webpackRuntimeFiles, message.entryPointFiles);
+						result = this.getUpdatedEmittedFiles(message.emittedFiles, message.chunkFiles);
 					} else {
 						result = { emittedFiles: message.emittedFiles, fallbackFiles: <string[]>[], hash: "" };
 					}
@@ -218,16 +218,13 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 		return args;
 	}
 
-	private getUpdatedEmittedFiles(emittedFiles: string[], webpackRuntimeFiles: string[], entryPointFiles: string[]) {
+	private getUpdatedEmittedFiles(emittedFiles: string[], chunkFiles: string[]) {
 		let fallbackFiles: string[] = [];
 		let hotHash;
 		let result = emittedFiles.slice();
 		const hotUpdateScripts = emittedFiles.filter(x => x.endsWith('.hot-update.js'));
-		if (webpackRuntimeFiles && webpackRuntimeFiles.length) {
-			result = result.filter(file => webpackRuntimeFiles.indexOf(file) === -1);
-		}
-		if (entryPointFiles && entryPointFiles.length) {
-			result = result.filter(file => entryPointFiles.indexOf(file) === -1);
+		if (chunkFiles && chunkFiles.length) {
+			result = result.filter(file => chunkFiles.indexOf(file) === -1);
 		}
 		hotUpdateScripts.forEach(hotUpdateScript => {
 			const { name, hash } = this.parseHotUpdateChunkName(hotUpdateScript);

--- a/lib/services/webpack/webpack.d.ts
+++ b/lib/services/webpack/webpack.d.ts
@@ -34,8 +34,7 @@ declare global {
 
 	interface IWebpackEmitMessage {
 		emittedFiles: string[];
-		webpackRuntimeFiles: string[];
-		entryPointFiles: string[];
+		chunkFiles: string[];
 	}
 
 	interface IPlatformProjectService extends NodeJS.EventEmitter, IPlatformProjectServiceBase {


### PR DESCRIPTION
Currently CLI has a logic to restart the application when one or more of the emitted files from webpack compilation is not hot update. When a lazy loaded code is changed in angular application and uglify option is provided, CLI always restarts the application. (as 0.js, 1.js are reported as changed). This happens due to the fact that CLI omits entry point files and runtime files from emitted files to check if all rest files are hot updates. As the lazy loaded chunks (`0.js`, `1.js`) are neither entry point files nor runtime files, they are not omitted and CLI decides that there is file that is not hot update and restarts the application. This PR changes this behavior and respects only chunk files from webpack compilation. Chunk files are all files except hot update files. Chunk files are: `runtime.js`, `tns_modules/inspector-modules.js`, `bundle.js`, `vendor.js` and all lazy loaded modules in other words runtime files + entry point files + splitted files from compilation + lazy loaded files for angular.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
