### PR TITLE
fix: update Angular deps during app migration

### DIFF
--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -70,6 +70,15 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 		{ packageName: "kinvey-nativescript-sdk", verifiedVersion: "4.2.1" },
 		{ packageName: "nativescript-plugin-firebase", verifiedVersion: "9.0.2" },
 		{ packageName: "nativescript-vue", verifiedVersion: "2.3.0" },
+		{
+			packageName: "nativescript-angular", verifiedVersion: "8.0.2",
+			shouldMigrateAction: async (projectData: IProjectData, allowInvalidVersions: boolean) => {
+				const dependency = { packageName: "nativescript-angular", verifiedVersion: "8.0.2", isDev: false };
+				const result = this.hasDependency(dependency, projectData) && await this.shouldMigrateDependencyVersion(dependency, projectData, allowInvalidVersions);
+				return result;
+			},
+			migrateAction: this.migrateNativeScriptAngular.bind(this)
+		},
 		{ packageName: "nativescript-permissions", verifiedVersion: "1.3.0" },
 		{ packageName: "nativescript-cardview", verifiedVersion: "3.2.0" },
 		{
@@ -81,7 +90,7 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 			},
 			migrateAction: this.migrateUnitTestRunner.bind(this)
 		},
-		{ packageName: MigrateController.typescriptPackageName, isDev: true, getVerifiedVersion: this.getAngularTypeScriptVersion.bind(this) },
+		{ packageName: MigrateController.typescriptPackageName, isDev: true, verifiedVersion: "3.4.5" },
 		{ packageName: "nativescript-localize", verifiedVersion: "4.2.0" },
 		{ packageName: "nativescript-dev-babel", verifiedVersion: "0.2.1" },
 		{ packageName: "nativescript-nfc", verifiedVersion: "4.0.1" }
@@ -177,31 +186,6 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 		if (shouldMigrate) {
 			this.$errors.failWithoutHelp(MigrateController.UNABLE_TO_MIGRATE_APP_ERROR);
 		}
-	}
-
-	private async getAngularTypeScriptVersion(projectData: IProjectData): Promise<string> {
-		let verifiedVersion = "3.4.1";
-		try {
-			const ngcPackageName = "@angular/compiler-cli";
-			// e.g. ~8.0.0
-			let ngcVersion = projectData.dependencies[ngcPackageName] || projectData.devDependencies[ngcPackageName];
-			if (ngcVersion) {
-				// e.g. 8.0.3
-				ngcVersion = await this.$packageInstallationManager.maxSatisfyingVersion(ngcPackageName, ngcVersion);
-				const ngcManifest = await this.getPackageManifest(ngcPackageName, ngcVersion);
-				// e.g. >=3.4 <3.5
-				verifiedVersion = (ngcManifest && ngcManifest.peerDependencies &&
-					ngcManifest.peerDependencies[MigrateController.typescriptPackageName]) || verifiedVersion;
-
-				// e.g. 3.4.4
-				verifiedVersion = await this.$packageInstallationManager.maxSatisfyingVersion(
-					MigrateController.typescriptPackageName, verifiedVersion);
-			}
-		} catch (error) {
-			this.$logger.warn(`Unable to determine the TypeScript version based on the Angular packages. Error is: '${error}'.`);
-		}
-
-		return verifiedVersion;
 	}
 
 	private async migrateOldAndroidAppResources(projectData: IProjectData, backupDir: string) {
@@ -329,33 +313,23 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 					this.$errors.failWithoutHelp("Failed to find replacement dependency.");
 				}
 
-				const replacementDepVersion = await this.getDependencyVerifiedVersion(replacementDep, projectData);
 				this.$logger.info(`Replacing '${dependency.packageName}' with '${replacementDep.packageName}'.`);
-				this.$pluginsService.addToPackageJson(replacementDep.packageName, replacementDepVersion, replacementDep.isDev, projectData.projectDir);
+				this.$pluginsService.addToPackageJson(replacementDep.packageName, replacementDep.verifiedVersion, replacementDep.isDev, projectData.projectDir);
 			}
 
 			return;
 		}
 
