### PR TITLE
feat: reduce HMR crashes in Preview and recover properly after them

### DIFF
--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -139,7 +139,7 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 		const platformHmrData = _.cloneDeep(hmrData);
 		const connectedDevices = this.$previewDevicesService.getDevicesForPlatform(platform);
 		if (!connectedDevices || !connectedDevices.length) {
-			this.$logger.warn("Unable to find any connected devices. In order to execute live sync, open your Preview app and optionally re-scan the QR code using the Playground app.");
+			this.$logger.warn(`Unable to find any connected devices for platform '${platform}'. In order to execute live sync, open your Preview app and optionally re-scan the QR code using the Playground app.`);
 			return;
 		}
 

--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -1,8 +1,8 @@
-import { Device, FilesPayload } from "nativescript-preview-sdk";
 import { TrackActionNames, PREPARE_READY_EVENT_NAME } from "../constants";
 import { PrepareController } from "./prepare-controller";
+import { Device, FilesPayload } from "nativescript-preview-sdk";
 import { performanceLog } from "../common/decorators";
-import { stringify } from "../common/helpers";
+import { stringify, deferPromise } from "../common/helpers";
 import { HmrConstants } from "../common/constants";
 import { EventEmitter } from "events";
 import { PrepareDataService } from "../services/prepare-data-service";
