### PR TITLE
fix: fix issues with Sidekick, cloud builds and multiple projects/devices

### DIFF
--- a/lib/controllers/build-controller.ts
+++ b/lib/controllers/build-controller.ts
@@ -89,10 +89,6 @@ export class BuildController extends EventEmitter implements IBuildController {
 		const outputPath = buildData.outputPath || platformData.getBuildOutputPath(buildData);
 		const changesInfo = this.$projectChangesService.currentChanges || await this.$projectChangesService.checkForChanges(platformData, projectData, buildData);
 
-		if (buildData.release && changesInfo.hasChanges) {
-			return true;
-		}
-
 		if (changesInfo.changesRequireBuild) {
 			return true;
 		}

--- a/lib/controllers/build-controller.ts
+++ b/lib/controllers/build-controller.ts
@@ -87,12 +87,12 @@ export class BuildController extends EventEmitter implements IBuildController {
 		const projectData = this.$projectDataService.getProjectData(buildData.projectDir);
 		const platformData = this.$platformsDataService.getPlatformData(buildData.platform, projectData);
 		const outputPath = buildData.outputPath || platformData.getBuildOutputPath(buildData);
+		const changesInfo = this.$projectChangesService.currentChanges || await this.$projectChangesService.checkForChanges(platformData, projectData, buildData);
 
-		if (buildData.release && this.$projectChangesService.currentChanges.hasChanges) {
+		if (buildData.release && changesInfo.hasChanges) {
 			return true;
 		}
 
-		const changesInfo = this.$projectChangesService.currentChanges || await this.$projectChangesService.checkForChanges(platformData, projectData, buildData);
 		if (changesInfo.changesRequireBuild) {
 			return true;
 		}

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -73,10 +73,6 @@ export class RunController extends EventEmitter implements IRunController {
 		const { projectDir, deviceIdentifiers, stopOptions } = data;
 		const liveSyncProcessInfo = this.$liveSyncProcessDataService.getPersistedData(projectDir);
 		if (liveSyncProcessInfo && !liveSyncProcessInfo.isStopped) {
-			if (this.prepareReadyEventHandler) {
-				this.removeListener(PREPARE_READY_EVENT_NAME, this.prepareReadyEventHandler);
-				this.prepareReadyEventHandler = null;
-			}
 
 			// In case we are coming from error during livesync, the current action is the one that erred (but we are still executing it),
 			// so we cannot await it as this will cause infinite loop.
@@ -113,6 +109,11 @@ export class RunController extends EventEmitter implements IRunController {
 				}
 
 				liveSyncProcessInfo.deviceDescriptors = [];
+
+				if (this.prepareReadyEventHandler) {
+					this.removeListener(PREPARE_READY_EVENT_NAME, this.prepareReadyEventHandler);
+					this.prepareReadyEventHandler = null;
+				}
 
 				const projectData = this.$projectDataService.getProjectData(projectDir);
 				await this.$hooksService.executeAfterHooks('watch', {

--- a/lib/services/platform/prepare-native-platform-service.ts
+++ b/lib/services/platform/prepare-native-platform-service.ts
@@ -15,11 +15,10 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 	@hook('prepareNativeApp')
 	public async prepareNativePlatform(platformData: IPlatformData, projectData: IProjectData, prepareData: IPrepareData): Promise<boolean> {
 		const { nativePrepare, release } = prepareData;
-		if (nativePrepare && nativePrepare.skipNativePrepare) {
-			return false;
-		}
-
 		const changesInfo = await this.$projectChangesService.checkForChanges(platformData, projectData, prepareData);
+		if (nativePrepare && nativePrepare.skipNativePrepare) {
+			return changesInfo.hasChanges;
+		}
 
 		const hasNativeModulesChange = !changesInfo || changesInfo.nativeChanged;
 		const hasConfigChange = !changesInfo || changesInfo.configChanged;


### PR DESCRIPTION
### Fix attaching/detaching from PREPARE_READY_EVENT
Currently we're attaching on `PREPARE_READY_EVENT` when run method is called. As Sidekick is long living process and run on device can be called more than once, we'll have more than one handlers for `PREPARE_READY_EVENT`. This means that we'll sync the changed files more than once. This PR fixes this behavior as ensures that we're attаching only once on `PREPARE_READY_EVENT` event and detaching from it on stop method.

### Don't provide device descriptors initially on syncChangedDataOnDevices
Currently CLI provides deviceDescriptors only initially when `syncChangedDataOnDevices` method is called. As Sidekick can add additional deviceDescriptors, CLI doesn't respect them when files are changed and syncs only initially set deviceDescriptors.

### Fix shouldBuild method for release cloud builds
Currently CLI throws an error for release cloud build as `this.$projectChangesService.currentChanges ` is undefined and CLI is not able to read `.hasChanges` of undefined. `this.$projectChangesService.currentChanges ` is populated when `this.$projectChangesService.checkForChanges` method is called. This method is called from nativePrepeare method which is not called for cloud builds as `skipNativePrepare` flag is true. Due to these reasons `this.$projectChangesService.currentChanges ` is undefined. This PR fixes this behavior as ensures that `this.$projectChangesService.checkForChanges` will be called and `this.$projectChangesService.currentChanges` will be populated.

### Fix `tns run` command when there is both iOS and android device and at least one platform is not added
When `tns run` command is executed and there is both `iOS` and `android` device and at least one platform is not added, CLI adds the missing platform and writes the version in package.json. As the native watcher watches the `package.json` file,  it reports that there is a native change. After that CLI rebuilds again the project as the native change is reported. In order to avoid such behavior, this PR call `checkForChanges` method before syncing the changed files when there is a native change.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
