### PR TITLE
feat: initial implementation of pods override

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -3,7 +3,7 @@ import { hook } from "../common/helpers";
 import { performanceLog, cache } from "../common/decorators";
 import { EventEmitter } from "events";
 import * as path from "path";
-import { PREPARE_READY_EVENT_NAME, WEBPACK_COMPILATION_COMPLETE, PACKAGE_JSON_FILE_NAME, PLATFORMS_DIR_NAME, TrackActionNames, AnalyticsEventLabelDelimiter } from "../constants";
+import { PREPARE_READY_EVENT_NAME, WEBPACK_COMPILATION_COMPLETE, PACKAGE_JSON_FILE_NAME, PLATFORMS_DIR_NAME, TrackActionNames, AnalyticsEventLabelDelimiter, CONFIG_NS_FILE_NAME } from "../constants";
 interface IPlatformWatcherData {
 	hasWebpackCompilerProcess: boolean;
 	nativeFilesWatcher: choki.FSWatcher;
@@ -189,6 +189,7 @@ export class PrepareController extends EventEmitter {
 
 		const patterns = [
 			path.join(projectData.projectDir, PACKAGE_JSON_FILE_NAME),
+			path.join(projectData.projectDir, CONFIG_NS_FILE_NAME),
 			path.join(projectData.getAppDirectoryPath(), PACKAGE_JSON_FILE_NAME),
 			path.join(projectData.getAppResourcesRelativeDirectoryPath(), platformData.normalizedPlatformName),
 		]

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -46,7 +46,13 @@ interface IPlatformsDataService {
 }
 
 interface INodeModulesBuilder {
-	prepareNodeModules(platformData: IPlatformData, projectData: IProjectData): Promise<void>;
+	prepareNodeModules(prepareNodeModulesData: IPrepareNodeModulesData): Promise<void>;
+}
+
+interface IPrepareNodeModulesData {
+	platformData: IPlatformData;
+	projectData: IProjectData;
+	forcePluginNativePrepare: boolean;
 }
 
 interface INodeModulesDependenciesBuilder {

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -52,7 +52,6 @@ interface INodeModulesBuilder {
 interface IPrepareNodeModulesData {
 	platformData: IPlatformData;
 	projectData: IProjectData;
-	forcePluginNativePrepare: boolean;
 }
 
 interface INodeModulesDependenciesBuilder {

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -12,9 +12,16 @@ interface IPluginsService {
 	 * @returns {IPackageJsonDepedenciesResult}
 	 */
 	getDependenciesFromPackageJson(projectDir: string): IPackageJsonDepedenciesResult;
-	preparePluginNativeCode(pluginData: IPluginData, platform: string, projectData: IProjectData): Promise<void>;
+	preparePluginNativeCode(preparePluginNativeCodeData: IPreparePluginNativeCodeData): Promise<void>;
 	convertToPluginData(cacheData: any, projectDir: string): IPluginData;
 	isNativeScriptPlugin(pluginPackageJsonPath: string): boolean;
+}
+
+interface IPreparePluginNativeCodeData {
+	pluginData: IPluginData;
+	platform: string;
+	projectData: IProjectData;
+	forcePluginNativePrepare: boolean;
 }
 
 interface IPackageJsonDepedenciesResult {

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -21,7 +21,6 @@ interface IPreparePluginNativeCodeData {
 	pluginData: IPluginData;
 	platform: string;
 	projectData: IProjectData;
-	forcePluginNativePrepare: boolean;
 }
 
 interface IPackageJsonDepedenciesResult {

--- a/lib/definitions/project-changes.d.ts
+++ b/lib/definitions/project-changes.d.ts
@@ -17,6 +17,7 @@ interface IProjectChangesInfo extends IAddedNativePlatform {
 	configChanged: boolean;
 	nativeChanged: boolean;
 	signingChanged: boolean;
+	nsConfigChanged: boolean;
 
 	readonly hasChanges: boolean;
 	readonly changesRequireBuild: boolean;

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -75,6 +75,7 @@ interface INsConfig {
 	appResourcesPath?: string;
 	shared?: boolean;
 	previewAppSchema?: string;
+	overridePods?: string
 }
 
 interface IProjectData extends ICreateProjectData {
@@ -406,10 +407,10 @@ interface ICocoaPodsService {
 	 * @param {string} moduleName The module which the Podfile is from.
 	 * @param {string} podfilePath The path to the podfile.
 	 * @param {IProjectData} projectData Information about the project.
-	 * @param {string} nativeProjectPath Path to the native Xcode project.
+	 * @param {IPlatformData} platformData Information about the platform.
 	 * @returns {Promise<void>}
 	 */
-	applyPodfileToProject(moduleName: string, podfilePath: string, projectData: IProjectData, nativeProjectPath: string): Promise<void>;
+	applyPodfileToProject(moduleName: string, podfilePath: string, projectData: IProjectData, platformData: IPlatformData): Promise<void>;
 
 	/**
 	 * Gives the path to the plugin's Podfile.

--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -93,10 +93,6 @@ ${versionResolutionHint}`);
 				finalPodfileContent = this.$cocoaPodsPlatformManager.addPlatformSection(projectData, podfilePlatformData, finalPodfileContent);
 			}
 
-			if (this.isMainPodFile(podfilePath, projectData, platformData) && projectData.nsConfig && projectData.nsConfig.overridePods) {
-				finalPodfileContent = this.overridePodsFromFile(finalPodfileContent, projectData, platformData);
-			}
-
 			finalPodfileContent = `${finalPodfileContent.trim()}${EOL}${EOL}${podfileContent.trim()}${EOL}`;
 			this.saveProjectPodfile(projectData, finalPodfileContent, nativeProjectPath);
 		}
@@ -234,14 +230,13 @@ ${versionResolutionHint}`);
 	}
 
 	private buildPodfileContent(pluginPodFilePath: string, pluginName: string, projectData: IProjectData, platformData: IPlatformData): { podfileContent: string, replacedFunctions: IRubyFunction[], podfilePlatformData: IPodfilePlatformData } {
-		const mainPodfilePath = this.getMainPodFilePath(projectData, platformData);
 		const pluginPodfileContent = this.$fs.readText(pluginPodFilePath);
 		const data = this.replaceHookContent(CocoaPodsService.PODFILE_POST_INSTALL_SECTION_NAME, pluginPodfileContent, pluginName);
 		const cocoapodsData = this.$cocoaPodsPlatformManager.replacePlatformRow(data.replacedContent, pluginPodFilePath);
 		const podfilePlatformData  = cocoapodsData.podfilePlatformData;
 		let replacedContent = cocoapodsData.replacedContent;
 
-		if (projectData.nsConfig && projectData.nsConfig.overridePods && mainPodfilePath !== pluginPodFilePath) {
+		if (projectData.nsConfig && projectData.nsConfig.overridePods && !this.isMainPodFile(pluginPodFilePath, projectData, platformData)) {
 			replacedContent = this.overridePodsFromFile(replacedContent, projectData, platformData);
 		}
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -495,9 +495,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		await this.prepareResources(pluginPlatformsFolderPath, pluginData, projectData);
 		await this.prepareFrameworks(pluginPlatformsFolderPath, pluginData, projectData);
 		await this.prepareStaticLibs(pluginPlatformsFolderPath, pluginData, projectData);
-
-		const projectRoot = this.getPlatformData(projectData).projectRoot;
-		await this.$cocoapodsService.applyPodfileToProject(pluginData.name, this.$cocoapodsService.getPluginPodfilePath(pluginData), projectData, projectRoot);
+		const platformData = this.getPlatformData(projectData);
+		await this.$cocoapodsService.applyPodfileToProject(pluginData.name, this.$cocoapodsService.getPluginPodfilePath(pluginData), projectData, platformData);
 	}
 
 	public async removePluginNativeCode(pluginData: IPluginData, projectData: IProjectData): Promise<void> {

--- a/lib/services/platform/prepare-native-platform-service.ts
+++ b/lib/services/platform/prepare-native-platform-service.ts
@@ -24,7 +24,7 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 		const hasConfigChange = !changesInfo || changesInfo.configChanged;
 		const hasChangesRequirePrepare = !changesInfo || changesInfo.changesRequirePrepare;
 
-		const hasChanges = hasNativeModulesChange || hasConfigChange || hasChangesRequirePrepare || changesInfo.nsConfigChanged;
+		const hasChanges = hasNativeModulesChange || hasConfigChange || hasChangesRequirePrepare;
 
 		if (changesInfo.hasChanges) {
 			await this.cleanProject(platformData, { release });
@@ -36,8 +36,8 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 			await platformData.platformProjectService.prepareProject(projectData, prepareData);
 		}
 
-		if (hasNativeModulesChange || changesInfo.nsConfigChanged) {
-			await this.$nodeModulesBuilder.prepareNodeModules({platformData, projectData, forcePluginNativePrepare: changesInfo.nsConfigChanged});
+		if (hasNativeModulesChange) {
+			await this.$nodeModulesBuilder.prepareNodeModules({platformData, projectData});
 		}
 
 		if (hasNativeModulesChange || hasConfigChange) {

--- a/lib/services/platform/prepare-native-platform-service.ts
+++ b/lib/services/platform/prepare-native-platform-service.ts
@@ -24,7 +24,7 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 		const hasConfigChange = !changesInfo || changesInfo.configChanged;
 		const hasChangesRequirePrepare = !changesInfo || changesInfo.changesRequirePrepare;
 
-		const hasChanges = hasNativeModulesChange || hasConfigChange || hasChangesRequirePrepare;
+		const hasChanges = hasNativeModulesChange || hasConfigChange || hasChangesRequirePrepare || changesInfo.nsConfigChanged;
 
 		if (changesInfo.hasChanges) {
 			await this.cleanProject(platformData, { release });
@@ -36,8 +36,8 @@ export class PrepareNativePlatformService implements IPrepareNativePlatformServi
 			await platformData.platformProjectService.prepareProject(projectData, prepareData);
 		}
 
-		if (hasNativeModulesChange) {
-			await this.$nodeModulesBuilder.prepareNodeModules(platformData, projectData);
+		if (hasNativeModulesChange || changesInfo.nsConfigChanged) {
+			await this.$nodeModulesBuilder.prepareNodeModules({platformData, projectData, forcePluginNativePrepare: changesInfo.nsConfigChanged});
 		}
 
 		if (hasNativeModulesChange || hasConfigChange) {

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -114,7 +114,7 @@ export class PluginsService implements IPluginsService {
 		}
 	}
 
-	public async preparePluginNativeCode({pluginData, platform, projectData, forcePluginNativePrepare}: IPreparePluginNativeCodeData): Promise<void> {
+	public async preparePluginNativeCode({pluginData, platform, projectData}: IPreparePluginNativeCodeData): Promise<void> {
 		const platformData = this.$platformsDataService.getPlatformData(platform, projectData);
 		pluginData.pluginPlatformsFolderPath = (_platform: string) => path.join(pluginData.fullPath, "platforms", _platform.toLowerCase());
 
@@ -126,7 +126,7 @@ export class PluginsService implements IPluginsService {
 			const oldPluginNativeHashes = allPluginsNativeHashes[pluginData.name];
 			const currentPluginNativeHashes = await this.getPluginNativeHashes(pluginPlatformsFolderPath);
 
-			if (forcePluginNativePrepare || !oldPluginNativeHashes || this.$filesHashService.hasChangesInShasums(oldPluginNativeHashes, currentPluginNativeHashes)) {
+			if (!oldPluginNativeHashes || this.$filesHashService.hasChangesInShasums(oldPluginNativeHashes, currentPluginNativeHashes)) {
 				await platformData.platformProjectService.preparePluginNativeCode(pluginData, projectData);
 				this.setPluginNativeHashes({
 					pathToPluginsBuildFile,

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -114,7 +114,7 @@ export class PluginsService implements IPluginsService {
 		}
 	}
 
-	public async preparePluginNativeCode(pluginData: IPluginData, platform: string, projectData: IProjectData): Promise<void> {
+	public async preparePluginNativeCode({pluginData, platform, projectData, forcePluginNativePrepare}: IPreparePluginNativeCodeData): Promise<void> {
 		const platformData = this.$platformsDataService.getPlatformData(platform, projectData);
 		pluginData.pluginPlatformsFolderPath = (_platform: string) => path.join(pluginData.fullPath, "platforms", _platform.toLowerCase());
 
@@ -126,7 +126,7 @@ export class PluginsService implements IPluginsService {
 			const oldPluginNativeHashes = allPluginsNativeHashes[pluginData.name];
 			const currentPluginNativeHashes = await this.getPluginNativeHashes(pluginPlatformsFolderPath);
 
-			if (!oldPluginNativeHashes || this.$filesHashService.hasChangesInShasums(oldPluginNativeHashes, currentPluginNativeHashes)) {
+			if (forcePluginNativePrepare || !oldPluginNativeHashes || this.$filesHashService.hasChangesInShasums(oldPluginNativeHashes, currentPluginNativeHashes)) {
 				await platformData.platformProjectService.preparePluginNativeCode(pluginData, projectData);
 				this.setPluginNativeHashes({
 					pathToPluginsBuildFile,

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { NativePlatformStatus, PACKAGE_JSON_FILE_NAME, APP_GRADLE_FILE_NAME, BUILD_XCCONFIG_FILE_NAME, PLATFORMS_DIR_NAME } from "../constants";
+import { NativePlatformStatus, PACKAGE_JSON_FILE_NAME, APP_GRADLE_FILE_NAME, BUILD_XCCONFIG_FILE_NAME, PLATFORMS_DIR_NAME, CONFIG_NS_FILE_NAME } from "../constants";
 import { getHash, hook } from "../common/helpers";
 
 const prepareInfoFileName = ".nsprepareinfo";
@@ -8,6 +8,7 @@ class ProjectChangesInfo implements IProjectChangesInfo {
 
 	public appResourcesChanged: boolean;
 	public configChanged: boolean;
+	public nsConfigChanged: boolean;
 	public nativeChanged: boolean;
 	public signingChanged: boolean;
 	public nativePlatformStatus: NativePlatformStatus;
@@ -69,6 +70,10 @@ export class ProjectChangesService implements IProjectChangesService {
 				this._prepareInfo.projectFileHash = this.getProjectFileStrippedHash(projectData.projectDir, platformData);
 				this._changesInfo.nativeChanged = this.isProjectFileChanged(projectData.projectDir, platformData);
 			}
+
+			// If this causes too much rebuilds of the plugins or uncecessary builds for Android, move overrideCocoapods to prepareInfo.
+			this._changesInfo.nsConfigChanged = this.filesChanged([path.join(projectData.projectDir, CONFIG_NS_FILE_NAME)]);
+			this._changesInfo.nativeChanged = this._changesInfo.nativeChanged || this._changesInfo.nsConfigChanged;
 
 			this.$logger.trace(`Set nativeChanged to ${this._changesInfo.nativeChanged}.`);
 
@@ -183,6 +188,7 @@ export class ProjectChangesService implements IProjectChangesService {
 		this._changesInfo.appResourcesChanged = true;
 		this._changesInfo.configChanged = true;
 		this._changesInfo.nativeChanged = true;
+		this._changesInfo.nsConfigChanged = true;
 		return true;
 	}
 

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -5,7 +5,7 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		private $pluginsService: IPluginsService
 	) { }
 
-	public async prepareNodeModules({platformData , projectData, forcePluginNativePrepare}: IPrepareNodeModulesData): Promise<void> {
+	public async prepareNodeModules({platformData , projectData}: IPrepareNodeModulesData): Promise<void> {
 		const dependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir);
 		if (_.isEmpty(dependencies)) {
 			return;
@@ -19,7 +19,7 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 			if (isPlugin) {
 				this.$logger.debug(`Successfully prepared plugin ${dependency.name} for ${platformData.normalizedPlatformName.toLowerCase()}.`);
 				const pluginData = this.$pluginsService.convertToPluginData(dependency, projectData.projectDir);
-				await this.$pluginsService.preparePluginNativeCode({pluginData, platform: platformData.normalizedPlatformName.toLowerCase(), projectData, forcePluginNativePrepare});
+				await this.$pluginsService.preparePluginNativeCode({pluginData, platform: platformData.normalizedPlatformName.toLowerCase(), projectData});
 			}
 		}
 	}

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -5,7 +5,7 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		private $pluginsService: IPluginsService
 	) { }
 
-	public async prepareNodeModules(platformData: IPlatformData, projectData: IProjectData): Promise<void> {
+	public async prepareNodeModules({platformData , projectData, forcePluginNativePrepare}: IPrepareNodeModulesData): Promise<void> {
 		const dependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir);
 		if (_.isEmpty(dependencies)) {
 			return;
@@ -19,7 +19,7 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 			if (isPlugin) {
 				this.$logger.debug(`Successfully prepared plugin ${dependency.name} for ${platformData.normalizedPlatformName.toLowerCase()}.`);
 				const pluginData = this.$pluginsService.convertToPluginData(dependency, projectData.projectDir);
-				await this.$pluginsService.preparePluginNativeCode(pluginData, platformData.normalizedPlatformName.toLowerCase(), projectData);
+				await this.$pluginsService.preparePluginNativeCode({pluginData, platform: platformData.normalizedPlatformName.toLowerCase(), projectData, forcePluginNativePrepare});
 			}
 		}
 	}

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -318,11 +318,18 @@ describe("Cocoapods support", () => {
 			const samplePluginData = {
 				pluginPlatformsFolderPath(platform: string): string {
 					return samplePluginPlatformsFolderPath;
-				}
+				},
+				name: "somePlugin"
 			};
 			const projectData: IProjectData = testInjector.resolve("projectData");
+			const pluginsService = testInjector.resolve("pluginsService");
+			pluginsService.getAllInstalledPlugins = () => {
+				return [samplePluginData];
+			};
+			const cocoapodsService = testInjector.resolve("cocoapodsService");
+			cocoapodsService.executePodInstall = async () => { /* */ };
 
-			await iOSProjectService.preparePluginNativeCode(samplePluginData, projectData);
+			await iOSProjectService.handleNativeDependenciesChange(projectData);
 
 			const projectPodfilePath = join(platformsFolderPath, "Podfile");
 			assert.isTrue(fs.exists(projectPodfilePath));
@@ -403,8 +410,14 @@ describe("Cocoapods support", () => {
 				fullPath: "fullPath"
 			};
 			const projectData: IProjectData = testInjector.resolve("projectData");
+			const pluginsService = testInjector.resolve("pluginsService");
+			pluginsService.getAllInstalledPlugins = () => {
+				return [samplePluginData];
+			};
+			const cocoapodsService = testInjector.resolve("cocoapodsService");
+			cocoapodsService.executePodInstall = async () => { /* */ };
 
-			await iOSProjectService.preparePluginNativeCode(samplePluginData, projectData);
+			await iOSProjectService.handleNativeDependenciesChange(projectData);
 
 			const projectPodfilePath = join(platformsFolderPath, "Podfile");
 			assert.isTrue(fs.exists(projectPodfilePath));

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -79,7 +79,10 @@ function createTestInjector(projectPath: string, projectName: string, xCode?: IX
 		projectDir: "",
 		appDirectoryPath: "",
 		appResourcesDirectoryPath: "",
-		getAppResourcesDirectoryPath: () => ""
+		getAppResourcesDirectoryPath: () => "",
+		nsConfig: {
+			overridePods: false
+		}
 	});
 	projectData.projectDir = temp.mkdirSync("projectDir");
 	projectData.appDirectoryPath = join(projectData.projectDir, "app");
@@ -241,7 +244,7 @@ describe("Cocoapods support", () => {
 
 			projectData.podfilePath = basePodfilePath;
 
-			await cocoapodsService.applyPodfileToProject(basePodfileModuleName, basePodfilePath, projectData, iOSProjectService.getPlatformData(projectData).projectRoot);
+			await cocoapodsService.applyPodfileToProject(basePodfileModuleName, basePodfilePath, projectData, iOSProjectService.getPlatformData(projectData));
 
 			const projectPodfilePath = join(platformsFolderPath, "Podfile");
 			assert.isTrue(fs.exists(projectPodfilePath), `File ${projectPodfilePath} must exist as we have already applied Podfile to it.`);
@@ -265,7 +268,7 @@ describe("Cocoapods support", () => {
 
 			fs.deleteFile(basePodfilePath);
 
-			await cocoapodsService.applyPodfileToProject(basePodfileModuleName, basePodfilePath, projectData, iOSProjectService.getPlatformData(projectData).projectRoot);
+			await cocoapodsService.applyPodfileToProject(basePodfileModuleName, basePodfilePath, projectData, iOSProjectService.getPlatformData(projectData));
 			assert.isFalse(fs.exists(projectPodfilePath), `The projectPodfilePath (${projectPodfilePath}) must not exist when all Podfiles have been deleted and project is prepared again. (i.e. CLI should delete the project Podfile in this case)`);
 		});
 

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -570,7 +570,7 @@ describe("Plugins service", () => {
 				`\n@#[line:1,col:39].` +
 				`\n@#[line:1,col:39].`;
 			mockBeginCommand(testInjector, expectedErrorMessage);
-			await pluginsService.preparePluginNativeCode(pluginsService.convertToPluginData(pluginJsonData, projectData.projectDir), "android", projectData);
+			await pluginsService.preparePluginNativeCode({pluginData: pluginsService.convertToPluginData(pluginJsonData, projectData.projectDir), platform: "android", projectData, forcePluginNativePrepare: false});
 		});
 	});
 
@@ -590,7 +590,8 @@ describe("Plugins service", () => {
 						preparePluginNativeCode: async (pluginData: IPluginData, projData: IProjectData) => {
 							testData.isPreparePluginNativeCodeCalled = true;
 						}
-					}
+					},
+					normalizedPlatformName: "iOS"
 				})
 			});
 
@@ -643,21 +644,21 @@ describe("Plugins service", () => {
 
 		it("does not prepare the files when plugin does not have platforms dir", async () => {
 			const testData = setupTest({ hasPluginPlatformsDir: false });
-			await testData.pluginsService.preparePluginNativeCode(testData.pluginData, platform, projectData);
+			await testData.pluginsService.preparePluginNativeCode({pluginData: testData.pluginData, platform, projectData});
 			assert.isFalse(testData.isPreparePluginNativeCodeCalled);
 		});
 
 		it("prepares the files when plugin has platforms dir and has not been built before", async () => {
 			const newPluginHashes = { "file": "hash" };
 			const testData = setupTest({ newPluginHashes, hasPluginPlatformsDir: true });
-			await testData.pluginsService.preparePluginNativeCode(testData.pluginData, platform, projectData);
+			await testData.pluginsService.preparePluginNativeCode({pluginData: testData.pluginData, platform, projectData});
 			assert.isTrue(testData.isPreparePluginNativeCodeCalled);
 			assert.deepEqual(testData.dataPassedToWriteJson, { [testData.pluginData.name]: newPluginHashes });
 		});
 
 		it("does not prepare the files when plugin has platforms dir and files have not changed since then", async () => {
 			const testData = setupTest({ hasChangesInShasums: false, buildDataFileExists: true, hasPluginPlatformsDir: true });
-			await testData.pluginsService.preparePluginNativeCode(testData.pluginData, platform, projectData);
+			await testData.pluginsService.preparePluginNativeCode({pluginData: testData.pluginData, platform, projectData});
 			assert.isFalse(testData.isPreparePluginNativeCodeCalled);
 		});
 	});

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -570,7 +570,7 @@ describe("Plugins service", () => {
 				`\n@#[line:1,col:39].` +
 				`\n@#[line:1,col:39].`;
 			mockBeginCommand(testInjector, expectedErrorMessage);
-			await pluginsService.preparePluginNativeCode({pluginData: pluginsService.convertToPluginData(pluginJsonData, projectData.projectDir), platform: "android", projectData, forcePluginNativePrepare: false});
+			await pluginsService.preparePluginNativeCode({pluginData: pluginsService.convertToPluginData(pluginJsonData, projectData.projectDir), platform: "android", projectData});
 		});
 	});
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes https://github.com/NativeScript/nativescript-cli/issues/5061

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
