### PR TITLE
feat: allow tag and range versions in the preview app plugin versions validation

### DIFF
--- a/lib/definitions/preview-app-livesync.d.ts
+++ b/lib/definitions/preview-app-livesync.d.ts
@@ -24,7 +24,7 @@ declare global {
 	interface IGetQrCodeUrlOptions extends IHasUseHotModuleReloadOption, IProjectDir { }
 
 	interface IPreviewAppPluginsService {
-		getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[];
+		getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): Promise<string[]>;
 		comparePluginsOnDevice(data: IPreviewAppLiveSyncData, device: Device): Promise<void>;
 		getExternalPlugins(device: Device): string[];
 	}
@@ -56,7 +56,7 @@ declare global {
 		updateConnectedDevices(devices: Device[]): void;
 		getDeviceById(id: string): Device;
 		getDevicesForPlatform(platform: string): Device[];
-		getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[];
+		getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): Promise<string[]>;
 	}
 
 	interface IPreviewSchemaService {

--- a/lib/services/livesync/playground/devices/preview-devices-service.ts
+++ b/lib/services/livesync/playground/devices/preview-devices-service.ts
@@ -35,7 +35,7 @@ export class PreviewDevicesService extends EventEmitter implements IPreviewDevic
 		return _.filter(this.connectedDevices, { platform: platform.toLowerCase() });
 	}
 
-	public getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): string[] {
+	public getPluginsUsageWarnings(data: IPreviewAppLiveSyncData, device: Device): Promise<string[]> {
 		return this.$previewAppPluginsService.getPluginsUsageWarnings(data, device);
 	}
 

--- a/test/services/playground/preview-app-plugins-service.ts
+++ b/test/services/playground/preview-app-plugins-service.ts
@@ -4,13 +4,13 @@ import { Device } from "nativescript-preview-sdk";
 import { assert } from "chai";
 import * as util from "util";
 import { PluginComparisonMessages } from "../../../lib/services/livesync/playground/preview-app-constants";
-import { ErrorsStub } from "../../stubs";
+import { ErrorsStub, PackageInstallationManagerStub } from "../../stubs";
 
 let readJsonParams: string[] = [];
 let warnParams: string[] = [];
 
 const deviceId = "myTestDeviceId";
-const projectDir =  "testProjectDir";
+const projectDir = "testProjectDir";
 
 function createTestInjector(localPlugins: IStringDictionary, options?: { isNativeScriptPlugin?: boolean, hasPluginNativeCode?: boolean }): IInjector {
 	options = options || {};
@@ -42,8 +42,10 @@ function createTestInjector(localPlugins: IStringDictionary, options?: { isNativ
 	});
 	injector.register("logger", {
 		trace: () => ({}),
-		warn: (message: string) =>  warnParams.push(message)
+		warn: (message: string) => warnParams.push(message)
 	});
+
+	injector.register("packageInstallationManager", PackageInstallationManagerStub);
 	injector.register("errors", ErrorsStub);
 	injector.register("previewAppPluginsService", PreviewAppPluginsService);
 	return injector;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The CLI requires hardcoded plugin versions from the Preview app.

## What is the new behavior?
The CLI supports any version formats from the Preview app (hardcoded, tag and range).