### PR TITLE
fix: open feedback form on preuninstall

### DIFF
--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,14 +1,11 @@
 "use strict";
 
+var path = require("path");
 var child_process = require("child_process");
-var commandArgs = ["bin/tns", "dev-preuninstall"];
+var commandArgs = [path.join(__dirname, "bin", "tns"), "dev-preuninstall"];
 
-var child = child_process.exec("node " + commandArgs.join(" "), function (error) {
-	if (error) {
-		// Some npm versions (3.0, 3.5.1, 3.7.3) remove the NativeScript node_modules before the preuninstall script is executed and the script can't find them (the preuninstall script is like postinstall script).
-		// The issue is described in the npm repository https://github.com/npm/npm/issues/8806 and it is not fixed in version 3.1.1 as commented in the conversation.
-		console.error("Failed to complete all pre-uninstall steps.");
-	}
+var childProcess = child_process.spawn(process.execPath, commandArgs, { stdio: "inherit"})
+
+childProcess.on("error", (err) => {
+	console.error(`Failed to complete all pre-uninstall steps. Error is ${err.message}`);
 });
-
-child.stdout.pipe(process.stdout);

--- a/test/preuninstall.ts
+++ b/test/preuninstall.ts
@@ -1,0 +1,65 @@
+import { assert } from "chai";
+
+// Use require instead of import in order to replace the `spawn` method of child_process
+const childProcess = require("child_process");
+
+import { SpawnOptions, ChildProcess } from "child_process";
+import * as path from "path";
+import { EventEmitter } from "events";
+
+describe("preuninstall.js", () => {
+	let isSpawnCalled = false;
+	let argsPassedToSpawn: string[] = [];
+	let optionsPassedToSpawn: any[];
+	let dataPassedToConsoleError: string[] = [];
+	const originalSpawn = childProcess.spawn;
+	const originalConsoleError = console.error;
+	let eventEmitter = new EventEmitter();
+
+	beforeEach(() => {
+		isSpawnCalled = false;
+		argsPassedToSpawn = [];
+		dataPassedToConsoleError = [];
+		optionsPassedToSpawn = [];
+		eventEmitter = new EventEmitter();
+		childProcess.spawn = (command: string, args?: string[], options?: SpawnOptions): ChildProcess => {
+			isSpawnCalled = true;
+			argsPassedToSpawn = args;
+			optionsPassedToSpawn.push(options);
+			return <any>eventEmitter;
+		};
+
+		console.error = (data: string) => {
+			dataPassedToConsoleError.push(data);
+		};
+	});
+
+	afterEach(() => {
+		childProcess.spawn = originalSpawn;
+		console.error = originalConsoleError;
+	});
+
+	it("calls dev-preuninstall command of CLI and prints with console.error the error in case childProcess emits error event", () => {
+		require(path.join(__dirname, "..", "preuninstall"));
+
+		assert.isTrue(isSpawnCalled, "child_process.spawn must be called from preuninstall.js");
+
+		const expectedPathToCliExecutable = path.join(__dirname, "..", "bin", "tns");
+
+		assert.isTrue(argsPassedToSpawn.indexOf(expectedPathToCliExecutable) !== -1, `The spawned args must contain path to TNS.
+				Expected path is: ${expectedPathToCliExecutable}, current args are: ${argsPassedToSpawn}.`);
+		assert.isTrue(argsPassedToSpawn.indexOf("dev-preuninstall") !== -1, `The spawned args must contain the name of the preuninstall command.
+				Expected path is: ${expectedPathToCliExecutable}, current args are: ${argsPassedToSpawn}.`);
+		assert.deepEqual(optionsPassedToSpawn, [{ stdio: "inherit" }], "The stdio must be inherit as this way CLI's command can determine correctly if terminal is in interactive mode.");
+		assert.deepEqual(dataPassedToConsoleError, []);
+
+		const errMsg = "this is error message";
+		eventEmitter.emit("error", new Error(errMsg));
+		assert.deepEqual(dataPassedToConsoleError, [`Failed to complete all pre-uninstall steps. Error is ${errMsg}`]);
+	});
+
+	it("ensure package.json has correct preuninstall script", () => {
+		const packageJsonData = require("../package.json");
+		assert.equal(packageJsonData.scripts.preuninstall, "node preuninstall.js");
+	});
+});


### PR DESCRIPTION
Currently the when the preuninstall step executes CLI's command, it exec's the process without inheriting the stdout. This way CLI always thinks the terminal is not interactive and never opens the feedback form.

Replace the exec with spawn and set "inherit" for stdout. This way CLI will determine if the terminal is in interactive mode correctly.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
CLI never opens the required uninstall feedback form.

## What is the new behavior?
When `npm uninstall -g nativescript` is executed, CLI will open the feedback form.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/4974

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
