### PR TITLE
fix: prepare of pods should work on case-sensitive systems

### DIFF
--- a/lib/controllers/preview-app-controller.ts
+++ b/lib/controllers/preview-app-controller.ts
@@ -138,7 +138,7 @@ export class PreviewAppController extends EventEmitter implements IPreviewAppCon
 	@performanceLog()
 	private async handlePrepareReadyEvent(data: IPreviewAppLiveSyncData, currentPrepareData: IFilesChangeEventData) {
 		const { hmrData, files, platform } = currentPrepareData;
-		const platformHmrData = _.cloneDeep(hmrData);
+		const platformHmrData = _.cloneDeep(hmrData) || <IPlatformHmrData>{};
 		const connectedDevices = this.$previewDevicesService.getDevicesForPlatform(platform);
 		if (!connectedDevices || !connectedDevices.length) {
 			this.$logger.warn(`Unable to find any connected devices for platform '${platform}'. In order to execute live sync, open your Preview app and optionally re-scan the QR code using the Playground app.`);

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -35,7 +35,7 @@ interface IBasePluginData {
 }
 
 interface IPluginData extends INodeModuleData {
-	platformsDataService: IPluginPlatformsData;
+	platformsData: IPluginPlatformsData;
 	/* Gets all plugin variables from plugin */
 	pluginVariables: IDictionary<IPluginVariableData>;
 	pluginPlatformsFolderPath(platform: string): string;

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -115,9 +115,8 @@ export class PluginsService implements IPluginsService {
 		}
 	}
 
-	public async preparePluginNativeCode({pluginData, platform, projectData}: IPreparePluginNativeCodeData): Promise<void> {
+	public async preparePluginNativeCode({ pluginData, platform, projectData }: IPreparePluginNativeCodeData): Promise<void> {
 		const platformData = this.$platformsDataService.getPlatformData(platform, projectData);
-		pluginData.pluginPlatformsFolderPath = (_platform: string) => path.join(pluginData.fullPath, "platforms", _platform.toLowerCase());
 
 		const pluginPlatformsFolderPath = pluginData.pluginPlatformsFolderPath(platform);
 		if (this.$fs.exists(pluginPlatformsFolderPath)) {
@@ -213,18 +212,18 @@ export class PluginsService implements IPluginsService {
 		pluginData.version = cacheData.version;
 		pluginData.fullPath = cacheData.directory || path.dirname(this.getPackageJsonFilePathForModule(cacheData.name, projectDir));
 		pluginData.isPlugin = !!cacheData.nativescript || !!cacheData.moduleInfo;
-		pluginData.pluginPlatformsFolderPath = (platform: string) => path.join(pluginData.fullPath, "platforms", platform);
+		pluginData.pluginPlatformsFolderPath = (platform: string) => path.join(pluginData.fullPath, "platforms", platform.toLowerCase());
 		const data = cacheData.nativescript || cacheData.moduleInfo;
 
 		if (pluginData.isPlugin) {
-			pluginData.platformsDataService = data.platforms;
+			pluginData.platformsData = data.platforms;
 			pluginData.pluginVariables = data.variables;
 		}
 
 		return pluginData;
 	}
 
-	private removeDependencyFromPackageJsonContent(dependency: string, packageJsonContent: Object): {hasModifiedPackageJson: boolean, packageJsonContent: Object} {
+	private removeDependencyFromPackageJsonContent(dependency: string, packageJsonContent: Object): { hasModifiedPackageJson: boolean, packageJsonContent: Object } {
 		let hasModifiedPackageJson = false;
 
 		if (packageJsonContent.devDependencies && packageJsonContent.devDependencies[dependency]) {
@@ -260,7 +259,7 @@ export class PluginsService implements IPluginsService {
 
 	private getPackageJsonFilePathForModule(moduleName: string, projectDir: string): string {
 		const pathToJsonFile = require.resolve(`${moduleName}/package.json`, {
-				paths: [projectDir]
+			paths: [projectDir]
 		});
 		return pathToJsonFile;
 	}
@@ -333,7 +332,7 @@ export class PluginsService implements IPluginsService {
 		let isValid = true;
 
 		const installedFrameworkVersion = this.getInstalledFrameworkVersion(platform, projectData);
-		const pluginPlatformsData = pluginData.platformsDataService;
+		const pluginPlatformsData = pluginData.platformsData;
 		if (pluginPlatformsData) {
 			const versionRequiredByPlugin = (<any>pluginPlatformsData)[platform];
 			if (!versionRequiredByPlugin) {

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -879,8 +879,9 @@ describe("handleNativeDependenciesChange", () => {
 	it("ensure the correct order of pod install and merging pod's xcconfig file", async () => {
 		const executedCocoapodsMethods: string[] = [];
 		const projectPodfilePath = "my/test/project/platforms/ios/Podfile";
+		const dir = temp.mkdirSync("myTestProjectPath");
 
-		const testInjector = createTestInjector("myTestProjectPath", "myTestProjectName");
+		const testInjector = createTestInjector(dir, "myTestProjectName");
 		const iOSProjectService = testInjector.resolve("iOSProjectService");
 		const projectData = testInjector.resolve("projectData");
 

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -171,7 +171,8 @@ function createTestInjector(options?: {
 		mapFilePath: (filePath: string) => path.join(path.join(platformsDirPath, "app"), path.relative(path.join(projectDirPath, "app"), filePath))
 	});
 	injector.register("previewDevicesService", {
-		getConnectedDevices: () => [deviceMockData]
+		getConnectedDevices: () => [deviceMockData],
+		getDevicesForPlatform: (platform: string): Device[] => [deviceMockData]
 	});
 	injector.register("previewAppFilesService", PreviewAppFilesService);
 	injector.register("previewQrCodeService", {


### PR DESCRIPTION
In case there's a case-sensitive file system, the preparation of Podfiles does not work as we check for `iOS` dir in the plugins, but the actual dir is `ios`.
Fix the case, add unit tests and remove some unneeded unit test.

Also fix some unit tests.
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/5159

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
