### PR TITLE
fix: temporary files created by CLI are not deleted in some cases

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -236,3 +236,4 @@ $injector.require("ipService", "./services/ip-service");
 $injector.require("jsonFileSettingsService", "./common/services/json-file-settings-service");
 $injector.require("markingModeService", "./services/marking-mode-service");
 $injector.require("metadataFilteringService", "./services/metadata-filtering-service");
+$injector.require("tempService", "./services/temp-service");

--- a/lib/commands/plugin/build-plugin.ts
+++ b/lib/commands/plugin/build-plugin.ts
@@ -1,7 +1,7 @@
 import { EOL } from "os";
 import * as path from "path";
 import * as constants from "../../constants";
-import * as temp from "temp";
+
 export class BuildPluginCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
 	public pluginProjectPath: string;
@@ -10,7 +10,8 @@ export class BuildPluginCommand implements ICommand {
 		private $errors: IErrors,
 		private $logger: ILogger,
 		private $fs: IFileSystem,
-		private $options: IOptions) {
+		private $options: IOptions,
+		private $tempService: ITempService) {
 
 		this.pluginProjectPath = path.resolve(this.$options.path || ".");
 	}
@@ -29,8 +30,7 @@ export class BuildPluginCommand implements ICommand {
 			}
 		}
 
