### PR TITLE
chore: create changelog for 6.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 NativeScript CLI Changelog
 ================
 
+6.2.0 (2019, November 1)
+==
+
+### New
+* [Implemented #5038](https://github.com/NativeScript/nativescript-cli/issues/5038): Deprecate support for markingMode:full
+* [Implemented #5049](https://github.com/NativeScript/nativescript-cli/issues/5049): Android App Bundle Improvements
+* [Implemented #5060](https://github.com/NativeScript/nativescript-cli/issues/5060): Kotlin usage tracking in android builds
+* [Implemented #5096](https://github.com/NativeScript/nativescript-cli/issues/5096): Reduce the npm requests when checking if the project should be migrated
+* [Implemented #5104](https://github.com/NativeScript/nativescript-cli/pull/5104): Allow tag and range versions in the preview app plugin versions validation
+* [Implemented #5107](https://github.com/NativeScript/nativescript-cli/issues/5107): Support V8 Snapshots on Windows
+
+### Fixed
+* [Fixed #3785](https://github.com/NativeScript/nativescript-cli/issues/3785): NativeScript CLI doesn't pause on webpack compilation errors
+* [Fixed #4681](https://github.com/NativeScript/nativescript-cli/issues/4681): `tns update ios` is not working
+* [Fixed #4963](https://github.com/NativeScript/nativescript-cli/issues/4963): Difference in hookArgs.prepareData.platform on prepare and run command
+* [Fixed #4995](https://github.com/NativeScript/nativescript-cli/issues/4995): Building plugin and running demo app fails if plugins has a surrounding gradle build
+* [Fixed #5005](https://github.com/NativeScript/nativescript-cli/issues/5005): Apple Watch extension with space in the name of `.entitlements` file is not working
+* [Fixed #5020](https://github.com/NativeScript/nativescript-cli/issues/5020): Stuck at "Restarting application on device" on Windows 10, iPad mini 2, compiled with NativeScript Sidekick cloud service.
+* [Fixed #5030](https://github.com/NativeScript/nativescript-cli/issues/5030): The `tns devices` command lists appletv as iOS platform
+* [Fixed #5034](https://github.com/NativeScript/nativescript-cli/issues/5034): Broken build when passing --i-cloud-container-environment
+* [Fixed #5056](https://github.com/NativeScript/nativescript-cli/issues/5056): Unable to process native iOS files and frameworks from scoped packages
+* [Fixed #5061](https://github.com/NativeScript/nativescript-cli/issues/5061): Unable to resolve cocoapods version conflicts
+* [Fixed #5063](https://github.com/NativeScript/nativescript-cli/issues/5063): Splash Screen asset generation fails for iOS
+* [Fixed #5070](https://github.com/NativeScript/nativescript-cli/issues/5070): The `tns test` command cannot work if the source code is not in `src` or `app` folder
+* [Fixed #5077](https://github.com/NativeScript/nativescript-cli/pull/5077): Pass allowProvisioningUpdates to xcodebuild only when building for device
+* [Fixed #5094](https://github.com/NativeScript/nativescript-cli/issues/5094): Add Theme v2 name to non-extenal modules when starting webpack
+
 6.1.2 (2019, September 18)
 ==
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
