### PR TITLE
fix: external files are not livesynced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 NativeScript CLI Changelog
 ================
 
+6.4.1 (2020, February 19)
+===
+
+### Fixed
+
+* [Fixed #5251](https://github.com/NativeScript/nativescript-cli/issues/5251): External files are not livesynced
+
+
 6.4.0 (2020, February 11)
 ===
 

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -49,11 +49,8 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 							return;
 						}
 
-						// the hash of the compilation is the same as the previous one
-						if (this.expectedHashes[platformData.platformNameLowerCase] === message.hash) {
-							return;
-						}
-
+						// Persist the previousHash value before calling `this.getUpdatedEmittedFiles` as it will modify the expectedHashes object with the current hash
+						const previousHash = this.expectedHashes[platformData.platformNameLowerCase];
 						let result;
 
 						if (prepareData.hmr) {
@@ -78,6 +75,12 @@ export class WebpackCompilerService extends EventEmitter implements IWebpackComp
 						};
 
 						this.$logger.trace("Generated data from webpack message:", data);
+
+						// the hash of the compilation is the same as the previous one and there are only hot updates produced
+						if (data.hasOnlyHotUpdateFiles && previousHash === message.hash) {
+							return;
+						}
+
 						if (data.files.length) {
 							this.emit(WEBPACK_COMPILATION_COMPLETE, data);
 						}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "preferGlobal": true,
-  "version": "6.4.0",
+  "version": "6.4.1",
   "author": "Telerik <support@telerik.com>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {


### PR DESCRIPTION
In case you have external files set in the webpack.config.js (or resources copied with CopyWebpackPlugin), the `tns run ...` command does not LiveSync them to device. Webpack compilation is triggered, but as the emitted files are not hot updates, the hot update hash of the compilation is the same as the previous one. In this case CLI decides there's nothing to sync.
To fix this extend the check in webpack-compiler-service to be based not only on the comparison between previous and current hash, but on the emitted files as well - if there are files which are not hot updates, continue the execution even if the previous and current hash are the same. That's exactly the case with externals.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes issue https://github.com/NativeScript/nativescript-cli/issues/5251
> NOTE: Current changes may cause regression for issues described in https://github.com/NativeScript/nativescript-cli/issues/5105 They should be checked as well.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