-		temp.track();
-		const tempAndroidProject = temp.mkdirSync("android-project");
+		const tempAndroidProject = await this.$tempService.mkdirSync("android-project");
 
 		const options: IPluginBuildOptions = {
 			aarOutputDir: platformsAndroidPath,

--- a/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -4,7 +4,6 @@ import { hook, getPidFromiOSSimulatorLogs } from "../../../helpers";
 import { cache } from "../../../decorators";
 import { IOS_LOG_PREDICATE } from "../../../constants";
 import * as path from "path";
-import * as temp from "temp";
 import * as log4js from "log4js";
 
 export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
@@ -16,6 +15,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 		private $options: IOptions,
 		private $fs: IFileSystem,
 		protected $deviceLogProvider: Mobile.IDeviceLogProvider,
+		private $tempService: ITempService,
 		$logger: ILogger,
 		$hooksService: IHooksService) {
 		super($logger, $hooksService, $deviceLogProvider);
@@ -28,8 +28,7 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	@hook('install')
 	public async installApplication(packageFilePath: string): Promise<void> {
 		if (this.$fs.exists(packageFilePath) && path.extname(packageFilePath) === ".zip") {
-			temp.track();
-			const dir = temp.mkdirSync("simulatorPackage");
+			const dir = await this.$tempService.mkdirSync("simulatorPackage");
 			await this.$fs.unzip(packageFilePath, dir);
 			const app = _.find(this.$fs.readDirectory(dir), directory => path.extname(directory) === ".app");
 			if (app) {

--- a/lib/common/mobile/mobile-helper.ts
+++ b/lib/common/mobile/mobile-helper.ts
@@ -1,13 +1,13 @@
 import * as helpers from "../helpers";
 import * as shell from "shelljs";
-import * as temp from "temp";
 
 export class MobileHelper implements Mobile.IMobileHelper {
 	private static DEVICE_PATH_SEPARATOR = "/";
 
 	constructor(private $errors: IErrors,
 		private $fs: IFileSystem,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants) { }
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $tempService: ITempService) { }
 
 	public get platformNames(): string[] {
 		return [this.$devicePlatformsConstants.iOS, this.$devicePlatformsConstants.Android];
@@ -58,8 +58,7 @@ export class MobileHelper implements Mobile.IMobileHelper {
 	}
 
 	public async getDeviceFileContent(device: Mobile.IDevice, deviceFilePath: string, projectData: IProjectData): Promise<string> {
-		temp.track();
-		const uniqueFilePath = temp.path({ suffix: ".tmp" });
+		const uniqueFilePath = await this.$tempService.path({ suffix: ".tmp" });
 		const platform = device.deviceInfo.platform.toLowerCase();
 		try {
 			await device.fileSystem.getFile(deviceFilePath, projectData.projectIdentifiers[platform], uniqueFilePath);

--- a/lib/common/test/unit-tests/mobile/android-device-file-system.ts
+++ b/lib/common/test/unit-tests/mobile/android-device-file-system.ts
@@ -8,6 +8,7 @@ import { DevicePlatformsConstants } from "../../../mobile/device-platforms-const
 import * as path from "path";
 import { assert } from "chai";
 import { LiveSyncPaths } from "../../../constants";
+import { TempServiceStub } from "../../../../../test/stubs";
 
 const myTestAppIdentifier = "org.nativescript.myApp";
 let isAdbPushExecuted = false;
@@ -64,7 +65,7 @@ function createTestInjector(): IInjector {
 	injector.register("errors", Errors);
 	injector.register("devicePlatformsConstants", DevicePlatformsConstants);
 	injector.register("projectFilesManager", {});
-
+	injector.register("tempService", TempServiceStub);
 	return injector;
 }
 

--- a/lib/common/test/unit-tests/mobile/ios-simulator-discovery.ts
+++ b/lib/common/test/unit-tests/mobile/ios-simulator-discovery.ts
@@ -5,7 +5,7 @@ import { assert } from "chai";
 import { DeviceDiscoveryEventNames, CONNECTED_STATUS } from "../../../constants";
 import { DevicePlatformsConstants } from "../../../mobile/device-platforms-constants";
 import { ErrorsStub, CommonLoggerStub, HooksServiceStub, LockServiceStub } from "../stubs";
-import { FileSystemStub, ChildProcessStub } from "../../../../../test/stubs";
+import { FileSystemStub, ChildProcessStub, TempServiceStub } from "../../../../../test/stubs";
 import { DeviceConnectionType } from "../../../../constants";
 
 let currentlyRunningSimulators: Mobile.IiSimDevice[];
@@ -45,7 +45,7 @@ function createTestInjector(): IInjector {
 	injector.register("options", {});
 	injector.register("hooksService", HooksServiceStub);
 	injector.register("logger", CommonLoggerStub);
-
+	injector.register("tempService", TempServiceStub);
 	return injector;
 }
 

--- a/lib/common/test/unit-tests/mobile/project-files-manager.ts
+++ b/lib/common/test/unit-tests/mobile/project-files-manager.ts
@@ -14,6 +14,7 @@ import { ProjectFilesProviderBase } from "../../../services/project-files-provid
 
 import temp = require("temp");
 import { LiveSyncPaths } from "../../../constants";
+import { TempServiceStub } from "../../../../../test/stubs";
 temp.track();
 
 const testedApplicationIdentifier = "com.telerik.myApp";
@@ -49,6 +50,7 @@ function createTestInjector(): IInjector {
 	});
 	testInjector.register("logger", Logger);
 	testInjector.register("config", {});
+	testInjector.register("tempService", TempServiceStub);
 	return testInjector;
 }
 

--- a/lib/definitions/ios.d.ts
+++ b/lib/definitions/ios.d.ts
@@ -30,8 +30,8 @@ declare global {
 	}
 
 	interface IExportOptionsPlistService {
-		createDevelopmentExportOptionsPlist(archivePath: string, projectData: IProjectData, buildConfig: IBuildConfig): IExportOptionsPlistOutput;
-		createDistributionExportOptionsPlist(projectRoot: string, projectData: IProjectData, buildConfig: IBuildConfig): IExportOptionsPlistOutput;
+		createDevelopmentExportOptionsPlist(archivePath: string, projectData: IProjectData, buildConfig: IBuildConfig): Promise<IExportOptionsPlistOutput>;
+		createDistributionExportOptionsPlist(projectRoot: string, projectData: IProjectData, buildConfig: IBuildConfig): Promise<IExportOptionsPlistOutput>;
 	}
 
 	interface IExportOptionsPlistOutput {

--- a/lib/definitions/temp-service.d.ts
+++ b/lib/definitions/temp-service.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Declares wrapped functions of temp module
+ */
+interface ITempService {
+	mkdirSync(affixes: string): Promise<string>;
+	path(options: ITempPathOptions): Promise<string>;
+}

--- a/lib/device-sockets/ios/app-debug-socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/app-debug-socket-proxy-factory.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from "events";
 import { CONNECTION_ERROR_EVENT_NAME } from "../../constants";
 import * as net from "net";
 import * as ws from "ws";
-import temp = require("temp");
 import { MessageUnpackStream } from "ios-device-lib";
 
 export class AppDebugSocketProxyFactory extends EventEmitter implements IAppDebugSocketProxyFactory {
@@ -13,6 +12,7 @@ export class AppDebugSocketProxyFactory extends EventEmitter implements IAppDebu
 		private $errors: IErrors,
 		private $lockService: ILockService,
 		private $options: IOptions,
+		private $tempService: ITempService,
 		private $net: INet) {
 		super();
 	}
@@ -72,7 +72,7 @@ export class AppDebugSocketProxyFactory extends EventEmitter implements IAppDebu
 			frontendSocket.resume();
 		});
 
-		const socketFileLocation = temp.path({ suffix: ".sock" });
+		const socketFileLocation = await this.$tempService.path({ suffix: ".sock" });
 		server.listen(socketFileLocation);
 		if (!this.$options.client) {
 			this.$logger.info("socket-file-location: " + socketFileLocation);

--- a/lib/helpers/platform-command-helper.ts
+++ b/lib/helpers/platform-command-helper.ts
@@ -1,6 +1,5 @@
 import * as path from "path";
 import * as semver from "semver";
-import * as temp from "temp";
 import * as constants from "../constants";
 import { PlatformController } from "../controllers/platform-controller";
 import { PlatformValidationService } from "../services/platform/platform-validation-service";
@@ -17,7 +16,8 @@ export class PlatformCommandHelper implements IPlatformCommandHelper {
 		private $platformsDataService: IPlatformsDataService,
 		private $platformValidationService: PlatformValidationService,
 		private $projectChangesService: IProjectChangesService,
-		private $projectDataService: IProjectDataService
+		private $projectDataService: IProjectDataService,
+		private $tempService: ITempService
 	) { }
 
 	public async addPlatforms(platforms: string[], projectData: IProjectData, frameworkPath: string): Promise<void> {
@@ -147,7 +147,7 @@ export class PlatformCommandHelper implements IPlatformCommandHelper {
 		const data = this.$projectDataService.getNSValue(projectData.projectDir, platformData.frameworkPackageName);
 		const currentVersion = data && data.version ? data.version : "0.2.0";
 
-		const installedModuleDir = temp.mkdirSync("runtime-to-update");
+		const installedModuleDir = await this.$tempService.mkdirSync("runtime-to-update");
 		let newVersion = version === constants.PackageVersion.NEXT ?
 			await this.$packageInstallationManager.getNextVersion(platformData.frameworkPackageName) :
 			version || await this.$packageInstallationManager.getLatestCompatibleVersion(platformData.frameworkPackageName);

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -7,7 +7,6 @@ import { attachAwaitDetach } from "../common/helpers";
 import * as projectServiceBaseLib from "./platform-project-service-base";
 import { PlistSession, Reporter } from "plist-merge-patch";
 import { EOL } from "os";
-import * as temp from "temp";
 import * as plist from "plist";
 import { IOSProvisionService } from "./ios-provision-service";
 import { IOSEntitlementsService } from "./ios-entitlements-service";
@@ -55,7 +54,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		private $iOSExtensionsService: IIOSExtensionsService,
 		private $iOSWatchAppService: IIOSWatchAppService,
 		private $iOSNativeTargetService: IIOSNativeTargetService,
-		private $sysInfo: ISysInfo) {
+		private $sysInfo: ISysInfo,
+		private $tempService: ITempService) {
 		super($fs, $projectDataService);
 	}
 
@@ -814,8 +814,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			// Set Entitlements Property to point to default file if not set explicitly by the user.
 			const entitlementsPropertyValue = this.$xcconfigService.readPropertyValue(pluginsXcconfigFilePath, constants.CODE_SIGN_ENTITLEMENTS);
 			if (entitlementsPropertyValue === null && this.$fs.exists(this.$iOSEntitlementsService.getPlatformsEntitlementsPath(projectData))) {
-				temp.track();
-				const tempEntitlementsDir = temp.mkdirSync("entitlements");
+				const tempEntitlementsDir = await this.$tempService.mkdirSync("entitlements");
 				const tempEntitlementsFilePath = path.join(tempEntitlementsDir, "set-entitlements.xcconfig");
 				const entitlementsRelativePath = this.$iOSEntitlementsService.getPlatformsEntitlementsRelativePath(projectData);
 				this.$fs.writeFile(tempEntitlementsFilePath, `CODE_SIGN_ENTITLEMENTS = ${entitlementsRelativePath}${EOL}`);

--- a/lib/services/ios/export-options-plist-service.ts
+++ b/lib/services/ios/export-options-plist-service.ts
@@ -1,11 +1,11 @@
 import * as path from "path";
-import * as temp from "temp";
 import * as mobileProvisionFinder from "ios-mobileprovision-finder";
 
 export class ExportOptionsPlistService implements IExportOptionsPlistService {
-	constructor(private $fs: IFileSystem) { }
+	constructor(private $fs: IFileSystem,
+		private $tempService: ITempService) { }
 
-	public createDevelopmentExportOptionsPlist(archivePath: string, projectData: IProjectData, buildConfig: IBuildConfig): IExportOptionsPlistOutput {
+	public async createDevelopmentExportOptionsPlist(archivePath: string, projectData: IProjectData, buildConfig: IBuildConfig): Promise<IExportOptionsPlistOutput> {
 		const exportOptionsMethod = this.getExportOptionsMethod(projectData, archivePath);
 		const provision = buildConfig.provision || buildConfig.mobileProvisionIdentifier;
 		const iCloudContainerEnvironment = buildConfig.iCloudContainerEnvironment;
@@ -37,8 +37,7 @@ export class ExportOptionsPlistService implements IExportOptionsPlistService {
 </plist>`;
 
 		// Save the options...
-		temp.track();
-		const exportOptionsPlistFilePath = temp.path({ prefix: "export-", suffix: ".plist" });
+		const exportOptionsPlistFilePath = await this.$tempService.path({ prefix: "export-", suffix: ".plist" });
 		this.$fs.writeFile(exportOptionsPlistFilePath, plistTemplate);
 
 		// The xcodebuild exportPath expects directory and writes the <project-name>.ipa at that directory.
@@ -48,7 +47,7 @@ export class ExportOptionsPlistService implements IExportOptionsPlistService {
 		return { exportFileDir, exportFilePath, exportOptionsPlistFilePath };
 	}
 
-	public createDistributionExportOptionsPlist(archivePath: string, projectData: IProjectData, buildConfig: IBuildConfig): IExportOptionsPlistOutput {
+	public async createDistributionExportOptionsPlist(archivePath: string, projectData: IProjectData, buildConfig: IBuildConfig): Promise<IExportOptionsPlistOutput> {
 		const provision = buildConfig.provision || buildConfig.mobileProvisionIdentifier;
 		const teamId = buildConfig.teamId;
 		let plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
@@ -80,8 +79,7 @@ export class ExportOptionsPlistService implements IExportOptionsPlistService {
 </plist>`;
 
 		// Save the options...
-		temp.track();
-		const exportOptionsPlistFilePath = temp.path({ prefix: "export-", suffix: ".plist" });
+		const exportOptionsPlistFilePath = await this.$tempService.path({ prefix: "export-", suffix: ".plist" });
 		this.$fs.writeFile(exportOptionsPlistFilePath, plistTemplate);
 
 		const exportFileDir = path.resolve(path.dirname(archivePath));

--- a/lib/services/ios/xcodebuild-service.ts
+++ b/lib/services/ios/xcodebuild-service.ts
@@ -28,7 +28,7 @@ export class XcodebuildService implements IXcodebuildService {
 
 	private async createDevelopmentArchive(platformData: IPlatformData, projectData: IProjectData, buildConfig: IBuildConfig): Promise<string> {
 		const archivePath = path.join(platformData.getBuildOutputPath(buildConfig), projectData.projectName + ".xcarchive");
-		const output = this.$exportOptionsPlistService.createDevelopmentExportOptionsPlist(archivePath, projectData, buildConfig);
+		const output = await this.$exportOptionsPlistService.createDevelopmentExportOptionsPlist(archivePath, projectData, buildConfig);
 		const args = [
 			"-exportArchive",
 			"-archivePath", archivePath,
@@ -42,7 +42,7 @@ export class XcodebuildService implements IXcodebuildService {
 
 	private async createDistributionArchive(platformData: IPlatformData, projectData: IProjectData, buildConfig: IBuildConfig): Promise<string> {
 		const archivePath = path.join(platformData.getBuildOutputPath(buildConfig), projectData.projectName + ".xcarchive");
-		const output = this.$exportOptionsPlistService.createDistributionExportOptionsPlist(archivePath, projectData, buildConfig);
+		const output = await this.$exportOptionsPlistService.createDistributionExportOptionsPlist(archivePath, projectData, buildConfig);
 		const args = [
 			"-exportArchive",
 			"-archivePath", archivePath,

--- a/lib/services/itmstransporter-service.ts
+++ b/lib/services/itmstransporter-service.ts
@@ -1,5 +1,4 @@
 import * as path from "path";
-import * as temp from "temp";
 import { ITMSConstants, INFO_PLIST_FILE_NAME } from "../constants";
 import { quoteString } from "../common/helpers";
 import { cache } from "../common/decorators";
@@ -13,7 +12,8 @@ export class ITMSTransporterService implements IITMSTransporterService {
 		private $injector: IInjector,
 		private $logger: ILogger,
 		private $plistParser: IPlistParser,
-		private $xcodeSelectService: IXcodeSelectService) { }
+		private $xcodeSelectService: IXcodeSelectService,
+		private $tempService: ITempService) { }
 
 	private get $projectData(): IProjectData {
 		return this.$injector.resolve("projectData");
@@ -27,10 +27,9 @@ export class ITMSTransporterService implements IITMSTransporterService {
 	}
 
 	public async upload(data: IITMSData): Promise<void> {
-		temp.track();
 		const itmsTransporterPath = await this.getITMSTransporterPath();
 		const ipaFileName = "app.ipa";
-		const itmsDirectory = temp.mkdirSync("itms-");
+		const itmsDirectory = await this.$tempService.mkdirSync("itms-");
 		const innerDirectory = path.join(itmsDirectory, "mybundle.itmsp");
 		const ipaFileLocation = path.join(innerDirectory, ipaFileName);
 		const loggingLevel = data.verboseLogging ? ITMSConstants.VerboseLoggingLevels.Verbose : ITMSConstants.VerboseLoggingLevels.Informational;
@@ -68,8 +67,7 @@ export class ITMSTransporterService implements IITMSTransporterService {
 			}
 
 			this.$logger.trace("--ipa set - extracting .ipa file to get app's bundle identifier");
-			temp.track();
-			const destinationDir = temp.mkdirSync("ipa-");
+			const destinationDir = await this.$tempService.mkdirSync("ipa-");
 			await this.$fs.unzip(ipaFilePath, destinationDir);
 
 			const payloadDir = path.join(destinationDir, "Payload");

--- a/lib/services/livesync/android-device-livesync-sockets-service.ts
+++ b/lib/services/livesync/android-device-livesync-sockets-service.ts
@@ -3,7 +3,6 @@ import { APP_FOLDER_NAME } from "../../constants";
 import { LiveSyncPaths } from "../../common/constants";
 import { AndroidLivesyncTool } from "./android-livesync-tool";
 import * as path from "path";
-import * as temp from "temp";
 import * as semver from "semver";
 
 export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncServiceBase implements IAndroidNativeScriptDeviceLiveSyncService, INativeScriptDeviceLiveSyncService {
@@ -22,6 +21,7 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 		private $cleanupService: ICleanupService,
 		private $fs: IFileSystem,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		private $tempService: ITempService,
 		$filesHashService: IFilesHashService) {
 		super($injector, platformsDataService, $filesHashService, $logger, device);
 		this.livesyncTool = this.$injector.resolve(AndroidLivesyncTool);
@@ -30,7 +30,7 @@ export class AndroidDeviceSocketsLiveSyncService extends AndroidDeviceLiveSyncSe
 	public async beforeLiveSyncAction(deviceAppData: Mobile.IDeviceAppData): Promise<void> {
 		if (!this.livesyncTool.hasConnection()) {
 			try {
-				const pathToLiveSyncFile = temp.path({ prefix: "livesync" });
+				const pathToLiveSyncFile = await this.$tempService.path({ prefix: "livesync" });
 				this.$fs.writeFile(pathToLiveSyncFile, "");
 				await this.device.fileSystem.putFile(pathToLiveSyncFile, this.getPathToLiveSyncFileOnDevice(deviceAppData.appIdentifier), deviceAppData.appIdentifier);
 				await this.device.applicationManager.startApplication({ appId: deviceAppData.appIdentifier, projectName: this.data.projectName, justLaunch: true, waitForDebugger: false, projectDir: deviceAppData.projectDir  });

--- a/lib/services/livesync/ios-livesync-service.ts
+++ b/lib/services/livesync/ios-livesync-service.ts
@@ -1,5 +1,4 @@
 import * as path from "path";
-import * as temp from "temp";
 
 import { IOSDeviceLiveSyncService } from "./ios-device-livesync-service";
 import { PlatformLiveSyncServiceBase } from "./platform-livesync-service-base";
@@ -11,6 +10,7 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		protected $platformsDataService: IPlatformsDataService,
 		protected $projectFilesManager: IProjectFilesManager,
 		private $injector: IInjector,
+		private $tempService: ITempService,
 		$devicePathProvider: IDevicePathProvider,
 		$logger: ILogger) {
 		super($fs, $logger, $platformsDataService, $projectFilesManager, $devicePathProvider);
@@ -28,8 +28,7 @@ export class IOSLiveSyncService extends PlatformLiveSyncServiceBase implements I
 		const deviceAppData = await this.getAppData(syncInfo);
 		const projectFilesPath = path.join(platformData.appDestinationDirectoryPath, APP_FOLDER_NAME);
 
-		temp.track();
-		const tempZip = temp.path({ prefix: "sync", suffix: ".zip" });
+		const tempZip = await this.$tempService.path({ prefix: "sync", suffix: ".zip" });
 		this.$logger.trace("Creating zip file: " + tempZip);
 
 		const filesToTransfer = this.$fs.enumerateFilesInDirectorySync(projectFilesPath);

--- a/lib/services/platform/add-platform-service.ts
+++ b/lib/services/platform/add-platform-service.ts
@@ -1,5 +1,4 @@
 import * as path from "path";
-import * as temp from "temp";
 import { PROJECT_FRAMEWORK_FOLDER_NAME, TrackActionNames, AnalyticsEventLabelDelimiter } from "../../constants";
 import { performanceLog } from "../../common/decorators";
 
@@ -9,7 +8,8 @@ export class AddPlatformService implements IAddPlatformService {
 		private $pacoteService: IPacoteService,
 		private $projectDataService: IProjectDataService,
 		private $terminalSpinnerService: ITerminalSpinnerService,
-		private $analyticsService: IAnalyticsService
+		private $analyticsService: IAnalyticsService,
+		private $tempService: ITempService
 	) { }
 
 	public async addPlatformSafe(projectData: IProjectData, platformData: IPlatformData, packageToInstall: string, nativePrepare: INativePrepare): Promise<string> {
@@ -45,11 +45,9 @@ export class AddPlatformService implements IAddPlatformService {
 	}
 
 	private async extractPackage(pkg: string): Promise<string> {
-		temp.track();
-		const downloadedPackagePath = temp.mkdirSync("runtimeDir");
+		const downloadedPackagePath = await this.$tempService.mkdirSync("runtimeDir");
 		await this.$pacoteService.extractPackage(pkg, downloadedPackagePath);
 		const frameworkDir = path.join(downloadedPackagePath, PROJECT_FRAMEWORK_FOLDER_NAME);
-
 		return path.resolve(frameworkDir);
 	}
 

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -4,7 +4,6 @@ import * as shelljs from "shelljs";
 import { format } from "util";
 import { exported } from "../common/decorators";
 import { Hooks, TemplatesV2PackageJsonKeysToRemove } from "../constants";
-import * as temp from "temp";
 import { performanceLog } from "../common/decorators";
 
 export class ProjectService implements IProjectService {
@@ -20,7 +19,8 @@ export class ProjectService implements IProjectService {
 		private $projectNameService: IProjectNameService,
 		private $projectTemplatesService: IProjectTemplatesService,
 		private $staticConfig: IStaticConfig,
-		private $packageInstallationManager: IPackageInstallationManager) { }
+		private $packageInstallationManager: IPackageInstallationManager,
+		private $tempService: ITempService) { }
 
 	public async validateProjectName(opts: { projectName: string, force: boolean, pathToProject: string }): Promise<string> {
 		let projectName = opts.projectName;
@@ -152,7 +152,7 @@ export class ProjectService implements IProjectService {
 
 		if (!this.$fs.exists(appResourcesDestinationPath)) {
 			this.$fs.createDirectory(appResourcesDestinationPath);
-			const tempDir = temp.mkdirSync("ns-default-template");
+			const tempDir = await this.$tempService.mkdirSync("ns-default-template");
 			// the template installed doesn't have App_Resources -> get from a default template
 			await this.$pacoteService.extractPackage(constants.RESERVED_TEMPLATE_NAMES["default"], tempDir);
 			const templateProjectData = this.$projectDataService.getProjectData(tempDir);

--- a/lib/services/project-templates-service.ts
+++ b/lib/services/project-templates-service.ts
@@ -1,9 +1,7 @@
 import * as path from "path";
-import * as temp from "temp";
 import * as constants from "../constants";
 import { format } from "util";
 import { performanceLog } from "../common/decorators";
-temp.track();
 
 export class ProjectTemplatesService implements IProjectTemplatesService {
 	private templatePackageContents: IDictionary<any> = {};

--- a/lib/services/temp-service.ts
+++ b/lib/services/temp-service.ts
@@ -1,0 +1,21 @@
+import * as temp from "temp";
+
+export class TempService implements ITempService {
+	constructor(private $cleanupService: ICleanupService) {
+		temp.track();
+	}
+
+	public async mkdirSync(affixes: string): Promise<string> {
+		const pathToDir = temp.mkdirSync(affixes);
+		await this.$cleanupService.addCleanupDeleteAction(pathToDir);
+		return pathToDir;
+	}
+
+	public async path(options: ITempPathOptions): Promise<string> {
+		const pathToFile = temp.path(options);
+		await this.$cleanupService.addCleanupDeleteAction(pathToFile);
+		return pathToFile;
+	}
+}
+
+$injector.register("tempService", TempService);

--- a/test/controllers/add-platform-controller.ts
+++ b/test/controllers/add-platform-controller.ts
@@ -1,4 +1,4 @@
-import { InjectorStub, PacoteServiceStub } from "../stubs";
+import { InjectorStub, PacoteServiceStub, TempServiceStub } from "../stubs";
 import { PlatformController } from "../../lib/controllers/platform-controller";
 import { AddPlatformService } from "../../lib/services/platform/add-platform-service";
 import { assert } from "chai";
@@ -23,6 +23,7 @@ function createInjector(data?: { latestFrameworkVersion: string }) {
 	injector.register("pacoteService", {
 		extractPackage: async (name: string): Promise<void> => { extractedPackageFromPacote = name; }
 	});
+	injector.register("tempService", TempServiceStub);
 
 	const logger = injector.resolve("logger");
 	logger.info = (message: string) => actualMessage = message;

--- a/test/controllers/prepare-controller.ts
+++ b/test/controllers/prepare-controller.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import { PrepareController } from "../../lib/controllers/prepare-controller";
 import { MobileHelper } from "../../lib/common/mobile/mobile-helper";
-import { InjectorStub } from "../stubs";
+import { InjectorStub, TempServiceStub } from "../stubs";
 import { PREPARE_READY_EVENT_NAME } from "../../lib/constants";
 
 const projectDir = "/path/to/my/projecDir";
@@ -61,6 +61,8 @@ function createTestInjector(data: { hasNativeChanges: boolean }): IInjector {
 	injector.register("analyticsService", {
 		trackEventActionInGoogleAnalytics: () => ({})
 	});
+
+	injector.register("tempService", TempServiceStub);
 
 	const prepareController: PrepareController = injector.resolve("prepareController");
 	prepareController.emit = (eventName: string, eventData: any) => {

--- a/test/controllers/run-controller.ts
+++ b/test/controllers/run-controller.ts
@@ -1,5 +1,5 @@
 import { RunController } from "../../lib/controllers/run-controller";
-import { InjectorStub } from "../stubs";
+import { InjectorStub, TempServiceStub } from "../stubs";
 import { LiveSyncServiceResolver } from "../../lib/resolvers/livesync-service-resolver";
 import { MobileHelper } from "../../lib/common/mobile/mobile-helper";
 import { assert } from "chai";
@@ -107,6 +107,7 @@ function createTestInjector() {
 	injector.register("analyticsService", ({}));
 	injector.register("debugController", {});
 	injector.register("liveSyncProcessDataService", LiveSyncProcessDataService);
+	injector.register("tempService", TempServiceStub);
 
 	const devicesService = injector.resolve("devicesService");
 	devicesService.getDevicesForPlatform = () => <any>[{ identifier: "myTestDeviceId1" }];

--- a/test/helpers/platform-command-helper.ts
+++ b/test/helpers/platform-command-helper.ts
@@ -1,6 +1,6 @@
 
 import { assert } from "chai";
-import { InjectorStub } from "../stubs";
+import { InjectorStub, TempServiceStub } from "../stubs";
 import { MobileHelper } from "../../lib/common/mobile/mobile-helper";
 import { DevicePlatformsConstants } from "../../lib/common/mobile/device-platforms-constants";
 import { PlatformCommandHelper } from "../../lib/helpers/platform-command-helper";
@@ -35,6 +35,7 @@ function createTestInjector() {
 
 	injector.register("mobileHelper", MobileHelper);
 	injector.register("devicePlatformsConstants", DevicePlatformsConstants);
+	injector.register("tempService", TempServiceStub);
 
 	return injector;
 }

--- a/test/ios-entitlements-service.ts
+++ b/test/ios-entitlements-service.ts
@@ -31,6 +31,8 @@ describe("IOSEntitlements Service Tests", () => {
 			getAllInstalledPlugins: async (): Promise<any[]> => []
 		});
 
+		testInjector.register("tempService", stubs.TempServiceStub);
+
 		return testInjector;
 	};
 

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -30,7 +30,7 @@ import { YarnPackageManager } from "../lib/yarn-package-manager";
 import { assert } from "chai";
 import { SettingsService } from "../lib/common/test/unit-tests/stubs";
 import { BUILD_XCCONFIG_FILE_NAME } from "../lib/constants";
-import { ProjectDataStub } from "./stubs";
+import { ProjectDataStub, TempServiceStub } from "./stubs";
 import { xcode } from "../lib/node/xcode";
 import temp = require("temp");
 import { CocoaPodsPlatformManager } from "../lib/services/cocoapods-platform-manager";
@@ -181,6 +181,8 @@ function createTestInjector(projectPath: string, projectName: string, xCode?: IX
 	testInjector.register("iOSNativeTargetService", {
 		setXcodeTargetBuildConfigurationProperties: () => { /* */ }
 	});
+	testInjector.register("tempService", TempServiceStub);
+
 	return testInjector;
 }
 

--- a/test/platform-commands.ts
+++ b/test/platform-commands.ts
@@ -192,6 +192,7 @@ function createTestInjector() {
 	});
 	testInjector.register("addPlatformService", {});
 	testInjector.register("platformController", {});
+	testInjector.register("tempService", stubs.TempServiceStub);
 	testInjector.register("platformCommandHelper", PlatformCommandHelper);
 
 	return testInjector;

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -161,6 +161,7 @@ function createTestInjector() {
 		setShouldDispose: (shouldDispose: boolean): void => undefined
 	});
 	testInjector.register("nodeModulesDependenciesBuilder", {});
+	testInjector.register("tempService", stubs.TempServiceStub);
 
 	return testInjector;
 }
@@ -550,6 +551,7 @@ describe("Plugins service", () => {
 			unitTestsInjector.register("mobileHelper", MobileHelper);
 			unitTestsInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 			unitTestsInjector.register("nodeModulesDependenciesBuilder", {});
+			unitTestsInjector.register("tempService", stubs.TempServiceStub);
 
 			const pluginsService: PluginsService = unitTestsInjector.resolve(PluginsService);
 			testData.pluginsService = pluginsService;
@@ -597,6 +599,7 @@ describe("Plugins service", () => {
 		unitTestsInjector.register("mobileHelper", MobileHelper);
 		unitTestsInjector.register("devicePlatformsConstants", DevicePlatformsConstants);
 		unitTestsInjector.register("nodeModulesDependenciesBuilder", {});
+		unitTestsInjector.register("tempService", stubs.TempServiceStub);
 		return unitTestsInjector;
 	};
 

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -3,7 +3,7 @@ import * as constants from "../lib/constants";
 import * as ProjectServiceLib from "../lib/services/project-service";
 import { assert } from "chai";
 import { SettingsService } from "../lib/common/test/unit-tests/stubs";
-import { LoggerStub, ErrorsStub } from "./stubs";
+import { LoggerStub, ErrorsStub, TempServiceStub } from "./stubs";
 import * as path from "path";
 
 describe("projectService", () => {
@@ -67,6 +67,7 @@ describe("projectService", () => {
 				downloadAndExtract: () => Promise.resolve(),
 				extractPackage: () => Promise.resolve()
 			});
+			testInjector.register("tempService", TempServiceStub);
 
 			return testInjector;
 		};
@@ -126,6 +127,7 @@ describe("projectService", () => {
 				manifest: () => Promise.resolve(),
 				downloadAndExtract: () => Promise.resolve()
 			});
+			testInjector.register("tempService", TempServiceStub);
 
 			return testInjector;
 		};

--- a/test/services/ios/export-options-plist-service.ts
+++ b/test/services/ios/export-options-plist-service.ts
@@ -1,6 +1,7 @@
 import { Yok } from "../../../lib/common/yok";
 import { ExportOptionsPlistService } from "../../../lib/services/ios/export-options-plist-service";
 import { assert } from "chai";
+import { TempServiceStub } from "../../stubs";
 
 let actualPlistTemplate: string = null;
 const projectName = "myProjectName";
@@ -15,6 +16,7 @@ function createTestInjector() {
 		}
 	});
 	injector.register("exportOptionsPlistService", ExportOptionsPlistService);
+	injector.register("tempService", TempServiceStub);
 
 	return injector;
 }
@@ -45,13 +47,13 @@ describe("ExportOptionsPlistService", () => {
 
 		_.each(testCases, testCase => {
 			_.each(["Development", "AdHoc", "Distribution", "Enterprise"], provisionType => {
-				it(testCase.name, () => {
+				it(testCase.name, async () => {
 					const injector = createTestInjector();
 					const exportOptionsPlistService = injector.resolve("exportOptionsPlistService");
 					exportOptionsPlistService.getExportOptionsMethod = () => provisionType;
 
 					const projectData = { projectName, projectIdentifiers: { ios: "org.nativescript.myTestApp" }};
-					exportOptionsPlistService.createDevelopmentExportOptionsPlist(archivePath, projectData, testCase.buildConfig);
+					await exportOptionsPlistService.createDevelopmentExportOptionsPlist(archivePath, projectData, testCase.buildConfig);
 
 					const template = actualPlistTemplate.split("\n").join(" ");
 					assert.isTrue(template.indexOf(`<key>method</key> 	<string>${provisionType}</string>`) > 0);
@@ -88,13 +90,13 @@ describe("ExportOptionsPlistService", () => {
 		];
 
 		_.each(testCases, testCase => {
-			it(testCase.name, () => {
+			it(testCase.name, async () => {
 				const injector = createTestInjector();
 				const exportOptionsPlistService = injector.resolve("exportOptionsPlistService");
 				exportOptionsPlistService.getExportOptionsMethod = () => "app-store";
 
 				const projectData = { projectName, projectIdentifiers: { ios: "org.nativescript.myTestApp" }};
-				exportOptionsPlistService.createDistributionExportOptionsPlist(projectRoot, projectData, testCase.buildConfig);
+				await exportOptionsPlistService.createDistributionExportOptionsPlist(projectRoot, projectData, testCase.buildConfig);
 
 				const template = actualPlistTemplate.split("\n").join(" ");
 				assert.isTrue(template.indexOf("<key>method</key>     <string>app-store</string>") > 0);

--- a/test/services/ios/xcodebuild-service.ts
+++ b/test/services/ios/xcodebuild-service.ts
@@ -17,8 +17,8 @@ let actualBuildOptions:IXcodebuildCommandOptions = null;
 function createTestInjector(): IInjector {
 	const injector = new Yok();
 	injector.register("exportOptionsPlistService", {
-		createDevelopmentExportOptionsPlist: () => exportOptionsPlistOutput,
-		createDistributionExportOptionsPlist: () => exportOptionsPlistOutput
+		createDevelopmentExportOptionsPlist: async () => exportOptionsPlistOutput,
+		createDistributionExportOptionsPlist: async () => exportOptionsPlistOutput
 	});
 	injector.register("xcodebuildArgsService", {
 		getBuildForDeviceArgs: async () => <string[]>[],

--- a/test/services/livesync/android-device-livesync-service-base.ts
+++ b/test/services/livesync/android-device-livesync-service-base.ts
@@ -186,7 +186,7 @@ function setup(options?: ITestSetupInput): ITestSetupOutput {
 
 	const injector = createTestInjector();
 	const fs = injector.resolve("fs");
-	const deviceHashService = new AndroidDeviceHashService(mockAdb(), appIdentifier, fs, injector.resolve("mobileHelper"));
+	const deviceHashService = new AndroidDeviceHashService(mockAdb(), appIdentifier, fs, injector.resolve("mobileHelper"), <any> { mkdirSync: async () => "" });
 	const localToDevicePaths = _.keys(filesToShasums).map(file => injector.resolve(LocalToDevicePathDataMock, { filePath: file }));
 	const deviceAppData = createDeviceAppData(deviceHashService);
 	const androidDeviceLiveSyncServiceBase = new AndroidDeviceLiveSyncServiceBaseMock(injector, mockPlatformsData(), mockFilesHashService(), mockLogger(), mockDevice(deviceHashService));

--- a/test/services/livesync/android-livesync-tool.ts
+++ b/test/services/livesync/android-livesync-tool.ts
@@ -1,7 +1,7 @@
 import { Yok } from "../../../lib/common/yok";
 import { assert } from "chai";
 import * as sinon from "sinon";
-import { LoggerStub } from "../../stubs";
+import { LoggerStub, TempServiceStub } from "../../stubs";
 import { AndroidLivesyncTool } from "../../../lib/services/livesync/android-livesync-tool";
 import { LiveSyncSocket } from "../../../lib/services/livesync/livesync-socket";
 import { MobileHelper } from "../../../lib/common/mobile/mobile-helper";
@@ -86,6 +86,7 @@ const createTestInjector = (socket: INetSocket, fileStreams: IDictionary<NodeJS.
 			throw new Error(message);
 		}
 	});
+	testInjector.register("tempService", TempServiceStub);
 
 	return testInjector;
 };

--- a/test/services/platform/add-platform-service.ts
+++ b/test/services/platform/add-platform-service.ts
@@ -1,4 +1,4 @@
-import { InjectorStub } from "../../stubs";
+import { InjectorStub, TempServiceStub } from "../../stubs";
 import { AddPlatformService } from "../../../lib/services/platform/add-platform-service";
 import { PacoteService } from "../../../lib/services/pacote-service";
 import { assert } from "chai";
@@ -22,6 +22,7 @@ function createTestInjector() {
 	injector.register("analyticsService", {
 		trackEventActionInGoogleAnalytics: () => ({})
 	});
+	injector.register("tempService", TempServiceStub);
 
 	const fs = injector.resolve("fs");
 	fs.exists = () => false;

--- a/test/services/playground/preview-app-livesync-service.ts
+++ b/test/services/playground/preview-app-livesync-service.ts
@@ -1,6 +1,6 @@
 import { Yok } from "../../../lib/common/yok";
 import * as _ from 'lodash';
-import { LoggerStub, ErrorsStub, MarkingModeServiceStub } from "../../stubs";
+import { LoggerStub, ErrorsStub, MarkingModeServiceStub, TempServiceStub } from "../../stubs";
 import { FilePayload, Device, FilesPayload } from "nativescript-preview-sdk";
 import * as chai from "chai";
 import * as path from "path";
@@ -189,6 +189,7 @@ function createTestInjector(options?: {
 	injector.register("pluginsService", {
 		ensureAllDependenciesAreInstalled: () => { return Promise.resolve(); }
 	});
+	injector.register("tempService", TempServiceStub);
 
 	return injector;
 }

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -10,6 +10,8 @@ import { Yok } from "./../lib/common/yok";
 import { HostInfo } from "./../lib/common/host-info";
 import { DevicePlatformsConstants } from "./../lib/common/mobile/device-platforms-constants";
 import { PrepareData } from "../lib/data/prepare-data";
+import * as temp from "temp";
+temp.track();
 
 export class LoggerStub implements ILogger {
 	initialize(opts?: ILoggerOptions): void { }
@@ -940,5 +942,15 @@ export class InjectorStub extends Yok implements IInjector {
 			getDeviceByIdentifier: (): Mobile.IDevice => undefined
 		});
 		this.register("terminalSpinnerService", TerminalSpinnerServiceStub);
+	}
+}
+
+export class TempServiceStub implements ITempService {
+	public async mkdirSync(affixes: string): Promise<string> {
+		return temp.mkdirSync(affixes);
+	}
+
+	public async path(options: ITempPathOptions): Promise<string> {
+		return temp.path(options);
 	}
 }


### PR DESCRIPTION
Currently CLI relies on temp module to create temporary files, which should be deleted once CLI process has no work left. However, in some cases, when Node.js crashes (or the process is killed with a signal) the temp module is unable to delete the files.
In order to fix this, introduce a tempService wrapper for temp module. For each path created by temp module, add a new cleanup action in the CLI's cleanup service, which will take care to delete the files even when the main CLI process dies with unusual error.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/5239

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
