### PR TITLE
fix: `tns info` should work with scoped modules

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -798,10 +798,10 @@ interface IVersionsService {
 	getNativescriptCliVersion(): Promise<IVersionInformation>;
 
 	/**
-	 * Gets version information about tns-core-modules.
-	 * @return {Promise<IVersionInformation>} The version information.
+	 * Gets version information about tns-core-modules and @nativescript/core packages.
+	 * @return {Promise<IVersionInformation[]>} The version information.
 	 */
-	getTnsCoreModulesVersion(): Promise<IVersionInformation>;
+	getTnsCoreModulesVersion(): Promise<IVersionInformation[]>;
 
 	/**
 	 * Gets versions information about nativescript runtimes.


### PR DESCRIPTION
Currently the `tns info` command fails when executed inside application in which `tns-core-modules` package is not available as dependency. This may happen in case you use only `@nativescript/core` package.
The problem is that CLI is trying to read the package.json of the `<project dir>/node_modules/tns-core-modules` and this operation fails.
To fix this, add checks for both `tns-core-modules` and `@nativescript/core` packages. Warnings/information will be shown only for the package used in package.json, i.e. in case you use `tns-core-modules`, we'll show information only for it.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns info` fails when executed in a project without `tns-core-modules` in it.

## What is the new behavior?
`tns info` succeeds when executed in a project without `tns-core-modules` in it.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/5192

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
