### PR TITLE
chore: update setup requirements link

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -66,15 +66,15 @@ export class StaticConfig implements IStaticConfig {
 		switch (process.platform) {
 			case "linux":
 				linkToSysRequirements =
-					"http://docs.nativescript.org/setup/ns-cli-setup/ns-setup-linux.html#system-requirements";
+					"https://docs.nativescript.org/start/general-requirements#full-setup-requirements-linux";
 				break;
 			case "win32":
 				linkToSysRequirements =
-					"http://docs.nativescript.org/setup/ns-cli-setup/ns-setup-win.html#system-requirements";
+					"https://docs.nativescript.org/start/general-requirements#full-setup-requirements-windows";
 				break;
 			case "darwin":
 				linkToSysRequirements =
-					"http://docs.nativescript.org/setup/ns-cli-setup/ns-setup-os-x.html#system-requirements";
+					"https://docs.nativescript.org/start/general-requirements#full-setup-requirements-macos";
 				break;
 			default:
 				linkToSysRequirements = "";


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
System requirements URL is not working.

## What is the new behavior?
The valid url shows up when your computer does not match the requirements.

Fixes #5432, #5352

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
