### PR TITLE
fix: emulator 29 is not started by default

### DIFF
--- a/lib/common/mobile/android/android-emulator-services.ts
+++ b/lib/common/mobile/android/android-emulator-services.ts
@@ -144,7 +144,15 @@ export class AndroidEmulatorServices implements Mobile.IEmulatorPlatformService 
 	}
 
 	private getBestFit(emulators: Mobile.IDeviceInfo[]) {
-		const best = _(emulators).maxBy(emulator => emulator.version);
+		let best: Mobile.IDeviceInfo = null;
+		for (const emulator of emulators) {
+			const currentVersion = emulator.version && semver.coerce(emulator.version);
+			const currentBestVersion = best && best.version && semver.coerce(best.version);
+			if (!best || (currentVersion && currentBestVersion && semver.gt(currentVersion, currentBestVersion))) {
+				best = emulator;
+			}
+		}
+
 		const minVersion = semver.coerce(AndroidVirtualDevice.MIN_ANDROID_VERSION);
 		const bestVersion = best && best.version && semver.coerce(best.version);
 

--- a/lib/common/test/unit-tests/services/json-file-settings-service.ts
+++ b/lib/common/test/unit-tests/services/json-file-settings-service.ts
@@ -129,7 +129,7 @@ describe("jsonFileSettingsService", () => {
 			const result = await new Promise((resolve, reject) => {
 				setTimeout(() => {
 					jsonFileSettingsService.getSettingValue<number>("prop1", { cacheTimeout: 1 }).then(resolve, reject);
-				}, 2);
+				}, 10);
 			});
 
 			assert.equal(result, null);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "6.3.1",
+  "version": "6.3.2",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {


### PR DESCRIPTION
In case you have emulator with API Level 29 and other older emulators, CLI should run the latest available (29), but it doesn't.
The problem is in the parsing of the string version - '9.0.0' is always newer than '10.0.0' which corresponds to API level 29. Fix the parsing, so now `tns run android` will correctly start latest available emulator in case there's nothing running.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/5200
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
