### PR TITLE
fix: exclude unsupported architectures from cocoapods

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,54 +1,57 @@
 {
-	// Use IntelliSense to learn about possible Node.js debug attributes.
-	// Hover to view descriptions of existing attributes.
-	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"type": "node",
-			"request": "launch",
-			"cwd": "${workspaceRoot}",
-			"sourceMaps": true,
-			// In case you want to debug child processes started from CLI:
-			// "autoAttachChildProcesses": true,
-			"name": "Launch CLI (Node 6+)",
-			"program": "${workspaceRoot}/lib/nativescript-cli.js",
-
-			// example commands
-			"args": [ "create", "cliapp", "--path", "${workspaceRoot}/scratch"]
-			// "args": [ "test", "android", "--justlaunch"]
-			// "args": [ "platform", "add", "android@1.3.0", "--path", "cliapp"]
-			// "args": [ "platform", "remove", "android", "--path", "cliapp"]
-			// "args": [ "plugin", "add", "nativescript-barcodescanner", "--path", "cliapp"]
-			// "args": [ "plugin", "remove", "nativescript-barcodescanner", "--path", "cliapp"]
-			// "args": [ "build", "android", "--path", "cliapp"]
-			// "args": [ "run", "android", "--path", "cliapp"]
-			// "args": [ "debug", "android", "--path", "cliapp"]
-			// "args": [ "livesync", "android", "--path", "cliapp"]
-			// "args": [ "livesync", "android", "--watch", "--path", "cliapp"],
-			// "args": [ "resources", "generate", "icons", "./test/image-generation-test.png", "--path", "cliapp" ],
-			// "args": [ "resources", "generate", "splashes", "./test/image-generation-test.png", "--path", "cliapp", "--background", "#8000ff" ],
-		},
-		{
-			// in case you want to debug a single test, modify it's code to be `it.only(...` instead of `it(...`
-			"type": "node",
-			"request": "launch",
-			"name": "Launch Tests (Node 6+)",
-			"program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-			"cwd": "${workspaceRoot}",
-			"sourceMaps": true
-		},
-
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Broker Process",
-			// In case you want to debug Analytics Broker process, add `--debug-brk=9897` (or --inspect-brk=9897) when spawning analytics-broker-process.
-			"port": 9897,
-			"sourceMaps": true
+  // Use IntelliSense to learn about possible Node.js debug attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "sourceMaps": true,
+      // In case you want to debug child processes started from CLI:
+      // "autoAttachChildProcesses": true,
+      "name": "Launch CLI (Node 6+)",
+      "program": "${workspaceRoot}/lib/nativescript-cli.js",
+      // example commands
+      "args": [
+        "create",
+        "cliapp",
+        "--path",
+        "${workspaceRoot}/scratch"
+      ]
+      // "args": [ "test", "android", "--justlaunch"]
+      // "args": [ "platform", "add", "android@1.3.0", "--path", "cliapp"]
+      // "args": [ "platform", "remove", "android", "--path", "cliapp"]
+      // "args": [ "plugin", "add", "nativescript-barcodescanner", "--path", "cliapp"]
+      // "args": [ "plugin", "remove", "nativescript-barcodescanner", "--path", "cliapp"]
+      // "args": [ "build", "android", "--path", "cliapp"]
+      // "args": [ "run", "android", "--path", "cliapp"]
+      // "args": [ "debug", "android", "--path", "cliapp"]
+      // "args": [ "livesync", "android", "--path", "cliapp"]
+      // "args": [ "livesync", "android", "--watch", "--path", "cliapp"],
+      // "args": [ "resources", "generate", "icons", "./test/image-generation-test.png", "--path", "cliapp" ],
+      // "args": [ "resources", "generate", "splashes", "./test/image-generation-test.png", "--path", "cliapp", "--background", "#8000ff" ],
     },
     {
-      "name": "Attach",
+      // in case you want to debug a single test, modify it's code to be `it.only(...` instead of `it(...`
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Tests (Node 6+)",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "cwd": "${workspaceRoot}",
+      "sourceMaps": true
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Broker Process",
+      // In case you want to debug Analytics Broker process, add `--debug-brk=9897` (or --inspect-brk=9897) when spawning analytics-broker-process.
+      "port": 9897,
+      "sourceMaps": true
+    },
+    {
+      "name": "Attach to Node Debugger",
       "port": 9229,
       "request": "attach",
       "skipFiles": [
@@ -56,6 +59,5 @@
       ],
       "type": "pwa-node"
     }
