### PR TITLE
feat: deprecate support for Xcode 10 and below

### DIFF
--- a/lib/common/declarations.d.ts
+++ b/lib/common/declarations.d.ts
@@ -1046,6 +1046,12 @@ interface ISysInfo {
 	 * @return {string} The range of supported Node.js versions.
 	 */
 	getSupportedNodeVersionRange(): string;
+
+	/**
+	 * Gets warning message in case the currently installed Xcode will not be supported in next versions
+	 * @returns {string}
+	 */
+	getXcodeWarning(): Promise<string>;
 }
 
 interface IHostInfo {

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -242,9 +242,12 @@ export class MacOSVersions {
 	public static Sierra = "10.12";
 	public static HighSierra = "10.13";
 	public static Mojave = "10.14";
+	public static Catalina = "10.15";
 }
 
 export const MacOSDeprecationStringFormat = "NativeScript does not support macOS %s and some functionality may not work. Please, upgrade to the latest macOS version.";
+export const XcodeDeprecationStringFormat = "The current Xcode version %s will not be supported in the next release of NativeScript. Consider updating your Xcode to latest official version.";
+
 export const PROGRESS_PRIVACY_POLICY_URL = "https://www.progress.com/legal/privacy-policy";
 export class SubscribeForNewsletterMessages {
 	public static AgreeToReceiveEmailMsg = "I agree".green.bold + " to receive email communications from Progress Software in the form of the NativeScript Newsletter. Consent may be withdrawn at any time.";

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -141,7 +141,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 		if (checkEnvironmentRequirementsOutput && checkEnvironmentRequirementsOutput.canExecute) {
 			const xcodeWarning = await this.$sysInfo.getXcodeWarning();
-			if (xcodeWarning ) {
+			if (xcodeWarning) {
 				this.$logger.warn(xcodeWarning);
 			}
 		}

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -54,7 +54,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		private $xcodebuildService: IXcodebuildService,
 		private $iOSExtensionsService: IIOSExtensionsService,
 		private $iOSWatchAppService: IIOSWatchAppService,
-		private $iOSNativeTargetService: IIOSNativeTargetService) {
+		private $iOSNativeTargetService: IIOSNativeTargetService,
+		private $sysInfo: ISysInfo) {
 		super($fs, $projectDataService);
 	}
 
@@ -138,6 +139,12 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			notConfiguredEnvOptions
 		});
 
+		if (checkEnvironmentRequirementsOutput && checkEnvironmentRequirementsOutput.canExecute) {
+			const xcodeWarning = await this.$sysInfo.getXcodeWarning();
+			if (xcodeWarning ) {
+				this.$logger.warn(xcodeWarning);
+			}
+		}
 		return {
 			checkEnvironmentRequirementsOutput
 		};

--- a/lib/sys-info.ts
+++ b/lib/sys-info.ts
@@ -1,9 +1,10 @@
 import * as path from "path";
 import { format } from "util";
 import { sysInfo } from "nativescript-doctor";
-import { MacOSVersions, MacOSDeprecationStringFormat } from "./constants";
+import { MacOSVersions, MacOSDeprecationStringFormat, XcodeDeprecationStringFormat } from "./constants";
 import { getNodeWarning } from "./common/verify-node-version";
 import { exported } from "./common/decorators";
+import * as semver from "semver";
 
 export class SysInfo implements ISysInfo {
 	private sysInfo: ISysInfoData = null;
@@ -78,6 +79,16 @@ export class SysInfo implements ISysInfo {
 				message: format(MacOSDeprecationStringFormat, macOSVersion),
 				severity: SystemWarningsSeverity.high
 			};
+		}
+
+		return null;
+	}
+
+	public async getXcodeWarning(): Promise<string> {
+		const xcodeVersion = await this.getXcodeVersion();
+		if (xcodeVersion && semver.lt(semver.coerce(xcodeVersion), "11.0.0")) {
+			const message = format(XcodeDeprecationStringFormat, xcodeVersion);
+			return message;
 		}
 
 		return null;


### PR DESCRIPTION
As from March 2020 iOS apps will have to be built with Xcode 10 in order to be uploaded to AppStore, deprecate the support for Xcode 10 and below - CLI will show warning in case such Xcode is used.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Implements issue https://github.com/NativeScript/nativescript-cli/issues/5230

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
