### PR TITLE
fix: stop all webpack processes from sidekick when stopping the livesync

### DIFF
--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -38,8 +38,10 @@ export class RunController extends EventEmitter implements IRunController {
 		const projectData = this.$projectDataService.getProjectData(projectDir);
 		await this.initializeSetup(projectData);
 
-		const platforms = this.$devicesService.getPlatformsFromDeviceDescriptors(deviceDescriptors);
 		const deviceDescriptorsForInitialSync = this.getDeviceDescriptorsForInitialSync(projectDir, deviceDescriptors);
+		const newPlatforms = this.$devicesService.getPlatformsFromDeviceDescriptors(deviceDescriptors);
+		const oldPlatforms = this.$liveSyncProcessDataService.getPlatforms(projectDir);
+		const platforms = _.uniq(_.concat(newPlatforms, oldPlatforms));
 
 		this.$liveSyncProcessDataService.persistData(projectDir, deviceDescriptors, platforms);
 

--- a/lib/definitions/livesync.d.ts
+++ b/lib/definitions/livesync.d.ts
@@ -492,5 +492,6 @@ declare global {
 		getAllPersistedData(): IDictionary<ILiveSyncProcessData>;
 		persistData(projectDir: string, deviceDescriptors: ILiveSyncDeviceDescriptor[], platforms: string[]): void;
 		hasDeviceDescriptors(projectDir: string): boolean;
+		getPlatforms(projectDir: string): string[];
 	}
 }

--- a/lib/services/livesync-process-data-service.ts
+++ b/lib/services/livesync-process-data-service.ts
@@ -6,7 +6,7 @@ export class LiveSyncProcessDataService implements ILiveSyncProcessDataService {
 		this.processes[projectDir].actionsChain = this.processes[projectDir].actionsChain || Promise.resolve();
 		this.processes[projectDir].currentSyncAction = this.processes[projectDir].actionsChain;
 		this.processes[projectDir].isStopped = false;
-		this.processes[projectDir].platforms = platforms;
+		this.processes[projectDir].platforms =  platforms;
 
 		const currentDeviceDescriptors = this.getDeviceDescriptors(projectDir);
 		this.processes[projectDir].deviceDescriptors = _.uniqBy(currentDeviceDescriptors.concat(deviceDescriptors), "identifier");
@@ -29,6 +29,12 @@ export class LiveSyncProcessDataService implements ILiveSyncProcessDataService {
 
 	public getAllPersistedData() {
 		return this.processes;
+	}
+
+	public getPlatforms(projectDir: string): string[] {
+		const liveSyncProcessesInfo = this.processes[projectDir] || <ILiveSyncProcessData>{};
+		const currentPlatforms = liveSyncProcessesInfo.platforms;
+		return currentPlatforms || [];
 	}
 }
 $injector.register("liveSyncProcessDataService", LiveSyncProcessDataService);

--- a/lib/services/livesync-process-data-service.ts
+++ b/lib/services/livesync-process-data-service.ts
@@ -6,7 +6,7 @@ export class LiveSyncProcessDataService implements ILiveSyncProcessDataService {
 		this.processes[projectDir].actionsChain = this.processes[projectDir].actionsChain || Promise.resolve();
 		this.processes[projectDir].currentSyncAction = this.processes[projectDir].actionsChain;
 		this.processes[projectDir].isStopped = false;
-		this.processes[projectDir].platforms =  platforms;
+		this.processes[projectDir].platforms = platforms;
 
 		const currentDeviceDescriptors = this.getDeviceDescriptors(projectDir);
 		this.processes[projectDir].deviceDescriptors = _.uniqBy(currentDeviceDescriptors.concat(deviceDescriptors), "identifier");


### PR DESCRIPTION
Currently when livesync is started on iOS device from sidekick, {N} CLI persist that livesync is started for iOS platform. After that if the livesync process is started on android device, {N} CLI overrides the persisted platforms and stores that the livesync is started for Android platform. However, when the livesync is stopped, {N} CLI stops it only for android platform. This means that the iOS webpack process is alive and continues to report data. This led to the multiple livesync messages when syncing the changes.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
