### PR TITLE
feat: allow modifying gradlew args in hooks

### DIFF
--- a/lib/services/android/gradle-build-args-service.ts
+++ b/lib/services/android/gradle-build-args-service.ts
@@ -3,6 +3,7 @@ import { Configurations } from "../../common/constants";
 
 export class GradleBuildArgsService implements IGradleBuildArgsService {
 	constructor(private $androidToolsInfo: IAndroidToolsInfo,
+		private $hooksService: IHooksService,
 		private $analyticsService: IAnalyticsService,
 		private $staticConfig: Config.IStaticConfig,
 		private $logger: ILogger) { }
@@ -14,6 +15,9 @@ export class GradleBuildArgsService implements IGradleBuildArgsService {
 		if (await this.$analyticsService.isEnabled(this.$staticConfig.TRACK_FEATURE_USAGE_SETTING_NAME)) {
 			args.push("-PgatherAnalyticsData=true");
 		}
+
+		// allow modifying gradle args from a `before-build-task-args` hook
+		await this.$hooksService.executeBeforeHooks('build-task-args', { hookArgs: { args } });
 
 		return args;
 	}

--- a/test/services/android/gradle-build-args-service.ts
+++ b/test/services/android/gradle-build-args-service.ts
@@ -16,6 +16,7 @@ function createTestInjector(): IInjector {
 		})
 	});
 	injector.register("logger", {});
+	injector.register("hooksService", stubs.HooksServiceStub);
 	injector.register("gradleBuildArgsService", GradleBuildArgsService);
 	injector.register("analyticsService", stubs.AnalyticsService);
 	injector.register("staticConfig", {TRACK_FEATURE_USAGE_SETTING_NAME: "TrackFeatureUsage"});


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included. **Updated the test to inject the hookService stub.**

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no way to add additional gradlew parameters to a build.

## What is the new behavior?
<!-- Describe the changes. -->
We can now create `before-build-task-args` hooks where we can modify the `args` array that's passed to `gradlew`. 

For example, to use wix/Detox - we need to alter a projects `app.gradle` and build the app with `assembleAndroidTest` passed to `gradlew`. To do this, we have to manually run `tns prepare android` and then run the correct `gradlew` command with our additional parameters. With this change, we can do this with a hook (would need to add a condition in a real app): 

```js
module.exports = function(hookArgs, $errors, $injector) {
    hookArgs.args.unshift('assembleAndroidTest')
    hookArgs.args.push('-DtestBuildType=debug')
}
```

Implements #2481

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
