### PR TITLE
feat(options): use the 'nsconfig.json' file to set tns options

### DIFF
--- a/docs/man_pages/project/testing/build-android.md
+++ b/docs/man_pages/project/testing/build-android.md
@@ -17,6 +17,7 @@ General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <Fil
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `android` subkey.
 * `--compileSdk` - Sets the Android SDK that will be used to build the project. `<API Level>` is a valid Android API level. For example: 28, 29. The minimum supported SDK is 28. <% if(isHtml) { %> For a complete list of the Android API levels and their corresponding Android versions, click [here](http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#platform).<% } %>
 * `--clean` - If set, forces the complete rebuild of the native application.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build. When set, you must also specify the `--key-store-*` options.

--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -21,6 +21,7 @@ General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [-
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `ios` subkey.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.
 * `--for-device` - If set, produces an application package that you can deploy on device. Otherwise, produces a build that you can run only in the native iOS Simulator.
 * `--i-cloud-container-environment` - If set, adds the passed `iCloudContainerEnvironment` when exporting an application package with the `--for-device` option.

--- a/docs/man_pages/project/testing/build.md
+++ b/docs/man_pages/project/testing/build.md
@@ -28,6 +28,7 @@ Usage | Synopsis
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with `android` and `ios` subkeys.
 * `--justlaunch` - If set, does not print the application output in the console.
 * `--release` -If set, produces a release build by running webpack in production mode and native build in release mode. Otherwise, produces a debug build.
 * `--device` - Specifies a connected device/emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device <Platform> --available-devices` command.

--- a/docs/man_pages/project/testing/debug-android.md
+++ b/docs/man_pages/project/testing/debug-android.md
@@ -21,6 +21,7 @@ Attach the debug tools to a running app in the native emulator | `$ tns debug an
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `android` subkey.
 * `--device` - Specifies a connected device/emulator on which to debug the app. `<Device ID>` is the device identifier or name of the target device as listed by the `$ tns device android` command.
 * `--emulator` - Specifies that you want to debug the app in the native Android emulator.
 * `--debug-brk` - Prepares, builds and deploys the application package on a device/emulator, generates a link for Chrome Developer Tools and stops at the first code statement.

--- a/docs/man_pages/project/testing/debug-ios.md
+++ b/docs/man_pages/project/testing/debug-ios.md
@@ -25,6 +25,7 @@ Attach the debug tools to a running app in the iOS simulator | `$ tns debug ios 
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `ios` subkey.
 * `--device` - Specifies a connected device or iOS simulator on which to run the app. `<Device ID>` is the device identifier of the target device as listed by the `$ tns device ios` command.
 * `--emulator` - Indicates that you want to debug your app in the iOS simulator.
 * `--debug-brk` - Prepares, builds and deploys the application package on a device or in a simulator, runs the app, launches the developer tools of your Safari browser and stops at the first code statement.

--- a/docs/man_pages/project/testing/deploy.md
+++ b/docs/man_pages/project/testing/deploy.md
@@ -21,11 +21,13 @@ Deploy on Android | `$ tns deploy android [--device <Device ID>] [--key-store-pa
 
 ### Options for iOS
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `ios` subkey.
 * `--device` - Deploys the project on the specified connected physical or virtual device. `<Device ID>` is the index or name of the target device as listed by the `$ tns devices` command.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.<% } %>
 
 ### Options<% if(isMacOS) { %> for Android<% } %>
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `android` subkey.
 * `--device` - Deploys the project on the specified connected physical or virtual device. `<Device ID>` is the index or name of the target device as listed by the `$ tns devices` command.
 * `--clean` - If set, forces the complete rebuild of the native application.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build. When set, you must also specify the `--key-store-*` options.

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -23,6 +23,7 @@ Start a default emulator if none are running, or run application on all connecte
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `android` subkey.
 * `--device` - Specifies a connected device or emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device android --available-devices` command.
 * `--emulator` - If set, runs the app in all available and configured Android emulators. It will start an emulator if none are already running.
 * `--justlaunch` - If set, does not print the application output in the console.

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -29,6 +29,7 @@ Start an emulator with specified device identifier and sdk | `$ tns run ios [--d
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `ios` subkey.
 * `--device` - Specifies a connected device/simulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device ios --available-devices` command.
 * `--emulator` - If set, runs the app in all available and configured ios simulators. It will start a simulator if none are already running.
 * `--sdk` - Specifies the target simulator's sdk.

--- a/docs/man_pages/project/testing/run.md
+++ b/docs/man_pages/project/testing/run.md
@@ -41,6 +41,7 @@ Run on a selected connected device or running emulator. Will start emulator with
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with `android` and `ios` subkeys.
 * `--justlaunch` - If set, does not print the application output in the console.
 * `--release` - If set, produces a release build by running webpack in production mode and native build in release mode. Otherwise, produces a debug build.
 * `--device` - Specifies a connected device/emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device <Platform> --available-devices` command.

--- a/docs/man_pages/project/testing/test-android.md
+++ b/docs/man_pages/project/testing/test-android.md
@@ -18,6 +18,7 @@ Run tests on a selected device | `$ tns test android --device <Device ID> [--wat
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `android` subkey.
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device and tests are re-run.
 * `--device` - Specifies the serial number or the index of the connected device on which to run the tests. To list all connected devices, grouped by platform, run `$ tns device`. `<Device ID>` is the device index or identifier as listed by the `$ tns device` command.
 * `--debug-brk` - Runs the tests under the debugger. The debugger will break just before your tests are executed, so you have a chance to place breakpoints.

--- a/docs/man_pages/project/testing/test-ios.md
+++ b/docs/man_pages/project/testing/test-ios.md
@@ -23,6 +23,7 @@ Run tests in the iOS Simulator | `$ tns test ios --emulator [--watch] [--debug-b
 
 ### Options
 
+* `--nsconfig` - If set, all the options below can be defined in the [nsconfig.json file](https://docs.nativescript.org/core-concepts/project-structure-app#the-nsconfigjson-file) at the root of your project. In the `nsconfig.json` file, you need to add the `tnsOptions` key with the `ios` subkey.
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device and tests are re-ran.
 * `--device` - Specifies the serial number or the index of the connected device on which you want to run tests. To list all connected devices, grouped by platform, run `$ tns device`. You cannot set `--device` and `--emulator` simultaneously. `<Device ID>` is the device index or identifier as listed by the `$ tns device` command.
 * `--emulator` - Runs tests on the iOS Simulator. You cannot set `--device` and `--emulator` simultaneously.

--- a/lib/data/controller-data-base.ts
+++ b/lib/data/controller-data-base.ts
@@ -1,7 +1,9 @@
 export class ControllerDataBase implements IControllerDataBase {
 	public nativePrepare?: INativePrepare;
+	public nsconfig?: boolean;
 
 	constructor(public projectDir: string, public platform: string, data: any) {
 		this.nativePrepare = data.nativePrepare;
+		this.nsconfig = data.nsconfig;
 	}
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -584,6 +584,7 @@ interface IOptions extends IRelease, IDeviceIdentifier, IJustLaunch, IAvd, IAvai
 	appleApplicationSpecificPassword: string;
 	appleSessionBase64: string;
 	markingMode: boolean;
+	nsconfig: boolean;
 }
 
 interface IEnvOptions {

--- a/lib/definitions/data.d.ts
+++ b/lib/definitions/data.d.ts
@@ -2,4 +2,5 @@ interface IControllerDataBase {
 	projectDir: string;
 	platform: string;
 	nativePrepare?: INativePrepare;
+	nsconfig?: boolean;
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -70,6 +70,11 @@ interface IProjectService {
 	isValidNativeScriptProject(pathToProject?: string): boolean;
 }
 
+interface ITnsOptions {
+	android?: IAndroidBuildData;
+	ios?: IiOSBuildData;
+}
+
 interface INsConfig {
 	appPath?: string;
 	appResourcesPath?: string;
@@ -77,6 +82,7 @@ interface INsConfig {
 	previewAppSchema?: string;
 	overridePods?: string;
 	webpackConfigPath?: string;
+	tnsOptions?: ITnsOptions;
 }
 
 interface IProjectData extends ICreateProjectData {

--- a/lib/helpers/nsconfig-helper.ts
+++ b/lib/helpers/nsconfig-helper.ts
@@ -1,0 +1,103 @@
+import { CONFIG_NS_FILE_NAME } from "../constants";
+import { existsSync, readFileSync } from "fs";
+import { sep } from "path";
+
+export default class NsConfigHelper  {
+	public static mergedOptions(initialArgv: any, argv: any): any {
+		const underdash: Array<string> = initialArgv._ || argv._ || [];
+		const projectDir = this._getProjectDir(argv.path);
+		const platformName = this._getPlatformName(underdash);
+		const platformOptions = this._getPlatformOptions(projectDir, platformName);
+		const formattedPlatformOptions = this._getFormattedPlatformOptions(platformOptions);
+
+		return { ...argv, ...formattedPlatformOptions, ...initialArgv };
+	}
+
+	private static _getFormattedPlatformOptions(platformOptions: any): any {
+		const formattedPlatformOptions: any = {};
+
+		for (const optionName in platformOptions) {
+			const optionNameVariant: string = this._getOptionNameVariant(optionName);
+			const optionValue: any = platformOptions[optionName];
+
+			if (typeof optionValue === "object" && optionValue !== null) {
+				this._getFormattedPlatformOptions(optionValue);
+			}
+
+			if (optionNameVariant) {
+				formattedPlatformOptions[optionNameVariant] = optionValue;
+			}
+
+			formattedPlatformOptions[optionName] = optionValue;
+		}
+
+		return formattedPlatformOptions;
+	}
+
+	private static _getOptionNameVariant(optionName: string): string {
+		let optionNameVariant: string = "";
+
+		if (this._isOptionNameDashed(optionName)) {
+			optionNameVariant = this._dashedToCapitalized(optionName);
+		} else if (this._isOptionNameCapitalized(optionName)) {
+			optionNameVariant = this._capitalizedToDashed(optionName);
+		}
+
+		return optionNameVariant;
+	}
+
+	private static _isOptionNameCapitalized(optionName: string): boolean {
+		const regex: RegExp = /[A-Z]/g;
+
+		return regex.test(optionName);
+	}
+
+	private static _isOptionNameDashed(optionName: string): boolean {
+		return optionName.indexOf("-") !== -1;
+	}
+
+	private static _capitalizedToDashed(optionName: string): string {
+		const regex: RegExp = /[A-Z]/g;
+		const dashedOptionName = optionName.replace(regex, "-$&");
+
+		return dashedOptionName.toLowerCase() || "";
+	}
+
+	private static _dashedToCapitalized(optionName: string): string {
+		const words = optionName.split("-") || [];
+		const capitalizedWords = words.map((word, index) => {
+			if (index === 0) {
+				return word;
+			}
+
+			return word.charAt(0).toUpperCase() + word.slice(1);
+		});
+
+		return capitalizedWords.join("") || "";
+	}
+
+	private static _getPlatformName(underdash: Array<string>): string {
+		const regex: RegExp = /^(android|ios)$/i;
+		const platformName: string = underdash.find(element => regex.test(element));
+
+		return platformName.toLowerCase() || "";
+	}
+
+	private static _getProjectDir(path?: string): string {
+		return path || process.cwd() || "";
+	}
+
+	private static _getPlatformOptions(projectDir: string, platformName: string): any {
+		const nsConfigData = this._getNsConfigData(projectDir);
+		const tnsOptionsData: any = nsConfigData.tnsOptions || {};
+
+		return tnsOptionsData[platformName] || {};
+	}
+
+	private static _getNsConfigData(projectDir: string): INsConfig {
+		const nsConfigPath: string = `${projectDir}${sep}${CONFIG_NS_FILE_NAME}`;
+		const nsConfigData: INsConfig = existsSync(nsConfigPath) ? JSON.parse(readFileSync(nsConfigPath, "utf8")) : {};
+
+		return nsConfigData;
+	}
+}

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -30,7 +30,7 @@ export class Options {
 		}
 
 		if (this.argv.nsconfig) {
-			this.argv = nsConfigHelper.mergedOptions(this.initialArgv, this.argv);
+			this.argv = nsConfigHelper.getMergedOptions(this.initialArgv, this.argv);
 		}
 
 		this.argv.bundle = "webpack";

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,5 +1,6 @@
 import * as helpers from "./common/helpers";
 import * as yargs from "yargs";
+import nsConfigHelper from "./helpers/nsconfig-helper";
 
 export class Options {
 	private static DASHED_OPTION_REGEX = /(.+?)([A-Z])(.*)/;
@@ -26,6 +27,10 @@ export class Options {
 		if (commandSpecificDashedOptions) {
 			_.extend(this.options, commandSpecificDashedOptions);
 			this.setArgv();
+		}
+
+		if (this.argv.nsconfig) {
+			this.argv = nsConfigHelper.mergedOptions(this.initialArgv, this.argv);
 		}
 
 		this.argv.bundle = "webpack";
@@ -118,6 +123,7 @@ export class Options {
 			collection: { type: OptionType.String, alias: "c", hasSensitiveValue: false },
 			json: { type: OptionType.Boolean, hasSensitiveValue: false },
 			avd: { type: OptionType.String, hasSensitiveValue: true },
+			nsconfig: { type: OptionType.Boolean, hasSensitiveValue: false },
 			// check not used
 			config: { type: OptionType.Array, hasSensitiveValue: false },
 			insecure: { type: OptionType.Boolean, alias: "k", hasSensitiveValue: false },

--- a/lib/services/build-artefacts-service.ts
+++ b/lib/services/build-artefacts-service.ts
@@ -46,8 +46,9 @@ export class BuildArtefactsService implements IBuildArtefactsService {
 		const outputPath = buildOutputOptions.outputPath || platformData.getBuildOutputPath(buildOutputOptions);
 		const applicationPackage = this.getLatestApplicationPackage(outputPath, platformData.getValidBuildOutputData(buildOutputOptions));
 		const packageFile = applicationPackage.packageName;
+		const directoryPath = path.extname(targetPath).length !== 0 ? path.dirname(targetPath) : targetPath;
 
-		this.$fs.ensureDirectoryExists(path.dirname(targetPath));
+		this.$fs.ensureDirectoryExists(directoryPath);
 
 		if (this.$fs.exists(targetPath) && this.$fs.getFsStats(targetPath).isDirectory()) {
 			const sourceFileName = path.basename(packageFile);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

**Tns options** are to be written each time to build, run, deploy, debug and test an Android and iOS application.

## What is the new behavior?
<!-- Describe the changes. -->

In addition to the current behavior, all tns options can be defined in the **nsconfig.json** file.

In the **nsconfig.json** file, you need to add the `tnsOptions` key with `android` and `ios` subkeys.

Option names are unchanged, they are those of the documentation of the CLI.

### Example

#### nsconfig.json

```json
{
    "tnsOptions": {
        "android": {
            "copyTo": "./_build/android",
            "keyStorePath": "./keys/android.keystore",
            "keyStoreAlias": "my_ns_project",
            "release": true,
            "aab": true,
            "env": {
                "uglify": true
            }
        }
    }
}
```

#### CLI

```shell
tns build android --nsconfig --key-store-password "my_pwd" --key-store-alias-password "my_pwd"
```

([see the original idea](https://github.com/elvticc/nativescript-build-release))

## Fixes/Implements/Closes

### Fixes

* [./lib/services/build-artefacts-service.ts](https://github.com/NativeScript/nativescript-cli/pull/5296/commits/c582bbe157824fed2a8dddce1c92c30cbcfded4d)
Create up to the last folder in the path with the **copyTo** option.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
