### PR TITLE
docs: remove --platform-template from CLI's help

### DIFF
--- a/docs/man_pages/project/configuration/platform-add.md
+++ b/docs/man_pages/project/configuration/platform-add.md
@@ -13,15 +13,14 @@ Configures the current project to target the selected platform. <% if(isHtml) { 
 
 Usage | Synopsis
 ------|-------
-Android latest runtime | `$ tns platform add android [--framework-path <File Path>] [--platform-template <Platform Template>]`
-Android selected runtime | `$ tns platform add android[@<Version>] [--framework-path <File Path>] [--platform-template <Platform Template>]`
+Android latest runtime | `$ tns platform add android [--framework-path <File Path>]`
+Android selected runtime | `$ tns platform add android[@<Version>] [--framework-path <File Path>] `
 <% if (isMacOS) { %>iOS latest runtime | `$ tns platform add ios [--framework-path <File Path>]`
-iOS selected runtime | `$ tns platform add ios[@<Version>] [--framework-path <File Path>] [--platform-template <Platform Template>]`<% } %>
+iOS selected runtime | `$ tns platform add ios[@<Version>] [--framework-path <File Path>] `<% } %>
 
 ### Options
 
 * `--framework-path` - Sets the path to a NativeScript runtime for the specified platform that you want to use instead of the default runtime. `<File Path>` must point to a valid npm package.
-* `--platform-template` - Sets the platform template that will be used for the native application. `<Platform Template>` is a valid npm package, path to directory, .tgz or GitHub URL that contains a native Android or iOS template.
 
 ### Arguments
 


### PR DESCRIPTION
The option has been deleted in CLI 6.0, but it is still available in the help.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4873

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
