### PR TITLE
fix: migrate fails when karma.config.js is missing

### DIFF
--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -286,23 +286,26 @@ export class MigrateController extends UpdateControllerBase implements IMigrateC
 
 	private async migrateUnitTestRunner(projectData: IProjectData, migrationBackupDirPath: string): Promise<IMigrationDependency[]> {
 		// Migrate karma.conf.js
-		const oldKarmaContent = this.$fs.readText(path.join(migrationBackupDirPath, constants.KARMA_CONFIG_NAME));
+		const pathToKarmaConfig = path.join(migrationBackupDirPath, constants.KARMA_CONFIG_NAME);
+		if (this.$fs.exists(pathToKarmaConfig)) {
+			const oldKarmaContent = this.$fs.readText(pathToKarmaConfig);
 
-		const regExp = /frameworks:\s+\[([\S\s]*?)\]/g;
-		const matches = regExp.exec(oldKarmaContent);
-		const frameworks = (matches && matches[1] && matches[1].trim()) || '["jasmine"]';
+			const regExp = /frameworks:\s+\[([\S\s]*?)\]/g;
+			const matches = regExp.exec(oldKarmaContent);
+			const frameworks = (matches && matches[1] && matches[1].trim()) || '["jasmine"]';
 
-		const testsDir = path.join(projectData.appDirectoryPath, 'tests');
-		const relativeTestsDir = path.relative(projectData.projectDir, testsDir);
-		const testFiles = `'${fromWindowsRelativePathToUnix(relativeTestsDir)}/**/*.*'`;
+			const testsDir = path.join(projectData.appDirectoryPath, 'tests');
+			const relativeTestsDir = path.relative(projectData.projectDir, testsDir);
+			const testFiles = `'${fromWindowsRelativePathToUnix(relativeTestsDir)}/**/*.*'`;
 
-		const karmaConfTemplate = this.$resources.readText('test/karma.conf.js');
-		const karmaConf = _.template(karmaConfTemplate)({ frameworks, testFiles });
-		this.$fs.writeFile(path.join(projectData.projectDir, constants.KARMA_CONFIG_NAME), karmaConf);
+			const karmaConfTemplate = this.$resources.readText('test/karma.conf.js');
+			const karmaConf = _.template(karmaConfTemplate)({ frameworks, testFiles });
+			this.$fs.writeFile(path.join(projectData.projectDir, constants.KARMA_CONFIG_NAME), karmaConf);
+		}
 
 		// Dependencies to migrate
 		const dependencies = [
-			{ packageName: "karma-webpack", verifiedVersion: "3.0.5", isDev: true, shouldAddIfMissing: !this.hasDependency({ packageName: "karma-webpack", isDev: true }, projectData) },
+			{ packageName: "karma-webpack", verifiedVersion: "3.0.5", isDev: true, shouldAddIfMissing: true },
 			{ packageName: "karma-jasmine", verifiedVersion: "2.0.1", isDev: true },
 			{ packageName: "karma-mocha", verifiedVersion: "1.3.0", isDev: true },
 			{ packageName: "karma-chai", verifiedVersion: "0.1.0", isDev: true },


### PR DESCRIPTION
In case you've installed `nativescript-unit-test-runner` , but you've not used `tns test init`, `tns migrate` command fails with error:
`Could not migrate the project! The error is: Error: ENOENT: no such file or directory, open '<project dir>/.migration_backup/karma.conf.js'`
Skip the migration of the `karma.conf.js` file in case it is missing. Also, ensure `karma-webpack` is always added by the migration when `nativescript-unit-test-runner` is migrated.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When you execute the following:
```
$ tns create myApp --js
$ cd myApp
$ npm i --save-dev nativescript-unit-test-runner
$ tns migrate
``` 
The command fails with error: `Could not migrate the project! The error is: Error: ENOENT: no such file or directory, open '<project dir>/.migration_backup/karma.conf.js'`

## What is the new behavior?
Command successfully migrates project which has nativescript-unit-test-runner, but does not have karma.conf.js file.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
