### PR TITLE
fix: skip snapshot tools based on skipNativePrepare

### DIFF
--- a/lib/controllers/deploy-controller.ts
+++ b/lib/controllers/deploy-controller.ts
@@ -11,7 +11,11 @@ export class DeployController {
 
 		const executeAction = async (device: Mobile.IDevice) => {
 			const deviceDescriptor = _.find(deviceDescriptors, dd => dd.identifier === device.deviceInfo.identifier);
-			await this.$prepareController.prepare(deviceDescriptor.buildData);
+			const prepareData = {
+				...deviceDescriptor.buildData,
+				nativePrepare: { skipNativePrepare: !!deviceDescriptor.skipNativePrepare }
+			};
+			await this.$prepareController.prepare(prepareData);
 			const packageFilePath = await deviceDescriptor.buildAction();
 			await this.$deviceInstallAppService.installOnDevice(device, { ...deviceDescriptor.buildData, buildForDevice: !device.isEmulator }, packageFilePath);
 		};

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -174,11 +174,18 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 
 		Object.assign(envData,
 			appPath && { appPath },
-			appResourcesPath && { appResourcesPath },
+			appResourcesPath && { appResourcesPath }
 		);
 
 		envData.verbose = envData.verbose || this.$logger.isVerbose();
 		envData.production = envData.production || prepareData.release;
+		// The snapshot generation is wrongly located in the Webpack plugin.
+		// It should be moved in the Native Prepare of the CLI or a Gradle task in the Runtime.
+		// As a workaround, we skip the mksnapshot, xxd and android-ndk calls based on skipNativePrepare.
+		// In this way the plugin will prepare only the snapshot JS entry without any native prepare and
+		// we will able to execute cloud builds with snapshot without having any local snapshot or Docker setup.
+		// TODO: Remove this flag when we remove the native part from the plugin.
+		envData.skipSnapshotTools = prepareData.nativePrepare && prepareData.nativePrepare.skipNativePrepare;
 
 		if (prepareData.env && (prepareData.env.sourceMap === false || prepareData.env.sourceMap === 'false')) {
 			delete envData.sourceMap;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
1) The `skipNativePrepare` flag is not passed during deploy in release.
2) The snapshot tools are executed and we will require their local setup even during cloud builds.

## What is the new behavior?
The snapshot tools are skipped during cloud build and the `skipNativePrepare` flag is properly passed during deploy in release.
