### PR TITLE
feat: cache shouldMigrate result

### DIFF
--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -232,9 +232,9 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 	private async getCachedShouldMigrate(projectDir: string, platform: string): Promise<boolean> {
 		let cachedShouldMigrateValue = null;
 
-		const cashedHash = await this.$jsonFileSettingsService.getSettingValue(getHash(`${projectDir}${platform.toLowerCase()}`));
-		const packageJsonShasum = await this.getPachageJsonHash(projectDir);
-		if (cashedHash === packageJsonShasum) {
+		const cachedHash = await this.$jsonFileSettingsService.getSettingValue(getHash(`${projectDir}${platform.toLowerCase()}`));
+		const packageJsonHash = await this.getPachageJsonHash(projectDir);
+		if (cachedHash === packageJsonHash) {
 			cachedShouldMigrateValue = false;
 		}
 
@@ -242,8 +242,8 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 	}
 
 	private async setCachedShouldMigrate(projectDir: string, platform: string): Promise<void> {
-		const packageJsonShasum = await this.getPachageJsonHash(projectDir);
-		await this.$jsonFileSettingsService.saveSetting(getHash(`${projectDir}${platform.toLowerCase()}`), packageJsonShasum);
+		const packageJsonHash = await this.getPachageJsonHash(projectDir);
+		await this.$jsonFileSettingsService.saveSetting(getHash(`${projectDir}${platform.toLowerCase()}`), packageJsonHash);
 	}
 
 	private async getPachageJsonHash(projectDir: string) {

--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -3,7 +3,7 @@ import * as semver from "semver";
 import * as constants from "../constants";
 import * as glob from "glob";
 import { UpdateControllerBase } from "./update-controller-base";
-import { fromWindowsRelativePathToUnix } from "../common/helpers";
+import { fromWindowsRelativePathToUnix, getHash } from "../common/helpers";
 
 export class MigrateController extends UpdateControllerBase implements IMigrateController {
 	private static COMMON_MIGRATE_MESSAGE = "not affect the codebase of the application and you might need to do additional changes manually – for more information, refer to the instructions in the following blog post: https://www.nativescript.org/blog/nativescript-6.0-application-migration";
@@ -27,7 +27,10 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 		private $pluginsService: IPluginsService,
 		private $projectDataService: IProjectDataService,
 		private $platformValidationService: IPlatformValidationService,
-		private $resources: IResourceLoader) {
+		private $resources: IResourceLoader,
+		private $injector: IInjector,
+		private $settingsService: ISettingsService,
+		private $staticConfig: Config.IStaticConfig) {
 		super($fs, $platformCommandHelper, $platformsDataService, $packageInstallationManager, $packageManager, $pacoteService);
 	}
 
@@ -45,6 +48,12 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 		constants.TSCCONFIG_TNS_JSON_NAME,
 		constants.KARMA_CONFIG_NAME
 	];
+
+	private get $jsonFileSettingsService(): IJsonFileSettingsService {
+		const cliVersion = semver.coerce(this.$staticConfig.version);
+		const shouldMigrateCacheFilePath = path.join(this.$settingsService.getProfileDir(), `should-migrate-cache-${cliVersion}.json`);
+		return this.$injector.resolve("jsonFileSettingsService", { jsonFileSettingsPath: shouldMigrateCacheFilePath });
+	}
 
 	private migrationDependencies: IMigrationDependency[] = [
 		{ packageName: constants.TNS_CORE_MODULES_NAME, verifiedVersion: "6.0.1" },
@@ -147,6 +156,30 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 	}
 
 	public async shouldMigrate({ projectDir, platforms, allowInvalidVersions = false }: IMigrationData): Promise<boolean> {
+		const remainingPlatforms = [];
+		let shouldMigrate = false;
+
+		for (const platform of platforms) {
+			const cachedResult = await this.getCachedShouldMigrate(projectDir, platform);
+			if (cachedResult !== false) {
+				remainingPlatforms.push(platform);
+			}
+		}
+
+		if (remainingPlatforms.length > 0) {
+			shouldMigrate = await this._shouldMigrate({ projectDir, platforms: remainingPlatforms, allowInvalidVersions });
+
+			if (!shouldMigrate) {
+				for (const remainingPlatform of remainingPlatforms) {
+					await this.setCachedShouldMigrate(projectDir, remainingPlatform);
+				}
+			}
+		}
+
+		return shouldMigrate;
+	}
+
+	private async _shouldMigrate({ projectDir, platforms, allowInvalidVersions }: IMigrationData): Promise<boolean> {
 		const projectData = this.$projectDataService.getProjectData(projectDir);
 		const shouldMigrateCommonMessage = "The app is not compatible with this CLI version and it should be migrated. Reason: ";
 
@@ -194,6 +227,28 @@ Running this command will ${MigrateController.COMMON_MIGRATE_MESSAGE}`;
 		if (shouldMigrate) {
 			this.$errors.fail(MigrateController.UNABLE_TO_MIGRATE_APP_ERROR);
 		}
+	}
+
+	private async getCachedShouldMigrate(projectDir: string, platform: string): Promise<boolean> {
+		let cachedShouldMigrateValue = null;
+
+		const cashedHash = await this.$jsonFileSettingsService.getSettingValue(getHash(`${projectDir}${platform.toLowerCase()}`));
+		const packageJsonShasum = await this.getPachageJsonHash(projectDir);
+		if (cashedHash === packageJsonShasum) {
+			cachedShouldMigrateValue = false;
+		}
+
+		return cachedShouldMigrateValue;
+	}
+
+	private async setCachedShouldMigrate(projectDir: string, platform: string): Promise<void> {
+		const packageJsonShasum = await this.getPachageJsonHash(projectDir);
+		await this.$jsonFileSettingsService.saveSetting(getHash(`${projectDir}${platform.toLowerCase()}`), packageJsonShasum);
+	}
+
+	private async getPachageJsonHash(projectDir: string) {
+		const projectPackageJsonFilePath = path.join(projectDir, constants.PACKAGE_JSON_FILE_NAME);
+		return await this.$fs.getFileShasum(projectPackageJsonFilePath);
 	}
 
 	private async migrateOldAndroidAppResources(projectData: IProjectData, backupDir: string) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
