### PR TITLE
feat: Support .xcframework bundles

### DIFF
--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -23,7 +23,6 @@ interface IPlatformData {
 	appDestinationDirectoryPath: string;
 	getBuildOutputPath(options: IBuildOutputOptions): string;
 	getValidBuildOutputData(buildOptions: IBuildOutputOptions): IValidBuildOutputData;
-	frameworkFilesExtensions: string[];
 	frameworkDirectoriesExtensions?: string[];
 	frameworkDirectoriesNames?: string[];
 	targetedOS?: string[];

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -79,7 +79,6 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 						regexes: [new RegExp(`${constants.APP_FOLDER_NAME}-.*-(${Configurations.Debug}|${Configurations.Release})${constants.APK_EXTENSION_NAME}`, "i"), new RegExp(`${packageName}-.*-(${Configurations.Debug}|${Configurations.Release})${constants.APK_EXTENSION_NAME}`, "i")]
 					};
 				},
-				frameworkFilesExtensions: [".jar", ".dat", ".so"],
 				configurationFileName: constants.MANIFEST_FILE_NAME,
 				configurationFilePath: path.join(...configurationsDirectoryArr),
 				relativeToFrameworkConfigurationFilePath: path.join(constants.SRC_DIR, constants.MAIN_DIR, constants.MANIFEST_FILE_NAME),

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -23,6 +23,7 @@ interface INativeSourceCodeGroup {
 
 const DevicePlatformSdkName = "iphoneos";
 const SimulatorPlatformSdkName = "iphonesimulator";
+const FRAMEWORK_EXTENSIONS = [".framework", ".xcframework"];
 
 const getPlatformSdkName = (forDevice: boolean): string => forDevice ? DevicePlatformSdkName : SimulatorPlatformSdkName;
 const getConfigurationName = (release: boolean): string => release ? Configurations.Release : Configurations.Debug;
@@ -89,7 +90,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 					};
 				},
 				frameworkFilesExtensions: [".a", ".framework", ".bin"],
-				frameworkDirectoriesExtensions: [".framework"],
+				frameworkDirectoriesExtensions: FRAMEWORK_EXTENSIONS,
 				frameworkDirectoriesNames: ["Metadata", "metadataGenerator", "NativeScript", "internal"],
 				targetedOS: ['darwin'],
 				configurationFileName: constants.INFO_PLIST_FILE_NAME,
@@ -155,6 +156,9 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			this.replaceFileName("-Info.plist", projectRootFilePath, projectData);
 		}
 		this.replaceFileName("-Prefix.pch", projectRootFilePath, projectData);
+		if (this.$fs.exists(path.join(projectRootFilePath, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER + ".entitlements"))) {
+			this.replaceFileName(".entitlements", projectRootFilePath, projectData);
+		}
 
 		const xcschemeDirPath = path.join(this.getPlatformData(projectData).projectRoot, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER + IosProjectConstants.XcodeProjExtName, "xcshareddata/xcschemes");
 		const xcschemeFilePath = path.join(xcschemeDirPath, IOSProjectService.IOS_PROJECT_NAME_PLACEHOLDER + IosProjectConstants.XcodeSchemeExtName);
@@ -225,17 +229,38 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		return Promise.resolve();
 	}
 
