### PR TITLE
fix: save and remove of user-settings are not working

### DIFF
--- a/lib/services/user-settings-service.ts
+++ b/lib/services/user-settings-service.ts
@@ -5,6 +5,7 @@ export class UserSettingsService implements IUserSettingsService {
 		const userSettingsFilePath = path.join(this.$settingsService.getProfileDir(), "user-settings.json");
 		return this.$injector.resolve("jsonFileSettingsService", { jsonFileSettingsPath: userSettingsFilePath });
 	}
+
 	constructor(private $injector: IInjector,
 		private $settingsService: ISettingsService) {
 	}
@@ -14,7 +15,7 @@ export class UserSettingsService implements IUserSettingsService {
 	}
 
 	public saveSetting<T>(key: string, value: T, cacheOpts?: IUseCacheOpts): Promise<void> {
-		return this.saveSetting<T>(key, value, cacheOpts);
+		return this.$jsonFileSettingsService.saveSetting<T>(key, value, cacheOpts);
 	}
 
 	public saveSettings(data: IDictionary<{}>, cacheOpts?: IUseCacheOpts): Promise<void> {
@@ -22,7 +23,7 @@ export class UserSettingsService implements IUserSettingsService {
 	}
 
 	public removeSetting(key: string): Promise<void> {
-		return this.removeSetting(key);
+		return this.$jsonFileSettingsService.removeSetting(key);
 	}
 
 	public loadUserSettingsFile(): Promise<void> {

--- a/test/services/user-settings-service.ts
+++ b/test/services/user-settings-service.ts
@@ -1,0 +1,82 @@
+import { Yok } from "../../lib/common/yok";
+import { UserSettingsService } from "../../lib/services/user-settings-service";
+import { assert } from "chai";
+import * as path from "path";
+
+class JsonFileSettingsServiceMock {
+	constructor(public jsonFileSettingsPath: string) { }
+}
+
+describe("userSettingsService", () => {
+	const profileDir = "my-profile-dir";
+	const expectedJsonFileSettingsFilePath = path.join(profileDir, "user-settings.json");
+
+	const createTestInjector = (): IInjector => {
+		const testInjector = new Yok();
+		testInjector.register("settingsService", {
+			getProfileDir: () => profileDir
+		});
+
+		testInjector.register("jsonFileSettingsService", JsonFileSettingsServiceMock);
+		testInjector.register("userSettingsService", UserSettingsService);
+		return testInjector;
+	};
+
+	const testCases = [
+		{
+			methodName: "getSettingValue",
+			input: ["settingName"],
+			expectedArgs: [
+				"settingName",
+				undefined
+			]
+		},
+		{
+			methodName: "saveSetting",
+			input: ["settingName", "settingValue"],
+			expectedArgs: [
+				"settingName",
+				"settingValue",
+				undefined
+			]
+		},
+		{
+			methodName: "saveSettings",
+			input: [{ value: { subValue: 1 } }],
+			expectedArgs: [
+				{ value: { subValue: 1 } },
+				undefined
+			]
+		},
+		{
+			methodName: "removeSetting",
+			input: ["settingName"],
+			expectedArgs: [
+				"settingName"
+			]
+		},
+		{
+			methodName: "loadUserSettingsFile",
+			input: [],
+			expectedArgs: []
+		}
+	];
+
+	for (const testCase of testCases) {
+		it(`calls ${testCase.methodName} method of jsonFileSettingsService with correct args`, async () => {
+			const testInjector = createTestInjector();
+			const dataPassedToJsonFileSettingsService: any[] = [];
+			const userSettingsService = testInjector.resolve("userSettingsService");
+			const jsonFileSettingsService = userSettingsService.$jsonFileSettingsService;
+
+			jsonFileSettingsService[testCase.methodName] = async (...args: any[]): Promise<void> => {
+				dataPassedToJsonFileSettingsService.push(...args);
+			};
+
+			await userSettingsService[testCase.methodName](...testCase.input);
+
+			assert.deepEqual(dataPassedToJsonFileSettingsService, testCase.expectedArgs);
+			assert.equal(jsonFileSettingsService.jsonFileSettingsPath, expectedJsonFileSettingsFilePath);
+		});
+	}
+});


### PR DESCRIPTION
Due to recent changes, trying to save a setting in the user-settings.json or to remove it from there is not working. This breaks all new users and the execution of commands like `tns usage-reporting enable/disable`, `tns error-reporting enable/disable`.
The problem is an infinite recursion in the userSettingsService, which should just call jsonFileSettingsService, but instead it calls itself.
Fix the recursion and add unit tests for the userSettingsService to ensure it acts as a proxy to jsonFileSettingsService.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
`tns error-reporting enable && tns error-reporting disable` are not working. New users are unable to use CLI.
`tns <any command> --profileDir <some dir>` is not working (this is the same what happens for new users.

## What is the new behavior?
`tns error-reporting enable && tns error-reporting disable` are working. New users are unable to use CLI.
`tns <any command> --profileDir <some dir>` is working (this is the same what happens for new users.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
