### PR TITLE
fix: preview and run do not work correctly 

### DIFF
--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -79,8 +79,10 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 					this.platformPrepareHandlers[device.platform] = true;
 
 					// TODO: Remove the handler once the preview operation for this platform is stopped
-					this.$prepareController.on(PREPARE_READY_EVENT_NAME, async currentPrepareData => {
-						await this.handlePrepareReadyEvent(data, currentPrepareData.hmrData, currentPrepareData.files, device.platform);
+					this.$prepareController.on(PREPARE_READY_EVENT_NAME, async (currentPrepareData: IFilesChangeEventData) => {
+						if (currentPrepareData.platform.toLowerCase() === device.platform.toLowerCase()) {
+							await this.handlePrepareReadyEvent(data, currentPrepareData.hmrData, currentPrepareData.files, device.platform);
+						}
 					});
 
 				}

--- a/lib/services/ios-log-filter.ts
+++ b/lib/services/ios-log-filter.ts
@@ -13,13 +13,11 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 
 	private partialLine: string = null;
 
-	constructor(private $logger: ILogger,
-		private $loggingLevels: Mobile.ILoggingLevels) {
+	constructor(private $loggingLevels: Mobile.ILoggingLevels) {
 	}
 
 	public filterData(data: string, loggingOptions: Mobile.IDeviceLogOptions = <any>{}): string {
 		const specifiedLogLevel = (loggingOptions.logLevel || '').toUpperCase();
-		this.$logger.trace("Logging options", loggingOptions);
 
 		if (specifiedLogLevel !== this.$loggingLevels.info || !data) {
 			return data;


### PR DESCRIPTION
…
In case there are multiple devices with the same platform, `run command` fails with error `Cannot read property hasNativeChanges of undefined`. The problem is that we return incorrect prepare data.
Also we have a problem in `tns preview` when multiple platforms are used - all files are send multiple times to each device as we have too many started webpack processes (in case you scan fast with devices) and we are also adding handler of the prepare ready event per each device instead per platform. Fix this by handling the event only once per platform

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