+	private async isDynamicFramework(frameworkPath: string): Promise<boolean> {
+		const frameworkName = path.basename(frameworkPath, path.extname(frameworkPath));
+		const isDynamicFrameworkBundle = async (bundlePath: string) => {
+			const frameworkBinaryPath = path.join(bundlePath, frameworkName);
+
+			return _.includes((await this.$childProcess.spawnFromEvent("file", [frameworkBinaryPath], "close")).stdout, "dynamically linked");
+		};
+
+		if (path.extname(frameworkPath) === ".xcframework") {
+			let isDynamic = true;
+			const subDirs = this.$fs.readDirectory(frameworkPath).filter(entry => this.$fs.getFsStats(entry).isDirectory());
+			for (const subDir of subDirs) {
+				const singlePlatformFramework = path.join(subDir, frameworkName + ".framework");
+				if (this.$fs.exists(singlePlatformFramework)) {
+					isDynamic = await isDynamicFrameworkBundle(singlePlatformFramework);
+					break;
+				}
+			}
+
+			return isDynamic;
+		} else {
+			return await isDynamicFrameworkBundle(frameworkName);
+		}
+	}
+
 	private async addFramework(frameworkPath: string, projectData: IProjectData): Promise<void> {
 		if (!this.$hostInfo.isWindows) {
 			this.validateFramework(frameworkPath);
 
 			const project = this.createPbxProj(projectData);
-			const frameworkName = path.basename(frameworkPath, path.extname(frameworkPath));
-			const frameworkBinaryPath = path.join(frameworkPath, frameworkName);
-			const isDynamic = _.includes((await this.$childProcess.spawnFromEvent("file", [frameworkBinaryPath], "close")).stdout, "dynamically linked");
 			const frameworkAddOptions: IXcode.Options = { customFramework: true };
-
-			if (isDynamic) {
+			if (this.isDynamicFramework(frameworkPath)) {
 				frameworkAddOptions["embed"] = true;
 			}
 
@@ -577,8 +602,10 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		return target;
 	}
 
-	private getAllLibsForPluginWithFileExtension(pluginData: IPluginData, fileExtension: string): string[] {
-		const filterCallback = (fileName: string, pluginPlatformsFolderPath: string) => path.extname(fileName) === fileExtension;
+	private getAllLibsForPluginWithFileExtension(pluginData: IPluginData, fileExtension: string | string[]): string[] {
+		const fileExtensions = _.isArray(fileExtension) ? fileExtension : [fileExtension];
+		const filterCallback = (fileName: string, pluginPlatformsFolderPath: string) =>
+		fileExtensions.indexOf(path.extname(fileName)) !== -1;
 		return this.getAllNativeLibrariesForPlugin(pluginData, IOSProjectService.IOS_PLATFORM_NAME, filterCallback);
 	}
 
@@ -599,7 +626,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		const plistJson = this.$plistParser.parseFileSync(infoPlistPath);
 		const packageType = plistJson["CFBundlePackageType"];
 
-		if (packageType !== "FMWK") {
+		if (packageType !== "FMWK" && packageType !== "XFWK") {
 			this.$errors.failWithoutHelp("The bundle at %s does not appear to be a dynamic framework.", libraryPath);
 		}
 	}
@@ -679,7 +706,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		this.savePbxProj(project, projectData);
 	}
 	private async prepareFrameworks(pluginPlatformsFolderPath: string, pluginData: IPluginData, projectData: IProjectData): Promise<void> {
-		for (const fileName of this.getAllLibsForPluginWithFileExtension(pluginData, ".framework")) {
+		for (const fileName of this.getAllLibsForPluginWithFileExtension(pluginData, FRAMEWORK_EXTENSIONS)) {
 			await this.addFramework(path.join(pluginPlatformsFolderPath, fileName), projectData);
 		}
 	}
@@ -700,7 +727,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 	private removeFrameworks(pluginPlatformsFolderPath: string, pluginData: IPluginData, projectData: IProjectData): void {
 		const project = this.createPbxProj(projectData);
-		_.each(this.getAllLibsForPluginWithFileExtension(pluginData, ".framework"), fileName => {
+		_.each(this.getAllLibsForPluginWithFileExtension(pluginData, FRAMEWORK_EXTENSIONS), fileName => {
 			const relativeFrameworkPath = this.getLibSubpathRelativeToProjectPath(fileName, projectData);
 			project.removeFramework(relativeFrameworkPath, { customFramework: true, embed: true });
 		});

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -89,7 +89,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 						packageNames: [`${projectData.projectName}.app`, `${projectData.projectName}.zip`]
 					};
 				},
-				frameworkFilesExtensions: [".a", ".framework", ".bin"],
 				frameworkDirectoriesExtensions: FRAMEWORK_EXTENSIONS,
 				frameworkDirectoriesNames: ["Metadata", "metadataGenerator", "NativeScript", "internal"],
 				targetedOS: ['darwin'],

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -42,7 +42,6 @@ class PlatformData implements IPlatformData {
 	getBuildOutputPath = () => "";
 	getValidBuildOutputData = (buildOptions: IBuildOutputOptions) => ({ packageNames: [""] });
 	validPackageNamesForDevice: string[] = [];
-	frameworkFilesExtensions = [".jar", ".dat"];
 	appDestinationDirectoryPath = "";
 	relativeToFrameworkConfigurationFilePath = "";
 	fastLivesyncFileExtensions: string[] = [];

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -383,7 +383,6 @@ export class PlatformProjectServiceStub extends EventEmitter implements IPlatfor
 			projectRoot: "",
 			getBuildOutputPath: (buildConfig: IBuildConfig) => "",
 			getValidBuildOutputData: (buildOptions: IBuildOutputOptions) => ({ packageNames: [] }),
-			frameworkFilesExtensions: [],
 			appDestinationDirectoryPath: "",
 			relativeToFrameworkConfigurationFilePath: "",
 			fastLivesyncFileExtensions: []
@@ -486,7 +485,6 @@ export class NativeProjectDataStub extends EventEmitter implements IPlatformsDat
 			appDestinationDirectoryPath: "",
 			getBuildOutputPath: () => "",
 			getValidBuildOutputData: (buildOptions: IBuildOutputOptions) => ({ packageNames: [] }),
-			frameworkFilesExtensions: [],
 			relativeToFrameworkConfigurationFilePath: "",
 			fastLivesyncFileExtensions: []
 		};


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

refs #4906

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
