### PR TITLE
fix: values-v<sdk> directories are not prepared correctly

### DIFF
--- a/test/services/android-project-service.ts
+++ b/test/services/android-project-service.ts
@@ -3,6 +3,7 @@ import { Yok } from "../../lib/common/yok";
 import * as stubs from "../stubs";
 import { assert } from "chai";
 import * as sinon from "sinon";
+import * as path from "path";
 import { GradleCommandService } from "../../lib/services/android/gradle-command-service";
 import { GradleBuildService } from "../../lib/services/android/gradle-build-service";
 import { GradleBuildArgsService } from "../../lib/services/android/gradle-build-args-service";
@@ -42,7 +43,7 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("gradleBuildService", GradleBuildService);
 	testInjector.register("gradleBuildArgsService", GradleBuildArgsService);
 	testInjector.register("analyticsService", stubs.AnalyticsService);
-	testInjector.register("staticConfig", {TRACK_FEATURE_USAGE_SETTING_NAME: "TrackFeatureUsage"});
+	testInjector.register("staticConfig", { TRACK_FEATURE_USAGE_SETTING_NAME: "TrackFeatureUsage" });
 	return testInjector;
 };
 
@@ -59,7 +60,7 @@ const getDefautlBuildConfig = (): IBuildConfig => {
 	};
 };
 
