### PR TITLE
feat: pass current CLI public lib path to webpack env

### DIFF
--- a/lib/services/project-config-service.ts
+++ b/lib/services/project-config-service.ts
@@ -27,7 +27,7 @@ import {
 	format as prettierFormat,
 	resolveConfig as resolvePrettierConfig,
 } from "prettier";
-import { cache } from "../common/decorators";
+import { cache, exported } from "../common/decorators";
 import { IOptions } from "../declarations";
 import semver = require("semver/preload");
 
@@ -123,6 +123,7 @@ export default {
 		};
 	}
 
+	@exported("projectConfigService")
 	public readConfig(projectDir?: string): INsConfig {
 		const info = this.detectProjectConfigs(projectDir);
 
@@ -159,10 +160,12 @@ export default {
 		return config;
 	}
 
+	@exported("projectConfigService")
 	public getValue(key: string): any {
 		return _.get(this.readConfig(), key);
 	}
 
+	@exported("projectConfigService")
 	public async setValue(
 		key: string,
 		value: SupportedConfigValues

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -318,7 +318,15 @@ export class WebpackCompilerService
 		Object.assign(
 			envData,
 			appPath && { appPath },
-			appResourcesPath && { appResourcesPath }
+			appResourcesPath && { appResourcesPath },
+			{
+				nativescriptLibPath: path.resolve(
+					__dirname,
+					"..",
+					"..",
+					"nativescript-cli-lib.js"
+				),
+			}
 		);
 
 		envData.verbose = envData.verbose || this.$logger.isVerbose();


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
There is currently no way to get values from the `nativescript.config.ts` file in the webpack config unless you use a `.js` config file.

## What is the new behavior?
<!-- Describe the changes. -->

With this change, the path to the nativescript lib (exposing the public API of the CLI) is passed to the webpack env, and the webpack config can read useful data from the CLI - inlcluding values from a ts config file. For example, the following would get the values from the `nativescript.config.ts` (or .js).

```js
const nativescriptLib = require(env.nativescriptLibPath)
const nsConfig = nativescriptLib.projectDataService.getProjectData().nsConfig
console.log(nsConfig)
```
Or even using the config service directly:
```js
const nativescriptLib = require(env.nativescriptLibPath)
console.log(nativescriptLib.projectConfigService.readConfig())
console.log(nativescriptLib.projectConfigService.getValue('id'))
// setValue is also exported for updating the config!
```

/cc @farfromrefug 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
