### PR TITLE
feat: support snapshots on Windows

### DIFF
--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -341,11 +341,7 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 	}
 
 	private async shouldMigrateDependencyVersion(dependency: IMigrationDependency, projectData: IProjectData, allowInvalidVersions: boolean): Promise<boolean> {
-		const devDependencies = projectData.devDependencies || {};
-		const dependencies = projectData.dependencies || {};
-		const packageName = dependency.packageName;
-		const referencedVersion = dependencies[packageName] || devDependencies[packageName];
-		const installedVersion = await this.getMaxDependencyVersion(dependency.packageName, referencedVersion);
+		const installedVersion = await this.$packageInstallationManager.getInstalledDependencyVersion(dependency.packageName, projectData.projectDir);
 		const requiredVersion = dependency.verifiedVersion;
 
 		return this.isOutdatedVersion(installedVersion, requiredVersion, allowInvalidVersions);

--- a/lib/controllers/update-controller-base.ts
+++ b/lib/controllers/update-controller-base.ts
@@ -56,7 +56,7 @@ export class UpdateControllerBase {
 		const currentPlatformVersion = this.$platformCommandHelper.getCurrentPlatformVersion(lowercasePlatform, projectData);
 		const platformData = this.$platformsDataService.getPlatformData(lowercasePlatform, projectData);
 		if (currentPlatformVersion) {
-			return await this.$packageInstallationManager.maxSatisfyingVersionSafe(platformData.frameworkPackageName, currentPlatformVersion) || currentPlatformVersion;
+			return await this.$packageInstallationManager.getMaxSatisfyingVersionSafe(platformData.frameworkPackageName, currentPlatformVersion) || currentPlatformVersion;
 		}
 	}
 

--- a/lib/controllers/update-controller-base.ts
+++ b/lib/controllers/update-controller-base.ts
@@ -56,21 +56,8 @@ export class UpdateControllerBase {
 		const currentPlatformVersion = this.$platformCommandHelper.getCurrentPlatformVersion(lowercasePlatform, projectData);
 		const platformData = this.$platformsDataService.getPlatformData(lowercasePlatform, projectData);
 		if (currentPlatformVersion) {
-			return await this.getMaxDependencyVersion(platformData.frameworkPackageName, currentPlatformVersion) || currentPlatformVersion;
+			return await this.$packageInstallationManager.maxSatisfyingVersionSafe(platformData.frameworkPackageName, currentPlatformVersion) || currentPlatformVersion;
 		}
-	}
-
-	protected async getMaxDependencyVersion(dependency: string, version: string): Promise<string> {
-		let maxDependencyVersion;
-		if (semver.valid(version)) {
-			maxDependencyVersion = version;
-		} else if (semver.validRange(version)) {
-			maxDependencyVersion = await this.$packageInstallationManager.maxSatisfyingVersion(dependency, version);
-		} else {
-			maxDependencyVersion = await this.$packageManager.getTagVersion(dependency, version);
-		}
-
-		return maxDependencyVersion;
 	}
 
 	private async _getPackageManifest(templateName: string, version: string): Promise<any> {

--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -139,8 +139,8 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 		const devDependencies = projectData.devDependencies || {};
 		const dependencies = projectData.dependencies || {};
 		const projectVersion = dependencies[dependency] || devDependencies[dependency];
-		const maxSatisfyingTargetVersion = await this.getMaxDependencyVersion(dependency, targetVersion);
-		const maxSatisfyingProjectVersion = await this.getMaxDependencyVersion(dependency, projectVersion);
+		const maxSatisfyingTargetVersion = await this.$packageInstallationManager.maxSatisfyingVersionSafe(dependency, targetVersion);
+		const maxSatisfyingProjectVersion = await this.$packageInstallationManager.maxSatisfyingVersionSafe(dependency, projectVersion);
 		return maxSatisfyingProjectVersion && maxSatisfyingTargetVersion && semver.gt(maxSatisfyingTargetVersion, maxSatisfyingProjectVersion);
 	}
 
@@ -177,7 +177,7 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 			return false;
 		}
 
-		const maxTemplateRuntimeVersion = await this.getMaxDependencyVersion(frameworkPackageName, templateRuntimeVersion);
+		const maxTemplateRuntimeVersion = await this.$packageInstallationManager.maxSatisfyingVersionSafe(frameworkPackageName, templateRuntimeVersion);
 		const maxRuntimeVersion = await this.getMaxRuntimeVersion({ platform, projectData });
 
 		return maxTemplateRuntimeVersion && maxRuntimeVersion && semver.gt(maxTemplateRuntimeVersion, maxRuntimeVersion);

--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -139,8 +139,8 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 		const devDependencies = projectData.devDependencies || {};
 		const dependencies = projectData.dependencies || {};
 		const projectVersion = dependencies[dependency] || devDependencies[dependency];
