### PR TITLE
fix: fix appstore list command for accounts with 2fa

### DIFF
--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -42,7 +42,8 @@ export class PublishIOS implements ICommand {
 		const user = await this.$applePortalSessionService.createUserSession({ username, password }, {
 			applicationSpecificPassword:  this.$options.appleApplicationSpecificPassword,
 			sessionBase64: this.$options.appleSessionBase64,
-			requireInteractiveConsole: true
+			requireInteractiveConsole: true,
+			requireApplicationSpecificPassword: true
 		});
 		if (!user.areCredentialsValid) {
 			this.$errors.failWithoutHelp(`Invalid username and password combination. Used '${username}' as the username.`);

--- a/lib/services/apple-portal/apple-portal-session-service.ts
+++ b/lib/services/apple-portal/apple-portal-session-service.ts
@@ -96,7 +96,8 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 				const statusCode = err && err.response && err.response.statusCode;
 				result.areCredentialsValid = statusCode !== 401 && statusCode !== 403;
 				result.isTwoFactorAuthenticationEnabled = statusCode === 409;
-				if (result.isTwoFactorAuthenticationEnabled && opts && !opts.applicationSpecificPassword) {
+
+				if (result.isTwoFactorAuthenticationEnabled && opts && opts.requireApplicationSpecificPassword && !opts.applicationSpecificPassword) {
 					this.$errors.failWithoutHelp(`Your account has two-factor authentication enabled but --appleApplicationSpecificPassword option is not provided.
 To generate an application-specific password, please go to https://appleid.apple.com/account/manage.
 This password will be used for the iTunes Transporter, which is used to upload your application.`);

--- a/lib/services/apple-portal/definitions.d.ts
+++ b/lib/services/apple-portal/definitions.d.ts
@@ -19,6 +19,7 @@ interface IAppleCreateUserSessionOptions {
 	applicationSpecificPassword?: string;
 	sessionBase64: string;
 	requireInteractiveConsole?: boolean;
+	requireApplicationSpecificPassword?: boolean;
 }
 
 interface IAppleLoginResult {


### PR DESCRIPTION
Currently `tns appstore list` command throws an error when account is with 2fa and `--appleApplicationSpecificPassword` option is not provided. We shouldn't throw an error in this situation as we don't need `--appleApplicationSpecificPassword` on `tns appstore list` command as we don't use third party application when executing this command. This option is mandatory only for `tns appstore upload` command where we use iTunesTransporter app when uploading the application.

Rel to: https://github.com/NativeScript/nativescript-cli/issues/4586

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
