### PR TITLE
fix: iOS device logs are not using source maps initially

### DIFF
--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -32,7 +32,9 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		const tempZip = temp.path({ prefix: "sync", suffix: ".zip" });
 		this.$logger.trace("Creating zip file: " + tempZip);
 
-		await this.$fs.zipFiles(tempZip, this.$fs.enumerateFilesInDirectorySync(projectFilesPath), (res) => {
+		const filesToTransfer = this.$fs.enumerateFilesInDirectorySync(projectFilesPath);
+
+		await this.$fs.zipFiles(tempZip, filesToTransfer, (res) => {
 			return path.join(APP_FOLDER_NAME, path.relative(projectFilesPath, res));
 		});
 
@@ -42,6 +44,8 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 			getRelativeToProjectBasePath: () => "../sync.zip",
 			deviceProjectRootPath: await deviceAppData.getDeviceProjectRootPath()
 		}]);
+
+		await deviceAppData.device.applicationManager.setTransferredAppFiles(filesToTransfer);
 
 		return {
 			deviceAppData,


### PR DESCRIPTION
When you run your app on iOS device for the first time, we execute full sync operation with a zip file. This does not gets in our logic for setting source maps of the transferred files and CLI does not use its logic to parse device logs and show the exact lines from original files.
Fix this by setting the source maps in this case.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Related to https://github.com/NativeScript/nativescript-cli/issues/4604

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
