### PR TITLE
fix: generate iOS images when we have their sizes

### DIFF
--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -282,8 +282,15 @@ export class ProjectDataService implements IProjectDataService {
 				}
 			});
 
-			if (!foundMatchingDefinition && image.filename) {
-				this.$logger.warn(`Didn't find a matching image definition for file ${path.join(path.basename(dirPath), image.filename)}. This file will be skipped from reources generation.`);
+			if (!foundMatchingDefinition) {
+				if (image.height && image.width) {
+					this.$logger.trace("Missing data for image", image, " in CLI's resource file, but we will try to generate images based on the size from Contents.json");
+					finalContent.images.push(image);
+				} else if (image.filename) {
+					this.$logger.warn(`Didn't find a matching image definition for file ${path.join(path.basename(dirPath), image.filename)}. This file will be skipped from resources generation.`);
+				} else {
+					this.$logger.trace(`Unable to detect data for image generation of image`, image);
+				}
 			}
 		});
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "6.2.1",
+  "version": "6.2.2",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {

--- a/resources/assets/image-definitions.json
+++ b/resources/assets/image-definitions.json
@@ -2,6 +2,27 @@
 	"ios": {
 		"icons": [
 			{
+				"width": 20,
+				"height": 20,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-20@3x.png",
+				"scale": "3x"
+			},
+			{
+				"width": 20,
+				"height": 20,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-20@2x.png",
+				"scale": "2x"
+			},
+			{
+				"width": 20,
+				"height": 20,
+				"directory": "Assets.xcassets/AppIcon.appiconset",
+				"filename": "icon-20.png",
+				"scale": "1x"
+			},
+			{
 				"width": 60,
 				"height": 60,
 				"directory": "Assets.xcassets/AppIcon.appiconset",


### PR DESCRIPTION
In case we do not have some of iOS Resource images in our image-definitions.json file, we do not generate images for them. This was not the case prior 6.2.0 release, so fix the behavior by getting back the old logic - get the image size from the Contents.json and generate image for it.
Also add the images from the templates that are currently missing from our `image-definitions.json` file.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
CLI does not generate image resources for iOS which are described in Contents.json, but are not described in CLI's image-definitions.json file.

## What is the new behavior?
CLI does not generate image resources for iOS which are described in Contents.json, but are not described in CLI's image-definitions.json file.

Fixes issue: https://github.com/NativeScript/nativescript-cli/issues/5126

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
