### PR TITLE
fix: tns update will not modify webpack.config.js of React/Svelte projects

### DIFF
--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -87,7 +87,11 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 		this.$fs.deleteDirectory(path.join(projectData.projectDir, constants.HOOKS_DIR_NAME));
 		this.$fs.deleteDirectory(path.join(projectData.projectDir, constants.PLATFORMS_DIR_NAME));
 		this.$fs.deleteDirectory(path.join(projectData.projectDir, constants.NODE_MODULES_FOLDER_NAME));
-		this.$fs.deleteFile(path.join(projectData.projectDir, constants.WEBPACK_CONFIG_NAME));
+		if (projectData.projectType === constants.ProjectTypes.ReactFlavorName || projectData.projectType === constants.ProjectTypes.SvelteFlavorName) {
+			this.$logger.warn(`As this project is of type ${projectData.projectType}, CLI will not update its ${constants.WEBPACK_CONFIG_NAME} file. Consider updating it manually.`);
+		} else {
+			this.$fs.deleteFile(path.join(projectData.projectDir, constants.WEBPACK_CONFIG_NAME));
+		}
 		this.$fs.deleteFile(path.join(projectData.projectDir, constants.PACKAGE_LOCK_JSON_FILE_NAME));
 		this.$logger.info("Clean old project artefacts complete.");
 	}


### PR DESCRIPTION
As both React and Svelte projects have custom webpack.config.js files, when `tns update` replaces the `webpack.config.js` file, the project becomes unusable. We do not have default webpack.config.js files for these templates, so for the momennt skip the replacement of the file during `tns update` and print informational warning.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Executing `tns upate` in React-nativescript or Svelte project replaces the webpack.config.js with default one for our JavaScript template. This makes the projects unusable and broken.

## What is the new behavior?
CLI prints a warning during `tns update` that it will not update the `webpack.config.js` file as the project type is `React` or `Svelte`

Fixes comment https://github.com/NativeScript/nativescript-cli/issues/4947#issuecomment-524914184

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
