### PR TITLE
fix: make the update command behave similar to the logic before 6.0.0

### DIFF
--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -4,6 +4,20 @@ import * as constants from "../constants";
 import { UpdateControllerBase } from "./update-controller-base";
 
 export class UpdateController extends UpdateControllerBase implements IUpdateController {
+	private getTemplateManifest: Function;
+	static readonly updatableDependencies: string[] = [constants.TNS_CORE_MODULES_NAME, constants.TNS_CORE_MODULES_WIDGETS_NAME];
+	static readonly folders: string[] = [
+		constants.LIB_DIR_NAME,
+		constants.HOOKS_DIR_NAME,
+		constants.WEBPACK_CONFIG_NAME,
+		constants.PACKAGE_JSON_FILE_NAME,
+		constants.PACKAGE_LOCK_JSON_FILE_NAME
+	];
+
+	static readonly backupFolder: string = ".update_backup";
+	static readonly updateFailMessage: string = "Could not update the project!";
+	static readonly backupFailMessage: string = "Could not backup project folders!";
+
 	constructor(
 		protected $fs: IFileSystem,
 		protected $platformsDataService: IPlatformsDataService,
@@ -16,23 +30,11 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 		private $pluginsService: IPluginsService,
 		private $pacoteService: IPacoteService,
 		private $projectDataService: IProjectDataService) {
-			super($fs, $platformCommandHelper, $platformsDataService, $packageInstallationManager, $packageManager);
-			this.getTemplateManifest = _.memoize(this._getTemplateManifest, (...args) => {
-				return args.join("@");
-			});
+		super($fs, $platformCommandHelper, $platformsDataService, $packageInstallationManager, $packageManager);
+		this.getTemplateManifest = _.memoize(this._getTemplateManifest, (...args) => {
+			return args.join("@");
+		});
 	}
-	private getTemplateManifest: Function;
-	static readonly folders: string[] = [
-		constants.LIB_DIR_NAME,
-		constants.HOOKS_DIR_NAME,
-		constants.WEBPACK_CONFIG_NAME,
-		constants.PACKAGE_JSON_FILE_NAME,
-		constants.PACKAGE_LOCK_JSON_FILE_NAME
-	];
-
-	static readonly backupFolder: string = ".update_backup";
-	static readonly updateFailMessage: string = "Could not update the project!";
-	static readonly backupFailMessage: string = "Could not backup project folders!";
 
 	public async update(updateOptions: IUpdateOptions): Promise<void> {
 		const projectData = this.$projectDataService.getProjectData(updateOptions.projectDir);
@@ -55,16 +57,16 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 		}
 	}
 
-	public async shouldUpdate({projectDir, version}: {projectDir: string, version?: string}): Promise<boolean> {
+	public async shouldUpdate({ projectDir, version }: { projectDir: string, version?: string }): Promise<boolean> {
 		const projectData = this.$projectDataService.getProjectData(projectDir);
 		const templateName = this.getTemplateName(projectData);
 		const templateManifest = await this.getTemplateManifest(templateName, version);
-		const dependencies = templateManifest.dependencies;
-		const devDependencies = templateManifest.devDependencies;
+		const dependencies = this.getUpdatableDependencies(templateManifest.dependencies);
+		const devDependencies = this.getUpdatableDependencies(templateManifest.devDependencies);
 
 		if (
-			await this.hasDependenciesToUpdate({dependencies, areDev: false, projectData}) ||
-			await this.hasDependenciesToUpdate({dependencies: devDependencies, areDev: true, projectData})
+			await this.hasDependenciesToUpdate({ dependencies, areDev: false, projectData }) ||
+			await this.hasDependenciesToUpdate({ dependencies: devDependencies, areDev: true, projectData })
 		) {
 			return true;
 		}
@@ -93,12 +95,14 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 	private async updateProject(projectData: IProjectData, version: string): Promise<void> {
 		const templateName = this.getTemplateName(projectData);
 		const templateManifest = await this.getTemplateManifest(templateName, version);
+		const dependencies = this.getUpdatableDependencies(templateManifest.dependencies);
+		const devDependencies = this.getUpdatableDependencies(templateManifest.devDependencies);
 
 		this.$logger.info("Start updating dependencies.");
-		await this.updateDependencies({ dependencies: templateManifest.dependencies, areDev: false, projectData});
+		await this.updateDependencies({ dependencies, areDev: false, projectData });
 		this.$logger.info("Finished updating dependencies.");
 		this.$logger.info("Start updating devDependencies.");
-		await this.updateDependencies({ dependencies: templateManifest.devDependencies, areDev: true, projectData});
+		await this.updateDependencies({ dependencies: devDependencies, areDev: true, projectData });
 		this.$logger.info("Finished updating devDependencies.");
 
 		this.$logger.info("Start updating runtimes.");
@@ -114,7 +118,7 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 		});
 	}
 
