### PR TITLE
fix: remove usages of logger.out in CLI code

### DIFF
--- a/lib/common/errors.ts
+++ b/lib/common/errors.ts
@@ -175,14 +175,15 @@ export class Errors implements IErrors {
 		try {
 			return await action();
 		} catch (ex) {
-			const loggerLevel: string = $injector.resolve("logger").getLevel().toUpperCase();
+			const logger = this.$injector.resolve("logger");
+			const loggerLevel: string = logger.getLevel().toUpperCase();
 			const printCallStack = this.printCallStack || loggerLevel === "TRACE" || loggerLevel === "DEBUG";
 			const message = printCallStack ? resolveCallStack(ex) : isInteractive() ? `\x1B[31;1m${ex.message}\x1B[0m` : ex.message;
 
 			if (ex.printOnStdout) {
-				this.$injector.resolve("logger").out(message);
+				logger.info(message);
 			} else {
-				console.error(message);
+				logger.error(message);
 			}
 
 			if (ex.suggestCommandHelp) {

--- a/lib/common/test/unit-tests/errors.ts
+++ b/lib/common/test/unit-tests/errors.ts
@@ -1,0 +1,189 @@
+import { Yok } from "../../yok";
+import { Errors } from "../../errors";
+import { CommonLoggerStub } from "./stubs";
+import { assert } from "chai";
+import * as path from "path";
+import { LoggerLevel } from "../../../constants";
+const helpers = require("../../helpers");
+const originalIsInteractive = helpers.isInteractive;
+const originalProcessExit = process.exit;
+
+describe("errors", () => {
+	let isInteractive = false;
+	let processExitCode = 0;
+
+	before(() => {
+		helpers.isInteractive = () => isInteractive;
+	});
+
+	after(() => {
+		helpers.isInteractive = originalIsInteractive;
+	});
+
+	const getTestInjector = (): IInjector => {
+		const testInjector = new Yok();
+		testInjector.register("errors", Errors);
+		testInjector.register("logger", CommonLoggerStub);
+		return testInjector;
+	};
+
+	describe("beginCommand", () => {
+		let testInjector: IInjector;
+		let errors: IErrors;
+		let logger: CommonLoggerStub;
+		const errMsg = "Error Message";
+		let isProcessExitCalled = false;
+		let isPrintCommandHelpSuggestionExecuted = false;
+		let actionResult = true;
+
+		beforeEach(() => {
+			(<any>process).exit = (code?: number): any => {
+				isProcessExitCalled = true;
+				processExitCode = code;
+			};
+			testInjector = getTestInjector();
+			errors = testInjector.resolve("errors");
+			logger = testInjector.resolve("logger");
+			isProcessExitCalled = false;
+			isPrintCommandHelpSuggestionExecuted = false;
+			actionResult = true;
+			isInteractive = false;
+		});
+
+		afterEach(() => {
+			process.exit = originalProcessExit;
+		});
+
+		const setupTest = (opts?: { err?: Error }): { action: () => Promise<boolean>, printCommandHelpSuggestion: () => Promise<void> } => {
+			const action = async () => {
+				if (opts && opts.err) {
+					throw opts.err;
+				}
+
+				return actionResult;
+			};
+
+			const printCommandHelpSuggestion = async () => {
+				isPrintCommandHelpSuggestionExecuted = true;
+			};
+
+			return { action, printCommandHelpSuggestion };
+		};
+
+		const assertProcessExited = () => {
+			assert.isTrue(isProcessExitCalled, "When the action fails, process.exit must be called.");
+			assert.equal(processExitCode, 127, "When the action fails, process.exit must be called with 127 by default.");
+		};
+
+		const assertPrintCommandHelpSuggestionIsNotCalled = () => {
+			assert.isFalse(isPrintCommandHelpSuggestionExecuted, "printCommandHelpSuggestion should not be called when the suggestCommandHelp is not set to the exception.");
+		};
+
+		it("executes the passed action and does not print anything when it is successful", async () => {
+			const { action, printCommandHelpSuggestion } = setupTest();
+			let result = await errors.beginCommand(action, printCommandHelpSuggestion);
+			assert.isTrue(result, "beginCommand must return the result of the passed action.");
+
+			actionResult = false;
+			result = await errors.beginCommand(action, printCommandHelpSuggestion);
+			assert.isFalse(result, "beginCommand must return the result of the passed action.");
+			assert.equal(logger.errorOutput, "");
+			assert.equal(logger.output, "");
+			assert.equal(logger.traceOutput, "");
+			assertPrintCommandHelpSuggestionIsNotCalled();
+		});
+
+		it("exits the process when the action fails", async () => {
+			const { action, printCommandHelpSuggestion } = setupTest({ err: new Error(errMsg) });
+			await errors.beginCommand(action, printCommandHelpSuggestion);
+			assertProcessExited();
+			assert.equal(logger.errorOutput, errMsg + '\n');
+			assertPrintCommandHelpSuggestionIsNotCalled();
+		});
+
+		describe("prints the stack trace of the error when", () => {
+			const assertCallStack = () => {
+				assert.isTrue(logger.errorOutput.indexOf(errMsg) !== -1, "The error output must contain the error message");
+				assert.isTrue(logger.errorOutput.indexOf("at Generator.next") !== -1, "The error output must contain callstack");
+				assert.isTrue(logger.errorOutput.indexOf(path.join("lib", "common")) !== -1, "The error output must contain path to lib/common, as this is the location of the file");
+			};
+
+			it("printCallStack property is set to true", async () => {
+				const { action, printCommandHelpSuggestion } = setupTest({ err: new Error(errMsg) });
+				errors.printCallStack = true;
+				await errors.beginCommand(action, printCommandHelpSuggestion);
+				assertCallStack();
+				assertProcessExited();
+				assertPrintCommandHelpSuggestionIsNotCalled();
+			});
+
+			it("loggerLevel is TRACE", async () => {
+				const { action, printCommandHelpSuggestion } = setupTest({ err: new Error(errMsg) });
+				logger.loggerLevel = LoggerLevel.TRACE;
+				await errors.beginCommand(action, printCommandHelpSuggestion);
+				assertCallStack();
+				assertProcessExited();
+				assertPrintCommandHelpSuggestionIsNotCalled();
+			});
+
+			it("loggerLevel is DEBUG", async () => {
+				const { action, printCommandHelpSuggestion } = setupTest({ err: new Error(errMsg) });
+				logger.loggerLevel = LoggerLevel.DEBUG;
+				await errors.beginCommand(action, printCommandHelpSuggestion);
+				assertCallStack();
+				assertProcessExited();
+				assertPrintCommandHelpSuggestionIsNotCalled();
+			});
+		});
+
+		it("colorizes the error message to stderr when the terminal is interactive", async () => {
+			const { action, printCommandHelpSuggestion } = setupTest({ err: new Error(errMsg) });
+			isInteractive = true;
+			await errors.beginCommand(action, printCommandHelpSuggestion);
+			assert.equal(logger.errorOutput, `\x1B[31;1m${errMsg}\x1B[0m\n`);
+			assertProcessExited();
+			assertPrintCommandHelpSuggestionIsNotCalled();
+		});
+
+		it("prints message on stdout instead of stderr when printOnStdout is set in the Error", async () => {
+			const errObj: any = new Error(errMsg);
+			errObj.printOnStdout = true;
+			const { action, printCommandHelpSuggestion } = setupTest({ err: errObj });
+			await errors.beginCommand(action, printCommandHelpSuggestion);
+			assert.equal(logger.errorOutput, "");
+			assert.equal(logger.output, `${errMsg}\n`);
+			assertProcessExited();
+			assertPrintCommandHelpSuggestionIsNotCalled();
+		});
+
+		it("suggests how to show command help when error's suggestCommandHelp is set", async () => {
+			const errObj: any = new Error(errMsg);
+			errObj.suggestCommandHelp = true;
+			const { action, printCommandHelpSuggestion } = setupTest({ err: errObj });
+			await errors.beginCommand(action, printCommandHelpSuggestion);
+			assert.equal(logger.errorOutput, `${errMsg}\n`);
+			assertProcessExited();
+			assert.isTrue(isPrintCommandHelpSuggestionExecuted, "printCommandHelpSuggestion should be called when the action fails with an error object for which suggestCommandHelp is true.");
+		});
+
+		it("exits with passed exit code when the error has errorCode set to number", async () => {
+			const errObj: any = new Error(errMsg);
+			errObj.errorCode = 222;
+			const { action, printCommandHelpSuggestion } = setupTest({ err: errObj });
+			await errors.beginCommand(action, printCommandHelpSuggestion);
+			assert.equal(logger.errorOutput, `${errMsg}\n`);
+			assert.isTrue(isProcessExitCalled, "When the action fails, process.exit must be called.");
+			assert.equal(processExitCode, errObj.errorCode, `When the action fails, process.exit must be called with ${errObj.errorCode}.`);
+		});
+
+		it("exits with default exit code code when the error has errorCode set to string", async () => {
+			const errObj: any = new Error(errMsg);
+			errObj.errorCode = "222";
+			const { action, printCommandHelpSuggestion } = setupTest({ err: errObj });
+			await errors.beginCommand(action, printCommandHelpSuggestion);
+			assert.equal(logger.errorOutput, `${errMsg}\n`);
+			assert.isTrue(isProcessExitCalled, "When the action fails, process.exit must be called.");
+			assert.equal(processExitCode, 127, "When the action fails, process.exit must be called with 127 by default.");
+		});
+	});
+});

--- a/lib/common/test/unit-tests/stubs.ts
+++ b/lib/common/test/unit-tests/stubs.ts
@@ -19,11 +19,14 @@ export class LockServiceStub implements ILockService {
 }
 
 export class CommonLoggerStub implements ILogger {
+	loggerLevel: string = "";
 	initialize(opts?: ILoggerOptions): void { }
 	initializeCliLogger(): void { }
-	getLevel(): string { return undefined; }
+	getLevel(): string { return this.loggerLevel; }
 	fatal(...args: any[]): void { }
-	error(...args: any[]): void { }
+	error(...args: any[]): void {
+		this.errorOutput += util.format.apply(null, args) + "\n";
+	}
 	warn(...args: any[]): void {
 		this.output += util.format.apply(null, args) + "\n";
 	}
@@ -37,6 +40,7 @@ export class CommonLoggerStub implements ILogger {
 
 	public output = "";
 	public traceOutput = "";
+	public errorOutput = "";
 
 	prepare(item: any): string {
 		return "";
@@ -46,7 +50,6 @@ export class CommonLoggerStub implements ILogger {
 		this.output += message;
 	}
 
-	out(formatStr?: any, ...args: any[]): void { }
 	write(...args: any[]): void { }
 	printInfoMessageOnSameLine(message: string): void { }
 	async printMsgWithTimeout(message: string, timeout: number): Promise<void> { }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -36,7 +36,6 @@ export class LoggerStub implements ILogger {
 
 	printMarkdown(message: string): void { }
 
-	out(formatStr?: any, ...args: any[]): void { }
 	write(...args: any[]): void { }
 	printInfoMessageOnSameLine(message: string): void { }
 	async printMsgWithTimeout(message: string, timeout: number): Promise<void> { }


### PR DESCRIPTION
`logger.out` has been removed before 6.0 release, but it has still been used in CLI's code. Remove its usages and add tests for `errors.beginCommand` (the one where the method has been used until now.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
`ANDROID_HOME=/invalid tns doctor` - fails and in interactive terminal prompts you to select option. If you choose Manually configure, CLI will print error `this.$injector.resolve(...).out is not a function` (NOTE: In non-interactive terminal the same happens).

## What is the new behavior?
<!-- Describe the changes. -->
`ANDROID_HOME=/invalid tns doctor` - fails and in interactive terminal prompts you to select option. If you choose Manually configure, CLI will prints where are the system requirements.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4958

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
