### PR TITLE
feat: introduce kotlin usage tracking

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -35,6 +35,8 @@ export const AWAIT_NOTIFICATION_TIMEOUT_SECONDS = 9;
 export const SRC_DIR = "src";
 export const MAIN_DIR = "main";
 export const ASSETS_DIR = "assets";
+export const ANDROID_ANALYTICS_DATA_DIR = "analytics";
+export const ANDROID_ANALYTICS_DATA_FILE = "build-statistics.json";
 export const MANIFEST_FILE_NAME = "AndroidManifest.xml";
 export const APP_GRADLE_FILE_NAME = "app.gradle";
 export const INFO_PLIST_FILE_NAME = "Info.plist";
@@ -188,7 +190,8 @@ export const enum TrackActionNames {
 	PreviewAppData = "Preview App Data",
 	UninstallCLI = "Uninstall CLI",
 	UsingRuntimeVersion = "Using Runtime Version",
-	AddPlatform = "Add Platform"
+	AddPlatform = "Add Platform",
+	UsingKotlin = "Using Kotlin"
 }
 
 export const AnalyticsEventLabelDelimiter = "__";

--- a/lib/definitions/gradle.d.ts
+++ b/lib/definitions/gradle.d.ts
@@ -15,6 +15,6 @@ interface IGradleBuildService {
 }
 
 interface IGradleBuildArgsService {
-	getBuildTaskArgs(buildData: IAndroidBuildData): string[];
+	getBuildTaskArgs(buildData: IAndroidBuildData): Promise<string[]>;
 	getCleanTaskArgs(buildData: IAndroidBuildData): string[];
 }