-	private async updateDependencies( {dependencies, areDev, projectData} : {dependencies: IDictionary<string>, areDev: boolean, projectData: IProjectData}) {
+	private async updateDependencies({ dependencies, areDev, projectData }: { dependencies: IDictionary<string>, areDev: boolean, projectData: IProjectData }) {
 		for (const dependency in dependencies) {
 			const templateVersion = dependencies[dependency];
 			if (!this.hasDependency({ packageName: dependency, isDev: areDev }, projectData)) {
@@ -134,11 +138,10 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 		const projectVersion = dependencies[dependency] || devDependencies[dependency];
 		const maxSatisfyingTargetVersion = await this.getMaxDependencyVersion(dependency, targetVersion);
 		const maxSatisfyingProjectVersion = await this.getMaxDependencyVersion(dependency, projectVersion);
-
 		return maxSatisfyingProjectVersion && maxSatisfyingTargetVersion && semver.gt(maxSatisfyingTargetVersion, maxSatisfyingProjectVersion);
 	}
 
-	private async hasDependenciesToUpdate({dependencies, areDev, projectData}: {dependencies: IDictionary<string>, areDev: boolean, projectData:IProjectData}) {
+	private async hasDependenciesToUpdate({ dependencies, areDev, projectData }: { dependencies: IDictionary<string>, areDev: boolean, projectData: IProjectData }) {
 		for (const dependency in dependencies) {
 			const templateVersion = dependencies[dependency];
 			if (!this.hasDependency({ packageName: dependency, isDev: areDev }, projectData)) {
@@ -165,24 +168,30 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 	}
 
 	private async shouldUpdateRuntimeVersion(templateRuntimeVersion: string, frameworkPackageName: string, platform: string, projectData: IProjectData): Promise<boolean> {
-		const hasRuntimeDependency = this.hasRuntimeDependency({platform, projectData});
+		const hasRuntimeDependency = this.hasRuntimeDependency({ platform, projectData });
 
 		if (!hasRuntimeDependency) {
 			return false;
 		}
 
 		const maxTemplateRuntimeVersion = await this.getMaxDependencyVersion(frameworkPackageName, templateRuntimeVersion);
-		const maxRuntimeVersion = await this.getMaxRuntimeVersion({platform, projectData});
+		const maxRuntimeVersion = await this.getMaxRuntimeVersion({ platform, projectData });
 
 		return maxTemplateRuntimeVersion && maxRuntimeVersion && semver.gt(maxTemplateRuntimeVersion, maxRuntimeVersion);
 	}
 
-	private async _getTemplateManifest(templateName: string, version: string) {
-		let packageVersion = version ? version : await this.$packageInstallationManager.getLatestCompatibleVersionSafe(templateName);
-		packageVersion = semver.valid(version) ? version : await this.$packageManager.getTagVersion(templateName, packageVersion);
-		packageVersion = packageVersion ? packageVersion : await this.$packageInstallationManager.getLatestCompatibleVersionSafe(templateName);
+	private async _getTemplateManifest(templateName: string, version?: string) {
+		const packageVersion = semver.valid(version) ||
+			await this.$packageManager.getTagVersion(templateName, version) ||
+			await this.$packageInstallationManager.getLatestCompatibleVersionSafe(templateName);
 
 		return await this.$pacoteService.manifest(`${templateName}@${packageVersion}`, { fullMetadata: true });
+	}
+
+	private getUpdatableDependencies(dependencies: IDictionary<string>): IDictionary<string> {
+		return _.pickBy(dependencies, (value, key) => {
+			return UpdateController.updatableDependencies.indexOf(key) > -1;
+		});
 	}
 
 	private getTemplateName(projectData: IProjectData) {

--- a/lib/package-manager.ts
+++ b/lib/package-manager.ts
@@ -72,6 +72,9 @@ export class PackageManager implements IPackageManager {
 
 	public async getTagVersion(packageName: string, tag: string): Promise<string> {
 		let version: string = null;
+		if (!tag) {
+			return null;
+		}
 
 		try {
 			const result = await this.view(packageName, { "dist-tags": true });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The `update` command is updating all dependencies from the project templates but it doesn't call their update scripts.

## What is the new behavior?
The `update` command is updating only the core-modules and the runtimes as it was before 6.0.0