### PR TITLE
fix: multiple errors in Sidekick

### DIFF
--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -43,7 +43,7 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 		this.$previewSdkService.stop();
 		this.$previewDevicesService.updateConnectedDevices([]);
 		if (this.prepareReadyEventHandler) {
-			this.removeListener(PREPARE_READY_EVENT_NAME, this.prepareReadyEventHandler);
+			this.$prepareController.removeListener(PREPARE_READY_EVENT_NAME, this.prepareReadyEventHandler);
 			this.prepareReadyEventHandler = null;
 		}
 	}
@@ -83,10 +83,12 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 				await this.$previewAppPluginsService.comparePluginsOnDevice(data, device);
 
 				if (!this.prepareReadyEventHandler) {
-					this.prepareReadyEventHandler = async (currentPrepareData: IFilesChangeEventData) => {
+					const handler = async (currentPrepareData: IFilesChangeEventData) => {
 						await this.handlePrepareReadyEvent(data, currentPrepareData);
 					};
-					this.$prepareController.on(PREPARE_READY_EVENT_NAME, this.prepareReadyEventHandler.bind(this));
+
+					this.prepareReadyEventHandler = handler.bind(this);
+					this.$prepareController.on(PREPARE_READY_EVENT_NAME, this.prepareReadyEventHandler);
 				}
 
 				data.env = data.env || {};

--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -15,6 +15,7 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 
 	constructor(
 		private $analyticsService: IAnalyticsService,
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $errors: IErrors,
 		private $hmrStatusService: IHmrStatusService,
 		private $logger: ILogger,
@@ -39,9 +40,13 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 		return result;
 	}
 
-	public async stopPreview(): Promise<void> {
+	public async stopPreview(data: IProjectDir): Promise<void> {
 		this.$previewSdkService.stop();
 		this.$previewDevicesService.updateConnectedDevices([]);
+
+		await this.$prepareController.stopWatchers(data.projectDir, this.$devicePlatformsConstants.Android);
+		await this.$prepareController.stopWatchers(data.projectDir, this.$devicePlatformsConstants.iOS);
+
 		if (this.prepareReadyEventHandler) {
 			this.$prepareController.removeListener(PREPARE_READY_EVENT_NAME, this.prepareReadyEventHandler);
 			this.prepareReadyEventHandler = null;

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -199,7 +199,7 @@ export class RunController extends EventEmitter implements IRunController {
 				result.didRestart = true;
 			}
 		} catch (err) {
-			this.$logger.info(`Error while trying to start application ${applicationIdentifier} on device ${liveSyncResultInfo.deviceAppData.device.deviceInfo.identifier}. Error is: ${err.message || err}`);
+			this.$logger.trace(`Error while trying to start application ${applicationIdentifier} on device ${liveSyncResultInfo.deviceAppData.device.deviceInfo.identifier}. Error is: ${err.message || err}`);
 			const msg = `Unable to start application ${applicationIdentifier} on device ${liveSyncResultInfo.deviceAppData.device.deviceInfo.identifier}. Try starting it manually.`;
 			this.$logger.warn(msg);
 
@@ -377,7 +377,7 @@ export class RunController extends EventEmitter implements IRunController {
 
 					await this.$deviceInstallAppService.installOnDevice(device, deviceDescriptor.buildData, rebuiltInformation[platformData.platformNameLowerCase].packageFilePath);
 					await platformLiveSyncService.syncAfterInstall(device, watchInfo);
-					await platformLiveSyncService.restartApplication(projectData, { deviceAppData, modifiedFilesData: [], isFullSync: false, useHotModuleReload: liveSyncInfo.useHotModuleReload });
+					await this.refreshApplication(projectData, { deviceAppData, modifiedFilesData: [], isFullSync: false, useHotModuleReload: liveSyncInfo.useHotModuleReload }, data, deviceDescriptor);
 				} else {
 					const isInHMRMode = liveSyncInfo.useHotModuleReload && data.hmrData && data.hmrData.hash;
 					if (isInHMRMode) {

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -77,6 +77,6 @@ declare global {
 
 	interface IPreviewAppController {
 		startPreview(data: IPreviewAppLiveSyncData): Promise<IQrCodeImageData>;
-		stopPreview(): Promise<void>;
+		stopPreview(data: IProjectDir): Promise<void>;
 	}
 }

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -72,6 +72,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 
 			childProcess.on("error", (err) => {
 				this.$logger.trace(`Unable to start webpack process in watch mode. Error is: ${err}`);
+				delete this.webpackProcesses[platformData.platformNameLowerCase];
 				reject(err);
 			});
 
@@ -82,6 +83,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 				this.$logger.trace(`Webpack process exited with code ${exitCode} when we expected it to be long living with watch.`);
 				const error = new Error(`Executing webpack failed with exit code ${exitCode}.`);
 				error.code = exitCode;
+				delete this.webpackProcesses[platformData.platformNameLowerCase];
 				reject(error);
 			});
 		});
@@ -97,12 +99,14 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 			const childProcess = await this.startWebpackProcess(platformData, projectData, prepareData);
 			childProcess.on("error", (err) => {
 				this.$logger.trace(`Unable to start webpack process in non-watch mode. Error is: ${err}`);
+				delete this.webpackProcesses[platformData.platformNameLowerCase];
 				reject(err);
 			});
 
 			childProcess.on("close", async (arg: any) => {
 				await this.$cleanupService.removeKillProcess(childProcess.pid.toString());
 
+				delete this.webpackProcesses[platformData.platformNameLowerCase];
 				const exitCode = typeof arg === "number" ? arg : arg && arg.code;
 				if (exitCode === 0) {
 					resolve();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {

--- a/test/controllers/run-controller.ts
+++ b/test/controllers/run-controller.ts
@@ -96,7 +96,8 @@ function createTestInjector() {
 			prepareData = currentPrepareData;
 			return { platform: prepareData.platform, hasNativeChanges: false };
 		},
-		on: () => ({})
+		on: () => ({}),
+		removeListener: (): void => undefined
 	});
 	injector.register("prepareNativePlatformService", {});
 	injector.register("projectChangesService", {});


### PR DESCRIPTION
### fix(cloud, sidekick): don't stop livesync on iOS device without developer disk image when app is built in cloud on windows

The livesync process is stopped when a native change is made in app built in cloud on windows OS. This happens as CLI builds the app and after that tries to restart it. As the `platformLiveSyncService.restartApplication` is without try/catch, the CLI is not able to start the application due to missing developer disk image mounted on device. After that an error is thrown and the livesync process is stopped. This PR replaces `platformLiveSyncService.restartApplication` with `this.refreshApplication`. The `this.refreshApplication` method has try/catch and shows a warning `Unable to start application...`  when an error is thrown during restart process. On the other side, this method has a check if a naive change occurs, so no additional checks will be executed from the method in order to determine if the application should be refreshed or restarted. (https://github.com/NativeScript/nativescript-cli/blob/24b21c4c3ec46ecf05f3b3aa1d2ed5b7d2301424/lib/controllers/run-controller.ts#L187)



### fix(run): remove prepareReadyEvent handler correctly on run
`tns run` (and using SK) should remove its handler for prepareControllers' `prepareReadyEvent` handler. However, this does not happend due to two reasons:
- we try to remove the handler from runControllers' event, but this handler is attached to `preparController`, so it actually remains and causes multiple issues in long living processes, when CLI is used as a library
- the event handler is not cached correctly as we attach its bound version, but cache it without the binding. So you cannot remove it.

This causes issues when running on device in Sidekick, closing the current app, open it again and try to livesync a change - we have many handlers for prepareReadyEvent and this causes multiple livesync operations.

### fix(preview): remove prepareReadyEvent handler correctly on preview
`tns preview` (and using SK) should remove its handler for prepareControllers' `prepareReadyEvent` handler. However, this does not happend due to two reasons:
- we try to remove the handler from prepareControllers' event, but this handler is attached to `preparController`, so it actually remains and causes multiple issues in long living processes, when CLI is used as a library
- the event handler is not cached correctly as we attach its bound version, but cache it without the binding. So you cannot remove it.

This causes issues when using preview in Sidekick, closing the current app, open it again and try to livesync a change - we have many handlers for prepareReadyEvent and this causes multiple livesync operations.

### fix: remove webpackCompilationComplete handler correctly on prepare
Commands using prepare of project (and using SK) should remove their handlers for webpackCompilerService's `webpackCompilationComplete` event. This is not happening and whenever we start new prepartion of the project, we attach new handler.

This causes issues when running on device in Sidekick, closing the current app, open it again and try to livesync a change - we have many handlers for prepareReadyEvent and this causes multiple livesync operations.

### fix: webpackCompilerService should not cache childProcesses forever
Currently the webpackCompilerService caches the started webpack processes, but it removes them from the cache only when someone calls `stopWebpackCompiler` method.
This is a major problem as we cache the first instance of the child process and we do not remove it, even when the process dies. For example, when you run just build, we start the webpack process without watch mode, the webpackCompilerService caches the child process, it exits, but the instance remains cached.
Trying to run the application on device does not start new webpack process and different failures occur.

### fix: stopPreview does not stop running webpack compilers  …
`stopPreview` method does not stop running webpack compilers, so it is no longer possible to run the same application on device (no matter preview, build or run). This happens in long living processes, like Sidekick.
To fix this, add new parameter to the method - an object containing the projectDir and use it to stop the processes.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
