### PR TITLE
fix: add more signing validations

### DIFF
--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,5 +1,6 @@
-import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE, AndroidAppBundleMessages } from "../constants";
+import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE, AndroidAppBundleMessages, ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE } from "../constants";
 import { ValidatePlatformCommandBase } from "./command-base";
+import { hasValidAndroidSigning } from "../common/helpers";
 
 export abstract class BuildCommandBase extends ValidatePlatformCommandBase {
 	constructor($options: IOptions,
@@ -123,8 +124,12 @@ export class BuildAndroidCommand extends BuildCommandBase implements ICommand {
 		this.$androidBundleValidatorHelper.validateRuntimeVersion(this.$projectData);
 		let canExecute = await super.canExecuteCommandBase(platform, { notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true } });
 		if (canExecute) {
-			if (this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
-				this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
+			if ((this.$options.release || this.$options.aab) && !hasValidAndroidSigning(this.$options)) {
+				if (this.$options.release) {
+					this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
+				} else {
+					this.$errors.failWithHelp(ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE);
+				}
 			}
 
 			canExecute = await super.validateArgs(args, platform);

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -1,6 +1,7 @@
-import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
+import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE, ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE } from "../constants";
 import { ValidatePlatformCommandBase } from "./command-base";
 import { DeployCommandHelper } from "../helpers/deploy-command-helper";
+import { hasValidAndroidSigning } from "../common/helpers";
 
 export class DeployOnDeviceCommand extends ValidatePlatformCommandBase implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
@@ -47,8 +48,12 @@ export class DeployOnDeviceCommand extends ValidatePlatformCommandBase implement
 			return false;
 		}
 
-		if (this.$mobileHelper.isAndroidPlatform(platform) && this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
-			this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
+		if (this.$mobileHelper.isAndroidPlatform(platform) && (this.$options.release || this.$options.aab) && !hasValidAndroidSigning(this.$options)) {
+			if (this.$options.release) {
+				this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
+			} else {
+				this.$errors.failWithHelp(ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE);
+			}
 		}
 
 		const result = await super.canExecuteCommandBase(platform, { validateOptions: true });

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -1,6 +1,7 @@
 import { ERROR_NO_VALID_SUBCOMMAND_FORMAT } from "../common/constants";
-import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE } from "../constants";
+import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE, ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE } from "../constants";
 import { cache } from "../common/decorators";
+import { hasValidAndroidSigning } from "../common/helpers";
 
 export class RunCommandBase implements ICommand {
 	private liveSyncCommandHelperAdditionalOptions: ILiveSyncCommandHelperAdditionalOptions = <ILiveSyncCommandHelperAdditionalOptions>{};
@@ -126,8 +127,12 @@ export class RunAndroidCommand implements ICommand {
 			this.$errors.fail(`Applications for platform ${this.$devicePlatformsConstants.Android} can not be built on this OS`);
 		}
 
-		if (this.$options.release && (!this.$options.keyStorePath || !this.$options.keyStorePassword || !this.$options.keyStoreAlias || !this.$options.keyStoreAliasPassword)) {
-			this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
+		if ((this.$options.release || this.$options.aab) && !hasValidAndroidSigning(this.$options)) {
+			if (this.$options.release) {
+				this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
+			} else {
+				this.$errors.failWithHelp(ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE);
+			}
 		}
 
 		return this.$platformValidationService.validateOptions(this.$options.provision, this.$options.teamId, this.$projectData, this.$devicePlatformsConstants.Android.toLowerCase());

--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -1,3 +1,6 @@
+import { hasValidAndroidSigning } from "../common/helpers";
+import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE, ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE } from "../constants";
+
 abstract class TestCommandBase {
 	public allowedParameters: ICommandParameter[] = [];
 	public dashedOptions = {
@@ -110,6 +113,21 @@ class TestAndroidCommand extends TestCommandBase implements ICommand {
 	public async execute(args: string[]): Promise<void> {
 		await this.$markingModeService.handleMarkingModeFullDeprecation({ projectDir: this.$projectData.projectDir, skipWarnings: true });
 		await super.execute(args);
+	}
+
+	async canExecute(args: string[]): Promise<boolean> {
+		const canExecuteBase = await super.canExecute(args);
+		if (canExecuteBase) {
+			if ((this.$options.release || this.$options.aab) && !hasValidAndroidSigning(this.$options)) {
+				if (this.$options.release) {
+					this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
+				} else {
+					this.$errors.failWithHelp(ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE);
+				}
+			}
+		}
+
+		return canExecuteBase;
 	}
 }
 

--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -736,4 +736,19 @@ export function annotate(fn: any) {
 	return $inject;
 }
 
+/**
+ * Returns true if all Android signing options are provided, false otherwise.
+ * @param {IAndroidSigningData} signingData The signing data to be validated.
+ * @return {void}
+ */
+export function hasValidAndroidSigning(signingData: Partial<IAndroidSigningData>): boolean {
+	const isValid = signingData &&
+		signingData.keyStorePath &&
+		signingData.keyStorePassword &&
+		signingData.keyStoreAlias &&
+		signingData.keyStoreAliasPassword;
+
+	return !!isValid;
+}
+
 //--- end part copied from AngularJS

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -150,7 +150,9 @@ export const DEBUGGER_DETACHED_EVENT_NAME = "debuggerDetached";
 export const VERSION_STRING = "version";
 export const INSPECTOR_CACHE_DIRNAME = "ios-inspector";
 export const POST_INSTALL_COMMAND_NAME = "post-install-cli";
-export const ANDROID_RELEASE_BUILD_ERROR_MESSAGE = "When producing a release build, you need to specify all --key-store-* options.";
+const ANDROID_SIGNING_REQUIRED_MESSAGE = "you need to specify all --key-store-* options.";
+export const ANDROID_RELEASE_BUILD_ERROR_MESSAGE = `When producing a release build, ${ANDROID_SIGNING_REQUIRED_MESSAGE}`;
+export const ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE = `When producing Android App Bundle, ${ANDROID_SIGNING_REQUIRED_MESSAGE}`;
 export const CACACHE_DIRECTORY_NAME = "_cacache";
 
 export const FILES_CHANGE_EVENT_NAME = "filesChangeEvent";

--- a/lib/services/android/android-bundle-tool-service.ts
+++ b/lib/services/android/android-bundle-tool-service.ts
@@ -1,4 +1,5 @@
 import { resolve, join } from "path";
+import { hasValidAndroidSigning } from "../../common/helpers";
 
 export class AndroidBundleToolService implements IAndroidBundleToolService {
 	private javaPath: string;
@@ -12,8 +13,8 @@ export class AndroidBundleToolService implements IAndroidBundleToolService {
 	}
 
 	public async buildApks(options: IBuildApksOptions): Promise<void> {
-		if (!options.signingData) {
-			this.$errors.fail(`Unable to build "apks" without a signing information.`);
+		if (!hasValidAndroidSigning(options.signingData)) {
+			this.$errors.fail(`Unable to build "apks" without a full signing information.`);
 		}
 
 		const aabToolResult = await this.execBundleTool([


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The errors for missing Android signing options with aab are misleading.

## What is the new behavior?
The Android signing is validated in the commands and the errors are more clear.

Related to: #5049 