### PR TITLE
fix: before-preview-sync hook has incorrect args

### DIFF
--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -25,7 +25,8 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 		private $previewDevicesService: IPreviewDevicesService,
 		private $previewQrCodeService: IPreviewQrCodeService,
 		private $previewSdkService: IPreviewSdkService,
-		private $prepareDataService: PrepareDataService
+		private $prepareDataService: PrepareDataService,
+		private $projectDataService: IProjectDataService
 	) { super(); }
 
 	public async startPreview(data: IPreviewAppLiveSyncData): Promise<IQrCodeImageData> {
@@ -66,7 +67,8 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 					});
 				}
 
-				await this.$hooksService.executeBeforeHooks("preview-sync", { ...data, platform: device.platform });
+				const projectData = this.$projectDataService.getProjectData(data.projectDir);
+				await this.$hooksService.executeBeforeHooks("preview-sync", { hookArgs: { ...data, platform: device.platform, projectData } });
 
 				if (data.useHotModuleReload) {
 					this.$hmrStatusService.attachToHmrStatusEvent();


### PR DESCRIPTION
The `before-preview-sync` hook has incorrect args - instead of having `hookArgs`, it has an object with data. This causes issues in all plugins which are using it. Get back the correct structure and add `projectData` as it is being used by kinvey-nativescript-sdk's hook.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