-		const maxSatisfyingTargetVersion = await this.$packageInstallationManager.maxSatisfyingVersionSafe(dependency, targetVersion);
-		const maxSatisfyingProjectVersion = await this.$packageInstallationManager.maxSatisfyingVersionSafe(dependency, projectVersion);
+		const maxSatisfyingTargetVersion = await this.$packageInstallationManager.getMaxSatisfyingVersionSafe(dependency, targetVersion);
+		const maxSatisfyingProjectVersion = await this.$packageInstallationManager.getMaxSatisfyingVersionSafe(dependency, projectVersion);
 		return maxSatisfyingProjectVersion && maxSatisfyingTargetVersion && semver.gt(maxSatisfyingTargetVersion, maxSatisfyingProjectVersion);
 	}
 
@@ -177,7 +177,7 @@ export class UpdateController extends UpdateControllerBase implements IUpdateCon
 			return false;
 		}
 
-		const maxTemplateRuntimeVersion = await this.$packageInstallationManager.maxSatisfyingVersionSafe(frameworkPackageName, templateRuntimeVersion);
+		const maxTemplateRuntimeVersion = await this.$packageInstallationManager.getMaxSatisfyingVersionSafe(frameworkPackageName, templateRuntimeVersion);
 		const maxRuntimeVersion = await this.getMaxRuntimeVersion({ platform, projectData });
 
 		return maxTemplateRuntimeVersion && maxRuntimeVersion && semver.gt(maxTemplateRuntimeVersion, maxRuntimeVersion);

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -98,12 +98,12 @@ interface IPackageInstallationManager {
 	getLatestVersion(packageName: string): Promise<string>;
 	getNextVersion(packageName: string): Promise<string>;
 	getLatestCompatibleVersion(packageName: string, referenceVersion?: string): Promise<string>;
-	maxSatisfyingVersion(packageName: string, versionRange: string): Promise<string>;
+	getMaxSatisfyingVersion(packageName: string, versionRange: string): Promise<string>;
 	getLatestCompatibleVersionSafe(packageName: string, referenceVersion?: string): Promise<string>;
 	getInspectorFromCache(inspectorNpmPackageName: string, projectDir: string): Promise<string>;
 	clearInspectorCache(): void;
 	getInstalledDependencyVersion(packageName: string, projectDir?: string): Promise<string>;
-	maxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string>;
+	getMaxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string>;
 }
 
 /**

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -102,6 +102,8 @@ interface IPackageInstallationManager {
 	getLatestCompatibleVersionSafe(packageName: string, referenceVersion?: string): Promise<string>;
 	getInspectorFromCache(inspectorNpmPackageName: string, projectDir: string): Promise<string>;
 	clearInspectorCache(): void;
+	getInstalledDependencyVersion(packageName: string, projectDir?: string): Promise<string>;
+	maxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string>;
 }
 
 /**

--- a/lib/package-installation-manager.ts
+++ b/lib/package-installation-manager.ts
@@ -33,21 +33,21 @@ export class PackageInstallationManager implements IPackageInstallationManager {
 			return latestVersion;
 		}
 
-		return await this.maxSatisfyingVersion(packageName, compatibleVersionRange) || latestVersion;
+		return await this.getMaxSatisfyingVersion(packageName, compatibleVersionRange) || latestVersion;
 	}
 
-	public async maxSatisfyingVersion(packageName: string, versionRange: string): Promise<string> {
+	public async getMaxSatisfyingVersion(packageName: string, versionRange: string): Promise<string> {
 		const data = await this.$packageManager.view(packageName, { "versions": true });
 
 		return semver.maxSatisfying(data, versionRange);
 	}
 
-	public async maxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string> {
+	public async getMaxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string> {
 		let maxDependencyVersion;
 		if (semver.valid(versionIdentifier)) {
 			maxDependencyVersion = versionIdentifier;
 		} else if (semver.validRange(versionIdentifier)) {
-			maxDependencyVersion = await this.maxSatisfyingVersion(packageName, versionIdentifier);
+			maxDependencyVersion = await this.getMaxSatisfyingVersion(packageName, versionIdentifier);
 		} else {
 			maxDependencyVersion = await this.$packageManager.getTagVersion(packageName, versionIdentifier);
 		}
@@ -60,7 +60,7 @@ export class PackageInstallationManager implements IPackageInstallationManager {
 		const devDependencies = projectData.devDependencies || {};
 		const dependencies = projectData.dependencies || {};
 		const referencedVersion = dependencies[packageName] || devDependencies[packageName];
-		const installedVersion = await this.maxSatisfyingVersionSafe(packageName, referencedVersion);
+		const installedVersion = await this.getMaxSatisfyingVersionSafe(packageName, referencedVersion);
 
 		return installedVersion;
 	}

--- a/lib/package-installation-manager.ts
+++ b/lib/package-installation-manager.ts
@@ -4,7 +4,7 @@ import * as constants from "./constants";
 
 export class PackageInstallationManager implements IPackageInstallationManager {
 	constructor(
-		private $packageManager: INodePackageManager,
+		private $packageManager: IPackageManager,
 		private $childProcess: IChildProcess,
 		private $logger: ILogger,
 		private $settingsService: ISettingsService,
@@ -40,6 +40,29 @@ export class PackageInstallationManager implements IPackageInstallationManager {
 		const data = await this.$packageManager.view(packageName, { "versions": true });
 
 		return semver.maxSatisfying(data, versionRange);
+	}
+
+	public async maxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string> {
+		let maxDependencyVersion;
+		if (semver.valid(versionIdentifier)) {
+			maxDependencyVersion = versionIdentifier;
+		} else if (semver.validRange(versionIdentifier)) {
+			maxDependencyVersion = await this.maxSatisfyingVersion(packageName, versionIdentifier);
+		} else {
+			maxDependencyVersion = await this.$packageManager.getTagVersion(packageName, versionIdentifier);
+		}
+
+		return maxDependencyVersion;
+	}
+
+	public async getInstalledDependencyVersion(packageName: string, projectDir?: string): Promise<string> {
+		const projectData = this.$projectDataService.getProjectData(projectDir);
+		const devDependencies = projectData.devDependencies || {};
+		const dependencies = projectData.dependencies || {};
+		const referencedVersion = dependencies[packageName] || devDependencies[packageName];
+		const installedVersion = await this.maxSatisfyingVersionSafe(packageName, referencedVersion);
+
+		return installedVersion;
 	}
 
 	public async getLatestCompatibleVersionSafe(packageName: string, referenceVersion?: string): Promise<string> {

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -200,11 +200,10 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 
 	private buildEnvCommandLineParams(envData: any, platformData: IPlatformData, prepareData: IPrepareData) {
 		const envFlagNames = Object.keys(envData);
-		const shouldSnapshot = prepareData.release && !this.$hostInfo.isWindows && this.$mobileHelper.isAndroidPlatform(platformData.normalizedPlatformName);
-		if (envData && envData.snapshot && !shouldSnapshot) {
+		const canSnapshot = prepareData.release && this.$mobileHelper.isAndroidPlatform(platformData.normalizedPlatformName);
+		if (envData && envData.snapshot && !canSnapshot) {
 			this.$logger.warn("Stripping the snapshot flag. " +
-				"Bear in mind that snapshot is only available in release builds and " +
-				"is NOT available on Windows systems.");
+				"Bear in mind that snapshot is only available in Android release builds.");
 			envFlagNames.splice(envFlagNames.indexOf("snapshot"), 1);
 		}
 

--- a/test/services/webpack/webpack-compiler-service.ts
+++ b/test/services/webpack/webpack-compiler-service.ts
@@ -15,6 +15,8 @@ function createTestInjector(): IInjector {
 	testInjector.register("hooksService", {});
 	testInjector.register("hostInfo", {});
 	testInjector.register("logger", {});
+	testInjector.register("errors", {});
+	testInjector.register("packageInstallationManager", {});
 	testInjector.register("mobileHelper", {});
 	testInjector.register("cleanupService", {});
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -252,6 +252,14 @@ export class PackageInstallationManagerStub implements IPackageInstallationManag
 	async maxSatisfyingVersion(): Promise<string> {
 		return "";
 	}
+
+	async getInstalledDependencyVersion(packageName: string, projectDir?: string): Promise<string> {
+		return Promise.resolve("");
+	}
+
+	async maxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string> {
+		return Promise.resolve(versionIdentifier);
+	}
 }
 
 export class NodePackageManagerStub implements INodePackageManager {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -249,7 +249,7 @@ export class PackageInstallationManagerStub implements IPackageInstallationManag
 		return Promise.resolve("");
 	}
 
-	async maxSatisfyingVersion(): Promise<string> {
+	async getMaxSatisfyingVersion(): Promise<string> {
 		return "";
 	}
 
@@ -257,7 +257,7 @@ export class PackageInstallationManagerStub implements IPackageInstallationManag
 		return Promise.resolve("");
 	}
 
-	async maxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string> {
+	async getMaxSatisfyingVersionSafe(packageName: string, versionIdentifier: string): Promise<string> {
 		return Promise.resolve(versionIdentifier);
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-dev-webpack/blob/master/CONTRIBUTING.md#testing-locally-by-running-e2e-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Providing the `--env.snapshot` flag on Windows is throwing an exception.

## What is the new behavior?
The `--env.snapshot` flag is valid on Windows and it is generating snapshots in a docker container.

Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/1054 and https://github.com/NativeScript/nativescript-dev-webpack/pull/1055