### PR TITLE
fix: allow pre-release versions of Webpack plugin 1.3.0

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -42,14 +42,14 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 					if (message.emittedFiles) {
 						if (isFirstWebpackWatchCompilation) {
 							isFirstWebpackWatchCompilation = false;
-						this.expectedHash = message.hash;
+							this.expectedHash = message.hash;
 							return;
 						}
 
 						let result;
 
 						if (prepareData.hmr) {
-						result = this.getUpdatedEmittedFiles(message.emittedFiles, message.chunkFiles, message.hash);
+							result = this.getUpdatedEmittedFiles(message.emittedFiles, message.chunkFiles, message.hash);
 						} else {
 							result = { emittedFiles: message.emittedFiles, fallbackFiles: <string[]>[], hash: "" };
 						}
@@ -219,7 +219,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 			} else if (this.$hostInfo.isWindows) {
 				const minWebpackPluginWithWinSnapshotsVersion = "1.3.0";
 				const installedWebpackPluginVersion = await this.$packageInstallationManager.getInstalledDependencyVersion(WEBPACK_PLUGIN_NAME, projectData.projectDir);
-				const hasWebpackPluginWithWinSnapshotsSupport = !!installedWebpackPluginVersion ? semver.gte(installedWebpackPluginVersion, minWebpackPluginWithWinSnapshotsVersion) : true;
+				const hasWebpackPluginWithWinSnapshotsSupport = !!installedWebpackPluginVersion ? semver.gte(semver.coerce(installedWebpackPluginVersion), minWebpackPluginWithWinSnapshotsVersion) : true;
 				if (!hasWebpackPluginWithWinSnapshotsSupport) {
 					this.$errors.fail(`In order to generate Snapshots on Windows, please upgrade your Webpack plugin version (npm i nativescript-dev-webpack@latest).`);
 				}


### PR DESCRIPTION
#4684  PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The `next` and `rc` versions of the Webpack plugin were not allowed.

## What is the new behavior?
The `next` and `rc` versions of the Webpack plugin are allowed.
