### PR TITLE
feat: expose before build hooks in order to support cloud builds without an extension

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -5,6 +5,7 @@ import * as semver from "semver";
 import * as projectServiceBaseLib from "./platform-project-service-base";
 import { DeviceAndroidDebugBridge } from "../common/mobile/android/device-android-debug-bridge";
 import { Configurations, LiveSyncPaths } from "../common/constants";
+import { hook } from "../common/helpers";
 import { performanceLog } from ".././common/decorators";
 
 export class AndroidProjectService extends projectServiceBaseLib.PlatformProjectServiceBase {
@@ -242,6 +243,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 	}
 
 	@performanceLog()
+	@hook('buildAndroid')
 	public async buildProject(projectRoot: string, projectData: IProjectData, buildData: IAndroidBuildData): Promise<void> {
 		const platformData = this.getPlatformData(projectData);
 		await this.$gradleBuildService.buildProject(platformData.projectRoot, buildData);

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -14,6 +14,7 @@ import { IOSEntitlementsService } from "./ios-entitlements-service";
 import { IOSBuildData } from "../data/build-data";
 import { IOSPrepareData } from "../data/prepare-data";
 import { BUILD_XCCONFIG_FILE_NAME, IosProjectConstants } from "../constants";
+import { hook } from "../common/helpers";
 
 interface INativeSourceCodeGroup {
 	name: string;
@@ -193,6 +194,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			path.join(projectRoot, projectData.projectName));
 	}
 
+	@hook('buildIOS')
 	public async buildProject(projectRoot: string, projectData: IProjectData, iOSBuildData: IOSBuildData): Promise<void> {
 		const platformData = this.getPlatformData(projectData);
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "6.3.2",
+  "version": "6.3.3",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {

--- a/test/services/android-project-service.ts
+++ b/test/services/android-project-service.ts
@@ -11,6 +11,7 @@ import { GradleBuildArgsService } from "../../lib/services/android/gradle-build-
 const createTestInjector = (): IInjector => {
 	const testInjector = new Yok();
 	testInjector.register("androidProjectService", AndroidProjectService);
+	testInjector.register("hooksService", stubs.HooksServiceStub);
 	testInjector.register("childProcess", stubs.ChildProcessStub);
 	testInjector.register("hostInfo", {});
 	testInjector.register("projectDataService", stubs.ProjectDataService);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
There's no way to override the CLI build logic through a hook.

## What is the new behavior?
We could override the CLI build logic through a before build hooks.

Related to: https://github.com/NativeScript/nativescript-cli/issues/5205