### PR TITLE
fix: handle correctly the compilation errors from webpack

### DIFF
--- a/lib/services/webpack/webpack.d.ts
+++ b/lib/services/webpack/webpack.d.ts
@@ -35,6 +35,7 @@ declare global {
 	interface IWebpackEmitMessage {
 		emittedFiles: string[];
 		chunkFiles: string[];
+		hash: string;
 	}
 
 	interface IPlatformProjectService extends NodeJS.EventEmitter, IPlatformProjectServiceBase {

--- a/test/services/webpack/webpack-compiler-service.ts
+++ b/test/services/webpack/webpack-compiler-service.ts
@@ -1,0 +1,71 @@
+import { Yok } from "../../../lib/common/yok";
+import { WebpackCompilerService } from "../../../lib/services/webpack/webpack-compiler-service";
+import { assert } from "chai";
+
+const chunkFiles = ["bundle.js", "runtime.js", "vendor.js"];
+
+function getAllEmittedFiles(hash: string) {
+	return ["bundle.js", "runtime.js", `bundle.${hash}.hot-update.js`, `${hash}.hot-update.json`];
+}
+
+function createTestInjector(): IInjector {
+	const testInjector = new Yok();
+	testInjector.register("webpackCompilerService", WebpackCompilerService);
+	testInjector.register("childProcess", {});
+	testInjector.register("hooksService", {});
+	testInjector.register("hostInfo", {});
+	testInjector.register("logger", {});
+	testInjector.register("mobileHelper", {});
+	testInjector.register("cleanupService", {});
+
+	return testInjector;
+}
+
+describe("WebpackCompilerService", () => {
+	let testInjector: IInjector = null;
+	let webpackCompilerService: WebpackCompilerService = null;
+
+	beforeEach(() => {
+		testInjector = createTestInjector();
+		webpackCompilerService = testInjector.resolve(WebpackCompilerService);
+	});
+
+	describe("getUpdatedEmittedFiles", () => {
+		// backwards compatibility with old versions of nativescript-dev-webpack
+		it("should return only hot updates when nextHash is not provided", async () => {
+			const result = webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash1"), chunkFiles, null);
+			const expectedEmittedFiles = ['bundle.hash1.hot-update.js', 'hash1.hot-update.json'];
+
+			assert.deepEqual(result.emittedFiles, expectedEmittedFiles);
+		});
+		// 2 successful webpack compilations
+		it("should return only hot updates when nextHash is provided", async () => {
+			webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash1"), chunkFiles, "hash2");
+			const result = webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash2"), chunkFiles, "hash3");
+
+			assert.deepEqual(result.emittedFiles, ['bundle.hash2.hot-update.js', 'hash2.hot-update.json']);
+		});
+		// 1 successful webpack compilation, n compilations with no emitted files
+		it("should return all files when there is a webpack compilation with no emitted files", () => {
+			webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash1"), chunkFiles, "hash2");
+			const result = webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash4"), chunkFiles, "hash5");
+
+			assert.deepEqual(result.emittedFiles, ['bundle.js', 'runtime.js', 'bundle.hash4.hot-update.js', 'hash4.hot-update.json']);
+		});
+		// 1 successful webpack compilation, n compilations with no emitted files, 1 successful webpack compilation
+		it("should return only hot updates after fixing the compilation error", () => {
+			webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash1"), chunkFiles, "hash2");
+			webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash5"), chunkFiles, "hash6");
+			const result = webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash6"), chunkFiles, "hash7");
+
+			assert.deepEqual(result.emittedFiles, ['bundle.hash6.hot-update.js', 'hash6.hot-update.json']);
+		});
+		// 1 webpack compilation with no emitted files
+		it("should return all files when first compilation on livesync change is not successful", () => {
+			(<any>webpackCompilerService).expectedHash = "hash1";
+			const result = webpackCompilerService.getUpdatedEmittedFiles(getAllEmittedFiles("hash1"), chunkFiles, "hash2");
+
+			assert.deepEqual(result.emittedFiles, ["bundle.hash1.hot-update.js", "hash1.hot-update.json"]);
+		});
+	});
+});


### PR DESCRIPTION
More info can be found here https://github.com/NativeScript/nativescript-dev-webpack/pull/1051.

Rel to: https://github.com/NativeScript/nativescript-cli/issues/3785

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
