### PR TITLE
Kddimitrov/fix podfile detection in nested plugins

### DIFF
--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -4,6 +4,7 @@ interface IPluginsService {
 	addToPackageJson(plugin: string, version: string, isDev: boolean, projectDir: string): void;
 	removeFromPackageJson(plugin: string, projectDir: string): void;
 	getAllInstalledPlugins(projectData: IProjectData): Promise<IPluginData[]>;
+	getAllProductionPlugins(projectData: IProjectData, dependencies?: IDependencyData[]): IPluginData[];
 	ensureAllDependenciesAreInstalled(projectData: IProjectData): Promise<void>;
 
 	/**

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -399,7 +399,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			});
 		};
 
-		const allPlugins = await this.getAllInstalledPlugins(projectData);
+		const allPlugins = this.getAllProductionPlugins(projectData);
 		for (const plugin of allPlugins) {
 			const pluginInfoPlistPath = path.join(plugin.pluginPlatformsFolderPath(IOSProjectService.IOS_PLATFORM_NAME), this.getPlatformData(projectData).configurationFileName);
 			makePatch(pluginInfoPlistPath);
@@ -452,8 +452,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		this.$fs.writeFile(this.getPlatformData(projectData).configurationFilePath, plistContent);
 	}
 
-	private getAllInstalledPlugins(projectData: IProjectData): Promise<IPluginData[]> {
-		return (<IPluginsService>this.$injector.resolve("pluginsService")).getAllInstalledPlugins(projectData);
+	private getAllProductionPlugins(projectData: IProjectData): IPluginData[] {
+		return (<IPluginsService>this.$injector.resolve("pluginsService")).getAllProductionPlugins(projectData);
 	}
 
 	private replace(name: string): string {
@@ -510,7 +510,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 	public async handleNativeDependenciesChange(projectData: IProjectData, opts: IRelease): Promise<void> {
 		const platformData = this.getPlatformData(projectData);
-		const pluginsData = await this.getAllInstalledPlugins(projectData);
+		const pluginsData = this.getAllProductionPlugins(projectData);
 		this.setProductBundleIdentifier(projectData);
 
 		await this.applyPluginsCocoaPods(pluginsData, projectData, platformData);
@@ -763,8 +763,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			this.$fs.deleteFile(pluginsXcconfigFilePath);
 		}
 
-		const pluginsService = <IPluginsService>this.$injector.resolve("pluginsService");
-		const allPlugins: IPluginData[] = await pluginsService.getAllInstalledPlugins(projectData);
+		const allPlugins: IPluginData[] = this.getAllProductionPlugins(projectData);
 		for (const plugin of allPlugins) {
 			const pluginPlatformsFolderPath = plugin.pluginPlatformsFolderPath(IOSProjectService.IOS_PLATFORM_NAME);
 			const pluginXcconfigFilePath = path.join(pluginPlatformsFolderPath, BUILD_XCCONFIG_FILE_NAME);

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -170,7 +170,7 @@ export class PluginsService implements IPluginsService {
 		return _.filter(nodeModules, nodeModuleData => nodeModuleData && nodeModuleData.isPlugin);
 	}
 
-	//This method will travers all non dev dependencies (not only the root/installed ones) and filter the plugins.
+	//This method will traverse all non dev dependencies (not only the root/installed ones) and filter the plugins.
 	public getAllProductionPlugins(projectData: IProjectData, dependencies?: IDependencyData[]): IPluginData[] {
 		const allProductionPlugins: IPluginData[] = [];
 		dependencies = dependencies || this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir);

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -32,7 +32,8 @@ export class PluginsService implements IPluginsService {
 		private $errors: IErrors,
 		private $filesHashService: IFilesHashService,
 		private $injector: IInjector,
-		private $mobileHelper: Mobile.IMobileHelper) { }
+		private $mobileHelper: Mobile.IMobileHelper,
+		private $nodeModulesDependenciesBuilder: INodeModulesDependenciesBuilder) { }
 
 	public async add(plugin: string, projectData: IProjectData): Promise<void> {
 		await this.ensure(projectData);
@@ -167,6 +168,26 @@ export class PluginsService implements IPluginsService {
 	public async getAllInstalledPlugins(projectData: IProjectData): Promise<IPluginData[]> {
 		const nodeModules = (await this.getAllInstalledModules(projectData)).map(nodeModuleData => this.convertToPluginData(nodeModuleData, projectData.projectDir));
 		return _.filter(nodeModules, nodeModuleData => nodeModuleData && nodeModuleData.isPlugin);
+	}
+
+	//This method will travers all non dev dependencies (not only the root/installed ones) and filter the plugins.
+	public getAllProductionPlugins(projectData: IProjectData, dependencies?: IDependencyData[]): IPluginData[] {
+		const allProductionPlugins: IPluginData[] = [];
+		dependencies = dependencies || this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir);
+
+		if (_.isEmpty(dependencies)) {
+			return allProductionPlugins;
+		}
+
+		_.forEach(dependencies, dependency => {
+			const isPlugin = !!dependency.nativescript;
+			if (isPlugin) {
+				const pluginData = this.convertToPluginData(dependency, projectData.projectDir);
+				allProductionPlugins.push(pluginData);
+			}
+		});
+
+		return allProductionPlugins;
 	}
 
 	public getDependenciesFromPackageJson(projectDir: string): IPackageJsonDepedenciesResult {

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -119,7 +119,8 @@ function createTestInjector(projectPath: string, projectName: string, xCode?: IX
 	});
 	testInjector.register("iosDeviceOperations", {});
 	testInjector.register("pluginsService", {
-		getAllInstalledPlugins: (): string[] => []
+		getAllInstalledPlugins: (): string[] => [],
+		getAllProductionPlugins: (): string[] => [],
 	});
 	testInjector.register("androidProcessService", {});
 	testInjector.register("sysInfo", {
@@ -323,7 +324,7 @@ describe("Cocoapods support", () => {
 			};
 			const projectData: IProjectData = testInjector.resolve("projectData");
 			const pluginsService = testInjector.resolve("pluginsService");
-			pluginsService.getAllInstalledPlugins = () => {
+			pluginsService.getAllProductionPlugins = () => {
 				return [samplePluginData];
 			};
 			const cocoapodsService = testInjector.resolve("cocoapodsService");
@@ -411,7 +412,7 @@ describe("Cocoapods support", () => {
 			};
 			const projectData: IProjectData = testInjector.resolve("projectData");
 			const pluginsService = testInjector.resolve("pluginsService");
-			pluginsService.getAllInstalledPlugins = () => {
+			pluginsService.getAllProductionPlugins = () => {
 				return [samplePluginData];
 			};
 			const cocoapodsService = testInjector.resolve("cocoapodsService");

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -150,6 +150,7 @@ function createTestInjector() {
 	testInjector.register("cleanupService", {
 		setShouldDispose: (shouldDispose: boolean): void => undefined
 	});
+	testInjector.register("nodeModulesDependenciesBuilder", {});
 
 	return testInjector;
 }
@@ -632,6 +633,7 @@ describe("Plugins service", () => {
 			unitTestsInjector.register("injector", unitTestsInjector);
 			unitTestsInjector.register("mobileHelper", MobileHelper);
 			unitTestsInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
+			unitTestsInjector.register("nodeModulesDependenciesBuilder", {});
 
 			const pluginsService: PluginsService = unitTestsInjector.resolve(PluginsService);
 			testData.pluginsService = pluginsService;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently only NativeScript plugins that are listed in package json are checked for `Podfile` in `platforms/ios` directory.

## What is the new behavior?
<!-- Describe the changes. -->
All installed NativeScript plugins are checked for `Podfile` in `platforms/ios` directory.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
