### PR TITLE
feat: add vue tabs navigation template to create project command

### DIFF
--- a/docs/man_pages/project/creation/create.md
+++ b/docs/man_pages/project/creation/create.md
@@ -53,6 +53,7 @@ Template | Command
 `Angular - Tabs` | tns create --template tns-template-tab-navigation-ng
 `Vue.js - Blank`, `--vue`, `--vuejs` | tns create --template tns-template-blank-vue
 `Vue.js - SideDrawer`, | tns create --template tns-template-drawer-navigation-vue
+`Vue.js - Tabs` | tns create --template tns-template-tab-navigation-vue
 
 ### Related Commands
 

--- a/lib/commands/create-project.ts
+++ b/lib/commands/create-project.ts
@@ -210,6 +210,11 @@ or --js flags.)
 			key: CreateProjectCommand.DrawerTemplateKey,
 			value: "tns-template-drawer-navigation-vue",
 			description: CreateProjectCommand.DrawerTemplateDescription
+		},
+		{
+			key: CreateProjectCommand.TabsTemplateKey,
+			value: "tns-template-tab-navigation-vue",
+			description: CreateProjectCommand.TabsTemplateDescription
 		}];
 
 		return templates;

--- a/test/project-commands.ts
+++ b/test/project-commands.ts
@@ -18,15 +18,14 @@ const expectedFlavorChoices = [
 	{ key: "Plain TypeScript", description: "Learn more at https://nativescript.org/typescript" },
 	{ key: "Plain JavaScript", description: "Use NativeScript without any framework" }
 ];
-const expectedTemplateChoices = [
-	{ key: "Hello World", description: "A Hello World app" },
-	{ key: "SideDrawer", description: "An app with pre-built pages that uses a drawer for navigation" },
-	{ key: "Tabs", description: "An app with pre-built pages that uses tabs for navigation" }
-];
-const expectedTemplateChoicesVue = [
-	{ key: "Blank", description: "A blank app" },
-	{ key: "SideDrawer", description: "An app with pre-built pages that uses a drawer for navigation" }
-];
+const templateChoises = {
+	helloWorld: { key: "Hello World", description: "A Hello World app" },
+	blank: { key: "Blank", description: "A blank app" },
+	sideDrawer: { key: "SideDrawer", description: "An app with pre-built pages that uses a drawer for navigation" },
+	tabs: { key: "Tabs", description: "An app with pre-built pages that uses tabs for navigation" }
+};
+const expectedTemplateChoices = [templateChoises.helloWorld, templateChoises.sideDrawer, templateChoises.tabs];
+const expectedTemplateChoicesVue = [templateChoises.blank, templateChoises.sideDrawer, templateChoises.tabs];
 
 class ProjectServiceMock implements IProjectService {
 	async validateProjectName(opts: { projectName: string, force: boolean, pathToProject: string }): Promise<string> {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
when vue flavor is selected, two options are presented - Blank and SideDrawer

## What is the new behavior?
when vue flavor is selected, three options are presented - Blank, SideDrawer and Tabs

Fixes/Implements/Closes #5032.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
