### PR TITLE
`tns test init --help` doesn't show the available unit testing frameworks

### DIFF
--- a/docs/man_pages/project/testing/test-init.md
+++ b/docs/man_pages/project/testing/test-init.md
@@ -17,7 +17,7 @@ General | `$ tns test init [--framework <Framework>]`
 
 ### Options
 
-* `--framework <Framework>` - Sets the unit testing framework to install. The following frameworks are available: <%= formatListOfNames(constants.TESTING_FRAMEWORKS, 'and') %>.
+* `--framework <Framework>` - Sets the unit testing framework to install. The following frameworks are available: <%= formatListOfNames(getUnitTestingFrameworkNames(), 'and') %>.
 
 <% if(isHtml) { %>
 

--- a/lib/common/services/micro-templating-service.ts
+++ b/lib/common/services/micro-templating-service.ts
@@ -6,7 +6,8 @@ import { formatListOfNames } from '../helpers';
 export class MicroTemplateService implements IMicroTemplateService {
 	private dynamicCallRegex: RegExp;
 
-	constructor(private $injector: IInjector) {
+	constructor(private $injector: IInjector,
+		private $testInitializationService: ITestInitializationService) {
 		// Injector's dynamicCallRegex doesn't have 'g' option, which we need here.
 		// Use ( ) in order to use $1 to get whole expression later
 		this.dynamicCallRegex = new RegExp(util.format("(%s)", this.$injector.dynamicCallRegex.source), "g");
@@ -37,6 +38,7 @@ export class MicroTemplateService implements IMicroTemplateService {
 		localVariables["isConsole"] = !isHtml;
 		localVariables["isHtml"] = isHtml;
 		localVariables["formatListOfNames"] = formatListOfNames;
+		localVariables["getUnitTestingFrameworkNames"] = this.$testInitializationService.getFrameworkNames;
 		localVariables["isJekyll"] = false;
 
 		return localVariables;

--- a/lib/common/test/unit-tests/services/help-service.ts
+++ b/lib/common/test/unit-tests/services/help-service.ts
@@ -34,6 +34,8 @@ const createTestInjector = (opts?: { isProjectTypeResult: boolean; isPlatformRes
 		getInstalledExtensionsData: (): IExtensionData[] => []
 	});
 
+	injector.register("testInitializationService", {});
+
 	injector.registerCommand("foo", {});
 
 	const microTemplateService: any = injector.resolve("microTemplateService");

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -376,6 +376,7 @@ interface ITestExecutionService {
 
 interface ITestInitializationService {
 	getDependencies(framework: string): IDependencyInformation[];
+	getFrameworkNames(): string[];
 }
 
 /**

--- a/lib/services/test-initialization-service.ts
+++ b/lib/services/test-initialization-service.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as fs from "fs";
 import { cache } from "../common/decorators";
 
 export class TestInitializationService implements ITestInitializationService {
@@ -26,6 +27,21 @@ export class TestInitializationService implements ITestInitializationService {
 			});
 
 		return targetFrameworkDependencies;
+	}
+
+	/**
+	 * This method is used from test-init.md file so it is not allowed to use "this" inside the method's body.
+	 */
+	@cache()
+	public getFrameworkNames(): string[] {
+		const configsPath = path.join(__dirname, "..", "..", "config");
+		const dependenciesPath = path.join(configsPath, "test-dependencies.json");
+		const allDependencies: { name: string, framework?: string }[] = JSON.parse(fs.readFileSync(dependenciesPath, { encoding: 'utf-8'}));
+		const frameworks = _.uniqBy(allDependencies, "framework")
+			.map(item => item && item.framework)
+			.filter(item => item);
+
+		return frameworks;
 	}
 }
 


### PR DESCRIPTION
`tns test init --help` doesn't show the available unit testing frameworks as the constant `constants.TESTING_FRAMEWORKS` that is used from the `test-init.md` file was deleted. On the other side, `test-dependencies.json` file was introduced in order to list all supported frameworks. So, this PR gets the supported unit testing framework names from `test-dependencies.json` file and prints them from `test-init.md` file.

Rel to: https://github.com/NativeScript/nativescript-cli/issues/5113

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
