### PR TITLE
feat: handle empty platforms folder

### DIFF
--- a/lib/controllers/platform-controller.ts
+++ b/lib/controllers/platform-controller.ts
@@ -149,6 +149,9 @@ export class PlatformController implements IPlatformController {
 				path.join(projectData.platformsDir, platformName)
 			).length;
 
+			// 5 is a magic number to approximate a valid platform folder
+			// any valid platform should contain at least 5 files
+			// we choose 5 to avoid false-positives due to system files like .DS_Store etc.
 			if (platformDirectoryItemCount <= 5) {
 				this.$logger.warn(
 					`The platforms/${platformName} folder appears to be invalid. If the build fails, run 'ns clean' and rebuild the app.`,

--- a/lib/controllers/platform-controller.ts
+++ b/lib/controllers/platform-controller.ts
@@ -152,7 +152,7 @@ export class PlatformController implements IPlatformController {
 
 			if (isPlatformDirectoryEmpty) {
 				this.$logger.warn(
-					`${projectData.platformsDir}/${platformName} folder is empty. Run 'ns clean' to generate required files.`,
+					`The platforms/${platformName} folder appears to be invalid. If the build fails, run 'ns clean' and rebuild the app.`,
 					{ wrapMessageWithBorders: true }
 				);
 			}

--- a/lib/controllers/platform-controller.ts
+++ b/lib/controllers/platform-controller.ts
@@ -143,6 +143,21 @@ export class PlatformController implements IPlatformController {
 		const hasPlatformDirectory = this.$fs.exists(
 			path.join(projectData.platformsDir, platformName)
 		);
+
+		if (hasPlatformDirectory) {
+			const isPlatformDirectoryEmpty =
+				this.$fs.readDirectory(
+					path.join(projectData.platformsDir, platformName)
+				).length <= 5;
+
+			if (isPlatformDirectoryEmpty) {
+				this.$logger.warn(
+					`${projectData.platformsDir}/${platformName} folder is empty. Run 'ns clean' to generate required files.`,
+					{ wrapMessageWithBorders: true }
+				);
+			}
+		}
+
 		const shouldAddNativePlatform =
 			!nativePrepare || !nativePrepare.skipNativePrepare;
 		const prepareInfo = this.$projectChangesService.getPrepareInfo(

--- a/lib/controllers/platform-controller.ts
+++ b/lib/controllers/platform-controller.ts
@@ -145,12 +145,11 @@ export class PlatformController implements IPlatformController {
 		);
 
 		if (hasPlatformDirectory) {
-			const isPlatformDirectoryEmpty =
-				this.$fs.readDirectory(
-					path.join(projectData.platformsDir, platformName)
-				).length <= 5;
+			const platformDirectoryItemCount = this.$fs.readDirectory(
+				path.join(projectData.platformsDir, platformName)
+			).length;
 
-			if (isPlatformDirectoryEmpty) {
+			if (platformDirectoryItemCount <= 5) {
 				this.$logger.warn(
 					`The platforms/${platformName} folder appears to be invalid. If the build fails, run 'ns clean' and rebuild the app.`,
 					{ wrapMessageWithBorders: true }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The CLI breaks when the platforms folder is empty.

## What is the new behavior?
Shows a warning with instructions to clean the project in case of broken platforms folder.
<img width="907" alt="Screenshot 2021-01-07 at 19 45 15" src="https://user-images.githubusercontent.com/33330538/103931613-df2cf180-5120-11eb-9ba9-5b9a58cc456f.png">

Fixes #5145


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