--- a/lib/services/android/gradle-build-args-service.ts
+++ b/lib/services/android/gradle-build-args-service.ts
@@ -3,11 +3,17 @@ import { Configurations } from "../../common/constants";
 
 export class GradleBuildArgsService implements IGradleBuildArgsService {
 	constructor(private $androidToolsInfo: IAndroidToolsInfo,
+		private $analyticsService: IAnalyticsService,
+		private $staticConfig: Config.IStaticConfig,
 		private $logger: ILogger) { }
 
-	public getBuildTaskArgs(buildData: IAndroidBuildData): string[] {
+	public async getBuildTaskArgs(buildData: IAndroidBuildData): Promise<string[]> {
 		const args = this.getBaseTaskArgs(buildData);
 		args.unshift(this.getBuildTaskName(buildData));
+
+		if (await this.$analyticsService.isEnabled(this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME)) {
+			args.push("-PgatherAnalyticsData=true");
+		}
 
 		return args;
 	}

--- a/lib/services/android/gradle-build-service.ts
+++ b/lib/services/android/gradle-build-service.ts
@@ -10,7 +10,7 @@ export class GradleBuildService extends EventEmitter implements IGradleBuildServ
 	) { super(); }
 
 	public async buildProject(projectRoot: string, buildData: IAndroidBuildData): Promise<void> {
-		const buildTaskArgs = this.$gradleBuildArgsService.getBuildTaskArgs(buildData);
+		const buildTaskArgs = await this.$gradleBuildArgsService.getBuildTaskArgs(buildData);
 		const spawnOptions = { emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME }, throwError: true };
 		const gradleCommandOptions = { cwd: projectRoot, message: "Gradle build...", stdio: buildData.buildOutputStdio, spawnOptions };
 

--- a/test/cocoapods-service.ts
+++ b/test/cocoapods-service.ts
@@ -40,6 +40,10 @@ function changeNewLineCharacter(input: string): string {
 }
 
 describe("Cocoapods service", () => {
+	if (require("os").platform() === "win32") {
+		console.log("Skipping 'Cocoapods service' tests. They can work only on macOS and Linux");
+		return;
+	}
 	const nativeProjectPath = "nativeProjectPath";
 	const mockPluginData: any = {
 		name: "plugin1",

--- a/test/services/android-project-service.ts
+++ b/test/services/android-project-service.ts
@@ -41,7 +41,8 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("gradleCommandService", GradleCommandService);
 	testInjector.register("gradleBuildService", GradleBuildService);
 	testInjector.register("gradleBuildArgsService", GradleBuildArgsService);
-
+	testInjector.register("analyticsService", stubs.AnalyticsService);
+	testInjector.register("staticConfig", {TRACK_FEATURE_USAGE_SETTING_NAME: "TrackFeatureUsage"});
 	return testInjector;
 };
 

--- a/test/services/ios/export-options-plist-service.ts
+++ b/test/services/ios/export-options-plist-service.ts
@@ -1,7 +1,6 @@
 import { Yok } from "../../../lib/common/yok";
 import { ExportOptionsPlistService } from "../../../lib/services/ios/export-options-plist-service";
 import { assert } from "chai";
-import { EOL } from "os";
 
 let actualPlistTemplate: string = null;
 const projectName = "myProjectName";
@@ -54,7 +53,7 @@ describe("ExportOptionsPlistService", () => {
 					const projectData = { projectName, projectIdentifiers: { ios: "org.nativescript.myTestApp" }};
 					exportOptionsPlistService.createDevelopmentExportOptionsPlist(archivePath, projectData, testCase.buildConfig);
 
-					const template = actualPlistTemplate.split(EOL).join(" ");
+					const template = actualPlistTemplate.split("\n").join(" ");
 					assert.isTrue(template.indexOf(`<key>method</key> 	<string>${provisionType}</string>`) > 0);
 					assert.isTrue(template.indexOf("<key>uploadBitcode</key>     <false/>") > 0);
 					assert.isTrue(template.indexOf("<key>compileBitcode</key>     <false/>") > 0);
@@ -97,7 +96,7 @@ describe("ExportOptionsPlistService", () => {
 				const projectData = { projectName, projectIdentifiers: { ios: "org.nativescript.myTestApp" }};
 				exportOptionsPlistService.createDistributionExportOptionsPlist(projectRoot, projectData, testCase.buildConfig);
 
-				const template = actualPlistTemplate.split(EOL).join(" ");
+				const template = actualPlistTemplate.split("\n").join(" ");
 				assert.isTrue(template.indexOf("<key>method</key>     <string>app-store</string>") > 0);
 				assert.isTrue(template.indexOf("<key>uploadBitcode</key>     <false/>") > 0);
 				assert.isTrue(template.indexOf("<key>compileBitcode</key>     <false/>") > 0);

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -59,12 +59,12 @@ const deviceMockData = <Device>{
 	platform: normalizedPlatformName
 };
 const defaultProjectFiles = [
-	"my/test/file1.js",
-	"my/test/file2.js",
-	"my/test/file3.js",
-	"my/test/nested/file1.js",
-	"my/test/nested/file2.js",
-	"my/test/nested/file3.js"
+	path.join("my", "test", "file1.js"),
+	path.join("my", "test", "file2.js"),
+	path.join("my", "test", "file3.js"),
+	path.join("my", "test", "nested", "file1.js"),
+	path.join("my", "test", "nested", "file2.js"),
+	path.join("my", "test", "nested", "file3.js")
 ];
 const syncFilesMockData = {
 	projectDir: projectDirPath,

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -859,6 +859,22 @@ export class MarkingModeServiceStub implements IMarkingModeService {
 	}
 }
 
+export class AnalyticsService implements IAnalyticsService {
+	async checkConsent(): Promise<void> { return ; }
+	async trackFeature(featureName: string): Promise<void> { return ; }
+	async trackException(exception: any, message: string): Promise<void> { return ; }
+	async setStatus(settingName: string, enabled: boolean): Promise<void> { return ; }
+	async getStatusMessage(settingName: string, jsonFormat: boolean, readableSettingName: string): Promise<string> { return "Fake message"; }
+	async isEnabled(settingName: string): Promise<boolean> { return false; }
+	async track(featureName: string, featureValue: string): Promise<void> { return ; }
+	async trackEventActionInGoogleAnalytics(data: IEventActionData) { return Promise.resolve(); }
+	async trackInGoogleAnalytics(data: IGoogleAnalyticsData) { return Promise.resolve(); }
+	async trackAcceptFeatureUsage(settings: { acceptTrackFeatureUsage: boolean }) { return Promise.resolve(); }
+	async trackPreviewAppData() { return Promise.resolve(); }
+	async finishTracking() { return Promise.resolve(); }
+	setShouldDispose() {}
+}
+
 export class InjectorStub extends Yok implements IInjector {
 	constructor() {
 		super();


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Currently we do not tack data about Kotlin usage.

## What is the new behavior?
We track data about Kotlin usage.

The PR also includes some fixes for our unit tests on Windows.

Fixes/Implements/Closes https://github.com/NativeScript/nativescript-cli/issues/5060

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
