### PR TITLE
fix: avoid getting crashed LiveSync when the fast sync fails

### DIFF
--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -1,5 +1,9 @@
 abstract class TestCommandBase {
 	public allowedParameters: ICommandParameter[] = [];
+	public dashedOptions = {
+		hmr: { type: OptionType.Boolean, default: false, hasSensitiveValue: false },
+	};
+
 	protected abstract platform: string;
 	protected abstract $projectData: IProjectData;
 	protected abstract $testExecutionService: ITestExecutionService;
@@ -50,6 +54,13 @@ abstract class TestCommandBase {
 
 	async canExecute(args: string[]): Promise<boolean | ICanExecuteCommandOutput> {
 		if (!this.$options.force) {
+			if (this.$options.hmr) {
+				// With HMR we are not restarting after LiveSync which is causing a 30 seconds app start on Android
+				// because the Runtime does not watch for the `/data/local/tmp<appId>-livesync-in-progress` file deletion.
+				// The App is closing itself after each test execution and the bug will be reproducible on each LiveSync.
+				this.$errors.fail("The `--hmr` option is not supported for this command.");
+			}
+
 			await this.$migrateController.validate({ projectDir: this.$projectData.projectDir, platforms: [this.platform] });
 		}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "6.0.2",
+  "version": "6.0.3",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

In short, the LiveSync crashes when the App is not started or installed on the device.

* Re-implements: https://github.com/NativeScript/nativescript-cli/pull/4020
* Imporves `tns test android` LiveSync performance (avoid waiting 30 seconds)

Related to: https://github.com/NativeScript/nativescript-cli/issues/4914
https://github.com/NativeScript/nativescript-cli/issues/4916