### PR TITLE
fix: improve check for duplicated NativeScript plugins

### DIFF
--- a/lib/definitions/plugins.d.ts
+++ b/lib/definitions/plugins.d.ts
@@ -4,7 +4,7 @@ interface IPluginsService {
 	addToPackageJson(plugin: string, version: string, isDev: boolean, projectDir: string): void;
 	removeFromPackageJson(plugin: string, projectDir: string): void;
 	getAllInstalledPlugins(projectData: IProjectData): Promise<IPluginData[]>;
-	getAllProductionPlugins(projectData: IProjectData, dependencies?: IDependencyData[]): IPluginData[];
+	getAllProductionPlugins(projectData: IProjectData, platform: string, dependencies?: IDependencyData[]): IPluginData[];
 	ensureAllDependenciesAreInstalled(projectData: IProjectData): Promise<void>;
 
 	/**

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -471,7 +471,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	private getAllProductionPlugins(projectData: IProjectData): IPluginData[] {
-		return (<IPluginsService>this.$injector.resolve("pluginsService")).getAllProductionPlugins(projectData);
+		return (<IPluginsService>this.$injector.resolve("pluginsService")).getAllProductionPlugins(projectData, this.getPlatformData(projectData).platformNameLowerCase);
 	}
 
 	private replace(name: string): string {

--- a/lib/services/metadata-filtering-service.ts
+++ b/lib/services/metadata-filtering-service.ts
@@ -23,7 +23,7 @@ export class MetadataFilteringService implements IMetadataFilteringService {
 		if (nativeApiConfiguration) {
 			const whitelistedItems: string[] = [];
 			if (nativeApiConfiguration["whitelist-plugins-usages"]) {
-				const plugins = this.$pluginsService.getAllProductionPlugins(projectData);
+				const plugins = this.$pluginsService.getAllProductionPlugins(projectData, platform);
 				for (const pluginData of plugins) {
 					const pathToPlatformsDir = pluginData.pluginPlatformsFolderPath(platform);
 					const pathToPluginsMetadataConfig = path.join(pathToPlatformsDir, MetadataFilteringConstants.NATIVE_API_USAGE_FILE_NAME);

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -9,7 +9,7 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		const dependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(projectData.projectDir);
 		await platformData.platformProjectService.beforePrepareAllPlugins(projectData, dependencies);
 
-		const pluginsData = this.$pluginsService.getAllProductionPlugins(projectData, dependencies);
+		const pluginsData = this.$pluginsService.getAllProductionPlugins(projectData, platformData.platformNameLowerCase, dependencies);
 		if (_.isEmpty(pluginsData)) {
 			return;
 		}

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -586,7 +586,8 @@ describe("Plugins service", () => {
 		unitTestsInjector.register("platformsDataService", {});
 		unitTestsInjector.register("filesHashService", {});
 		unitTestsInjector.register("fs", {
-			exists: (filePath: string) => false
+			exists: (filePath: string) => filePath.indexOf("ios") !== -1,
+			readDirectory: (dir: string) => dir.indexOf("nativescript-ui-core") !== -1 ? ["a.framework"] : []
 		});
 		unitTestsInjector.register("packageManager", {});
 		unitTestsInjector.register("options", {});
@@ -796,7 +797,7 @@ describe("Plugins service", () => {
 						"version": "4.0.0",
 					}
 				],
-				expectedWarning: "Detected same versions (4.0.0) of the nativescript-ui-core installed at locations: /Users/username/projectDir/node_modules/nativescript-ui-core, " +
+				expectedWarning: "Detected the framework a.framework is installed multiple times from the same versions of plugin (4.0.0) at locations: /Users/username/projectDir/node_modules/nativescript-ui-core, " +
 					"/Users/username/projectDir/node_modules/nativescript-ui-listview/node_modules/nativescript-ui-core"
 			},
 			{
@@ -844,10 +845,45 @@ describe("Plugins service", () => {
 						"dependencies": []
 					},
 				],
-				expectedOutput: new Error(`Cannot use different versions of a NativeScript plugin in your application.
-nativescript-ui-core plugin occurs multiple times in node_modules:\n` +
+				expectedOutput: new Error(`Cannot use the same framework a.framework multiple times in your application.
+This framework comes from nativescript-ui-core plugin, which is installed multiple times in node_modules:\n` +
 					"* Path: /Users/username/projectDir/node_modules/nativescript-ui-core, version: 3.0.0\n" +
-					"* Path: /Users/username/projectDir/node_modules/nativescript-ui-listview/node_modules/nativescript-ui-core, version: 4.0.0\n" +
+					"* Path: /Users/username/projectDir/node_modules/nativescript-ui-listview/node_modules/nativescript-ui-core, version: 4.0.0\n\n" +
+					`Probably you need to update your dependencies, remove node_modules and try again.`),
+			},
+			{
+				testName: "fails when same framework is installed from multiple plugins",
+				inputDependencies: [
+					{
+						"name": "nativescript-ui-core-forked",
+						"directory": "/Users/username/projectDir/node_modules/nativescript-ui-core-forked",
+						"depth": 0,
+						"version": "3.0.0",
+						"nativescript": {
+							"platforms": {
+								"android": "6.0.0",
+								"ios": "6.0.0"
+							}
+						},
+						"dependencies": []
+					},
+					{
+						"name": "nativescript-ui-core",
+						"directory": "/Users/username/projectDir/node_modules/nativescript-ui-core",
+						"depth": 0,
+						"version": "3.0.0",
+						"nativescript": {
+							"platforms": {
+								"android": "6.0.0",
+								"ios": "6.0.0"
+							}
+						},
+						"dependencies": []
+					},
+				],
+				expectedOutput: new Error(`Detected the framework a.framework is installed from multiple plugins at locations:\n` +
+					"/Users/username/projectDir/node_modules/nativescript-ui-core-forked/platforms/ios/a.framework\n" +
+					"/Users/username/projectDir/node_modules/nativescript-ui-core/platforms/ios/a.framework\n\n" +
 					`Probably you need to update your dependencies, remove node_modules and try again.`),
 			}
 		];
@@ -858,9 +894,9 @@ nativescript-ui-core plugin occurs multiple times in node_modules:\n` +
 				const pluginsService: IPluginsService = unitTestsInjector.resolve(PluginsService);
 
 				if (testCase.expectedOutput instanceof Error) {
-					assert.throws(() => pluginsService.getAllProductionPlugins(<any>{ projectDir: "projectDir" }, testCase.inputDependencies), testCase.expectedOutput.message);
+					assert.throws(() => pluginsService.getAllProductionPlugins(<any>{ projectDir: "projectDir" }, "ios", testCase.inputDependencies), testCase.expectedOutput.message);
 				} else {
-					const plugins = pluginsService.getAllProductionPlugins(<any>{ projectDir: "projectDir" }, testCase.inputDependencies);
+					const plugins = pluginsService.getAllProductionPlugins(<any>{ projectDir: "projectDir" }, "ios", testCase.inputDependencies);
 
 					if (testCase.expectedWarning) {
 						const logger = unitTestsInjector.resolve<stubs.LoggerStub>("logger");
@@ -884,8 +920,8 @@ nativescript-ui-core plugin occurs multiple times in node_modules:\n` +
 			const pluginsService: IPluginsService = unitTestsInjector.resolve(PluginsService);
 			const inputDependencies = [
 				{
-					"name": "tns-core-modules",
-					"directory": "/Users/username/projectDir/node_modules/tns-core-modules",
+					"name": "nativescript-ui-core",
+					"directory": "/Users/username/projectDir/node_modules/nativescript-ui-core",
 					"depth": 0,
 					"version": "6.3.0",
 					"nativescript": {
@@ -899,8 +935,8 @@ nativescript-ui-core plugin occurs multiple times in node_modules:\n` +
 					]
 				},
 				{
-					"name": "tns-core-modules",
-					"directory": "/Users/username/projectDir/node_modules/some-package/tns-core-modules",
+					"name": "nativescript-ui-core",
+					"directory": "/Users/username/projectDir/node_modules/some-package/nativescript-ui-core",
 					"depth": 1,
 					"version": "6.3.0",
 					"nativescript": {
@@ -916,16 +952,16 @@ nativescript-ui-core plugin occurs multiple times in node_modules:\n` +
 			];
 
 			_.range(3).forEach(() => {
-				pluginsService.getAllProductionPlugins(<any>{ projectDir: "projectDir" }, inputDependencies);
+				pluginsService.getAllProductionPlugins(<any>{ projectDir: "projectDir" }, "ios", inputDependencies);
 			});
 
 			const logger = unitTestsInjector.resolve<stubs.LoggerStub>("logger");
 
-			const expectedWarnMessage = "Detected same versions (%s) of the tns-core-modules installed at locations: /Users/username/projectDir/node_modules/tns-core-modules, /Users/username/projectDir/node_modules/some-package/tns-core-modules\n";
+			const expectedWarnMessage = "Detected the framework a.framework is installed multiple times from the same versions of plugin (%s) at locations: /Users/username/projectDir/node_modules/nativescript-ui-core, /Users/username/projectDir/node_modules/some-package/nativescript-ui-core\n";
 			assert.equal(logger.warnOutput, util.format(expectedWarnMessage, "6.3.0"), "The warn message must be shown only once - the result of the private method must be cached as input dependencies have not changed");
 			inputDependencies[0].version = "1.0.0";
 			inputDependencies[1].version = "1.0.0";
-			pluginsService.getAllProductionPlugins(<any>{ projectDir: "projectDir" }, inputDependencies);
+			pluginsService.getAllProductionPlugins(<any>{ projectDir: "projectDir" }, "ios", inputDependencies);
 			assert.equal(logger.warnOutput, util.format(expectedWarnMessage, "6.3.0") + util.format(expectedWarnMessage, "1.0.0"), "When something in input dependencies change, the cached value shouldn't be taken into account");
 		});
 	});


### PR DESCRIPTION
Currently CLI fails when different versions of the same plugin are used. However, this introduces a lot of issues for Android, where the `nativescript-permissions` plugin is used by most of the other plugins. When they hardcode different version, CLI stops the build. However, this plugin is pure JS and does not have native part.
To resolve this, separate the checks for iOS and Android. For Android, the SBG may fail in case different versions of the plugin are detected. However, there's no easy way to determine this, so just make the checks and show debug messages.
For iOS the build will fail in case framework is linked multiple times from different locations, so group the plugins by frameworks and fail in case the same framework is listed multiple times by different plugins or by different versions of the same plugin

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Related to issue https://github.com/NativeScript/nativescript-cli/issues/5214

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
