### PR TITLE
feat: open feedback form when CLI is uninstalled

### DIFF
--- a/lib/common/commands/preuninstall.ts
+++ b/lib/common/commands/preuninstall.ts
@@ -1,28 +1,44 @@
 ﻿import * as path from "path";
-import { doesCurrentNpmCommandMatch } from "../helpers";
+import { doesCurrentNpmCommandMatch, isInteractive } from "../helpers";
+import { TrackActionNames, AnalyticsEventLabelDelimiter } from "../../constants";
 
 export class PreUninstallCommand implements ICommand {
-	public disableAnalytics = true;
+	private static FEEDBACK_FORM_URL = "https://www.nativescript.org/uninstall-feedback";
 
 	public allowedParameters: ICommandParameter[] = [];
 
-	constructor(private $extensibilityService: IExtensibilityService,
+	constructor(private $analyticsService: IAnalyticsService,
+		private $extensibilityService: IExtensibilityService,
 		private $fs: IFileSystem,
+		private $opener: IOpener,
 		private $packageInstallationManager: IPackageInstallationManager,
 		private $settingsService: ISettingsService) { }
 
 	public async execute(args: string[]): Promise<void> {
 		const isIntentionalUninstall = doesCurrentNpmCommandMatch([/^uninstall$/, /^remove$/, /^rm$/, /^r$/, /^un$/, /^unlink$/]);
+
+		await this.$analyticsService.trackEventActionInGoogleAnalytics({
+			action: TrackActionNames.UninstallCLI,
+			additionalData: `isIntentionalUninstall${AnalyticsEventLabelDelimiter}${isIntentionalUninstall}${AnalyticsEventLabelDelimiter}isInteractive${AnalyticsEventLabelDelimiter}${!!isInteractive()}`
+		});
+
 		if (isIntentionalUninstall) {
-			this.handleIntentionalUninstall();
+			await this.handleIntentionalUninstall();
 		}
 
 		this.$fs.deleteFile(path.join(this.$settingsService.getProfileDir(), "KillSwitches", "cli"));
 	}
 
-	private handleIntentionalUninstall(): void {
+	private async handleIntentionalUninstall(): Promise<void> {
 		this.$extensibilityService.removeAllExtensions();
 		this.$packageInstallationManager.clearInspectorCache();
+		await this.handleFeedbackForm();
+	}
+
+	private async handleFeedbackForm(): Promise<void> {
+		if (isInteractive()) {
+			this.$opener.open(PreUninstallCommand.FEEDBACK_FORM_URL);
+		}
 	}
 }
 

--- a/lib/common/test/unit-tests/preuninstall.ts
+++ b/lib/common/test/unit-tests/preuninstall.ts
@@ -1,0 +1,145 @@
+import { assert } from "chai";
+import { Yok } from "../../yok";
+import { PreUninstallCommand } from "../../commands/preuninstall";
+import * as path from "path";
+const helpers = require("../../helpers");
+
+describe("preuninstall", () => {
+	const profileDir = "profileDir";
+	const createTestInjector = (): IInjector => {
+		const testInjector = new Yok();
+
+		testInjector.register("extensibilityService", {
+			removeAllExtensions: (): void => undefined
+		});
+
+		testInjector.register("fs", {
+			deleteFile: (pathToFile: string): void => undefined
+		});
+
+		testInjector.register("packageInstallationManager", {
+			clearInspectorCache: (): void => undefined
+		});
+
+		testInjector.register("settingsService", {
+			getProfileDir: (): string => profileDir
+		});
+
+		testInjector.register("opener", {
+			open: (filename: string, appname?: string): void => undefined
+		});
+
+		testInjector.register("analyticsService", {
+			trackEventActionInGoogleAnalytics: async (data: IEventActionData): Promise<void> => undefined
+		});
+
+		testInjector.registerCommand("dev-preuninstall", PreUninstallCommand);
+
+		return testInjector;
+	};
+
+	it("cleans the KillSwitches/cli file", async () => {
+		helpers.doesCurrentNpmCommandMatch = () => false;
+		const testInjector = createTestInjector();
+		const fs = testInjector.resolve<IFileSystem>("fs");
+		const deletedFiles: string[] = [];
+		fs.deleteFile = (pathToFile: string) => {
+			deletedFiles.push(pathToFile);
+		};
+
+		const preUninstallCommand: ICommand = testInjector.resolveCommand("dev-preuninstall");
+		await preUninstallCommand.execute([]);
+		assert.deepEqual(deletedFiles, [path.join(profileDir, "KillSwitches", "cli")]);
+	});
+
+	it("tracks correct data in analytics", async () => {
+		const testData: { isInteractive: boolean, isIntentionalUninstall: boolean, expecteEventLabelData: string }[] = [
+			{
+				isIntentionalUninstall: false,
+				isInteractive: false,
+				expecteEventLabelData: `isIntentionalUninstall__false__isInteractive__false`
+			},
+			{
+				isIntentionalUninstall: true,
+				isInteractive: false,
+				expecteEventLabelData: `isIntentionalUninstall__true__isInteractive__false`
+			},
+			{
+				isIntentionalUninstall: false,
+				isInteractive: true,
+				expecteEventLabelData: `isIntentionalUninstall__false__isInteractive__true`
+			},
+			{
+				isIntentionalUninstall: true,
+				isInteractive: true,
+				expecteEventLabelData: `isIntentionalUninstall__true__isInteractive__true`
+			}
+		];
+
+		const testInjector = createTestInjector();
+		const analyticsService = testInjector.resolve<IAnalyticsService>("analyticsService");
+		let trackedData: IEventActionData[] = [];
+		analyticsService.trackEventActionInGoogleAnalytics = async (data: IEventActionData): Promise<void> => {
+			trackedData.push(data);
+		};
+
+		const preUninstallCommand: ICommand = testInjector.resolveCommand("dev-preuninstall");
+		for (const testCase of testData) {
+			helpers.isInteractive = () => testCase.isInteractive;
+			helpers.doesCurrentNpmCommandMatch = () => testCase.isIntentionalUninstall;
+			await preUninstallCommand.execute([]);
+			assert.deepEqual(trackedData, [{
+				action: "Uninstall CLI",
+				additionalData: testCase.expecteEventLabelData
+			}]);
+			trackedData = [];
+		}
+	});
+
+	it("removes all extensions and inspector cache when uninstall command is executed", async () => {
+		helpers.doesCurrentNpmCommandMatch = () => true;
+		helpers.isInteractive = () => false;
+
+		const testInjector = createTestInjector();
+		const fs = testInjector.resolve<IFileSystem>("fs");
+		const deletedFiles: string[] = [];
+		fs.deleteFile = (pathToFile: string) => {
+			deletedFiles.push(pathToFile);
+		};
+
+		const extensibilityService = testInjector.resolve<IExtensibilityService>("extensibilityService");
+		let isRemoveAllExtensionsCalled = false;
+		extensibilityService.removeAllExtensions = () => {
+			isRemoveAllExtensionsCalled = true;
+		};
+
+		const packageInstallationManager = testInjector.resolve<IPackageInstallationManager>("packageInstallationManager");
+		let isClearInspectorCacheCalled = false;
+		packageInstallationManager.clearInspectorCache = () => {
+			isClearInspectorCacheCalled = true;
+		};
+
+		const preUninstallCommand: ICommand = testInjector.resolveCommand("dev-preuninstall");
+		await preUninstallCommand.execute([]);
+		assert.deepEqual(deletedFiles, [path.join(profileDir, "KillSwitches", "cli")]);
+
+		assert.isTrue(isRemoveAllExtensionsCalled, "When uninstall is called, `removeAllExtensions` method must be called");
+		assert.isTrue(isClearInspectorCacheCalled, "When uninstall is called, `clearInspectorCache` method must be called");
+	});
+
+	it("opens the uninstall feedback form when terminal is interactive and uninstall is called", async () => {
+		helpers.doesCurrentNpmCommandMatch = () => true;
+		helpers.isInteractive = () => true;
+
+		const testInjector = createTestInjector();
+		const opener = testInjector.resolve<IOpener>("opener");
+		const openParams: any[] = [];
+		opener.open = (filename: string, appname?: string) => {
+			openParams.push({ filename, appname });
+		};
+
+		const preUninstallCommand: ICommand = testInjector.resolveCommand("dev-preuninstall");
+		await preUninstallCommand.execute([]);
+		assert.deepEqual(openParams, [{ filename: "https://www.nativescript.org/uninstall-feedback", appname: undefined }]);
+	});
+});

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -185,7 +185,8 @@ export const enum TrackActionNames {
 	Options = "Options",
 	AcceptTracking = "Accept Tracking",
 	Performance = "Performance",
-	PreviewAppData = "Preview App Data"
+	PreviewAppData = "Preview App Data",
+	UninstallCLI = "Uninstall CLI"
 }
 
 export const AnalyticsEventLabelDelimiter = "__";


### PR DESCRIPTION
In case CLI is uninstalled, open a feedback form, so the user might explain why they've uninstalled the product.
Add analytics tracking for the uninstall call. Remove the `disableAnalytics` property of the `dev-preuninstall` command - this way we'll receive information for the number of times the command has been executed (usually it is called from CLI's preuninstall script).
Also add custom data in the analytics, so we'll be able to generate report to see how many times users uninstall the CLI (actually executing `npm uninstall...`) and if this happens from interactive terminal.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
When you execute `npm uninstall -g nativescript`, CLI removes several directories and does not collect any information about the action and why it has been executed by the user.

## What is the new behavior?
CLI collects information in analytics when the preuninstall action is executed. In case the command was actually `npm uninstall...` and the terminal is interactive, CLI will open a feedback form, where the user can describe why the product has been uninstalled.

Implements issue https://github.com/NativeScript/nativescript-cli/issues/4974

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
