### PR TITLE
fix: ensure data is sent to analytics on preuninstall 

### DIFF
--- a/lib/common/commands/preuninstall.ts
+++ b/lib/common/commands/preuninstall.ts
@@ -27,6 +27,7 @@ export class PreUninstallCommand implements ICommand {
 		}
 
 		this.$fs.deleteFile(path.join(this.$settingsService.getProfileDir(), "KillSwitches", "cli"));
+		await this.$analyticsService.finishTracking();
 	}
 
 	private async handleIntentionalUninstall(): Promise<void> {

--- a/lib/common/declarations.d.ts
+++ b/lib/common/declarations.d.ts
@@ -207,6 +207,12 @@ declare const enum TrackingTypes {
 	 * Defines that the broker process should get and track the data from preview app to Google Analytics
 	 */
 	PreviewAppData = "PreviewAppData",
+
+	/**
+	 * Defines that the broker process should send all the pending information to Analytics.
+	 * After that the process should send information it has finished tracking and die gracefully.
+	 */
+	FinishTracking = "FinishTracking",
 }
 
 /**
@@ -688,6 +694,7 @@ interface IAnalyticsService {
 	setStatus(settingName: string, enabled: boolean): Promise<void>;
 	getStatusMessage(settingName: string, jsonFormat: boolean, readableSettingName: string): Promise<string>;
 	isEnabled(settingName: string): Promise<boolean>;
+	finishTracking(): Promise<void>;
 
 	/**
 	 * Tracks the answer of question if user allows to be tracked.

--- a/lib/detached-processes/detached-process-enums.d.ts
+++ b/lib/detached-processes/detached-process-enums.d.ts
@@ -5,7 +5,12 @@ declare const enum DetachedProcessMessages {
 	/**
 	 * The detached process is initialized and is ready to receive information for tracking.
 	 */
-	ProcessReadyToReceive = "ProcessReadyToReceive"
+	ProcessReadyToReceive = "ProcessReadyToReceive",
+
+	/**
+	 * The detached process finished its tasks and will now exit.
+	 */
+	ProcessFinishedTasks = "ProcessFinishedTasks"
 }
 
 /**

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -3,6 +3,9 @@
 var path = require("path");
 var child_process = require("child_process");
 var commandArgs = [path.join(__dirname, "bin", "tns"), "dev-preuninstall"];
+if (process.env.NS_CLI_PREUNINSTALL_ANALYTICS_LOG_FILE) {
+	commandArgs.push("--analyticsLogFile", process.env.NS_CLI_PREUNINSTALL_ANALYTICS_LOG_FILE);
+}
 
 var childProcess = child_process.spawn(process.execPath, commandArgs, { stdio: "inherit"})
 


### PR DESCRIPTION
### feat: enable to possibility to ensure analytics tracking is finished 
Introudce finishTracking method in `analyticsService` which will ensure all pending information is send to Google Analytics. This is required for some rare cases in which we want to be sure all the information has been sent.

### fix: ensure data is sent to analytics on preuninstall  
CLI's analytics process is a detached one, so during `preuninstall` command, CLI just sends information to the detached process what should be tracked and finishes CLI's execution. After that `npm` starts removing the CLI package and its `node_modules`.
At this point the analytics process may still work and trying to send data, but as it relies on components in node_modules, which npm currently deletes, it fails to send information to Google Analytics.
To ensure correct data is send to Analytics, ensure tracking is finished before ending the preuninstall command.

### feat: create analyticsLogFile during preuninstall
In case the environment variable `NS_CLI_PREUNINSTALL_ANALYTICS_LOG_FILE` is set and `npm un -g nativescript` or `npm i -g nativescript` is executed, CLI will use the value of the variable as path for the analyticsLogFile. This way it will be easy to check what information is tracked during install/uninstall of the CLI.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
During uninstall of CLI, some information may not be send to analytics.

## What is the new behavior?
During uninstall of CLI, all information that must be tracked will be send to Google Analytics.

Related to https://github.com/NativeScript/nativescript-cli/issues/4974

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
