### PR TITLE
feat(publish): ability to publish applications using Xcode 11

### DIFF
--- a/lib/common/services/xcode-select-service.ts
+++ b/lib/common/services/xcode-select-service.ts
@@ -35,15 +35,9 @@ export class XcodeSelectService implements IXcodeSelectService {
 			this.$errors.fail("xcodebuild execution failed. Make sure that you have latest Xcode and tools installed.");
 		}
 
-		const xcodeVersionMatch = xcodeVer.match(/Xcode (.*)/),
-			xcodeVersionGroup = xcodeVersionMatch && xcodeVersionMatch[1],
-			xcodeVersionSplit = xcodeVersionGroup && xcodeVersionGroup.split(".");
+		const [ major, minor, patch ] = xcodeVer.split(".");
 
-		return {
-			major: xcodeVersionSplit && xcodeVersionSplit[0],
-			minor: xcodeVersionSplit && xcodeVersionSplit[1],
-			patch: xcodeVersionSplit && xcodeVersionSplit[2]
-		};
+		return { major, minor, patch };
 	}
 }
 

--- a/lib/common/test/unit-tests/xcode-select-service.ts
+++ b/lib/common/test/unit-tests/xcode-select-service.ts
@@ -59,7 +59,7 @@ describe("xcode-select-service", () => {
 	});
 
 	it("gets correct Xcode version", async () => {
-		injector = createTestInjector({ xcodeSelectStdout: null, isDarwin: true, xcodeVersionOutput: "Xcode 7.3\nBuild version 7D175" });
+		injector = createTestInjector({ xcodeSelectStdout: null, isDarwin: true, xcodeVersionOutput: "7.3" });
 		service = injector.resolve("$xcodeSelectService");
 
 		const xcodeVersion = await service.getXcodeVersion();

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -639,6 +639,7 @@ interface IITMSData {
  * Used for communicating with Xcode's iTMS Transporter tool.
  */
 interface IITMSTransporterService {
+	validate(): Promise<void>;
 	/**
 	 * Uploads an .ipa package to iTunes Connect.
 	 * @param  {IITMSData}     data Data needed to upload the package

--- a/test/tns-appstore-upload.ts
+++ b/test/tns-appstore-upload.ts
@@ -124,6 +124,7 @@ class AppStore {
 
 	expectITMSTransporterUpload() {
 		this.expectedItmsTransporterServiceUploadCalls = 1;
+		this.itmsTransporterService.validate = () => Promise.resolve();
 		this.itmsTransporterService.upload = (options: IITMSData) => {
 			this.itmsTransporterServiceUploadCalls++;
 			chai.assert.equal(options.ipaFilePath, "/Users/person/git/MyProject/platforms/ios/archive/MyProject.ipa");


### PR DESCRIPTION
As `Application Loader` is no longer included in Xcode 11, CLI is not able to find the path to itmsTransporter and throws an error. However, `itmsTransporter` app is already part of `ContentDeliveryServices.framework` which is part of `SharedFrameworks` which are included in `Xcode 11` itself. So this PR returns the correct path to itmsTransporter app based on xcode's version.
Also this PR checks first if the path to itmsTransporter exists and after that builds the application.

Currently `getXcodeVersion` always returns `{ major: null, minor: null, patch: null }`. This method uses internally `sysInfo.getXcodeVersion()`. On the other side, `sysInfo.getXcodeVersion()` returns the xocde's version in format `major.minor.patch` - for example `10.3.4`. After getting the result of `sysInfo.getXcodeVersion()`, NativeScript CLI matches the received output with `/Xcode (.*)/` regex. As the received output doesn't contain `Xcode`, the match always returns null and as result `getXcodeVersion()` always returns `{ major: null, minor: null, patch: null }`.

Rel to: https://github.com/NativeScript/nativescript-cli/issues/4908

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
