### PR TITLE
chore: update required deps for 6.0

### DIFF
--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -54,7 +54,7 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 		{ packageName: "nativescript-dev-sass", isDev: true, replaceWith: "node-sass" },
 		{ packageName: "nativescript-dev-typescript", isDev: true, replaceWith: MigrateController.typescriptPackageName },
 		{ packageName: "nativescript-dev-less", isDev: true, shouldRemove: true, warning: "LESS CSS is not supported out of the box. In order to enable it, follow the steps in this feature request: https://github.com/NativeScript/nativescript-dev-webpack/issues/967" },
-		{ packageName: constants.WEBPACK_PLUGIN_NAME, isDev: true, shouldAddIfMissing: true, verifiedVersion: "1.0.0" },
+		{ packageName: constants.WEBPACK_PLUGIN_NAME, isDev: true, shouldAddIfMissing: true, verifiedVersion: "1.0.1" },
 		{ packageName: "nativescript-camera", verifiedVersion: "4.5.0" },
 		{ packageName: "nativescript-geolocation", verifiedVersion: "5.1.0" },
 		{ packageName: "nativescript-imagepicker", verifiedVersion: "6.2.0" },
@@ -99,7 +99,7 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 	get verifiedPlatformVersions(): IDictionary<string> {
 		return {
 			[this.$devicePlatformsConstants.Android.toLowerCase()]: "6.0.0",
-			[this.$devicePlatformsConstants.iOS.toLowerCase()]: "6.0.0"
+			[this.$devicePlatformsConstants.iOS.toLowerCase()]: "6.0.1"
 		};
 	}
 


### PR DESCRIPTION
Update nativescirpt-dev-webpack and ios-runtime to their latest versions. We'll require at least these versions when running the application.
