### PR TITLE
fix(ios): remove VALID_ARCHS from cocoapods for xcode 12

### DIFF
--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -146,6 +146,7 @@ ${versionResolutionHint}`);
 			const exclusions = `
 post_install do |installer|
   installer.pods_project.build_configurations.each do |config|
+    config.build_settings.delete "VALID_ARCHS"
     config.build_settings["EXCLUDED_ARCHS_x86_64"] = "arm64 arm64e"
     config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "i386 armv6 armv7 armv7s armv8 $(EXCLUDED_ARCHS_$(NATIVE_ARCH_64_BIT))"
     config.build_settings["EXCLUDED_ARCHS[sdk=iphoneos*]"] = "i386 armv6 armv7 armv7s armv8 x86_64"

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -268,6 +268,7 @@ describe("Cocoapods support", () => {
 				`# Begin Podfile - ${projectPath}/platforms/ios/Podfile-exclusions`,
 				`def post_installNativeScript_CLI_Architecture_Exclusions_0 (installer)`,
 				`  installer.pods_project.build_configurations.each do |config|`,
+				`    config.build_settings.delete "VALID_ARCHS"`,
 				`    config.build_settings["EXCLUDED_ARCHS_x86_64"] = "arm64 arm64e"`,
 				`    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "i386 armv6 armv7 armv7s armv8 $(EXCLUDED_ARCHS_$(NATIVE_ARCH_64_BIT))"`,
 				`    config.build_settings["EXCLUDED_ARCHS[sdk=iphoneos*]"] = "i386 armv6 armv7 armv7s armv8 x86_64"`,


### PR DESCRIPTION
* `VALID_ARCHS` cause problems with Xcode 12 due to the change mentioned in the [Xcode 12 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes) [search for `VALID_ARCHS` - even though listed under Deprecations this appears to not totally be the case - it has been found that they cause broad reaching problems when present in building projects with Xcode 12]
* This clears that value for any Cocoapods which may have that set and haven't yet removed it
* We may want to release as `7.1.0` of cli since this would probably affect users building with Xcode 11.x still
* Or the recommendation can be to use Xcode 12 with {N} 7 in general and release as 7.0.10 of cli