### PR TITLE
feat: allow setting custom webpack config file

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -75,7 +75,8 @@ interface INsConfig {
 	appResourcesPath?: string;
 	shared?: boolean;
 	previewAppSchema?: string;
-	overridePods?: string
+	overridePods?: string;
+	webpackConfigPath?: string;
 }
 
 interface IProjectData extends ICreateProjectData {
@@ -105,6 +106,13 @@ interface IProjectData extends ICreateProjectData {
 	 * Defines the schema for the preview app
 	 */
 	previewAppSchema: string;
+
+	/**
+	 * Defines the path to the configuration file passed to webpack process.
+	 * By default this is the webpack.config.js at the root of the application.
+	 * The value can be changed by setting `webpackConfigPath` in nsconfig.json.
+	 */
+	webpackConfigPath: string;
 
 	/**
 	 * Initializes project data with the given project directory. If none supplied defaults to --path option or cwd.

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -70,6 +70,7 @@ export class ProjectData implements IProjectData {
 	public podfilePath: string;
 	public isShared: boolean;
 	public previewAppSchema: string;
+	public webpackConfigPath: string;
 
 	constructor(private $fs: IFileSystem,
 		private $errors: IErrors,
@@ -145,6 +146,7 @@ export class ProjectData implements IProjectData {
 			this.podfilePath = path.join(this.appResourcesDirectoryPath, this.$devicePlatformsConstants.iOS, constants.PODFILE_NAME);
 			this.isShared = !!(this.nsConfig && this.nsConfig.shared);
 			this.previewAppSchema = this.nsConfig && this.nsConfig.previewAppSchema;
+			this.webpackConfigPath = (this.nsConfig && this.nsConfig.webpackConfigPath) ? path.resolve(this.projectDir, this.nsConfig.webpackConfigPath) : path.join(this.projectDir, "webpack.config.js");
 			return;
 		}
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "6.3.3",
+  "version": "6.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "6.3.3",
+  "version": "6.4.0",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -328,6 +328,7 @@ export class NodePackageManagerStub implements INodePackageManager {
 export class ProjectDataStub implements IProjectData {
 	projectDir: string;
 	projectName: string;
+	webpackConfigPath: string;
 	get platformsDir(): string {
 		return this.platformsDirCache || (this.projectDir && join(this.projectDir, "platforms")) || "";
 	}


### PR DESCRIPTION
Currently CLI passes the webpack.config.js at the root of the application as config to the spawned webpack process. This file is managed by both the developers and nativescript-dev-webpack (when you update this package, you often have to update the file, which overrides any custom settings).
In order to allow easier upgrades and customizations, add an option in nsconfig.json (`webpackConfigPath`) to set the path to config file passed to webpack process. This way, the `webpack.config.js` can be managed by nativescript-dev-webpack and all customizations can be done in another file. The path to custom file can be set in nsconfig.json and CLI will pass it to webpack.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

Implements issue https://github.com/NativeScript/nativescript-cli/issues/5218

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