-
-	]
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,7 +46,16 @@
 			// In case you want to debug Analytics Broker process, add `--debug-brk=9897` (or --inspect-brk=9897) when spawning analytics-broker-process.
 			"port": 9897,
 			"sourceMaps": true
-		}
+    },
+    {
+      "name": "Attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "pwa-node"
+    }
 
 	]
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -594,6 +594,11 @@ interface ICocoaPodsService {
 		platformData: IPlatformData
 	): Promise<void>;
 
+	applyPodfileArchExclusions(
+		projectData: IProjectData,
+		platformData: IPlatformData
+	): Promise<void>;
+
 	/**
 	 * Prepares the Podfile content of a plugin and merges it in the project's Podfile.
 	 * @param {string} moduleName The module which the Podfile is from.
@@ -660,8 +665,6 @@ interface ICocoaPodsService {
 		platformData: IPlatformData,
 		opts: IRelease
 	): Promise<void>;
-
-	applyPodfileArchExclusions(platformData: IPlatformData): Promise<void>;
 }
 
 interface ICocoaPodsPlatformManager {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -660,6 +660,8 @@ interface ICocoaPodsService {
 		platformData: IPlatformData,
 		opts: IRelease
 	): Promise<void>;
+
+	applyPodfileArchExclusions(platformData: IPlatformData): Promise<void>;
 }
 
 interface ICocoaPodsPlatformManager {

--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -143,14 +143,14 @@ ${versionResolutionHint}`);
 		const exclusionsPodfile = path.join(projectRoot, "Podfile-exclusions");
 
 		if (!this.$fs.exists(exclusionsPodfile)) {
-			const exclusions = `${EOL}
+			const exclusions = `
 post_install do |installer|
   installer.pods_project.build_configurations.each do |config|
     config.build_settings["EXCLUDED_ARCHS_x86_64"] = "arm64 arm64e"
     config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "i386 armv6 armv7 armv7s armv8 $(EXCLUDED_ARCHS_$(NATIVE_ARCH_64_BIT))"
     config.build_settings["EXCLUDED_ARCHS[sdk=iphoneos*]"] = "i386 armv6 armv7 armv7s armv8 x86_64"
   end
-end`;
+end`.trim();
 			this.$fs.writeFile(exclusionsPodfile, exclusions);
 		}
 

--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -48,6 +48,27 @@ export class CocoaPodsService implements ICocoaPodsService {
 		return `${EOL}end`;
 	}
 
+	public async applyPodfileArchExclusions(
+		platformData: IPlatformData
+	): Promise<void> {
+		const { projectRoot } = platformData;
+		const projectPodfilePath = this.getProjectPodfilePath(projectRoot);
+		if (this.$fs.exists(projectPodfilePath)) {
+			let projectPodfileContent = this.$fs.exists(projectPodfilePath)
+				? this.$fs.readText(projectPodfilePath).trim()
+				: "";
+			projectPodfileContent += `${EOL}post_install do |installer|
+  installer.pods_project.build_configurations.each do |config|
+    # config.build_settings.delete "VALID_ARCHS"
+    config.build_settings["EXCLUDED_ARCHS_x86_64"] = "arm64 arm64e"
+    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "i386 armv6 armv7 armv7s armv8 $(EXCLUDED_ARCHS_$(NATIVE_ARCH_64_BIT))"
+    config.build_settings["EXCLUDED_ARCHS[sdk=iphoneos*]"] = "i386 armv6 armv7 armv7s armv8 x86_64"
+  end
+end`;
+			this.$fs.writeFile(projectPodfilePath, projectPodfileContent);
+		}
+	}
+
 	public getProjectPodfilePath(projectRoot: string): string {
 		return path.join(projectRoot, PODFILE_NAME);
 	}

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -933,8 +933,11 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		this.setProductBundleIdentifier(projectData);
 
 		await this.applyPluginsCocoaPods(pluginsData, projectData, platformData);
-		await this.$cocoapodsService.applyPodfileArchExclusions(platformData);
 		await this.$cocoapodsService.applyPodfileFromAppResources(
+			projectData,
+			platformData
+		);
+		await this.$cocoapodsService.applyPodfileArchExclusions(
 			projectData,
 			platformData
 		);

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -933,6 +933,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		this.setProductBundleIdentifier(projectData);
 
 		await this.applyPluginsCocoaPods(pluginsData, projectData, platformData);
+		await this.$cocoapodsService.applyPodfileArchExclusions(platformData);
 		await this.$cocoapodsService.applyPodfileFromAppResources(
 			projectData,
 			platformData


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
