### PR TITLE
fix: remove local caching of getting company data

### DIFF
--- a/lib/controllers/company-insights-controller.ts
+++ b/lib/controllers/company-insights-controller.ts
@@ -1,63 +1,26 @@
 
 import { AnalyticsEventLabelDelimiter } from "../constants";
 import { cache } from "../common/decorators";
-import * as path from "path";
 import * as util from "util";
 
 export class CompanyInsightsController implements ICompanyInsightsController {
-	private static CACHE_TIMEOUT = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
-	private get $jsonFileSettingsService(): IJsonFileSettingsService {
-		return this.$injector.resolve<IJsonFileSettingsService>("jsonFileSettingsService", {
-			jsonFileSettingsPath: path.join(this.$settingsService.getProfileDir(), "company-insights-data.json")
-		});
-	}
-
 	constructor(private $config: IConfiguration,
 		private $httpClient: Server.IHttpClient,
-		private $injector: IInjector,
 		private $ipService: IIPService,
-		private $logger: ILogger,
-		private $settingsService: ISettingsService) { }
+		private $logger: ILogger) { }
 
 	public async getCompanyData(): Promise<ICompanyData> {
 		let companyData: ICompanyData = null;
-		const { currentPublicIP, cacheKey } = await this.getIPInfo();
-
-		companyData = await this.getCompanyDataFromCache(cacheKey);
-
-		if (!companyData && currentPublicIP) {
-			companyData = await this.getCompanyDataFromPlaygroundInsightsEndpoint(currentPublicIP);
-			if (companyData && currentPublicIP) {
-				await this.$jsonFileSettingsService.saveSetting<ICompanyData>(cacheKey, companyData, { useCaching: true });
-			}
-		}
-
-		return companyData;
-	}
-
-	private async getIPInfo(): Promise<{ currentPublicIP: string, cacheKey: string }> {
 		let currentPublicIP: string = null;
-		let keyInJsonFile: string = null;
 
 		try {
 			currentPublicIP = await this.$ipService.getCurrentIPv4Address();
-			keyInJsonFile = `companyInformation_${currentPublicIP}`;
 		} catch (err) {
 			this.$logger.trace(`Unable to get current public ip address. Error is: `, err);
 		}
 
-		return { currentPublicIP, cacheKey: keyInJsonFile };
-	}
-
-	private async getCompanyDataFromCache(keyInJsonFile: string): Promise<ICompanyData> {
-		let companyData: ICompanyData = null;
-
-		try {
-			if (keyInJsonFile) {
-				companyData = await this.$jsonFileSettingsService.getSettingValue<ICompanyData>(keyInJsonFile, { cacheTimeout: CompanyInsightsController.CACHE_TIMEOUT });
-			}
-		} catch (err) {
-			this.$logger.trace(`Unable to get data from file, error is:`, err);
+		if (currentPublicIP) {
+			companyData = await this.getCompanyDataFromPlaygroundInsightsEndpoint(currentPublicIP);
 		}
 
 		return companyData;

--- a/test/config/config-json.ts
+++ b/test/config/config-json.ts
@@ -1,0 +1,21 @@
+import { assert } from "chai";
+describe("config.json", () => {
+	const expectedData = {
+		"DEBUG": false,
+		"TYPESCRIPT_COMPILER_OPTIONS": {},
+		"ANDROID_DEBUG_UI_MAC": "Google Chrome",
+		"USE_POD_SANDBOX": false,
+		"DISABLE_HOOKS": false,
+		"UPLOAD_PLAYGROUND_FILES_ENDPOINT": "https://play.nativescript.org/api/files",
+		"SHORTEN_URL_ENDPOINT": "https://play.nativescript.org/api/shortenurl?longUrl=%s",
+		"INSIGHTS_URL_ENDPOINT": "https://play-server.nativescript.org/api/insights?ipAddress=%s",
+		"WHOAMI_URL_ENDPOINT": "https://play.nativescript.org/api/whoami",
+		"PREVIEW_APP_ENVIRONMENT": "live",
+		"GA_TRACKING_ID": "UA-111455-51"
+	};
+
+	it("validates content is correct", () => {
+		const data = require("../../config/config.json");
+		assert.deepEqual(data, expectedData, "Data in config.json is not correct. Is this expected?");
+	});
+});


### PR DESCRIPTION
As we have implemented the caching in the server, there's no need to have local cache for getting company data.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
