### PR TITLE
fix(ios): isDynamicFramework check for `.xcframework`s

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -238,7 +238,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 		if (path.extname(frameworkPath) === ".xcframework") {
 			let isDynamic = true;
-			const subDirs = this.$fs.readDirectory(frameworkPath).filter(entry => this.$fs.getFsStats(entry).isDirectory());
+			const subDirs = this.$fs.readDirectory(frameworkPath).filter(entry => this.$fs.getFsStats(path.join(frameworkPath, entry)).isDirectory());
 			for (const subDir of subDirs) {
 				const singlePlatformFramework = path.join(subDir, frameworkName + ".framework");
 				if (this.$fs.exists(singlePlatformFramework)) {


### PR DESCRIPTION
Pass full path instead of only file name to `getFsStats`

<!--0
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

related to #4907  