### PR TITLE
fix: support node <= 8.9.4 (lookbehind is supported only with the `harmony` flag)

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as child_process from "child_process";
+import * as semver from "semver";
 import { EventEmitter } from "events";
 import { performanceLog } from "../../common/decorators";
 import { WEBPACK_COMPILATION_COMPLETE } from "../../constants";
@@ -130,8 +131,10 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 	private async startWebpackProcess(platformData: IPlatformData, projectData: IProjectData, prepareData: IPrepareData): Promise<child_process.ChildProcess> {
 		const envData = this.buildEnvData(platformData.platformNameLowerCase, projectData, prepareData);
 		const envParams = this.buildEnvCommandLineParams(envData, platformData, prepareData);
+		const additionalNodeArgs = semver.major(process.version) <= 8 ? ["--harmony"] : [];
 
 		const args = [
+			...additionalNodeArgs,
 			path.join(projectData.projectDir, "node_modules", "webpack", "bin", "webpack.js"),
 			"--preserve-symlinks",
 			`--config=${path.join(projectData.projectDir, "webpack.config.js")}`,


### PR DESCRIPTION
https://node.green/#ES2018-features--RegExp-Lookbehind-Assertions

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.