### PR TITLE
fix: certificates and provision parsing should work on macOS Catalina

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4038,9 +4038,9 @@
       }
     },
     "ios-mobileprovision-finder": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ios-mobileprovision-finder/-/ios-mobileprovision-finder-1.0.10.tgz",
-      "integrity": "sha1-UaXn+TzUCwN/fI8+JwXjSI11VgE=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ios-mobileprovision-finder/-/ios-mobileprovision-finder-1.0.11.tgz",
+      "integrity": "sha512-abq25CblgdjIAD2t6YkYoE7SvK8eN9OWKLH4Bspi8mzpGhZEBhwkWr5HT9nTy+9BA8Zyz1bMuvUyC5pBPDVFlg==",
       "requires": {
         "chalk": "^1.1.3",
         "plist": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "iconv-lite": "0.4.11",
     "inquirer": "6.2.0",
     "ios-device-lib": "0.6.0",
-    "ios-mobileprovision-finder": "1.0.10",
+    "ios-mobileprovision-finder": "1.0.11",
     "ios-sim-portable": "4.0.9",
     "istextorbinary": "2.2.1",
     "jimp": "0.2.28",


### PR DESCRIPTION
Currently, in case you pass `--provision` to `tns prepare/build/run/debug/test` command and you have macOS Catalina installed, CLI fails with error: `Expected "SHA-1 hash: " or end of input but "S" found`.
The problem is that the `security` command used by `ios-mobileprovision-finder` package has a different output in macOS Catalina. To fix this, update the ios-mobileprovision-finder version.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Running `tns prepare ios --provision` fails on macOS Catalina.

## What is the new behavior?
CLI can parse certificates and provsions on macOS Catalina, i.e. `tns prepare ios --provision` shows correct output.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4934
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
