### PR TITLE
feat: improve detection of NativeScript plugins

### DIFF
--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -368,6 +368,8 @@ interface IDependencyData {
 	 * Dependencies of the current module.
 	 */
 	dependencies?: string[];
+
+	version: string;
 }
 
 interface INpmsResult {

--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -14,7 +14,6 @@ interface IPluginsService {
 	 */
 	getDependenciesFromPackageJson(projectDir: string): IPackageJsonDepedenciesResult;
 	preparePluginNativeCode(preparePluginNativeCodeData: IPreparePluginNativeCodeData): Promise<void>;
-	convertToPluginData(cacheData: any, projectDir: string): IPluginData;
 	isNativeScriptPlugin(pluginPackageJsonPath: string): boolean;
 }
 
@@ -44,7 +43,7 @@ interface IPluginData extends INodeModuleData {
 interface INodeModuleData extends IBasePluginData {
 	fullPath: string;
 	isPlugin: boolean;
-	moduleInfo: any;
+	nativescript: any;
 }
 
 interface IPluginPlatformsData {

--- a/lib/tools/node-modules/node-modules-dependencies-builder.ts
+++ b/lib/tools/node-modules/node-modules-dependencies-builder.ts
@@ -93,7 +93,8 @@ export class NodeModulesDependenciesBuilder implements INodeModulesDependenciesB
 		const dependency: IDependencyData = {
 			name,
 			directory,
-			depth
+			depth,
+			version: null
 		};
 
 		const packageJsonPath = path.join(directory, PACKAGE_JSON_FILE_NAME);
@@ -102,6 +103,7 @@ export class NodeModulesDependenciesBuilder implements INodeModulesDependenciesB
 		if (packageJsonExists) {
 			const packageJsonContents = this.$fs.readJson(packageJsonPath);
 
+			dependency.version = packageJsonContents.version;
 			if (!!packageJsonContents.nativescript) {
 				// add `nativescript` property, necessary for resolving plugins
 				dependency.nativescript = packageJsonContents.nativescript;

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -17,7 +17,9 @@ export class LoggerStub implements ILogger {
 	getLevel(): string { return undefined; }
 	fatal(...args: string[]): void { }
 	error(...args: string[]): void { }
-	warn(...args: string[]): void { }
+	warn(...args: string[]): void {
+		this.warnOutput += util.format.apply(null, args) + "\n";
+	}
 	info(...args: string[]): void {
 		this.output += util.format.apply(null, args) + "\n";
 	}
@@ -29,6 +31,7 @@ export class LoggerStub implements ILogger {
 
 	public output = "";
 	public traceOutput = "";
+	public warnOutput = "";
 
 	prepare(item: any): string {
 		return "";


### PR DESCRIPTION
Currently in case you have multiple occurences of a NativeScript plugin in node_modules, most of the time the build of application fails. For iOS Xcode fails with duplicate resources (most commonly frameworks) and for Android the Static Binding Generator will fail in case the JavaScript of a plugin differs.

Improve the handling by checking the versions of NativeScript plugins. In case the same version is installed multiple times, show warning to the user and link only one of the versions to the native build.
In case multiple versions are detected, throw an error - currently we cannot support this case.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

Implements issue https://github.com/NativeScript/nativescript-cli/issues/5214
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
