### PR TITLE
fix: ability to publish iOS applications for users with two-factor authentication enabled

### DIFF
--- a/docs/man_pages/publishing/apple-login.md
+++ b/docs/man_pages/publishing/apple-login.md
@@ -1,5 +1,5 @@
 <% if (isJekyll) { %>---
-title: tns appstore
+title: tns apple-login
 position: 5
 ---<% } %>
 
@@ -15,15 +15,11 @@ Usage | Synopsis
 ---|---
 General | `$ tns apple-login [<Apple ID>] [<Password>]`
 
-<% if((isConsole && isMacOS) || isHtml) { %>
-
-### Options
-
 ### Arguments
 
 * `<Apple ID>` and `<Password>` are your credentials for logging into iTunes Connect.
 
-### Command Limitations
+<% if(isHtml) { %>s
 
 ### Related Commands
 

--- a/docs/man_pages/publishing/apple-login.md
+++ b/docs/man_pages/publishing/apple-login.md
@@ -1,0 +1,39 @@
+<% if (isJekyll) { %>---
+title: tns appstore
+position: 5
+---<% } %>
+
+# tns apple-login
+
+### Description
+
+Uses the provided Apple credentials to obtain Apple session which can be used when publishing to Apple AppStore.
+
+### Commands
+
+Usage | Synopsis
+---|---
+General | `$ tns apple-login [<Apple ID>] [<Password>]`
+
+<% if((isConsole && isMacOS) || isHtml) { %>
+
+### Options
+
+### Arguments
+
+* `<Apple ID>` and `<Password>` are your credentials for logging into iTunes Connect.
+
+### Command Limitations
+
+### Related Commands
+
+Command | Description
+----------|----------
+[appstore](appstore.html) | Lists applications registered in iTunes Connect.
+[appstore upload](appstore-upload.html) | Uploads project to iTunes Connect.
+[build](../project/testing/build.html) | Builds the project for the selected target platform and produces an application package that you can manually deploy on device or in the native emulator.
+[build ios](../project/testing/build-ios.html) | Builds the project for iOS and produces an APP or IPA that you can manually deploy in the iOS Simulator or on device, respectively.
+[deploy](../project/testing/deploy.html) | Builds and deploys the project to a connected physical or virtual device.
+[run](../project/testing/run.html) | Runs your project on a connected device or in the native emulator for the selected platform.
+[run ios](../project/testing/run-ios.html) | Runs your project on a connected iOS device or in the iOS Simulator, if configured.
+<% } %>

--- a/docs/man_pages/publishing/appstore-upload.md
+++ b/docs/man_pages/publishing/appstore-upload.md
@@ -8,6 +8,7 @@ position: 1
 ### Description
 
 Uploads project to iTunes Connect. The command either issues a production build and uploads it to iTunes Connect, or uses an already built package to upload.
+The user will be prompted interactively for verification code when two-factor authentication enabled account is used. As on non-interactive console (CI), you will not be prompt for verification code. In this case, you need to generate a login session for your apple's account in advance using `tns apple-login` command. The generated value must be provided via the `--appleSessionBase64` option and is only valid for up to a month. Meaning you'll need to create a new session every month.
 
 <% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help appstore upload`<% } %>
 <% if((isConsole && isMacOS) || isHtml) { %>
@@ -22,8 +23,8 @@ Upload package | `$ tns appstore upload [<Apple ID> [<Password>]] --ipa <Ipa Fil
 ### Options
 
 * `--ipa` - If set, will use provided .ipa file instead of building the project.
-* `--appleApplicationSpecificPassword` - Specified the password for your Apple ID that let you sign in to your account and securely access the information you stores from iTunes Transporter application.
-* `--appleSessionBase64` - The session that will be reused instead of triggering a new login each time NativeScript CLI communicates with Apple's APIs.
+* `--appleApplicationSpecificPassword` - Specifies the password for accessing the information you store in iTunes Transporter application.
+* `--appleSessionBase64` - The session that will be used instead of triggering a new login each time NativeScript CLI communicates with Apple's APIs.
 
 ### Arguments
 

--- a/docs/man_pages/publishing/appstore-upload.md
+++ b/docs/man_pages/publishing/appstore-upload.md
@@ -22,6 +22,8 @@ Upload package | `$ tns appstore upload [<Apple ID> [<Password>]] --ipa <Ipa Fil
 ### Options
 
 * `--ipa` - If set, will use provided .ipa file instead of building the project.
+* `--appleApplicationSpecificPassword` - Specified the password for your Apple ID that let you sign in to your account and securely access the information you stores from iTunes Transporter application.
+* `--appleSessionBase64` - The session that will be reused instead of triggering a new login each time NativeScript CLI communicates with Apple's APIs.
 
 ### Arguments
 

--- a/docs/man_pages/publishing/publish-ios.md
+++ b/docs/man_pages/publishing/publish-ios.md
@@ -24,7 +24,9 @@ Upload package | `$ tns publish ios [<Apple ID> [<Password>]] --ipa <Ipa File Pa
 
 * `--ipa` - If set, will use provided .ipa file instead of building the project.
 * `--team-id` - Specified the team id for which Xcode will try to find distribution certificate and provisioning profile when exporting for AppStore submission.
-
+* `--appleApplicationSpecificPassword` - Specified the password for your Apple ID that let you sign in to your account and securely access the information you stores from iTunes Transporter application.
+* `--appleSessionBase64` - The session that will be reused instead of triggering a new login each time NativeScript CLI communicates with Apple's APIs.
+ 
 ### Arguments
 
 * `<Apple ID>` and `<Password>` are your credentials for logging into iTunes Connect.

--- a/docs/man_pages/publishing/publish-ios.md
+++ b/docs/man_pages/publishing/publish-ios.md
@@ -8,6 +8,7 @@ position: 3
 ### Description
 
 Uploads project to iTunes Connect. The command either issues a production build and uploads it to iTunes Connect, or uses an already built package to upload.
+The user will be prompted interactively for verification code when two-factor authentication enabled account is used. As on non-interactive console (CI), you will not be prompt for verification code. In this case, you need to generate a login session for your apple's account in advance using `tns apple-login` command. The generated value must be provided via the `--appleSessionBase64` option and is only valid for up to a month. Meaning you'll need to create a new session every month.
 
 <% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help publish ios`<% } %>
 
@@ -24,8 +25,8 @@ Upload package | `$ tns publish ios [<Apple ID> [<Password>]] --ipa <Ipa File Pa
 
 * `--ipa` - If set, will use provided .ipa file instead of building the project.
 * `--team-id` - Specified the team id for which Xcode will try to find distribution certificate and provisioning profile when exporting for AppStore submission.
-* `--appleApplicationSpecificPassword` - Specified the password for your Apple ID that let you sign in to your account and securely access the information you stores from iTunes Transporter application.
-* `--appleSessionBase64` - The session that will be reused instead of triggering a new login each time NativeScript CLI communicates with Apple's APIs.
+* `--appleApplicationSpecificPassword` - Specifies the password for accessing the information you store in iTunes Transporter application.
+* `--appleSessionBase64` - The session that will be used instead of triggering a new login each time NativeScript CLI communicates with Apple's APIs.
  
 ### Arguments
 

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -100,6 +100,7 @@ $injector.requireCommand("dev-generate-help", "./commands/generate-help");
 $injector.requireCommand("appstore|*list", "./commands/appstore-list");
 $injector.requireCommand("appstore|upload", "./commands/appstore-upload");
 $injector.requireCommand("publish|ios", "./commands/appstore-upload");
+$injector.requireCommand("apple-login", "./commands/apple-login");
 $injector.require("itmsTransporterService", "./services/itmstransporter-service");
 
 $injector.requireCommand("setup|*", "./commands/setup");

--- a/lib/commands/apple-login.ts
+++ b/lib/commands/apple-login.ts
@@ -1,0 +1,34 @@
+import { StringCommandParameter } from "../common/command-params";
+
+export class AppleLogin implements ICommand {
+	public allowedParameters: ICommandParameter[] = [new StringCommandParameter(this.$injector), new StringCommandParameter(this.$injector)];
+
+	constructor(
+		private $applePortalSessionService: IApplePortalSessionService,
+		private $errors: IErrors,
+		private $injector: IInjector,
+		private $logger: ILogger,
+		private $prompter: IPrompter
+	) { }
+
+	public async execute(args: string[]): Promise<void> {
+		let username = args[0];
+		if (!username) {
+			username = await this.$prompter.getString("Apple ID", { allowEmpty: false });
+		}
+
+		let password = args[1];
+		if (!password) {
+			password = await this.$prompter.getPassword("Apple ID password");
+		}
+
+		const user = await this.$applePortalSessionService.createUserSession({ username, password });
+		if (!user.areCredentialsValid) {
+			this.$errors.failWithoutHelp(`Invalid username and password combination. Used '${username}' as the username.`);
+		}
+
+		const output = Buffer.from(user.userSessionCookie).toString("base64");
+		this.$logger.info(output);
+	}
+}
+$injector.registerCommand("apple-login", AppleLogin);

--- a/lib/commands/appstore-list.ts
+++ b/lib/commands/appstore-list.ts
@@ -12,7 +12,8 @@ export class ListiOSApps implements ICommand {
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $platformValidationService: IPlatformValidationService,
 		private $errors: IErrors,
-		private $prompter: IPrompter) {
+		private $prompter: IPrompter,
+		private $options: IOptions) {
 		this.$projectData.initializeProjectData();
 	}
 
@@ -32,7 +33,9 @@ export class ListiOSApps implements ICommand {
 			password = await this.$prompter.getPassword("Apple ID password");
 		}
 
-		const user = await this.$applePortalSessionService.createUserSession({ username, password });
+		const user = await this.$applePortalSessionService.createUserSession({ username, password }, {
+			sessionBase64: this.$options.appleSessionBase64,
+		});
 		if (!user.areCredentialsValid) {
 			this.$errors.failWithoutHelp(`Invalid username and password combination. Used '${username}' as the username.`);
 		}

--- a/lib/commands/appstore-list.ts
+++ b/lib/commands/appstore-list.ts
@@ -6,6 +6,7 @@ export class ListiOSApps implements ICommand {
 
 	constructor(private $injector: IInjector,
 		private $applePortalApplicationService: IApplePortalApplicationService,
+		private $applePortalSessionService: IApplePortalSessionService,
 		private $logger: ILogger,
 		private $projectData: IProjectData,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
@@ -31,7 +32,12 @@ export class ListiOSApps implements ICommand {
 			password = await this.$prompter.getPassword("Apple ID password");
 		}
 
-		const applications = await this.$applePortalApplicationService.getApplications({ username, password });
+		const user = await this.$applePortalSessionService.createUserSession({ username, password });
+		if (!user.areCredentialsValid) {
+			this.$errors.failWithoutHelp(`Invalid username and password combination. Used '${username}' as the username.`);
+		}
+
+		const applications = await this.$applePortalApplicationService.getApplications(user);
 
 		if (!applications || !applications.length) {
 			this.$logger.info("Seems you don't have any applications yet.");

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -42,7 +42,7 @@ export class PublishIOS implements ICommand {
 		const user = await this.$applePortalSessionService.createUserSession({ username, password }, {
 			applicationSpecificPassword:  this.$options.appleApplicationSpecificPassword,
 			sessionBase64: this.$options.appleSessionBase64,
-			ensureConsoleIsInteractive: true
+			requireInteractiveConsole: true
 		});
 		if (!user.areCredentialsValid) {
 			this.$errors.failWithoutHelp(`Invalid username and password combination. Used '${username}' as the username.`);

--- a/lib/common/constants.ts
+++ b/lib/common/constants.ts
@@ -95,6 +95,7 @@ export class HttpStatusCodes {
 	static NOT_MODIFIED = 304;
 	static PAYMENT_REQUIRED = 402;
 	static PROXY_AUTHENTICATION_REQUIRED = 407;
+	static CONFLICTING_RESOURCE = 409;
 }
 
 export const HttpProtocolToPort: IDictionary<number> = {

--- a/lib/common/http-client.ts
+++ b/lib/common/http-client.ts
@@ -255,7 +255,9 @@ private defaultUserAgent: string;
 			this.$logger.error(`You can run ${EOL}\t${clientNameLowerCase} proxy set <url> <username> <password>.${EOL}In order to supply ${clientNameLowerCase} with the credentials needed.`);
 			return "Your proxy requires authentication.";
 		} else if (statusCode === HttpStatusCodes.PAYMENT_REQUIRED) {
-			return util.format("Your subscription has expired.");
+			return "Your subscription has expired.";
+		} else if (statusCode === HttpStatusCodes.CONFLICTING_RESOURCE) {
+			return "The request conflicts with the current state of the server.";
 		} else {
 			this.$logger.trace("Request was unsuccessful. Server returned: ", body);
 			try {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -568,6 +568,8 @@ interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvai
 	analyticsLogFile: string;
 	performance: Object;
 	cleanupLogFile: string;
+	appleApplicationSpecificPassword: string;
+	appleSessionBase64: string;
 }
 
 interface IEnvOptions {
@@ -609,7 +611,13 @@ interface IAndroidResourcesMigrationService {
 /**
  * Describes properties needed for uploading a package to iTunes Connect
  */
-interface IITMSData extends ICredentials {
+interface IITMSData {
+	credentials: ICredentials;
+
+	user: IApplePortalUserDetail;
+
+	applicationSpecificPassword: string;
+		
 	/**
 	 * Path to a .ipa file which will be uploaded.
 	 * @type {string}

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -145,7 +145,9 @@ export class Options {
 			hooks: { type: OptionType.Boolean, default: true, hasSensitiveValue: false },
 			link: { type: OptionType.Boolean, default: false, hasSensitiveValue: false },
 			aab: { type: OptionType.Boolean, hasSensitiveValue: false },
-			performance: { type: OptionType.Object, hasSensitiveValue: true }
+			performance: { type: OptionType.Object, hasSensitiveValue: true },
+			appleApplicationSpecificPassword: { type: OptionType.String, hasSensitiveValue: true },
+			appleSessionBase64: { type: OptionType.String, hasSensitiveValue: true },
 		};
 	}
 

--- a/lib/services/apple-portal/apple-portal-application-service.ts
+++ b/lib/services/apple-portal/apple-portal-application-service.ts
@@ -5,10 +5,9 @@ export class ApplePortalApplicationService implements IApplePortalApplicationSer
 		private $httpClient: Server.IHttpClient
 	) { }
 
-	public async getApplications(credentials: ICredentials): Promise<IApplePortalApplicationSummary[]> {
+	public async getApplications(user: IApplePortalUserDetail): Promise<IApplePortalApplicationSummary[]> {
 		let result: IApplePortalApplicationSummary[] = [];
 
-		const user = await this.$applePortalSessionService.createUserSession(credentials);
 		for (const account of user.associatedAccounts) {
 			const contentProviderId = account.contentProvider.contentProviderId;
 			const dsId = user.sessionToken.dsId;
@@ -36,10 +35,10 @@ export class ApplePortalApplicationService implements IApplePortalApplicationSer
 		return JSON.parse(response.body).data;
 	}
 
-	public async getApplicationByBundleId(credentials: ICredentials, bundleId: string): Promise<IApplePortalApplicationSummary> {
-		const applications = await this.getApplications(credentials);
+	public async getApplicationByBundleId(user: IApplePortalUserDetail, bundleId: string): Promise<IApplePortalApplicationSummary> {
+		const applications = await this.getApplications(user);
 		if (!applications || !applications.length) {
-			this.$errors.failWithoutHelp(`Cannot find any registered applications for Apple ID ${credentials.username} in iTunes Connect.`);
+			this.$errors.failWithoutHelp(`Cannot find any registered applications for Apple ID ${user.userName} in iTunes Connect.`);
 		}
 
 		const application = _.find(applications, app => app.bundleId === bundleId);

--- a/lib/services/apple-portal/apple-portal-cookie-service.ts
+++ b/lib/services/apple-portal/apple-portal-cookie-service.ts
@@ -1,6 +1,6 @@
 export class ApplePortalCookieService implements IApplePortalCookieService {
 	private userSessionCookies: IStringDictionary = {};
-	private validUserSessionCookieNames = ["myacinfo", "dqsid", "itctx", "itcdq", "acn01"];
+	private validUserSessionCookieNames = ["myacinfo", "dqsid", "itctx", "itcdq", "acn01", "DES"];
 	private validWebSessionCookieNames = ["wosid", "woinst", "itctx"];
 
 	public getWebSessionCookie(cookiesData: string[]): string {
@@ -29,7 +29,7 @@ export class ApplePortalCookieService implements IApplePortalCookieService {
 			for (const cookie of parts) {
 				const trimmedCookie = cookie.trim();
 				const [cookieKey, cookieValue] = trimmedCookie.split("=");
-				if (_.includes(validCookieNames, cookieKey)) {
+				if (_.includes(validCookieNames, cookieKey) || _.some(validCookieNames, validCookieName => cookieKey.startsWith(validCookieName))) {
 					result[cookieKey] = { key: cookieKey, value: cookieValue, cookie: trimmedCookie };
 				}
 			}

--- a/lib/services/apple-portal/apple-portal-session-service.ts
+++ b/lib/services/apple-portal/apple-portal-session-service.ts
@@ -102,7 +102,7 @@ To generate an application-specific password, please go to https://appleid.apple
 This password will be used for the iTunes Transporter, which is used to upload your application.`);
 				}
 
-				if (result.isTwoFactorAuthenticationEnabled && opts && opts.ensureConsoleIsInteractive && !isInteractive()) {
+				if (result.isTwoFactorAuthenticationEnabled && opts && opts.requireInteractiveConsole && !isInteractive()) {
 					this.$errors.failWithoutHelp(`Your account has two-factor authentication enabled, but your console is not interactive.
 For more details how to set up your environment, please execute "tns publish ios --help".`);
 				}

--- a/lib/services/apple-portal/apple-portal-session-service.ts
+++ b/lib/services/apple-portal/apple-portal-session-service.ts
@@ -1,3 +1,5 @@
+import { isInteractive } from "../../common/helpers";
+
 export class ApplePortalSessionService implements IApplePortalSessionService {
 	private loginConfigEndpoint = "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com";
 	private defaultLoginConfig = {
@@ -7,42 +9,33 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 
 	constructor(
 		private $applePortalCookieService: IApplePortalCookieService,
+		private $errors: IErrors,
 		private $httpClient: Server.IHttpClient,
-		private $logger: ILogger
+		private $logger: ILogger,
+		private $prompter: IPrompter
 	) { }
 
-	public async createUserSession(credentials: ICredentials): Promise<IApplePortalUserDetail> {
-		const loginConfig = await this.getLoginConfig();
-		const loginUrl = `${loginConfig.authServiceUrl}/auth/signin`;
-		const loginResponse = await this.$httpClient.httpRequest({
-			url: loginUrl,
-			method: "POST",
-			body: JSON.stringify({
-				accountName: credentials.username,
-				password: credentials.password,
-				rememberMe: true
-			}),
-			headers: {
-				'Content-Type': 'application/json',
-				'X-Requested-With': 'XMLHttpRequest',
-				'X-Apple-Widget-Key': loginConfig.authServiceKey,
-				'Accept': 'application/json, text/javascript'
+	public async createUserSession(credentials: ICredentials, opts?: IAppleCreateUserSessionOptions): Promise<IApplePortalUserDetail> {
+		const loginResult = await this.login(credentials, opts);
+
+		if (!opts || !opts.sessionBase64) {
+			if (loginResult.isTwoFactorAuthenticationEnabled) {
+				const authServiceKey = (await this.getLoginConfig()).authServiceKey;
+				await this.handleTwoFactorAuthentication(loginResult.scnt, loginResult.xAppleIdSessionId, authServiceKey);
 			}
-		});
 
-		this.$applePortalCookieService.updateUserSessionCookie(loginResponse.headers["set-cookie"]);
+			const sessionResponse = await this.$httpClient.httpRequest({
+				url: "https://appstoreconnect.apple.com/olympus/v1/session",
+				method: "GET",
+				headers: {
+					'Cookie': this.$applePortalCookieService.getUserSessionCookie()
+				}
+			});
 
-		const sessionResponse = await this.$httpClient.httpRequest({
-			url: "https://appstoreconnect.apple.com/olympus/v1/session",
-			method: "GET",
-			headers: {
-				'Cookie': this.$applePortalCookieService.getUserSessionCookie()
-			}
-		});
+			this.$applePortalCookieService.updateUserSessionCookie(sessionResponse.headers["set-cookie"]);
+		}
 
-		this.$applePortalCookieService.updateUserSessionCookie(sessionResponse.headers["set-cookie"]);
-
-		const userDetailResponse = await this.$httpClient.httpRequest({
+		const userDetailsResponse = await this.$httpClient.httpRequest({
 			url: "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/user/detail",
 			method: "GET",
 			headers: {
@@ -51,9 +44,12 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 			}
 		});
 
-		this.$applePortalCookieService.updateUserSessionCookie(userDetailResponse.headers["set-cookie"]);
+		this.$applePortalCookieService.updateUserSessionCookie(userDetailsResponse.headers["set-cookie"]);
 
-		return JSON.parse(userDetailResponse.body).data;
+		const userdDetails = JSON.parse(userDetailsResponse.body).data;
+		const result = { ...userdDetails, ...loginResult, userSessionCookie: this.$applePortalCookieService.getUserSessionCookie() };
+
+		return result;
 	}
 
 	public async createWebSession(contentProviderId: number, dsId: string): Promise<string> {
@@ -79,6 +75,72 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 		return webSessionCookie;
 	}
 
+	private async login(credentials: ICredentials, opts?: IAppleCreateUserSessionOptions): Promise<IAppleLoginResult> {
+		const result = {
+			scnt: <string>null,
+			xAppleIdSessionId: <string>null,
+			isTwoFactorAuthenticationEnabled: false,
+			areCredentialsValid: true
+		};
+
+		if (opts && opts.sessionBase64) {
+			const decodedSession = Buffer.from(opts.sessionBase64, "base64").toString("utf8");
+
+			this.$applePortalCookieService.updateUserSessionCookie([decodedSession]);
+
+			result.isTwoFactorAuthenticationEnabled = decodedSession.indexOf("DES") > -1;
+		} else {
+			try {
+				await this.loginCore(credentials);
+			} catch (err) {
+				const statusCode = err && err.response && err.response.statusCode;
+				result.areCredentialsValid = statusCode !== 401 && statusCode !== 403;
+				result.isTwoFactorAuthenticationEnabled = statusCode === 409;
+				if (result.isTwoFactorAuthenticationEnabled && opts && !opts.applicationSpecificPassword) {
+					this.$errors.failWithoutHelp(`Your account has two-factor authentication enabled but --appleApplicationSpecificPassword option is not provided.
+To generate an application-specific password, please go to https://appleid.apple.com/account/manage.
+This password will be used for the iTunes Transporter, which is used to upload your application.`);
+				}
+
+				if (result.isTwoFactorAuthenticationEnabled && opts && opts.ensureConsoleIsInteractive && !isInteractive()) {
+					this.$errors.failWithoutHelp(`Your account has two-factor authentication enabled, but your console is not interactive.
+For more details how to set up your environment, please execute "tns publish ios --help".`);
+				}
+
+				const headers = (err && err.response && err.response.headers) || {};
+				result.scnt = headers.scnt;
+				result.xAppleIdSessionId = headers['x-apple-id-session-id'];
+			}
+		}
+
+		return result;
+	}
+
+	private async loginCore(credentials: ICredentials): Promise<void> {
+		const loginConfig = await this.getLoginConfig();
+		const loginUrl = `${loginConfig.authServiceUrl}/auth/signin`;
+		const headers = {
+			'Content-Type': 'application/json',
+			'X-Requested-With': 'XMLHttpRequest',
+			'X-Apple-Widget-Key': loginConfig.authServiceKey,
+			'Accept': 'application/json, text/javascript'
+		};
+		const body = JSON.stringify({
+			accountName: credentials.username,
+			password: credentials.password,
+			rememberMe: true
+		});
+
+		const loginResponse = await this.$httpClient.httpRequest({
+			url: loginUrl,
+			method: "POST",
+			body,
+			headers
+		});
+
+		this.$applePortalCookieService.updateUserSessionCookie(loginResponse.headers["set-cookie"]);
+	}
+
 	private async getLoginConfig(): Promise<{authServiceUrl: string, authServiceKey: string}> {
 		let config = null;
 
@@ -90,6 +152,47 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 		}
 
 		return config || this.defaultLoginConfig;
+	}
+
+	private async handleTwoFactorAuthentication(scnt: string, xAppleIdSessionId: string, authServiceKey: string): Promise<void> {
+		const headers = {
+			'scnt': scnt,
+			'X-Apple-Id-Session-Id': xAppleIdSessionId,
+			'X-Apple-Widget-Key': authServiceKey,
+			'Accept': 'application/json'
+		};
+		const authResponse = await this.$httpClient.httpRequest({
+			url: "https://idmsa.apple.com/appleauth/auth",
+			method: "GET",
+			headers
+		});
+
+		const data = JSON.parse(authResponse.body);
+		if (data.trustedPhoneNumbers && data.trustedPhoneNumbers.length) {
+			const parsedAuthResponse = JSON.parse(authResponse.body);
+			const token = await this.$prompter.getString(`Please enter the ${parsedAuthResponse.securityCode.length} digit code`, { allowEmpty: false });
+
+			await this.$httpClient.httpRequest({
+				url: `https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode`,
+				method: "POST",
+				body: JSON.stringify({
+					securityCode: {
+						code: token.toString()
+					}
+				}),
+				headers: { ...headers, 'Content-Type': "application/json" }
+			});
+
+			const authTrustResponse = await this.$httpClient.httpRequest({
+				url: "https://idmsa.apple.com/appleauth/auth/2sv/trust",
+				method: "GET",
+				headers
+			});
+
+			this.$applePortalCookieService.updateUserSessionCookie(authTrustResponse.headers["set-cookie"]);
+		} else {
+			this.$errors.failWithoutHelp(`Although response from Apple indicated activated Two-step Verification or Two-factor Authentication, NativeScript CLI don't know how to handle this response: ${data}`);
+		}
 	}
 }
 $injector.register("applePortalSessionService", ApplePortalSessionService);

--- a/lib/services/apple-portal/definitions.d.ts
+++ b/lib/services/apple-portal/definitions.d.ts
@@ -1,6 +1,6 @@
 interface IApplePortalSessionService {
-	createUserSession(credentials: ICredentials): Promise<IApplePortalUserDetail>;
 	createWebSession(contentProviderId: number, dsId: string): Promise<string>;
+	createUserSession(credentials: ICredentials, opts?: IAppleCreateUserSessionOptions): Promise<IApplePortalUserDetail>;
 }
 
 interface IApplePortalCookieService {
@@ -10,12 +10,25 @@ interface IApplePortalCookieService {
 }
 
 interface IApplePortalApplicationService {
-	getApplications(credentials: ICredentials): Promise<IApplePortalApplicationSummary[]>
+	getApplications(user: IApplePortalUserDetail): Promise<IApplePortalApplicationSummary[]>
 	getApplicationsByProvider(contentProviderId: number, dsId: string): Promise<IApplePortalApplication>;
-	getApplicationByBundleId(credentials: ICredentials, bundleId: string): Promise<IApplePortalApplicationSummary>;
+	getApplicationByBundleId(user: IApplePortalUserDetail, bundleId: string): Promise<IApplePortalApplicationSummary>;
 }
 
-interface IApplePortalUserDetail {
+interface IAppleCreateUserSessionOptions {
+	applicationSpecificPassword: string;
+	sessionBase64: string;
+	ensureConsoleIsInteractive: boolean;
+}
+
+interface IAppleLoginResult {
+	scnt: string;
+	xAppleIdSessionId: string;
+	isTwoFactorAuthenticationEnabled: boolean;
+	areCredentialsValid: boolean;
+}
+
+interface IApplePortalUserDetail extends IAppleLoginResult {
 	associatedAccounts: IApplePortalAssociatedAccountData[];
 	sessionToken: {
 		dsId: string;
@@ -29,8 +42,10 @@ interface IApplePortalUserDetail {
 	userName: string;
 	userId: string;
 	contentProvider: string;
+	authServiceKey: string;
 	visibility: boolean;
 	DYCVisibility: boolean;
+	userSessionCookie: string;
 }
 
 interface IApplePortalAssociatedAccountData {

--- a/lib/services/apple-portal/definitions.d.ts
+++ b/lib/services/apple-portal/definitions.d.ts
@@ -16,9 +16,9 @@ interface IApplePortalApplicationService {
 }
 
 interface IAppleCreateUserSessionOptions {
-	applicationSpecificPassword: string;
+	applicationSpecificPassword?: string;
 	sessionBase64: string;
-	ensureConsoleIsInteractive: boolean;
+	requireInteractiveConsole?: boolean;
 }
 
 interface IAppleLoginResult {

--- a/test/tns-appstore-upload.ts
+++ b/test/tns-appstore-upload.ts
@@ -71,6 +71,13 @@ class AppStore {
 						return this.iOSPlatformData;
 					}
 				},
+				"applePortalSessionService": {
+					createUserSession: () => {
+						return {
+							areCredentialsValid: true
+						};
+					}
+				}
 			}
 		});
 
@@ -120,8 +127,8 @@ class AppStore {
 		this.itmsTransporterService.upload = (options: IITMSData) => {
 			this.itmsTransporterServiceUploadCalls++;
 			chai.assert.equal(options.ipaFilePath, "/Users/person/git/MyProject/platforms/ios/archive/MyProject.ipa");
-			chai.assert.equal(options.username, AppStore.itunesconnect.user);
-			chai.assert.equal(options.password, AppStore.itunesconnect.pass);
+			chai.assert.equal(options.credentials.username, AppStore.itunesconnect.user);
+			chai.assert.equal(options.credentials.password, AppStore.itunesconnect.pass);
 			chai.assert.equal(options.verboseLogging, false);
 			return Promise.resolve();
 		};


### PR DESCRIPTION
Currently the users are not able to publish applications to AppStore if their accounts are with [two-factor authentication enabled](https://support.apple.com/en-us/HT204915). The current PR introduces support for publishing iOS apps for accounts with two-factor authentication enabled and shouldn't affect how publish command works for accounts without two-factor authentication. To support it, we need 2 additional options:
* appleApplicationSpecificPassword
* appleSessionBase64

The `--appleApplicationSpecificPassword` option is a password for user's Apple ID that let the user sign in to his account and securely access the information he stores from iTunes Transporter application. This option is mandatory for all accounts with two-factor authentication enabled. To generate an application specific password, follow the steps below:
1. Go to https://appleid.apple.com/account/manage
2. Generate a new application specific password
3. Provide the generated application specific password using `--appleApplicationSpecificPassword` option.

The `--appleSessionBase64` option is a base 64 string that actually is the session cookie. This session will be reused instead of triggering a new login each time NativeScript CLI communicates with Apple's APIs.

This PR introduces a new command `tns apple-login` as well.

The `tns apple-login` command uses the provided credentials to obtain Apple session, encode the received session in base64 format and print it on console.

### How tns publish works?

NativeScript CLI tries to sign in the user with provided username and password. If the request fails with statusCode 409, NativeScript CLI consider this as an account with two-factor authentication enabled. If the account is with two-factor authentication, CLI prompts the user for the verification code.

#### Interactive console

1. If the account is with two-factor authentication and `--applicationSpecificPassword` option is not provided, NativeScript CLI throws an error as `iTunes Transporter` will not be able to upload the application.
2. If the account is with two-factor authentication and `--applicationSpecificPassword` option is provided:
    *  If `--appleSessionBase64` is provided, CLI decodes it and tries to sign in the user with provided session.
    * If `--appleSessionBase64` is not provided, CLI will sign in the user with provided credentials.
3. If the account is without two-factor authentication, `--applicationSpecificPassword` option is not respected.
4. If the account is without two-factor authentication, `--appleSessionBase64` is respected and NativeScript CLI reuse the provided session instead of triggering a new login.

#### Non-interactive console (CI)

When the console is not interactive, NativeScript CLI doesn't prompt for verification code. 
1. Execute `tns apple-login` and copy the printed session
2. Execute `tns publish ios <username> <password> --appleApplicationSpecificPassword <app-specific-password> --appleSessionBase64 <session>`

The session should be valid for about one month, meaning a new session should be generated every month. Usually the user will only know about it when the build starts failing.

> NOTE: An Apple ID session is only valid for a certain region, meaning if the CI system is in a different region than the local machine, the user might run into issues.

### Current behavior vs new behavior

|   	|   tns publish ios	| tns appstore list  	|  
|---	|:-:	|---	|
|  current behavior	|   build the application and fail if provided credentials are invalid	|  show `Invalid username and password combination. Used '${username}' as the username.`	| 
|  new behavior	|  validate the credentials and build the application if credentials are valid	|  show { "serviceErrors" : [ { "code" : "-20101", "message" : "Your Apple ID or password was incorrect." } ]}	| 

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Rel to: https://github.com/NativeScript/nativescript-cli/issues/4586

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
