### PR TITLE
fix: pass allowProvisioningUpdates to xcodebuild only when building for device

### DIFF
--- a/lib/services/ios/xcodebuild-args-service.ts
+++ b/lib/services/ios/xcodebuild-args-service.ts
@@ -48,7 +48,8 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 		const args = [
 			"archive",
 			"-archivePath", archivePath,
-			"-configuration", buildConfig.release ? Configurations.Release : Configurations.Debug
+			"-configuration", buildConfig.release ? Configurations.Release : Configurations.Debug,
+			'-allowProvisioningUpdates'
 		]
 			.concat(this.getXcodeProjectArgs(platformData.projectRoot, projectData, ProductArgs.scheme))
 			.concat(architectures)
@@ -92,8 +93,7 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 
 		args = args.concat([
 			"BUILD_DIR=" + path.join(platformData.projectRoot, constants.BUILD_DIR),
-			'SHARED_PRECOMPS_DIR=' + path.join(platformData.projectRoot, 'build', 'sharedpch'),
-			'-allowProvisioningUpdates'
+			'SHARED_PRECOMPS_DIR=' + path.join(platformData.projectRoot, constants.BUILD_DIR, 'sharedpch')
 		]);
 
 		return args;

--- a/test/services/ios/xcodebuild-args-service.ts
+++ b/test/services/ios/xcodebuild-args-service.ts
@@ -33,7 +33,6 @@ function getCommonArgs() {
 	return [
 		"BUILD_DIR=" + path.join(projectRoot, "build"),
 		"SHARED_PRECOMPS_DIR=" + path.join(projectRoot, 'build', 'sharedpch'),
-		"-allowProvisioningUpdates"
 	];
 }
 
@@ -119,7 +118,8 @@ describe("xcodebuildArgsService", () => {
 							const expectedArgs = [
 								"archive",
 								"-archivePath", path.join(buildOutputPath, `${projectName}.xcarchive`),
-								"-configuration", configuration
+								"-configuration", configuration,
+								"-allowProvisioningUpdates"
 							]
 							.concat(getXcodeProjectArgs({ hasProjectWorkspace }))
 							.concat(testCase.expectedArgs)


### PR DESCRIPTION
The `-allowProvisioningUpdates` option is passed to `xcodebuild` no matter if building for device or for simulator.
According to the documentation of `xcodebuild`:
```
Allow xcodebuild to communicate with the Apple Developer website. For automatically signed targets, xcodebuild will create and update profiles, app IDs, and certificates. For manually signed targets, xcodebuild will download missing or updated provisioning profiles. Requires a developer account to have been added in Xcode's Accounts preference pane.
```

It seems it shouldn't be passed when building for simulator.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
