### PR TITLE
fix: parse options correctly

### DIFF
--- a/lib/options.ts
+++ b/lib/options.ts
@@ -6,7 +6,6 @@ export class Options {
 	private static NONDASHED_OPTION_REGEX = /(.+?)[-]([a-zA-Z])(.*)/;
 
 	private optionsWhiteList = ["ui", "recursive", "reporter", "require", "timeout", "_", "$0"]; // These options shouldn't be validated
-	private yargsArgv: yargs.Argv;
 	private globalOptions: IDictionary<IDashedOption> = {
 		log: { type: OptionType.String, hasSensitiveValue: false },
 		verbose: { type: OptionType.Boolean, alias: "v", hasSensitiveValue: false },
@@ -19,6 +18,7 @@ export class Options {
 		_: { type: OptionType.String, hasSensitiveValue: false }
 	};
 
+	private initialArgv: yargs.Arguments;
 	public argv: yargs.Arguments;
 	public options: IDictionary<IDashedOption>;
 
@@ -31,7 +31,7 @@ export class Options {
 		this.argv.bundle = "webpack";
 
 		// Check if the user has explicitly provide --hmr and --release options from command line
-		if (this.yargsArgv.argv.release && this.yargsArgv.argv.hmr) {
+		if (this.initialArgv.release && this.initialArgv.hmr) {
 			this.$errors.failWithoutHelp("The options --release and --hmr cannot be used simultaneously.");
 		}
 
@@ -250,8 +250,9 @@ export class Options {
 			opts[this.getDashedOptionName(key)] = value;
 		});
 
-		this.yargsArgv = yargs(process.argv.slice(2));
-		this.argv = this.yargsArgv.options(<any>opts).argv;
+		const parsed = yargs(process.argv.slice(2));
+		this.initialArgv = parsed.argv;
+		this.argv = parsed.options(<any>opts).argv;
 
 		// For backwards compatibility
 		// Previously profileDir had a default option and calling `this.$options.profileDir` always returned valid result.

--- a/test/options.ts
+++ b/test/options.ts
@@ -292,7 +292,7 @@ describe("options", () => {
 				name: "should set hmr to true by default",
 				expectedHmrValue: true
 			}, {
-				name: "set set hmr to false when --no-hmr is provided",
+				name: "should set hmr to false when --no-hmr is provided",
 				args: ["--no-hmr"],
 				expectedHmrValue: false
 			}, {
@@ -319,6 +319,7 @@ describe("options", () => {
 					options.setupOptions(testCase.commandSpecificDashedOptions);
 
 					assert.equal(testCase.expectedHmrValue, options.argv.hmr);
+					assert.isFalse(isExecutionStopped);
 
 					(testCase.args || []).forEach(arg => process.argv.pop());
 				});


### PR DESCRIPTION
Currently `tns run android --release` throws an error that `--hmr` and `--release` cannot be used simultaneously. After parsing `this.yargsArgv = yargs(process.argv.slice(2))` command line options, only `--release` option is true as it is expected to be. For some reason after calling `this.argv = this.yargsArgv.options(<any>opts).argv`, `this.yargsArgv` is modified and `this.yargsArgv.hmr` is true which is not the expected behavior. It seems like a strange behavior of yargs. In order to fix it, we parse the command line only once and persist the `argv` object of initial parsed command line.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
