### PR TITLE
fix: `tns update` command should work with npm tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ NativeScript CLI Changelog
 ### New
 
 * [Implemented #5205](https://github.com/NativeScript/nativescript-cli/issues/5205): Support build hooks
-* [Implemented #5210](https://github.com/NativeScript/nativescript-cli/issues/5210): Support environment check hooks 
+* [Implemented #5210](https://github.com/NativeScript/nativescript-cli/issues/5210): Support environment check hooks
 
 ### Fixed
 
 * [Fixed #3818](https://github.com/NativeScript/nativescript-cli/issues/3818): Cannot set property 'socket' of null
+* [Fixed #5072](https://github.com/NativeScript/nativescript-cli/issues/5072):`tns update next` doesn't work with CLI 6+
 
 
 6.3.2 (2020, January 9)


### PR DESCRIPTION
In the past `tns update` command worked with tags, but since 6.0 this was broken. The logic in Update Controller requires a valid package.json from template with same version. However, our templates do not have `next`, `rc`, etc. versions and passing tag to the command fails.
In order to fix this, construct the required template manually. For each of the packages we would update, check if the has a valid version with the same tag and get the current version behind this tag.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`tns update next` fails.

## What is the new behavior?
`tns update next` passes.

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/5072

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
