### PR TITLE
fix: add cache decorator when getting ip address

### DIFF
--- a/lib/services/ip-service.ts
+++ b/lib/services/ip-service.ts
@@ -1,9 +1,12 @@
+import { cache } from "../common/decorators";
+
 export class IPService implements IIPService {
 	private static GET_IP_TIMEOUT = 1000;
 	constructor(private $config: IConfiguration,
 		private $httpClient: Server.IHttpClient,
 		private $logger: ILogger) { }
 
+	@cache()
 	public async getCurrentIPv4Address(): Promise<string> {
 		const ipAddress = await this.getIPAddressFromServiceReturningJSONWithIPProperty(this.$config.WHOAMI_URL_ENDPOINT) ||
 			await this.getIPAddressFromServiceReturningJSONWithIPProperty("https://api.myip.com") ||

--- a/test/services/ip-service.ts
+++ b/test/services/ip-service.ts
@@ -135,5 +135,25 @@ describe("ipService", () => {
 			assert.isTrue(logger.traceOutput.indexOf(errMsgForMyipCom) !== -1, `Trace output\n'${logger.traceOutput}'\ndoes not contain expected message:\n${errMsgForMyipCom}`);
 			assert.isTrue(logger.traceOutput.indexOf(errMsgForIpifyOrg) !== -1, `Trace output\n'${logger.traceOutput}'\ndoes not contain expected message:\n${errMsgForMyipCom}`);
 		});
+
+		it("is called only once per process", async () => {
+			const testInjector = createTestInjector();
+			const httpClient = testInjector.resolve<Server.IHttpClient>("httpClient");
+			let httpRequestCounter = 0;
+			httpClient.httpRequest = async (options: any, proxySettings?: IProxySettings): Promise<Server.IResponse> => {
+				httpRequestCounter++;
+				return <any>{ body: JSON.stringify({ ip }) };
+			};
+
+			const ipService = testInjector.resolve<IIPService>("ipService");
+
+			const ipAddress = await ipService.getCurrentIPv4Address();
+			assert.equal(httpRequestCounter, 1);
+			assert.equal(ipAddress, ip);
+
+			const ipAddress2 = await ipService.getCurrentIPv4Address();
+			assert.equal(httpRequestCounter, 1);
+			assert.equal(ipAddress2, ip);
+		});
 	});
 });


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
