### PR TITLE
feat: add tracking for React and Svelte projecs

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -136,6 +136,8 @@ export class ProjectTypes {
 	public static VueFlavorName = VueFlavorName;
 	public static TsFlavorName = "Pure TypeScript";
 	public static JsFlavorName = "Pure JavaScript";
+	public static ReactFlavorName = "React";
+	public static SvelteFlavorName = "Svelte";
 }
 export const BUILD_OUTPUT_EVENT_NAME = "buildOutput";
 export const CONNECTION_ERROR_EVENT_NAME = "connectionError";

--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -204,6 +204,10 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 				template = constants.RESERVED_TEMPLATE_NAMES.javascript;
 				break;
 			}
+			default: {
+				template = constants.RESERVED_TEMPLATE_NAMES.javascript;
+				break;
+			}
 		}
 
 		return template;

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -28,6 +28,14 @@ export class ProjectData implements IProjectData {
 			requiredDependencies: ["nativescript-vue"]
 		},
 		{
+			type: constants.ProjectTypes.ReactFlavorName,
+			requiredDependencies: ["react-nativescript"]
+		},
+		{
+			type: constants.ProjectTypes.SvelteFlavorName,
+			requiredDependencies: ["svelte-native"]
+		},
+		{
 			type: constants.ProjectTypes.TsFlavorName,
 			requiredDependencies: ["typescript", "nativescript-dev-typescript"]
 		}

--- a/test/controllers/update-controller.ts
+++ b/test/controllers/update-controller.ts
@@ -2,7 +2,7 @@ import * as stubs from "./../stubs";
 import * as yok from "../../lib/common/yok";
 import { UpdateController } from "../../lib/controllers/update-controller";
 import { assert } from "chai";
-import * as sinon from 'sinon';
+import * as sinon from "sinon";
 import * as path from "path";
 import { Options } from "../../lib/options";
 import { StaticConfig } from "../../lib/config";
@@ -21,7 +21,7 @@ function createTestInjector(
 		checkConsent: async (): Promise<void> => undefined,
 		trackFeature: async (): Promise<void> => undefined
 	});