-describe("androidDeviceDebugService", () => {
+describe("androidProjectService", () => {
 	let injector: IInjector;
 	let androidProjectService: IPlatformProjectService;
 	let sandbox: sinon.SinonSandbox = null;
@@ -74,7 +75,7 @@ describe("androidDeviceDebugService", () => {
 		sandbox.restore();
 	});
 
-	describe("buildPlatform", () => {
+	describe("buildProject", () => {
 		let projectData: IProjectData;
 		let childProcess: stubs.ChildProcessStub;
 
@@ -136,6 +137,184 @@ describe("androidDeviceDebugService", () => {
 
 			//assert
 			assert.include(childProcess.lastCommandArgs, "bundleDebug");
+		});
+	});
+
+	describe("prepareAppResources", () => {
+		const projectDir = "testDir";
+		const pathToAppResourcesDir = path.join(projectDir, "app", "App_Resources");
+		const pathToAppResourcesAndroid = path.join(pathToAppResourcesDir, "Android");
+		const pathToPlatformsAndroid = path.join(projectDir, "platforms", "android");
+		const pathToResDirInPlatforms = path.join(pathToPlatformsAndroid, "app", "src", "main", "res");
+		const valuesV27Path = path.join(pathToResDirInPlatforms, "values-v27");
+		const valuesV28Path = path.join(pathToResDirInPlatforms, "values-v28");
+		const libsPath = path.join(pathToResDirInPlatforms, "libs");
+		const drawableHdpiPath = path.join(pathToResDirInPlatforms, "drawable-hdpi");
+		const drawableLdpiPath = path.join(pathToResDirInPlatforms, "drawable-ldpi");
+		let deletedDirs: string[] = [];
+		let copiedFiles: { sourceFileName: string, destinationFileName: string }[] = [];
+		let readDirectoryResults: IDictionary<string[]> = {};
+		let fs: IFileSystem = null;
+		let projectData: IProjectData = null;
+		let compileSdkVersion = 29;
+
+		beforeEach(() => {
+			projectData = injector.resolve("projectData");
+			projectData.projectDir = projectDir;
+			projectData.appResourcesDirectoryPath = pathToAppResourcesDir;
+
+			deletedDirs = [];
+			copiedFiles = [];
+			readDirectoryResults = {};
+
+			fs = injector.resolve<IFileSystem>("fs");
+			fs.deleteDirectory = (directory: string): void => {
+				deletedDirs.push(directory);
+			};
+			fs.copyFile = (sourceFileName: string, destinationFileName: string): void => {
+				copiedFiles.push({ sourceFileName, destinationFileName });
+			};
+			fs.readDirectory = (dir: string): string[] => {
+				return readDirectoryResults[dir] || [];
+			};
+
+			compileSdkVersion = 29;
+
+			const androidToolsInfo = injector.resolve<IAndroidToolsInfo>("androidToolsInfo");
+			androidToolsInfo.getToolsInfo = (config?: IProjectDir): IAndroidToolsInfoData => {
+				return <any>{
+					compileSdkVersion
+				};
+			};
+
+		});
+
+		describe("when new Android App_Resources structure is detected (post {N} 4.0 structure)", () => {
+			const pathToSrcDirInAppResources = path.join(pathToAppResourcesAndroid, "src");
+			beforeEach(() => {
+				const androidResourcesMigrationService = injector.resolve<IAndroidResourcesMigrationService>("androidResourcesMigrationService");
+				androidResourcesMigrationService.hasMigrated = () => true;
+			});
+
+			it("copies everything from App_Resources/Android/src to correct location in platforms", async () => {
+				await androidProjectService.prepareAppResources(projectData);
+
+				assert.deepEqual(copiedFiles, [{ sourceFileName: path.join(pathToSrcDirInAppResources, "*"), destinationFileName: path.join(projectData.projectDir, "platforms", "android", "app", "src") }]);
+			});
+
+			it("deletes correct values-<sdk> directories based on the compileSdk", async () => {
+				readDirectoryResults = {
+					[`${pathToResDirInPlatforms}`]: [
+						"values",
+						"values-v21",
+						"values-v26",
+						"values-v27",
+						"values-v28"
+					]
+				};
+
+				compileSdkVersion = 26;
+				await androidProjectService.prepareAppResources(projectData);
+				assert.deepEqual(deletedDirs, [
+					valuesV27Path,
+					valuesV28Path
+				]);
+			});
+
+			it("deletes drawable directories when they've been previously prepared", async () => {
+				readDirectoryResults = {
+					[path.join(pathToSrcDirInAppResources, "main", "res")]: [
+						"drawable-hdpi",
+						"drawable-ldpi",
+						"values",
+						"values-v21",
+						"values-v29"
+					],
+					[`${pathToResDirInPlatforms}`]: [
+						"drawable-hdpi",
+						"drawable-ldpi",
+						"drawable-mdpi",
+						"values",
+						"values-v21",
+						"values-v29"
+					]
+				};
+
+				await androidProjectService.prepareAppResources(projectData);
+
+				// NOTE: Currently the drawable-mdpi directory is not deleted from prepared App_Resources as it does not exist in the currently prepared App_Resources
+				// This is not correct behavior and it should be fixed in a later point.
+				assert.deepEqual(deletedDirs, [
+					drawableHdpiPath,
+					drawableLdpiPath
+				]);
+			});
+		});
+
+		describe("when old Android App_Resources structure is detected (post {N} 4.0 structure)", () => {
+			beforeEach(() => {
+				const androidResourcesMigrationService = injector.resolve<IAndroidResourcesMigrationService>("androidResourcesMigrationService");
+				androidResourcesMigrationService.hasMigrated = () => false;
+			});
+
+			it("copies everything from App_Resources/Android to correct location in platforms", async () => {
+				await androidProjectService.prepareAppResources(projectData);
+
+				assert.deepEqual(copiedFiles, [{ sourceFileName: path.join(pathToAppResourcesAndroid, "*"), destinationFileName: pathToResDirInPlatforms }]);
+			});
+
+			it("deletes correct values-<sdk> directories based on the compileSdk", async () => {
+				readDirectoryResults = {
+					[`${pathToResDirInPlatforms}`]: [
+						"values",
+						"values-v21",
+						"values-v26",
+						"values-v27",
+						"values-v28"
+					]
+				};
+
+				compileSdkVersion = 26;
+
+				await androidProjectService.prepareAppResources(projectData);
+
+				// During preparation of old App_Resources, CLI copies all of them in platforms and after that deletes the libs directory.
+				assert.deepEqual(deletedDirs, [
+					libsPath,
+					valuesV27Path,
+					valuesV28Path
+				]);
+			});
+
+			it("deletes drawable directories when they've been previously prepared", async () => {
+				readDirectoryResults = {
+					[`${pathToAppResourcesAndroid}`]: [
+						"drawable-hdpi",
+						"drawable-ldpi",
+						"values",
+						"values-v21",
+						"values-v29"
+					],
+					[`${pathToResDirInPlatforms}`]: [
+						"drawable-hdpi",
+						"drawable-ldpi",
+						"drawable-mdpi",
+						"values",
+						"values-v21",
+						"values-v29"
+					]
+				};
+
+				await androidProjectService.prepareAppResources(projectData);
+				// NOTE: Currently the drawable-mdpi directory is not deleted from prepared App_Resources as it does not exist in the currently prepared App_Resources
+				// This is not correct behavior and it should be fixed in a later point.
+				// During preparation of old App_Resources, CLI copies all of them in platforms and after that deletes the libs directory.
+				assert.deepEqual(deletedDirs, [
+					drawableHdpiPath,
+					drawableLdpiPath,
+					libsPath
+				]);
+			});
 		});
 	});
 });


### PR DESCRIPTION
In Android's resources you can have different `values-v<sdk version>` directories which are used at runtime to differentiate resources for API levels.
In CLI we had a logic to include in native build only the `values-v<sdk version>` directories which are equal or lower to the SDK used for building the application.
This means that if you are using compileSdk 28, but you have `values-v29` directory in your resources it shouldn't be included in the native build.

Due to many changes in the structure of App_Resources/Android and the gradle template in NativeScript 4.0, this logic has been broken.
Fix it and execute it on every prepare of App_Resources.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
CLI prepares values-v<sdk> directories based on the current compileSdk

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/5120

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
