### PR TITLE
fix: speed up the prepare process

### DIFF
--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -273,38 +273,6 @@ export function getRelativeToRootPath(rootPath: string, filePath: string): strin
 	return relativeToRootPath;
 }
 
-function getVersionArray(version: string | IVersionData): number[] {
-	let result: number[] = [];
-	const parseLambda = (x: string) => parseInt(x, 10);
-	const filterLambda = (x: number) => !isNaN(x);
-
-	if (typeof version === "string") {
-		const versionString = <string>version.split("-")[0];
-		result = _.map(versionString.split("."), parseLambda);
-	} else {
-		result = _(version).map(parseLambda).filter(filterLambda).value();
-	}
-
-	return result;
-}
-
-export function versionCompare(version1: string | IVersionData, version2: string | IVersionData): number {
-	const v1array = getVersionArray(version1),
-		v2array = getVersionArray(version2);
-
-	if (v1array.length !== v2array.length) {
-		throw new Error("Version strings are not in the same format");
-	}
-
-	for (let i = 0; i < v1array.length; ++i) {
-		if (v1array[i] !== v2array[i]) {
-			return v1array[i] > v2array[i] ? 1 : -1;
-		}
-	}
-
-	return 0;
-}
-
 export function isInteractive(): boolean {
 	const result = isRunningInTTY() && !isCIEnvironment();
 	return result;

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -850,23 +850,6 @@ interface IXcprojService {
 	 * @return {string} The full path to the xcodeproj
 	 */
 	getXcodeprojPath(projectData: IProjectData, projectRoot: string): string;
-	/**
-	 * Checks whether the system needs xcproj to execute ios builds successfully.
-	 * In case the system does need xcproj but does not have it, prints an error message.
-	 * @param {IVerifyXcprojOptions} opts whether to fail with error message or not
-	 * @return {Promise<boolean>} whether an error occurred or not.
-	 */
-	verifyXcproj(opts: IVerifyXcprojOptions): Promise<boolean>;
-	/**
-	 * Collects information about xcproj.
-	 * @return {Promise<XcprojInfo>} collected info about xcproj.
-	 */
-	getXcprojInfo(): Promise<IXcprojInfo>;
-	/**
-	 * Checks if xcproj is available and throws an error in case when it is not available.
-	 * @return {Promise<boolean>}
-	 */
-	checkIfXcodeprojIsRequired(): Promise<boolean>;
 }
 
 /**

--- a/lib/services/xcconfig-service.ts
+++ b/lib/services/xcconfig-service.ts
@@ -4,8 +4,7 @@ import { Configurations } from "../common/constants";
 export class XcconfigService implements IXcconfigService {
 	constructor(
 		private $childProcess: IChildProcess,
-		private $fs: IFileSystem,
-		private $xcprojService: IXcprojService) { }
+		private $fs: IFileSystem) { }
 
 	public getPluginsXcconfigFilePaths(projectRoot: string): IStringDictionary {
 		return {
@@ -26,9 +25,6 @@ export class XcconfigService implements IXcconfigService {
 		if (!this.$fs.exists(destinationFile)) {
 			this.$fs.writeFile(destinationFile, "");
 		}
-
-		// TODO: Consider to remove this method
-		await this.$xcprojService.checkIfXcodeprojIsRequired();
 
 		const escapedDestinationFile = destinationFile.replace(/'/g, "\\'");
 		const escapedSourceFile = sourceFile.replace(/'/g, "\\'");

--- a/lib/services/xcproj-service.ts
+++ b/lib/services/xcproj-service.ts
@@ -1,83 +1,9 @@
-import * as semver from "semver";
-import * as helpers from "../common/helpers";
-import { EOL } from "os";
 import * as path from "path";
 import { IosProjectConstants } from "../constants";
 
 class XcprojService implements IXcprojService {
-	private xcprojInfoCache: IXcprojInfo;
-
-	constructor(private $childProcess: IChildProcess,
-		private $errors: IErrors,
-		private $logger: ILogger,
-		private $sysInfo: ISysInfo,
-		private $xcodeSelectService: IXcodeSelectService) {
-	}
-
 	public getXcodeprojPath(projectData: IProjectData, projectRoot: string): string {
 		return path.join(projectRoot, projectData.projectName + IosProjectConstants.XcodeProjExtName);
-	}
-
-	public async verifyXcproj(opts: IVerifyXcprojOptions): Promise<boolean> {
-		const xcprojInfo = await this.getXcprojInfo();
-		if (xcprojInfo.shouldUseXcproj && !xcprojInfo.xcprojAvailable) {
-			const errorMessage = `You are using CocoaPods version ${xcprojInfo.cocoapodVer} which does not support Xcode ${xcprojInfo.xcodeVersion.major}.${xcprojInfo.xcodeVersion.minor} yet.${EOL}${EOL}You can update your cocoapods by running $sudo gem install cocoapods from a terminal.${EOL}${EOL}In order for the NativeScript CLI to be able to work correctly with this setup you need to install xcproj command line tool and add it to your PATH. Xcproj can be installed with homebrew by running $ brew install xcproj from the terminal`;
-			if (opts.shouldFail) {
-				this.$errors.fail(errorMessage);
-			} else {
-				this.$logger.warn(errorMessage);
-			}
-
-			return true;
-		}
-
-		return false;
-	}
-
-	public async getXcprojInfo(): Promise<IXcprojInfo> {
-		if (!this.xcprojInfoCache) {
-			let cocoapodVer = await this.$sysInfo.getCocoaPodsVersion();
-			const xcodeVersion = await this.$xcodeSelectService.getXcodeVersion();
-
-			if (cocoapodVer && !semver.valid(cocoapodVer)) {
-				// Cocoapods betas have names like 1.0.0.beta.8
-				// These 1.0.0 betas are not valid semver versions, but they are working fine with XCode 7.3
-				// So get only the major.minor.patch version and consider them as 1.0.0
-				cocoapodVer = _.take(cocoapodVer.split("."), 3).join(".");
-			}
-
-			xcodeVersion.patch = xcodeVersion.patch || "0";
-			// CocoaPods with version lower than 1.0.0 don't support Xcode 7.3 yet
-			// https://github.com/CocoaPods/CocoaPods/issues/2530#issuecomment-210470123
-			// as a result of this all .pbxprojects touched by CocoaPods get converted to XML plist format
-			const shouldUseXcproj = cocoapodVer && !!(semver.lt(cocoapodVer, "1.0.0") && ~helpers.versionCompare(xcodeVersion, "7.3.0"));
-			let xcprojAvailable: boolean;
-
-			if (shouldUseXcproj) {
-				// if that's the case we can use xcproj gem to convert them back to ASCII plist format
-				try {
-					await this.$childProcess.exec("xcproj --version");
-					xcprojAvailable = true;
-				} catch (e) {
-					xcprojAvailable = false;
-				}
-			}
-
-			this.xcprojInfoCache = { cocoapodVer, xcodeVersion, shouldUseXcproj, xcprojAvailable };
-		}
-
-		return this.xcprojInfoCache;
-	}
-
-	public async checkIfXcodeprojIsRequired(): Promise<boolean> {
-		const xcprojInfo = await this.getXcprojInfo();
-		if (xcprojInfo.shouldUseXcproj && !xcprojInfo.xcprojAvailable) {
-			const errorMessage = `You are using CocoaPods version ${xcprojInfo.cocoapodVer} which does not support Xcode ${xcprojInfo.xcodeVersion.major}.${xcprojInfo.xcodeVersion.minor} yet.${EOL}${EOL}You can update your cocoapods by running $sudo gem install cocoapods from a terminal.${EOL}${EOL}In order for the NativeScript CLI to be able to work correctly with this setup you need to install xcproj command line tool and add it to your PATH. Xcproj can be installed with homebrew by running $ brew install xcproj from the terminal`;
-
-			this.$errors.fail(errorMessage);
-
-			return true;
-		}
 	}
 }
 

--- a/test/cocoapods-service.ts
+++ b/test/cocoapods-service.ts
@@ -740,45 +740,6 @@ end`
 				stderr: "",
 				exitCode: 0
 			});
-
-			const xcprojService = testInjector.resolve<IXcprojService>("xcprojService");
-			xcprojService.verifyXcproj = async (opts: IVerifyXcprojOptions): Promise<boolean> => false;
-			xcprojService.getXcprojInfo = async (): Promise<IXcprojInfo> => (<any>{});
-		});
-
-		it("fails when pod executable is not found", async () => {
-			const childProcess = testInjector.resolve<IChildProcess>("childProcess");
-			childProcess.exec = async (command: string, options?: any, execOptions?: IExecOptions): Promise<any> => {
-				assert.equal(command, "which pod");
-				throw new Error("Missing pod executable");
-			};
-
-			await assert.isRejected(cocoapodsService.executePodInstall(projectRoot, xcodeProjPath), "CocoaPods or ruby gem 'xcodeproj' is not installed. Run `sudo gem install cocoapods` and try again.");
-		});
-
-		it("fails when xcodeproj executable is not found", async () => {
-			const childProcess = testInjector.resolve<IChildProcess>("childProcess");
-			childProcess.exec = async (command: string, options?: any, execOptions?: IExecOptions): Promise<any> => {
-				if (command === "which pod") {
-					return;
-				}
-
-				assert.equal(command, "which xcodeproj");
-				throw new Error("Missing xcodeproj executable");
-
-			};
-
-			await assert.isRejected(cocoapodsService.executePodInstall(projectRoot, xcodeProjPath), "CocoaPods or ruby gem 'xcodeproj' is not installed. Run `sudo gem install cocoapods` and try again.");
-		});
-
-		it("fails with correct error when xcprojService.verifyXcproj throws", async () => {
-			const expectedError = new Error("err");
-			const xcprojService = testInjector.resolve<IXcprojService>("xcprojService");
-			xcprojService.verifyXcproj = async (opts: IVerifyXcprojOptions): Promise<boolean> => {
-				throw expectedError;
-			};
-
-			await assert.isRejected(cocoapodsService.executePodInstall(projectRoot, xcodeProjPath), expectedError);
 		});
 
 		["pod", "sandbox-pod"].forEach(podExecutable => {
@@ -799,18 +760,6 @@ end`
 				await cocoapodsService.executePodInstall(projectRoot, xcodeProjPath);
 				assert.equal(commandCalled, podExecutable);
 			});
-		});
-
-		it("calls xcprojService.verifyXcproj with correct arguments", async () => {
-			const xcprojService = testInjector.resolve<IXcprojService>("xcprojService");
-			let optsPassedToVerifyXcproj: any = null;
-			xcprojService.verifyXcproj = async (opts: IVerifyXcprojOptions): Promise<boolean> => {
-				optsPassedToVerifyXcproj = opts;
-				return false;
-			};
-
-			await cocoapodsService.executePodInstall(projectRoot, xcodeProjPath);
-			assert.deepEqual(optsPassedToVerifyXcproj, { shouldFail: true });
 		});
 
 		it("calls pod install spawnFromEvent with correct arguments", async () => {
@@ -846,7 +795,7 @@ end`
 			await assert.isRejected(cocoapodsService.executePodInstall(projectRoot, xcodeProjPath), "'pod install' command failed.");
 		});
 
-		it("returns the result of the pod install spawnFromEvent methdo", async () => {
+		it("returns the result of the pod install spawnFromEvent method", async () => {
 			const childProcess = testInjector.resolve<IChildProcess>("childProcess");
 			const expectedResult = {
 				stdout: "pod install finished",
@@ -859,49 +808,6 @@ end`
 
 			const result = await cocoapodsService.executePodInstall(projectRoot, xcodeProjPath);
 			assert.deepEqual(result, expectedResult);
-		});
-
-		it("executes xcproj command with correct arguments when is true", async () => {
-			const xcprojService = testInjector.resolve<IXcprojService>("xcprojService");
-			xcprojService.getXcprojInfo = async (): Promise<IXcprojInfo> => (<any>{
-				shouldUseXcproj: true
-			});
-
-			const spawnFromEventCalls: any[] = [];
-			const childProcess = testInjector.resolve<IChildProcess>("childProcess");
-			childProcess.spawnFromEvent = async (command: string, args: string[], event: string, options?: any, spawnFromEventOptions?: ISpawnFromEventOptions): Promise<ISpawnResult> => {
-				spawnFromEventCalls.push({
-					command,
-					args,
-					event,
-					options,
-					spawnFromEventOptions
-				});
-				return {
-					stdout: "",
-					stderr: "",
-					exitCode: 0
-				};
-			};
-
-			await cocoapodsService.executePodInstall(projectRoot, xcodeProjPath);
-			assert.deepEqual(spawnFromEventCalls, [
-				{
-					command: "pod",
-					args: ["install"],
-					event: "close",
-					options: { cwd: projectRoot, stdio: ['pipe', process.stdout, process.stdout] },
-					spawnFromEventOptions: { throwError: false }
-				},
-				{
-					command: "xcproj",
-					args: ["--project", xcodeProjPath, "touch"],
-					event: "close",
-					options: undefined,
-					spawnFromEventOptions: undefined
-				}
-			]);
-
 		});
 	});
 


### PR DESCRIPTION
Currently CLI executes `which pod` and `which xcodeproj` every time when `pod install` is executed e.g on every native change. Also, CLI checks if env is correctly setup on every "prepare" related command - e.g prepare, build, run, debug and test. However, [which xcodeproj](https://github.com/NativeScript/nativescript-doctor/blob/065325fc362262b197c065e621e66866f2d57b45/lib/sys-info.ts#L131)
and [pod --version](https://github.com/NativeScript/nativescript-doctor/blob/065325fc362262b197c065e621e66866f2d57b45/lib/sys-info.ts#L162) are included in the checks for correctly setup env. So these checks shouldn't be executed before each `pod install` as it aditionally slow down the prepare process.

Currently CLI checks if `xcproj` executable is available on user's machine in case when CocoaPods version is lower than `1.0.0` and Xcode's version is greater than `7.3` and uses it to convert the project to ASCII plist format. This logic was needed as there is an issue in case when CocoaPods is with version lower than 1.0.0 and Xcode is with version >= 7.3.0 - all `.pbxproject` files are converted to XML plst format. However, CLI requires Xcode 10 as min supported version and based [on this blog post](http://blog.cocoapods.org/CocoaPods-1.3.0/) it seems it is not possible to use CocoaPods with version lower than 1.0.0 and Xcode 10+.

Rel to: https://github.com/NativeScript/nativescript-cli/issues/4971

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
