### PR TITLE
fix: handle preview issues

### DIFF
--- a/lib/services/livesync/playground/preview-qr-code-service.ts
+++ b/lib/services/livesync/playground/preview-qr-code-service.ts
@@ -44,8 +44,6 @@ export class PreviewQrCodeService implements IPreviewQrCodeService {
 		const qrCodeUrl = this.$previewSdkService.getQrCodeUrl(options);
 		const url = await this.getShortenUrl(qrCodeUrl);
 
-		this.$logger.info("======== qrCodeUrl ======== ", qrCodeUrl);
-
 		this.$logger.info();
 		const message = `${EOL} Generating qrcode for url ${url}.`;
 		this.$logger.trace(message);


### PR DESCRIPTION
#### fix: remove debug qr code message

#### fix: do not start multiple watchers  …
In some cases (for example `tns preview` and scan QR code simultaneously with several devices) we start multiple watchers per platform. We should always have single watcher per platform (one from webpack and one native in fact).

#### fix: handle preview initial sync once per device  …
Handle preview initial sync once per device (in some cases PubNub reports the device multiple times). Also prepare all the files once per platform, not per each device.


## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