-	testInjector.register('errors', stubs.ErrorsStub);
+	testInjector.register("errors", stubs.ErrorsStub);
 	testInjector.register("staticConfig", StaticConfig);
 	testInjector.register("projectData", {
 		projectDir,
@@ -32,29 +32,29 @@ function createTestInjector(
 	testInjector.register("migrateController", {
 		shouldMigrate: () => { return false; },
 	});
-	testInjector.register('fs', stubs.FileSystemStub);
-	testInjector.register('platformCommandHelper', {
+	testInjector.register("fs", stubs.FileSystemStub);
+	testInjector.register("platformCommandHelper", {
 		getCurrentPlatformVersion: () => {
 			return "5.2.0";
 		}
 	});
 
-	testInjector.register('packageManager', {
+	testInjector.register("packageManager", {
 		getTagVersion: () => {
 			return "2.3.0";
 		}
 	});
 	testInjector.register("addPlatformService", {
-		setPlatformVersion: () => {/**/}
+		setPlatformVersion: () => {/**/ }
 	});
 	testInjector.register("pluginsService", {
-		addToPackageJson: () => {/**/}
+		addToPackageJson: () => {/**/ }
 	});
-	testInjector.register('devicePlatformsConstants', DevicePlatformsConstants);
-	testInjector.register('packageInstallationManager', stubs.PackageInstallationManagerStub);
-	testInjector.register('platformsDataService', stubs.NativeProjectDataStub);
+	testInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
+	testInjector.register("packageInstallationManager", stubs.PackageInstallationManagerStub);
+	testInjector.register("platformsDataService", stubs.NativeProjectDataStub);
 	testInjector.register("pacoteService", stubs.PacoteServiceStub);
-	testInjector.register('projectDataService', stubs.ProjectDataService);
+	testInjector.register("projectDataService", stubs.ProjectDataService);
 	testInjector.register("updateController", UpdateController);
 
 	return testInjector;
@@ -78,7 +78,7 @@ describe("update controller method tests", () => {
 		sandbox.stub(fs, "copyFile").throws();
 		const updateController = testInjector.resolve("updateController");
 
-		await updateController.update({projectDir: projectFolder, version: "3.3.0"});
+		await updateController.update({ projectDir: projectFolder, version: "3.3.0" });
 
 		assert.isTrue(deleteDirectory.calledWith(path.join(projectFolder, UpdateController.backupFolder)));
 		assert.isFalse(deleteDirectory.calledWith(path.join(projectFolder, "platforms")));
@@ -90,7 +90,7 @@ describe("update controller method tests", () => {
 		const copyFileStub = sandbox.stub(fs, "copyFile");
 		const updateController = testInjector.resolve("updateController");
 
-		await updateController.update({projectDir: projectFolder, version: "3.3.0"});
+		await updateController.update({ projectDir: projectFolder, version: "3.3.0" });
 
 		assert.isTrue(copyFileStub.calledWith(path.join(projectFolder, "package.json")));
 		for (const folder of UpdateController.folders) {
@@ -108,11 +108,94 @@ describe("update controller method tests", () => {
 		const updateController = testInjector.resolve("updateController");
 		const tempDir = path.join(projectFolder, UpdateController.backupFolder);
 
-		await updateController.update({projectDir: projectFolder, version: "3.3.0"});
+		await updateController.update({ projectDir: projectFolder, version: "3.3.0" });
 
 		assert.isTrue(copyFileStub.calledWith(path.join(tempDir, "package.json"), projectFolder));
 		for (const folder of UpdateController.folders) {
 			assert.isTrue(copyFileStub.calledWith(path.join(tempDir, folder), projectFolder));
 		}
 	});
+
+	for (const projectType of ["Angular", "React"]) {
+		it(`should update dependencies from project type: ${projectType}`, async () => {
+			const testInjector = createTestInjector();
+			testInjector.resolve("platformCommandHelper").removePlatforms = () => {
+				throw new Error();
+			};
+
+			const fs = testInjector.resolve("fs");
+			const copyFileStub = sandbox.stub(fs, "copyFile");
+			const updateController = testInjector.resolve("updateController");
+			const tempDir = path.join(projectFolder, UpdateController.backupFolder);
+
+			const projectDataService = testInjector.resolve<IProjectDataService>("projectDataService");
+			projectDataService.getProjectData = (projectDir: string) => {
+				return <any>{
+					projectDir,
+					projectType,
+					dependencies: {
+						"tns-core-modules": "0.1.0",
+					},
+					devDependencies: {
+						"nativescript-dev-webpack": "1.1.3"
+					}
+				};
+			};
+
+			const packageInstallationManager = testInjector.resolve<IPackageInstallationManager>("packageInstallationManager");
+			const latestCompatibleVersion = "1.1.1";
+			packageInstallationManager.getLatestCompatibleVersionSafe = async (packageName: string, referenceVersion?: string): Promise<string> => {
+				assert.isString(packageName);
+				assert.isFalse(_.isEmpty(packageName));
+				return latestCompatibleVersion;
+			};
+
+			const pacoteService = testInjector.resolve<IPacoteService>("pacoteService");
+			pacoteService.manifest = async (packageName: string, options?: IPacoteManifestOptions): Promise<any> => {
+				assert.isString(packageName);
+				assert.isFalse(_.isEmpty(packageName));
+
+				return {
+					dependencies: {
+						"tns-core-modules": "1.0.0",
+						"dep2": "1.1.0"
+					},
+					devDependencies: {
+						"devDep1": "1.2.0",
+						"nativescript-dev-webpack": "1.3.0"
+					},
+					name: "template1"
+				};
+			};
+
+			const pluginsService = testInjector.resolve<IPluginsService>("pluginsService");
+			const dataAddedToPackageJson: IDictionary<any> = {
+				dependencies: {},
+				devDependencies: {}
+			};
+			pluginsService.addToPackageJson = (plugin: string, version: string, isDev: boolean, projectDir: string): void => {
+				if (isDev) {
+					dataAddedToPackageJson.devDependencies[plugin] = version;
+				} else {
+					dataAddedToPackageJson.dependencies[plugin] = version;
+				}
+			};
+
+			await updateController.update({ projectDir: projectFolder });
+
+			assert.isTrue(copyFileStub.calledWith(path.join(tempDir, "package.json"), projectFolder));
+			for (const folder of UpdateController.folders) {
+				assert.isTrue(copyFileStub.calledWith(path.join(tempDir, folder), projectFolder));
+			}
+
+			assert.deepEqual(dataAddedToPackageJson, {
+				dependencies: {
+					"tns-core-modules": "1.0.0",
+				},
+				devDependencies: {
+					"nativescript-dev-webpack": "1.3.0"
+				}
+			});
+		});
+	}
 });

--- a/test/project-data.ts
+++ b/test/project-data.ts
@@ -100,6 +100,14 @@ describe("projectData", () => {
 			assertProjectType({ "nativescript-vue": "*" }, { "typescript": "*" }, "Vue.js");
 		});
 
+		it("detects project as React when react-nativescript exists as dependency and typescript is devDependency", () => {
+			assertProjectType({ "react-nativescript": "*" }, null, "React");
+		});
+
+		it("detects project as Svelte when react-nativescript exists as dependency and typescript is devDependency", () => {
+			assertProjectType({ "svelte-native": "*" }, null, "Svelte");
+		});
+
 		it("detects project as TypeScript when nativescript-dev-typescript exists as dependency", () => {
 			assertProjectType(null, { "nativescript-dev-typescript": "*" }, "Pure TypeScript");
 		});


### PR DESCRIPTION
Add tracking in CLI analytics for React and Svelte project types. As we do not have templates for those two project types, when CLI detects a project from this type and the `tns update` command is executed, get the dependencies for update from the default hellow world JS template.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
CLI does not track React and Svelte projects

## What is the new behavior?
CLI tracks projects as React when `react-nativescript` is added as dependency.
CLI tracks projects as Svelte when `svelte-native` is added as dependency.

Implements issue: https://github.com/NativeScript/nativescript-cli/issues/4947 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