-		const dependencyVersion = await this.getDependencyVerifiedVersion(dependency, projectData);
 		if (hasDependency && await this.shouldMigrateDependencyVersion(dependency, projectData, allowInvalidVersions)) {
-			this.$logger.info(`Updating '${dependency.packageName}' to compatible version '${dependencyVersion}'`);
-			this.$pluginsService.addToPackageJson(dependency.packageName, dependencyVersion, dependency.isDev, projectData.projectDir);
+			this.$logger.info(`Updating '${dependency.packageName}' to compatible version '${dependency.verifiedVersion}'`);
+			this.$pluginsService.addToPackageJson(dependency.packageName, dependency.verifiedVersion, dependency.isDev, projectData.projectDir);
 			return;
 		}
 
 		if (!hasDependency && dependency.shouldAddIfMissing) {
-			this.$logger.info(`Adding '${dependency.packageName}' with version '${dependencyVersion}'`);
-			this.$pluginsService.addToPackageJson(dependency.packageName, dependencyVersion, dependency.isDev, projectData.projectDir);
+			this.$logger.info(`Adding '${dependency.packageName}' with version '${dependency.verifiedVersion}'`);
+			this.$pluginsService.addToPackageJson(dependency.packageName, dependency.verifiedVersion, dependency.isDev, projectData.projectDir);
 		}
-	}
-
-	private async getDependencyVerifiedVersion(dependency: IMigrationDependency, projectData: IProjectData): Promise<string> {
-		if (!dependency.verifiedVersion && dependency.getVerifiedVersion) {
-			dependency.verifiedVersion = await dependency.getVerifiedVersion(projectData);
-		}
-
-		return dependency.verifiedVersion;
 	}
 
 	private async shouldMigrateDependencyVersion(dependency: IMigrationDependency, projectData: IProjectData, allowInvalidVersions: boolean): Promise<boolean> {
@@ -364,7 +338,7 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 		const packageName = dependency.packageName;
 		const referencedVersion = dependencies[packageName] || devDependencies[packageName];
 		const installedVersion = await this.getMaxDependencyVersion(dependency.packageName, referencedVersion);
-		const requiredVersion = await this.getDependencyVerifiedVersion(dependency, projectData);
+		const requiredVersion = dependency.verifiedVersion;
 
 		return this.isOutdatedVersion(installedVersion, requiredVersion, allowInvalidVersions);
 	}
@@ -406,6 +380,23 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 			{ packageName: "karma-chai", verifiedVersion: "0.1.0", isDev: true },
 			{ packageName: "karma-qunit", verifiedVersion: "3.1.2", isDev: true },
 			{ packageName: "karma", verifiedVersion: "4.1.0", isDev: true },
+		];
+
+		return dependencies;
+	}
+
+	private async migrateNativeScriptAngular(): Promise<IMigrationDependency[]> {
+		const dependencies = [
+			{ packageName: "@angular/platform-browser-dynamic", verifiedVersion: "8.0.0", shouldAddIfMissing: true },
+			{ packageName: "@angular/common", verifiedVersion: "8.0.0", shouldAddIfMissing: true },
+			{ packageName: "@angular/compiler", verifiedVersion: "8.0.0", shouldAddIfMissing: true },
+			{ packageName: "@angular/core", verifiedVersion: "8.0.0", shouldAddIfMissing: true },
+			{ packageName: "@angular/forms", verifiedVersion: "8.0.0", shouldAddIfMissing: true },
+			{ packageName: "@angular/http", verifiedVersion: "8.0.0-beta.10", shouldAddIfMissing: true },
+			{ packageName: "@angular/platform-browser", verifiedVersion: "8.0.0", shouldAddIfMissing: true },
+			{ packageName: "@angular/router", verifiedVersion: "8.0.0", shouldAddIfMissing: true },
+			{ packageName: "rxjs", verifiedVersion: "6.3.3", shouldAddIfMissing: true },
+			{ packageName: "zone.js", verifiedVersion: "0.9.1", shouldAddIfMissing: true }
 		];
 
 		return dependencies;

--- a/lib/definitions/migrate.d.ts
+++ b/lib/definitions/migrate.d.ts
@@ -19,7 +19,6 @@ interface IMigrationDependency extends IDependency {
 	replaceWith?: string;
 	warning?: string;
 	verifiedVersion?: string;
-	getVerifiedVersion?: (projectData: IProjectData) => Promise<string>;
 	shouldAddIfMissing?: boolean;
 	shouldMigrateAction?: (projectData: IProjectData, allowInvalidVersions: boolean) => Promise<boolean>;
 	migrateAction?: (projectData: IProjectData, migrationBackupDirPath: string) => Promise<IMigrationDependency[]>;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The Angular dependencies are not updated during `tns migrate` causing invalid dependencies state when migrating Angular 5 app. The invalid state is caused by the `nativescript-dev-webpack` plugin which updates the `@angular/compiler-cli` and `@ngtools/webpack` to `8.0.0` which are not compatible with Angular < 7.

## What is the new behavior?
`tns migrate` is not updating the Angular deps in order to ensure compatibiltiy between`@angular/compiler-cli`, `@ngtools/webpack` and the rest of the Angular dependencies.