### PR TITLE
fix: fix cloud deploy command

### DIFF
--- a/lib/common/mobile/mobile-core/devices-service.ts
+++ b/lib/common/mobile/mobile-core/devices-service.ts
@@ -444,7 +444,7 @@ export class DevicesService extends EventEmitter implements Mobile.IDevicesServi
 				}
 			} catch (err) {
 				err.deviceIdentifier = device.deviceInfo.identifier;
-				this.$logger.trace(`Error while executing action on device ${device.deviceInfo.identifier}. The error is ${err}`);
+				this.$logger.trace(`Error while executing action on device ${device.deviceInfo.identifier}. The error is`, err);
 				errors.push(err);
 			}
 		}

--- a/lib/controllers/deploy-controller.ts
+++ b/lib/controllers/deploy-controller.ts
@@ -1,16 +1,18 @@
 export class DeployController {
 
 	constructor(
-		private $buildController: IBuildController,
 		private $deviceInstallAppService: IDeviceInstallAppService,
-		private $devicesService: Mobile.IDevicesService
+		private $devicesService: Mobile.IDevicesService,
+		private $prepareController: IPrepareController
 	) { }
 
 	public async deploy(data: IDeployData): Promise<void> {
 		const { buildData, deviceDescriptors } = data;
 
 		const executeAction = async (device: Mobile.IDevice) => {
-			const packageFilePath = await this.$buildController.prepareAndBuild({ ...buildData, buildForDevice: !device.isEmulator });
+			await this.$prepareController.prepare(buildData);
+			const deviceDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
+			const packageFilePath = await deviceDescriptor.buildAction();
 			await this.$deviceInstallAppService.installOnDevice(device, { ...buildData, buildForDevice: !device.isEmulator }, packageFilePath);
 		};
 

--- a/lib/controllers/deploy-controller.ts
+++ b/lib/controllers/deploy-controller.ts
@@ -7,13 +7,13 @@ export class DeployController {
 	) { }
 
 	public async deploy(data: IDeployData): Promise<void> {
-		const { buildData, deviceDescriptors } = data;
+		const { deviceDescriptors } = data;
 
 		const executeAction = async (device: Mobile.IDevice) => {
-			await this.$prepareController.prepare(buildData);
 			const deviceDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
+			await this.$prepareController.prepare(deviceDescriptor.buildData);
 			const packageFilePath = await deviceDescriptor.buildAction();
-			await this.$deviceInstallAppService.installOnDevice(device, { ...buildData, buildForDevice: !device.isEmulator }, packageFilePath);
+			await this.$deviceInstallAppService.installOnDevice(device, { ...deviceDescriptor.buildData, buildForDevice: !device.isEmulator }, packageFilePath);
 		};
 
 		await this.$devicesService.execute(executeAction, (device: Mobile.IDevice) => _.some(deviceDescriptors, deviceDescriptor => deviceDescriptor.identifier === device.deviceInfo.identifier));

--- a/lib/definitions/run.d.ts
+++ b/lib/definitions/run.d.ts
@@ -8,7 +8,6 @@ declare global {
 	}
 
 	interface IDeployData {
-		buildData: IBuildData;
 		deviceDescriptors: ILiveSyncDeviceDescriptor[];
 	}
 

--- a/lib/helpers/deploy-command-helper.ts
+++ b/lib/helpers/deploy-command-helper.ts
@@ -36,7 +36,7 @@ export class DeployCommandHelper {
 
 				const buildAction = additionalOptions && additionalOptions.buildPlatform ?
 					additionalOptions.buildPlatform.bind(additionalOptions.buildPlatform, d.deviceInfo.platform, buildData, this.$projectData) :
-					this.$buildController.prepareAndBuild.bind(this.$buildController, d.deviceInfo.platform, buildData, this.$projectData);
+					this.$buildController.build.bind(this.$buildController, d.deviceInfo.platform, buildData, this.$projectData);
 
 				const info: ILiveSyncDeviceDescriptor = {
 					identifier: d.deviceInfo.identifier,

--- a/lib/helpers/deploy-command-helper.ts
+++ b/lib/helpers/deploy-command-helper.ts
@@ -36,7 +36,7 @@ export class DeployCommandHelper {
 
 				const buildAction = additionalOptions && additionalOptions.buildPlatform ?
 					additionalOptions.buildPlatform.bind(additionalOptions.buildPlatform, d.deviceInfo.platform, buildData, this.$projectData) :
-					this.$buildController.build.bind(this.$buildController, d.deviceInfo.platform, buildData, this.$projectData);
+					this.$buildController.build.bind(this.$buildController, buildData);
 
 				const info: ILiveSyncDeviceDescriptor = {
 					identifier: d.deviceInfo.identifier,

--- a/lib/helpers/deploy-command-helper.ts
+++ b/lib/helpers/deploy-command-helper.ts
@@ -32,7 +32,7 @@ export class DeployCommandHelper {
 					projectDir: this.$projectData.projectDir
 				});
 
-				const buildData = this.$buildDataService.getBuildData(this.$projectData.projectDir, d.deviceInfo.platform, { ...this.$options, outputPath, buildForDevice: !d.isEmulator });
+				const buildData = this.$buildDataService.getBuildData(this.$projectData.projectDir, d.deviceInfo.platform, { ...this.$options.argv, outputPath, buildForDevice: !d.isEmulator, skipWatcher: !this.$options.watch });
 
 				const buildAction = additionalOptions && additionalOptions.buildPlatform ?
 					additionalOptions.buildPlatform.bind(additionalOptions.buildPlatform, d.deviceInfo.platform, buildData, this.$projectData) :
@@ -50,10 +50,7 @@ export class DeployCommandHelper {
 				return info;
 			});
 
-		await this.$deployController.deploy({
-			buildData: this.$buildDataService.getBuildData(this.$projectData.projectDir, platform, { ...this.$options.argv, skipWatcher: !this.$options.watch }),
-			deviceDescriptors
-		});
+		await this.$deployController.deploy({ deviceDescriptors });
 	}
 }
 $injector.register("deployCommandHelper", DeployCommandHelper);

--- a/lib/helpers/livesync-command-helper.ts
+++ b/lib/helpers/livesync-command-helper.ts
@@ -100,7 +100,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 		const { liveSyncInfo, deviceDescriptors } = await this.executeLiveSyncOperationCore(devices, platform, additionalOptions);
 
 		if (this.$options.release) {
-			await this.runInRelease(platform, deviceDescriptors, liveSyncInfo);
+			await this.runInRelease(platform, deviceDescriptors);
 			return;
 		}
 
@@ -160,7 +160,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 		return { liveSyncInfo, deviceDescriptors };
 	}
 
-	private async runInRelease(platform: string, deviceDescriptors: ILiveSyncDeviceDescriptor[], liveSyncInfo: ILiveSyncInfo): Promise<void> {
+	private async runInRelease(platform: string, deviceDescriptors: ILiveSyncDeviceDescriptor[]): Promise<void> {
 		await this.$devicesService.initialize({
 			platform,
 			deviceId: this.$options.device,
@@ -169,12 +169,7 @@ export class LiveSyncCommandHelper implements ILiveSyncCommandHelper {
 			sdk: this.$options.sdk
 		});
 
-		const buildData = this.$buildDataService.getBuildData(liveSyncInfo.projectDir, platform, { ...this.$options.argv, clean: true, watch: false });
-
-		await this.$deployController.deploy({
-			buildData,
-			deviceDescriptors
-		});
+		await this.$deployController.deploy({ deviceDescriptors });
 
 		for (const deviceDescriptor of deviceDescriptors) {
 			const device = this.$devicesService.getDeviceByIdentifier(deviceDescriptor.identifier);


### PR DESCRIPTION
Currently `tns cloud deploy` command starts local build as the provided buildAction through deviceDescriptor is not executed from deployController.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
