### PR TITLE
feat: doctor improvements

### DIFF
--- a/lib/common/commands/doctor.ts
+++ b/lib/common/commands/doctor.ts
@@ -6,7 +6,7 @@ export class DoctorCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 
 	public execute(args: string[]): Promise<void> {
-		return this.$doctorService.printWarnings({ trackResult: false, projectDir: this.$projectHelper.projectDir });
+		return this.$doctorService.printWarnings({ trackResult: false, projectDir: this.$projectHelper.projectDir, forceCheck: true });
 	}
 }
 

--- a/lib/common/declarations.d.ts
+++ b/lib/common/declarations.d.ts
@@ -1195,7 +1195,7 @@ interface IDoctorService {
 	 * @param configOptions: defines if the result should be tracked by Analytics
 	 * @returns {Promise<void>}
 	 */
-	printWarnings(configOptions?: { trackResult: boolean, projectDir?: string, runtimeVersion?: string, options?: IOptions }): Promise<void>;
+	printWarnings(configOptions?: { trackResult?: boolean, projectDir?: string, runtimeVersion?: string, options?: IOptions, forceCheck?: boolean }): Promise<void>;
 	/**
 	 * Runs the setup script on host machine
 	 * @returns {Promise<ISpawnResult>}
@@ -1206,7 +1206,7 @@ interface IDoctorService {
 	 * @param platform @optional The current platform
 	 * @returns {Promise<boolean>} true if the environment is properly configured for local builds
 	 */
-	canExecuteLocalBuild(platform?: string, projectDir?: string, runtimeVersion?: string): Promise<boolean>;
+	canExecuteLocalBuild(configuration?: { platform?: string, projectDir?: string, runtimeVersion?: string, forceCheck?: boolean }): Promise<boolean>;
 
 	/**
 	 * Checks and notifies users for deprecated short imports in their applications.

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -80,6 +80,7 @@ interface ICheckEnvironmentRequirementsInput {
 	runtimeVersion?: string;
 	options?: IOptions;
 	notConfiguredEnvOptions?: INotConfiguredEnvOptions;
+	forceCheck?: boolean;
 }
 
 interface ICheckEnvironmentRequirementsOutput {

--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -57,7 +57,8 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 			};
 		}
 
-		const canExecute = await this.$doctorService.canExecuteLocalBuild(platform, projectDir, runtimeVersion);
+		const canExecute = await this.$doctorService.canExecuteLocalBuild({ platform, projectDir, runtimeVersion, forceCheck: input.forceCheck });
+
 		if (!canExecute) {
 			if (!isInteractive()) {
 				await this.$analyticsService.trackEventActionInGoogleAnalytics({
@@ -80,7 +81,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 			if (selectedOption === PlatformEnvironmentRequirements.LOCAL_SETUP_OPTION_NAME) {
 				await this.$doctorService.runSetupScript();
 
-				if (await this.$doctorService.canExecuteLocalBuild(platform, projectDir, runtimeVersion)) {
+				if (await this.$doctorService.canExecuteLocalBuild({ platform, projectDir, runtimeVersion, forceCheck: input.forceCheck })) {
 					return {
 						canExecute: true,
 						selectedOption
@@ -114,7 +115,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 
 			if (selectedOption === PlatformEnvironmentRequirements.BOTH_CLOUD_SETUP_AND_LOCAL_SETUP_OPTION_NAME) {
 				await this.processBothCloudBuildsAndSetupScript();
-				if (await this.$doctorService.canExecuteLocalBuild(platform, projectDir, runtimeVersion)) {
+				if (await this.$doctorService.canExecuteLocalBuild({ platform, projectDir, runtimeVersion, forceCheck: input.forceCheck })) {
 					return {
 						canExecute: true,
 						selectedOption

--- a/test/services/doctor-service.ts
+++ b/test/services/doctor-service.ts
@@ -13,8 +13,9 @@ class DoctorServiceInheritor extends DoctorService {
 		$projectDataService: IProjectDataService,
 		$fs: IFileSystem,
 		$terminalSpinnerService: ITerminalSpinnerService,
-		$versionsService: IVersionsService) {
-		super($analyticsService, $hostInfo, $logger, $childProcess, $injector, $projectDataService, $fs, $terminalSpinnerService, $versionsService);
+		$versionsService: IVersionsService,
+		$settingsService: ISettingsService) {
+		super($analyticsService, $hostInfo, $logger, $childProcess, $injector, $projectDataService, $fs, $terminalSpinnerService, $versionsService, $settingsService);
 	}
 
 	public getDeprecatedShortImportsInFiles(files: string[], projectDir: string): { file: string, line: string }[] {
@@ -34,6 +35,13 @@ describe("doctorService", () => {
 		testInjector.register("fs", {});
 		testInjector.register("terminalSpinnerService", {});
 		testInjector.register("versionsService", {});
+		testInjector.register("settingsService", {
+			getProfileDir: (): string => ""
+		});
+		testInjector.register("jsonFileSettingsService", {
+			getSettingValue: async (settingName: string, cacheOpts?: ICacheTimeoutOpts): Promise<any> => undefined,
+			saveSetting: async (key: string, value: any, cacheOpts?: IUseCacheOpts): Promise<void> => undefined
+		});
 
 		return testInjector;
 	};


### PR DESCRIPTION
Currently each project related CLI command checks the status of the machine. This takes between 4 and 9 seconds on different machines. Cache the result per project and based on the environment variables used in the checks.

In case `tns doctor` is called, force the check of the environment requirements. In case an issue is detected, remove the file with cached information for all projects - there seems to be issue with the configuration, so we need to check all projects again.
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Implements issue https://github.com/NativeScript/nativescript-cli/issues/5180.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
