### PR TITLE
fix: do not require signing when the aab will not be deployed by the CLI

### DIFF
--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -1,4 +1,4 @@
-import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE, AndroidAppBundleMessages, ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE } from "../constants";
+import { ANDROID_RELEASE_BUILD_ERROR_MESSAGE, AndroidAppBundleMessages } from "../constants";
 import { ValidatePlatformCommandBase } from "./command-base";
 import { hasValidAndroidSigning } from "../common/helpers";
 
@@ -124,12 +124,8 @@ export class BuildAndroidCommand extends BuildCommandBase implements ICommand {
 		this.$androidBundleValidatorHelper.validateRuntimeVersion(this.$projectData);
 		let canExecute = await super.canExecuteCommandBase(platform, { notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true } });
 		if (canExecute) {
-			if ((this.$options.release || this.$options.aab) && !hasValidAndroidSigning(this.$options)) {
-				if (this.$options.release) {
-					this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
-				} else {
-					this.$errors.failWithHelp(ANDROID_APP_BUNDLE_SIGNING_ERROR_MESSAGE);
-				}
+			if (this.$options.release && !hasValidAndroidSigning(this.$options)) {
+				this.$errors.failWithHelp(ANDROID_RELEASE_BUILD_ERROR_MESSAGE);
 			}
 
 			canExecute = await super.validateArgs(args, platform);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns build android --aab` requires signing options.

## What is the new behavior?
`tns build android --aab` does not require signing options as we won't produce apks and deploy on device.