### PR TITLE
fix(cli): add iCloudContainerEnvironment export option

### DIFF
--- a/lib/services/ios/export-options-plist-service.ts
+++ b/lib/services/ios/export-options-plist-service.ts
@@ -8,6 +8,7 @@ export class ExportOptionsPlistService implements IExportOptionsPlistService {
 	public createDevelopmentExportOptionsPlist(archivePath: string, projectData: IProjectData, buildConfig: IBuildConfig): IExportOptionsPlistOutput {
 		const exportOptionsMethod = this.getExportOptionsMethod(projectData, archivePath);
 		const provision = buildConfig.provision || buildConfig.mobileProvisionIdentifier;
+		const iCloudContainerEnvironment = buildConfig.iCloudContainerEnvironment;
 		let plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -25,7 +26,13 @@ export class ExportOptionsPlistService implements IExportOptionsPlistService {
     <key>uploadBitcode</key>
     <false/>
     <key>compileBitcode</key>
-    <false/>
+    <false/>`;
+		if (iCloudContainerEnvironment) {
+			plistTemplate += `
+    <key>iCloudContainerEnvironment</key>
+    <string>${iCloudContainerEnvironment}</string>`;
+		}
+		plistTemplate += `
 </dict>
 </plist>`;
 

--- a/test/services/ios/export-options-plist-service.ts
+++ b/test/services/ios/export-options-plist-service.ts
@@ -36,6 +36,11 @@ describe("ExportOptionsPlistService", () => {
 				name: "should create export options plist with mobileProvisionIdentifier",
 				buildConfig: { mobileProvisionIdentifier: "myTestProvision" },
 				expectedPlist: "<key>provisioningProfiles</key> <dict> 	<key>org.nativescript.myTestApp</key> 	<string>myTestProvision</string> </dict>"
+			},
+			{
+				name: "should create export options plist with Production iCloudContainerEnvironment",
+				buildConfig: { iCloudContainerEnvironment: "Production" },
+				expectedPlist: "<key>iCloudContainerEnvironment</key>     <string>Production</string>"
 			}
 		];
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [X] Tests for the changes are included.

Fixes #5034

I also added a test to help prevent this from happening again.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
