### PR TITLE
fix: fix definition files so nativescript-cloud can be successfully built

### DIFF
--- a/lib/definitions/nativescript-dev-xcode.d.ts
+++ b/lib/definitions/nativescript-dev-xcode.d.ts
@@ -1,0 +1,62 @@
+declare module "nativescript-dev-xcode" {
+	interface Options {
+		[key: string]: any;
+
+		customFramework?: boolean;
+		embed?: boolean;
+		relativePath?: string;
+	}
+
+	class project {
+		constructor(filename: string);
+
+		parse(callback: () => void): void;
+		parseSync(): void;
+
+		writeSync(options: any): string;
+
+		addFramework(filepath: string, options?: Options): void;
+		removeFramework(filePath: string, options?: Options): void;
+	
+		addPbxGroup(filePathsArray: any[], name: string, path: string, sourceTree: string): void;
+		
+		removePbxGroup(groupName: string, path: string): void;
+		
+		addToHeaderSearchPaths(options?: Options): void;
+		removeFromHeaderSearchPaths(options?: Options): void;
+		updateBuildProperty(key: string, value: any): void;
+
+		pbxXCBuildConfigurationSection(): any;
+
+		addTarget(targetName: string, targetType: string, targetPath?: string, parentTarget?: string): target;
+		addBuildPhase(filePathsArray: string[],
+			buildPhaseType: string,
+			comment: string,
+			target?: string,
+			optionsOrFolderType?: Object|string,
+			subfolderPath?: string
+		): any;
+		addToBuildSettings(buildSetting: string, value: any, targetUuid?: string): void;
+		addPbxGroup(
+			filePathsArray: string[],
+			name: string,
+			path: string,
+			sourceTree: string,
+			opt: {filesRelativeToProject?: boolean, target?: string, uuid?: string, isMain?: boolean }
+		): group;
+		addBuildProperty(prop: string, value: any, build_name?: string, productName?: string): void;
+		addToHeaderSearchPaths(file: string|Object, productName?: string): void;
+		removeTargetsByProductType(targetType: string): void;
+		getFirstTarget(): {uuid: string};
+	}
+
+	class target {
+		uuid: string;
+		pbxNativeTarget: {productName: string}
+	}
+
+	class group {
+		uuid: string;
+		pbxGroup: Object;
+	}
+}

--- a/lib/definitions/xcode.d.ts
+++ b/lib/definitions/xcode.d.ts
@@ -1,62 +1,12 @@
-declare module "nativescript-dev-xcode" {
-	interface Options {
-		[key: string]: any;
+/// <reference path="./nativescript-dev-xcode.d.ts" />
 
-		customFramework?: boolean;
-		embed?: boolean;
-		relativePath?: string;
-	}
+import * as xcode from "nativescript-dev-xcode";
 
-	class project {
-		constructor(filename: string);
-
-		parse(callback: () => void): void;
-		parseSync(): void;
-
-		writeSync(options: any): string;
-
-		addFramework(filepath: string, options?: Options): void;
-		removeFramework(filePath: string, options?: Options): void;
-	
-		addPbxGroup(filePathsArray: any[], name: string, path: string, sourceTree: string): void;
-		
-		removePbxGroup(groupName: string, path: string): void;
-		
-		addToHeaderSearchPaths(options?: Options): void;
-		removeFromHeaderSearchPaths(options?: Options): void;
-		updateBuildProperty(key: string, value: any): void;
-
-		pbxXCBuildConfigurationSection(): any;
-
-		addTarget(targetName: string, targetType: string, targetPath?: string, parentTarget?: string): target;
-		addBuildPhase(filePathsArray: string[],
-			buildPhaseType: string,
-			comment: string,
-			target?: string,
-			optionsOrFolderType?: Object|string,
-			subfolderPath?: string
-		): any;
-		addToBuildSettings(buildSetting: string, value: any, targetUuid?: string): void;
-		addPbxGroup(
-			filePathsArray: string[],
-			name: string,
-			path: string,
-			sourceTree: string,
-			opt: {filesRelativeToProject?: boolean, target?: string, uuid?: string, isMain?: boolean }
-		): group;
-		addBuildProperty(prop: string, value: any, build_name?: string, productName?: string): void;
-		addToHeaderSearchPaths(file: string|Object, productName?: string): void;
-		removeTargetsByProductType(targetType: string): void;
-		getFirstTarget(): {uuid: string};
-	}
-
-	class target {
-		uuid: string;
-		pbxNativeTarget: {productName: string}
-	}
-
-	class group {
-		uuid: string;
-		pbxGroup: Object;
+declare global {
+	type IXcode = typeof xcode;
+	export namespace IXcode {
+		export type target = xcode.target;
+		export type project = xcode.project;
+		export interface Options extends xcode.Options {} // tslint:disable-line
 	}
 }

--- a/lib/node/xcode.ts
+++ b/lib/node/xcode.ts
@@ -1,14 +1,5 @@
 import * as xcode from "nativescript-dev-xcode";
 
-declare global {
-	type IXcode = typeof xcode;
-	export namespace IXcode {
-		export type target = xcode.target;
-		export type project = xcode.project;
-		export interface Options extends xcode.Options {} // tslint:disable-line
-	}
-}
-
 export { xcode };
 
 $injector.register("xcode", xcode);


### PR DESCRIPTION
Currently `nativescript-cloud` cannot be built with latest master branch of CLI due to the following errors:
```
node_modules/nativescript/lib/definitions/project.d.ts(476,96): error TS2503: Cannot find namespace 'IXcode'.
node_modules/nativescript/lib/definitions/project.d.ts(476,165): error TS2503: Cannot find namespace 'IXcode'.
node_modules/nativescript/lib/definitions/project.d.ts(479,128): error TS2503: Cannot find namespace 'IXcode'.
node_modules/nativescript/lib/definitions/project.d.ts(480,99): error TS2503: Cannot find namespace 'IXcode'.
```

The issue happens as `IXcode` interface is already used from project.d.ts file. As `nativescript-cloud` lib generates `references.d.ts` file with references to all `.d.ts` files from NativeScript CLI, we need a separate `.d.ts`  file for `IXcode` interface. This way, it will be included in the generated `references.d.ts` file and cloud-lib will be successfully built.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
