### PR TITLE
feat: add env check hook in order to allow cloud builds without any native local setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NativeScript CLI Changelog
 ### New
 
 * [Implemented #5205](https://github.com/NativeScript/nativescript-cli/issues/5205): Support build hooks
+* [Implemented #5210](https://github.com/NativeScript/nativescript-cli/issues/5210): Support environment check hooks 
 
 ### Fixed
 

--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -1,5 +1,5 @@
 import { NATIVESCRIPT_CLOUD_EXTENSION_NAME, TrackActionNames } from "../constants";
-import { isInteractive } from "../common/helpers";
+import { isInteractive, hook } from "../common/helpers";
 import { EOL } from "os";
 
 export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequirements {
@@ -39,6 +39,7 @@ export class PlatformEnvironmentRequirements implements IPlatformEnvironmentRequ
 		"deploy": "tns cloud deploy"
 	};
 
+	@hook("checkEnvironment")
 	public async checkEnvironmentRequirements(input: ICheckEnvironmentRequirementsInput): Promise<ICheckEnvironmentRequirementsOutput> {
 		const { platform, projectDir, runtimeVersion } = input;
 		const notConfiguredEnvOptions = input.notConfiguredEnvOptions || {};

--- a/test/services/platform-environment-requirements.ts
+++ b/test/services/platform-environment-requirements.ts
@@ -18,8 +18,9 @@ function createTestInjector() {
 	testInjector.register("analyticsService", {
 		trackEventActionInGoogleAnalytics: () => ({})
 	});
-	testInjector.register("commandsService", {currentCommandData: {commandName: "test", commandArguments: [""]}});
+	testInjector.register("commandsService", { currentCommandData: { commandName: "test", commandArguments: [""] } });
 	testInjector.register("doctorService", {});
+	testInjector.register("hooksService", stubs.HooksServiceStub);
 	testInjector.register("errors", {
 		fail: (err: any) => {
 			throw new Error(err.formatStr || err.message || err);
@@ -47,10 +48,10 @@ describe("platformEnvironmentRequirements ", () => {
 	describe("checkRequirements", () => {
 		let testInjector: IInjector = null;
 		let platformEnvironmentRequirements: IPlatformEnvironmentRequirements = null;
-		let promptForChoiceData: {message: string, choices: string[]}[] = [];
+		let promptForChoiceData: { message: string, choices: string[] }[] = [];
 		let isExtensionInstallCalled = false;
 
-		function mockDoctorService(data: {canExecuteLocalBuild: boolean, mockSetupScript?: boolean}) {
+		function mockDoctorService(data: { canExecuteLocalBuild: boolean, mockSetupScript?: boolean }) {
 			const doctorService = testInjector.resolve("doctorService");
 			doctorService.canExecuteLocalBuild = () => data.canExecuteLocalBuild;
 			if (data.mockSetupScript) {
@@ -58,10 +59,10 @@ describe("platformEnvironmentRequirements ", () => {
 			}
 		}
 
-		function mockPrompter(data: {firstCallOptionName: string, secondCallOptionName?: string}) {
+		function mockPrompter(data: { firstCallOptionName: string, secondCallOptionName?: string }) {
 			const prompter = testInjector.resolve("prompter");
 			prompter.promptForChoice = (message: string, choices: string[]) => {
-				promptForChoiceData.push({message: message, choices: choices});
+				promptForChoiceData.push({ message: message, choices: choices });
 
 				if (promptForChoiceData.length === 1) {
 					return Promise.resolve(data.firstCallOptionName);
@@ -73,7 +74,7 @@ describe("platformEnvironmentRequirements ", () => {
 			};
 		}
 
-		function mockNativeScriptCloudExtensionService(data: {isInstalled: boolean}) {
+		function mockNativeScriptCloudExtensionService(data: { isInstalled: boolean }) {
 			const nativeScriptCloudExtensionService = testInjector.resolve("nativeScriptCloudExtensionService");
 			nativeScriptCloudExtensionService.isInstalled = () => data.isInstalled;
 			nativeScriptCloudExtensionService.install = () => { isExtensionInstallCalled = true; };
@@ -124,7 +125,7 @@ describe("platformEnvironmentRequirements ", () => {
 			mockPrompter({ firstCallOptionName: PlatformEnvironmentRequirements.CLOUD_SETUP_OPTION_NAME });
 			mockNativeScriptCloudExtensionService({ isInstalled: true });
 
-			await assert.isRejected(platformEnvironmentRequirements.checkEnvironmentRequirements({ platform, notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true }}));
+			await assert.isRejected(platformEnvironmentRequirements.checkEnvironmentRequirements({ platform, notConfiguredEnvOptions: { hideSyncToPreviewAppOption: true } }));
 			assert.isTrue(promptForChoiceData.length === 1);
 			assert.isTrue(isExtensionInstallCalled);
 			assert.deepEqual("To continue, choose one of the following options: ", promptForChoiceData[0].message);
@@ -135,13 +136,13 @@ describe("platformEnvironmentRequirements ", () => {
 			mockPrompter({ firstCallOptionName: PlatformEnvironmentRequirements.CLOUD_SETUP_OPTION_NAME });
 			mockNativeScriptCloudExtensionService({ isInstalled: true });
 
-			await assert.isRejected(platformEnvironmentRequirements.checkEnvironmentRequirements({ platform, notConfiguredEnvOptions: { hideCloudBuildOption: true }}));
+			await assert.isRejected(platformEnvironmentRequirements.checkEnvironmentRequirements({ platform, notConfiguredEnvOptions: { hideCloudBuildOption: true } }));
 			assert.isTrue(promptForChoiceData.length === 1);
 			assert.isTrue(isExtensionInstallCalled);
 			assert.deepEqual("To continue, choose one of the following options: ", promptForChoiceData[0].message);
 			assert.deepEqual(['Sync to Playground', 'Configure for Local Builds', 'Skip Step and Configure Manually'], promptForChoiceData[0].choices);
 		});
-		it("should skip env check when NS_SKIP_ENV_CHECK environment variable is passed", async() => {
+		it("should skip env check when NS_SKIP_ENV_CHECK environment variable is passed", async () => {
 			(<any>process.env).NS_SKIP_ENV_CHECK = true;
 
 			const output = await platformEnvironmentRequirements.checkEnvironmentRequirements({ platform });
@@ -153,7 +154,7 @@ describe("platformEnvironmentRequirements ", () => {
 
 		describe("when local setup option is selected", () => {
 			beforeEach(() => {
-				mockPrompter( {firstCallOptionName: PlatformEnvironmentRequirements.LOCAL_SETUP_OPTION_NAME});
+				mockPrompter({ firstCallOptionName: PlatformEnvironmentRequirements.LOCAL_SETUP_OPTION_NAME });
 			});
 
 			it("should return true when env is configured after executing setup script", async () => {
@@ -169,7 +170,7 @@ describe("platformEnvironmentRequirements ", () => {
 
 			describe("and env is not configured after executing setup script", () => {
 				it("should setup manually when cloud extension is installed", async () => {
-					mockDoctorService( { canExecuteLocalBuild: false, mockSetupScript: true });
+					mockDoctorService({ canExecuteLocalBuild: false, mockSetupScript: true });
 					mockPrompter({ firstCallOptionName: PlatformEnvironmentRequirements.LOCAL_SETUP_OPTION_NAME, secondCallOptionName: PlatformEnvironmentRequirements.MANUALLY_SETUP_OPTION_NAME });
 					mockNativeScriptCloudExtensionService({ isInstalled: true });
 


### PR DESCRIPTION
# PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
There's no way to override the CLI env checks through a hook.

## What is the new behavior?
We are able to override the CLI env checks through a before `checkEnvironment` hooks.

Related to: https://github.com/NativeScript/nativescript-cli/issues/5210