@@ -11,7 +11,12 @@ import { PreviewAppLiveSyncEvents } from "../services/livesync/playground/previe
 export class PreviewAppController extends EventEmitter implements IPreviewAppController {
 	private prepareReadyEventHandler: any = null;
 	private deviceInitializationPromise: IDictionary<boolean> = {};
-	private promise = Promise.resolve();
+	private devicesLiveSyncChain: IDictionary<Promise<void>> = {};
+	private devicesCanExecuteHmr: IDictionary<boolean> = {};
+	// holds HMR files per device in order to execute batch upload on fast updates
+	private devicesHmrFiles: IDictionary<string[]> = {};
+	// holds the current HMR hash per device in order to watch the proper hash status on fast updates
+	private devicesCurrentHmrHash: IDictionary<string> = {};
 
 	constructor(
 		private $analyticsService: IAnalyticsService,
@@ -89,6 +94,7 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 
 				if (data.useHotModuleReload) {
 					this.$hmrStatusService.attachToHmrStatusEvent();
+					this.devicesCanExecuteHmr[device.id] = true;
 				}
 
 				await this.$previewAppPluginsService.comparePluginsOnDevice(data, device);
@@ -109,13 +115,13 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 				await this.$prepareController.prepare(prepareData);
 
 				try {
-					const payloads = await this.getInitialFilesForPlatformSafe(data, device.platform);
+					const payloads = await this.getInitialFilesForDeviceSafe(data, device);
 					return payloads;
 				} finally {
 					this.deviceInitializationPromise[device.id] = null;
 				}
 			} catch (error) {
-				this.$logger.trace(`Error while sending files on device ${device && device.id}. Error is`, error);
+				this.$logger.trace(`Error while sending files on device '${device && device.id}'. Error is`, error);
 				this.emit(PreviewAppLiveSyncEvents.PREVIEW_APP_LIVE_SYNC_ERROR, {
 					error,
 					data,
@@ -129,52 +135,95 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 
 	@performanceLog()
 	private async handlePrepareReadyEvent(data: IPreviewAppLiveSyncData, currentPrepareData: IFilesChangeEventData) {
-		await this.promise
-			.then(async () => {
-				const { hmrData, files, platform } = currentPrepareData;
-				const platformHmrData = _.cloneDeep(hmrData);
+		const { hmrData, files, platform } = currentPrepareData;
+		const platformHmrData = _.cloneDeep(hmrData);
+		const connectedDevices = this.$previewDevicesService.getDevicesForPlatform(platform);
+		if (!connectedDevices || !connectedDevices.length) {
+			this.$logger.warn("Unable to find any connected devices. In order to execute live sync, open your Preview app and optionally re-scan the QR code using the Playground app.");
+			return;
+		}
 
-				this.promise = this.syncFilesForPlatformSafe(data, { filesToSync: files }, platform);
-				await this.promise;
+		await Promise.all(_.map(connectedDevices, async (device) => {
+			const previousSync = this.devicesLiveSyncChain[device.id] || Promise.resolve();
+			const currentSyncDeferPromise = deferPromise<void>();
+			this.devicesLiveSyncChain[device.id] = currentSyncDeferPromise.promise;
+			this.devicesCurrentHmrHash[device.id] = this.devicesCurrentHmrHash[device.id] || platformHmrData.hash;
+			this.devicesHmrFiles[device.id] = this.devicesHmrFiles[device.id] || [];
+			this.devicesHmrFiles[device.id].push(...files);
+			await previousSync;
+			if (!this.devicesHmrFiles[device.id] || !this.devicesHmrFiles[device.id].length) {
+				this.$logger.info("Skipping files sync. The changes are already batch transferred in a previous sync.");
+				currentSyncDeferPromise.resolve();
+				return;
+			}
 
-				if (data.useHotModuleReload && platformHmrData.hash) {
-					const devices = this.$previewDevicesService.getDevicesForPlatform(platform);
+			try {
 
-					await Promise.all(_.map(devices, async (previewDevice: Device) => {
-						const status = await this.$hmrStatusService.getHmrStatus(previewDevice.id, platformHmrData.hash);
-						if (status === HmrConstants.HMR_ERROR_STATUS) {
-							const originalUseHotModuleReload = data.useHotModuleReload;
-							data.useHotModuleReload = false;
-							await this.syncFilesForPlatformSafe(data, { filesToSync: platformHmrData.fallbackFiles }, platform, previewDevice.id);
-							data.useHotModuleReload = originalUseHotModuleReload;
-						}
-					}));
+				let executeHmrSync = false;
+				const hmrHash = this.devicesCurrentHmrHash[device.id];
+				this.devicesCurrentHmrHash[device.id] = null;
+				if (data.useHotModuleReload && hmrHash) {
+					if (this.devicesCanExecuteHmr[device.id]) {
+						executeHmrSync = true;
+						this.$hmrStatusService.watchHmrStatus(device.id, hmrHash);
+					}
 				}
-			});
+
+				const filesToSync = executeHmrSync ? this.devicesHmrFiles[device.id] : platformHmrData.fallbackFiles;
+				this.devicesHmrFiles[device.id] = [];
+				if (executeHmrSync) {
+					await this.syncFilesForPlatformSafe(data, { filesToSync }, platform, device);
+					const status = await this.$hmrStatusService.getHmrStatus(device.id, hmrHash);
+					if (!status) {
+						this.devicesCanExecuteHmr[device.id] = false;
+						const noStatusWarning = this.getDeviceMsg(device.name,
+							"Unable to get LiveSync status from the Preview app. Ensure the app is running in order to sync changes.");
+						this.$logger.warn(noStatusWarning);
+					} else {
+						this.devicesCanExecuteHmr[device.id] = status === HmrConstants.HMR_SUCCESS_STATUS;
+					}
+				} else {
+					const noHmrData = _.assign({}, data, { useHotModuleReload: false });
+					await this.syncFilesForPlatformSafe(noHmrData, { filesToSync }, platform, device);
+					this.devicesCanExecuteHmr[device.id] = true;
+				}
+				currentSyncDeferPromise.resolve();
+			} catch (e) {
+				currentSyncDeferPromise.resolve();
+			}
+		}));
 	}
 
-	private async getInitialFilesForPlatformSafe(data: IPreviewAppLiveSyncData, platform: string): Promise<FilesPayload> {
-		this.$logger.info(`Start sending initial files for platform ${platform}.`);
+	private getDeviceMsg(deviceId: string, message: string) {
+		return `[${deviceId}] ${message}`;
+	}
+
+	private async getInitialFilesForDeviceSafe(data: IPreviewAppLiveSyncData, device: Device): Promise<FilesPayload> {
+		const platform = device.platform;
+		this.$logger.info(`Start sending initial files for device '${device.name}'.`);
 
 		try {
 			const payloads = this.$previewAppFilesService.getInitialFilesPayload(data, platform);
-			this.$logger.info(`Successfully sent initial files for platform ${platform}.`);
+			this.$logger.info(`Successfully sent initial files for device '${device.name}'.`);
 			return payloads;
 		} catch (err) {
-			this.$logger.warn(`Unable to apply changes for platform ${platform}. Error is: ${err}, ${stringify(err)}`);
+			this.$logger.warn(`Unable to apply changes for device '${device.name}'. Error is: ${err}, ${stringify(err)}`);
 		}
 	}
 
-	private async syncFilesForPlatformSafe(data: IPreviewAppLiveSyncData, filesData: IPreviewAppFilesData, platform: string, deviceId?: string): Promise<void> {
+	private async syncFilesForPlatformSafe(data: IPreviewAppLiveSyncData, filesData: IPreviewAppFilesData, platform: string, device: Device): Promise<void> {
+		const deviceId = device && device.id || "";
+
 		try {
 			const payloads = this.$previewAppFilesService.getFilesPayload(data, filesData, platform);
+			payloads.deviceId = deviceId;
 			if (payloads && payloads.files && payloads.files.length) {
-				this.$logger.info(`Start syncing changes for platform ${platform}.`);
+				this.$logger.info(`Start syncing changes for device '${device.name}'.`);
 				await this.$previewSdkService.applyChanges(payloads);
-				this.$logger.info(`Successfully synced ${payloads.files.map(filePayload => filePayload.file.yellow)} for platform ${platform}.`);
+				this.$logger.info(`Successfully synced '${payloads.files.map(filePayload => filePayload.file.yellow)}' for device '${device.name}'.`);
 			}
 		} catch (error) {
-			this.$logger.warn(`Unable to apply changes for platform ${platform}. Error is: ${error}, ${JSON.stringify(error, null, 2)}.`);
+			this.$logger.warn(`Unable to apply changes for device '${device.name}'. Error is: ${error}, ${JSON.stringify(error, null, 2)}.`);
 			this.emit(PreviewAppLiveSyncEvents.PREVIEW_APP_LIVE_SYNC_ERROR, {
 				error,
 				data,

--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -176,9 +176,7 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 					const status = await this.$hmrStatusService.getHmrStatus(device.id, hmrHash);
 					if (!status) {
 						this.devicesCanExecuteHmr[device.id] = false;
-						const noStatusWarning = this.getDeviceMsg(device.name,
-							"Unable to get LiveSync status from the Preview app. Ensure the app is running in order to sync changes.");
-						this.$logger.warn(noStatusWarning);
+						this.$logger.warn(`Unable to get LiveSync status from the Preview app for device ${this.getDeviceDisplayName(device)}. Ensure the app is running in order to sync changes.`);
 					} else {
 						this.devicesCanExecuteHmr[device.id] = status === HmrConstants.HMR_SUCCESS_STATUS;
 					}
@@ -194,20 +192,20 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 		}));
 	}
 
-	private getDeviceMsg(deviceId: string, message: string) {
-		return `[${deviceId}] ${message}`;
+	private getDeviceDisplayName(device: Device) {
+		return `${device.name} (${device.id})`.cyan;
 	}
 
 	private async getInitialFilesForDeviceSafe(data: IPreviewAppLiveSyncData, device: Device): Promise<FilesPayload> {
 		const platform = device.platform;
-		this.$logger.info(`Start sending initial files for device '${device.name}'.`);
+		this.$logger.info(`Start sending initial files for device ${this.getDeviceDisplayName(device)}.`);
 
 		try {
 			const payloads = this.$previewAppFilesService.getInitialFilesPayload(data, platform);
-			this.$logger.info(`Successfully sent initial files for device '${device.name}'.`);
+			this.$logger.info(`Successfully sent initial files for device ${this.getDeviceDisplayName(device)}.`);
 			return payloads;
 		} catch (err) {
-			this.$logger.warn(`Unable to apply changes for device '${device.name}'. Error is: ${err}, ${stringify(err)}`);
+			this.$logger.warn(`Unable to apply changes for device ${this.getDeviceDisplayName(device)}. Error is: ${err}, ${stringify(err)}`);
 		}
 	}
 
@@ -218,12 +216,12 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 			const payloads = this.$previewAppFilesService.getFilesPayload(data, filesData, platform);
 			payloads.deviceId = deviceId;
 			if (payloads && payloads.files && payloads.files.length) {
-				this.$logger.info(`Start syncing changes for device '${device.name}'.`);
+				this.$logger.info(`Start syncing changes for device ${this.getDeviceDisplayName(device)}.`);
 				await this.$previewSdkService.applyChanges(payloads);
-				this.$logger.info(`Successfully synced '${payloads.files.map(filePayload => filePayload.file.yellow)}' for device '${device.name}'.`);
+				this.$logger.info(`Successfully synced '${payloads.files.map(filePayload => filePayload.file.yellow)}' for device ${this.getDeviceDisplayName(device)}.`);
 			}
 		} catch (error) {
-			this.$logger.warn(`Unable to apply changes for device '${device.name}'. Error is: ${error}, ${JSON.stringify(error, null, 2)}.`);
+			this.$logger.warn(`Unable to apply changes for device ${this.getDeviceDisplayName(device)}. Error is: ${error}, ${JSON.stringify(error, null, 2)}.`);
 			this.emit(PreviewAppLiveSyncEvents.PREVIEW_APP_LIVE_SYNC_ERROR, {
 				error,
 				data,

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -396,7 +396,8 @@ export class RunController extends EventEmitter implements IRunController {
 
 						if (!liveSyncResultInfo.didRecover && isInHMRMode) {
 							const status = await this.$hmrStatusService.getHmrStatus(device.deviceInfo.identifier, data.hmrData.hash);
-							if (status === HmrConstants.HMR_ERROR_STATUS) {
+							// error or timeout
+							if (status !== HmrConstants.HMR_SUCCESS_STATUS) {
 								watchInfo.filesToSync = data.hmrData.fallbackFiles;
 								liveSyncResultInfo = await platformLiveSyncService.liveSyncWatchAction(device, watchInfo);
 								// We want to force a restart of the application.

--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -14,7 +14,7 @@ declare global {
 
 	interface IPreviewAppLiveSyncData extends IProjectDir, IHasUseHotModuleReloadOption, IEnvOptions { }
 
-	interface IPreviewSdkService extends EventEmitter {
+	interface IPreviewSdkService {
 		getQrCodeUrl(options: IGetQrCodeUrlOptions): string;
 		initialize(projectDir: string, getInitialFiles: (device: Device) => Promise<FilesPayload>): void;
 		applyChanges(filesPayload: FilesPayload): Promise<void>;

--- a/lib/services/livesync/playground/preview-sdk-service.ts
+++ b/lib/services/livesync/playground/preview-sdk-service.ts
@@ -1,8 +1,7 @@
 import { MessagingService, Config, Device, DeviceConnectedMessage, SdkCallbacks, ConnectedDevices, FilesPayload } from "nativescript-preview-sdk";
-import { EventEmitter } from "events";
 const pako = require("pako");
 
-export class PreviewSdkService extends EventEmitter implements IPreviewSdkService {
+export class PreviewSdkService implements IPreviewSdkService {
 	private static MAX_FILES_UPLOAD_BYTE_LENGTH = 15 * 1024 * 1024; // In MBs
 	private messagingService: MessagingService = null;
 	private instanceId: string = null;
@@ -13,7 +12,6 @@ export class PreviewSdkService extends EventEmitter implements IPreviewSdkServic
 		private $previewDevicesService: IPreviewDevicesService,
 		private $previewAppLogProvider: IPreviewAppLogProvider,
 		private $previewSchemaService: IPreviewSchemaService) {
-			super();
 	}
 
 	public getQrCodeUrl(options: IGetQrCodeUrlOptions): string {

--- a/lib/services/log-parser-service.ts
+++ b/lib/services/log-parser-service.ts
@@ -7,7 +7,7 @@ export class LogParserService extends EventEmitter implements ILogParserService 
 
 	constructor(private $deviceLogProvider: Mobile.IDeviceLogProvider,
 		private $errors: IErrors,
-		private $previewSdkService: IPreviewSdkService) {
+		private $previewAppLogProvider: IPreviewAppLogProvider) {
 		super();
 	}
 
@@ -23,10 +23,12 @@ export class LogParserService extends EventEmitter implements ILogParserService 
 	@cache()
 	private startParsingLogCore(): void {
 		this.$deviceLogProvider.on(DEVICE_LOG_EVENT_NAME, this.processDeviceLogResponse.bind(this));
-		this.$previewSdkService.on(DEVICE_LOG_EVENT_NAME, this.processDeviceLogResponse.bind(this));
+		this.$previewAppLogProvider.on(DEVICE_LOG_EVENT_NAME, (deviceId: string, message: string) => {
+			this.processDeviceLogResponse(message, deviceId);
+		});
 	}
 
-	private processDeviceLogResponse(message: string, deviceIdentifier: string, devicePlatform: string) {
+	private processDeviceLogResponse(message: string, deviceIdentifier: string, devicePlatform?: string) {
 		const lines = message.split("\n");
 		_.forEach(lines, line => {
 			_.forEach(this.parseRules, parseRule => {

--- a/test/services/ios-debugger-port-service.ts
+++ b/test/services/ios-debugger-port-service.ts
@@ -30,6 +30,7 @@ const device = <Mobile.IDevice>{
 function createTestInjector() {
 	const injector = new Yok();
 
+	injector.register("previewAppLogProvider", { on: () => ({}) });
 	injector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	injector.register("deviceLogProvider", DeveiceLogProviderMock);
 	injector.register("errors", ErrorsStub);

--- a/test/services/log-parser-service.ts
+++ b/test/services/log-parser-service.ts
@@ -20,6 +20,7 @@ class DeveiceLogProviderMock extends EventEmitter {
 
 function createTestInjector() {
 	const injector = new Yok();
+	injector.register("previewAppLogProvider", { on: () => ({}) });
 	injector.register("deviceLogProvider", DeveiceLogProviderMock);
 	injector.register("previewSdkService", {
 		on: () => ({})


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
1) We are not able to recover after an HMR crash on iOS. (it's working on Android just because the Preview app is requesting new files after crashes).
2) There's no indication when we've lost connection with the devices. The CLI is just not printing anything.
3) We are not printing any hints for starting the Preview app when there is an HMR status timeout.
4) The device-specific logs are misleading as they are not printed with a device name prefix.
5) Run with HMR is not assuming the HMR status timeout as HMR error and not retrying with full sync.
7) HMR updates are not chained causing wrong statuses and crashes from parallel updates.
8) HMR updates are not batched on fast changes leading to slow app updates.

## What is the new behavior?
1) We are executing HMR or full sync based on the previous HMR sync status.
2) "No connected devices" info is logged when there aren't any connected devices.
3) A hint for starting the Preview app is logged on HMR status timeout.
4) The device-specific logs are printed with a device name prefix.
5) Run with HMR is now assuming the HMR status timeout as HMR error and retrying with full sync.
7) HMR updates are now chained in order to avoid getting a wrong status from parallel updates.
8) HMR updates are batched in order to avoid slower updates on fast changes.

The image below shows three possible solutions to the above-mentioned problems:
![Preview LiveSync](https://user-images.githubusercontent.com/1865068/67564646-138adc80-f72c-11e9-982f-61f956fd15e6.png)
After analyzing the CLI logs, we found out that just a few users are using `tns preview` with more than one device from the same platform and this PR is implementing the simplest solution (the `simplest but more expensive` path from the diagram). In other words, it won't generate much more traffic through the message queue as almost all of the users are using just a single device per platform.

Related to: https://github.com/NativeScript/playground-feedback/issues/139