### PR TITLE
chore: improve log trace messages

### DIFF
--- a/lib/common/dispatchers.ts
+++ b/lib/common/dispatchers.ts
@@ -19,7 +19,8 @@ export class CommandDispatcher implements ICommandDispatcher {
 			// CommandDispatcher is called from external CLI's only, so pass the path to their package.json
 			const sysInfo = await this.$sysInfo.getSysInfo({ pathToNativeScriptCliPackageJson: path.join(__dirname, "..", "..", "package.json") });
 			this.$logger.trace("System information:");
-			this.$logger.trace(sysInfo);
+			this.$logger.trace(JSON.stringify(sysInfo, null, 2));
+			this.$logger.trace("Current CLI version: ", this.$staticConfig.version);
 		}
 
 		let commandName = this.getCommandName();

--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -12,7 +12,10 @@ const originalProcessOn = process.on;
 
 process.on = (event: string, listener: any): any => {
 	if (event === "SIGINT") {
-		logger.trace(new Error(`Trying to handle SIGINT event. CLI overrides this behavior and does not allow handling SIGINT as this causes issues with Ctrl + C in terminal`).stack);
+		logger.trace(`Trying to handle SIGINT event. CLI overrides this behavior and does not allow handling SIGINT as this causes issues with Ctrl + C in terminal.`);
+		const msg = "The stackTrace of the location trying to handle SIGINT is:";
+		const stackTrace = new Error(msg).stack || '';
+		logger.trace(stackTrace.replace(`Error: ${msg}`, msg));
 	} else {
 		return originalProcessOn.apply(process, [event, listener]);
 	}

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -229,7 +229,6 @@ export class ProjectChangesService implements IProjectChangesService {
 		const dirName = path.basename(dir);
 		this.$logger.trace(`containsNewerFiles will check ${dir}`);
 		if (_.startsWith(dirName, '.')) {
-			this.$logger.trace(`containsNewerFiles returns false for ${dir} as its name starts with dot (.) .`);
 			return false;
 		}
 
@@ -258,7 +257,6 @@ export class ProjectChangesService implements IProjectChangesService {
 			}
 		}
 
-		this.$logger.trace(`containsNewerFiles returns false for ${dir}.`);
 		return false;
 	}
 

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -33,6 +33,8 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 				const childProcess = await this.startWebpackProcess(platformData, projectData, prepareData);
 
 				childProcess.on("message", (message: string | IWebpackEmitMessage) => {
+					this.$logger.trace("Message from webpack", message);
+
 					if (message === "Webpack compilation complete.") {
 						this.$logger.info("Webpack build done!");
 						resolve(childProcess);
@@ -74,6 +76,7 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 							platform: platformData.platformNameLowerCase
 						};
 
+						this.$logger.trace("Generated data from webpack message:", data);
 						if (data.files.length) {
 							this.emit(WEBPACK_COMPILATION_COMPLETE, data);
 						}


### PR DESCRIPTION
Improve log trace messages with:
1. Remove some `containsNewerFiles` logs which do not give any useful information
2. Add trace for messages send by webpack process to CLI and the data prepared by CLI from those messages.
3. Printing the sysinfo information is now formatted correctly.
4. Print the current CLI version as it is not included in the sysinfo.
5. Override of SIGINT handler seems like an error in the trace logs - fix it by removing the "Error:" part from it.

