### PR TITLE
fix: fix the missing icons in newly created apps on iOS devices

### DIFF
--- a/lib/services/platform/add-platform-service.ts
+++ b/lib/services/platform/add-platform-service.ts
@@ -1,13 +1,12 @@
 import * as path from "path";
 import * as temp from "temp";
-import { PROJECT_FRAMEWORK_FOLDER_NAME, NativePlatformStatus } from "../../constants";
+import { PROJECT_FRAMEWORK_FOLDER_NAME } from "../../constants";
 import { performanceLog } from "../../common/decorators";
 
 export class AddPlatformService implements IAddPlatformService {
 	constructor(
 		private $fs: IFileSystem,
 		private $pacoteService: IPacoteService,
-		private $projectChangesService: IProjectChangesService,
 		private $projectDataService: IProjectDataService,
 		private $terminalSpinnerService: ITerminalSpinnerService
 	) { }
@@ -61,7 +60,6 @@ export class AddPlatformService implements IAddPlatformService {
 		platformData.platformProjectService.ensureConfigurationFileInAppResources(projectData);
 		await platformData.platformProjectService.interpolateData(projectData);
 		platformData.platformProjectService.afterCreateProject(platformData.projectRoot, projectData);
-		await this.$projectChangesService.setNativePlatformStatus(platformData, projectData, { nativePlatformStatus: NativePlatformStatus.requiresPrepare });
 	}
 }
 $injector.register("addPlatformService", AddPlatformService);


### PR DESCRIPTION
Currently the icons of newly created apps are not displayed when running the application on iOS device. This happens as the icons are not included into `.pbxproject` file. This happens as the `prepareProject` method is not called due to this check https://github.com/NativeScript/nativescript-cli/blob/release/lib/services/platform/prepare-native-platform-service.ts#L35. This check is based on hasChangesRequirePrepare from `projectChangesService` which value is based on `appResourcesChanged` and `signingChanged` - https://github.com/NativeScript/nativescript-cli/blob/release/lib/services/project-changes-service.ts#L27. The values of those properties are not populated correctly initially when the application is without `platforms` directory.

This functionality was broken with this PR https://github.com/NativeScript/nativescript-cli/pull/4836/files. As this PR changes the behavior of this if, now it never passes and respectively appResourcesChanged and signingChanged are with false values. In other words, we've broken the functionality that set initial values of those properties.

In order to set correctly the initial values of those properties, we decided deleting the setNativePlatformStatus call after adding the platform. This functionally was added in this PR https://github.com/NativeScript/nativescript-cli/pull/4139. So here come the question how calling setNativePlatformStatus after adding the platform reflects the current issue with missing icons on device.

`setNativePlatformStatus` method sets the nativePlatformStatus property in _prepareInfo and saves it to `.nsprepareinfo` file which happens when adding the platform. After that, CLI calls `ensurePrepareInfo` method https://github.com/NativeScript/nativescript-cli/blob/release/lib/services/project-changes-service.ts#L160. As we've already saved prepareInfo to `.nsprepareinfo` file, this if always passes https://github.com/NativeScript/nativescript-cli/blob/release/lib/services/project-changes-service.ts#L162 and we've never reached the code that sets the default values here https://github.com/NativeScript/nativescript-cli/blob/release/lib/services/project-changes-service.ts#L183. This happens as we've already saved `.nsprepareinfo` from `setNativePlatformStatus` method. As calling `setNativePlatformStatus` after adding the platform was introduced as a bug fix when supporting legacy and bundle workflow, we decided to delete this call. This way, we'll ensure that initially when the project is without platforms directory, this code we'll be called https://github.com/NativeScript/nativescript-cli/blob/release/lib/services/project-changes-service.ts#L183 and the initial values of properties will be set correctly.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
