### PR TITLE
fix: default appPath in new project

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -369,7 +369,7 @@ interface IProjectConfigService {
 
 	detectProjectConfigs(projectDir?: string): IProjectConfigInformation;
 
-	getDefaultTSConfig(appId: string): string;
+	getDefaultTSConfig(appId: string, appPath: string): string;
 
 	writeDefaultConfig(projectDir?: string, appId?: string): boolean | string;
 

--- a/lib/services/project-config-service.ts
+++ b/lib/services/project-config-service.ts
@@ -64,11 +64,15 @@ export class ProjectConfigService implements IProjectConfigService {
 		return this.$injector.resolve("projectHelper");
 	}
 
-	public getDefaultTSConfig(appId: string = "org.nativescript.app") {
+	public getDefaultTSConfig(
+		appId: string = "org.nativescript.app",
+		appPath: string = "app"
+	) {
 		return `import { NativeScriptConfig } from '@nativescript/core';
 
 export default {
   id: '${appId}',
+  appPath: '${appPath}',
   appResourcesPath: 'App_Resources',
   android: {
     v8Flags: '--expose_gc',
@@ -274,7 +278,19 @@ export default {
 			return false;
 		}
 
-		this.$fs.writeFile(TSConfigPath, this.getDefaultTSConfig(appId));
+		const possibleAppPaths = [
+			path.resolve(projectDir, constants.SRC_DIR),
+			path.resolve(projectDir, constants.APP_FOLDER_NAME),
+		];
+
+		let appPath = possibleAppPaths.find((possiblePath) =>
+			this.$fs.exists(possiblePath)
+		);
+		if (appPath) {
+			appPath = path.relative(projectDir, appPath).replace(path.sep, "/");
+		}
+
+		this.$fs.writeFile(TSConfigPath, this.getDefaultTSConfig(appId, appPath));
 
 		return TSConfigPath;
 	}

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -622,11 +622,12 @@ export class ProjectConfigServiceStub implements IProjectConfigService {
 		};
 	}
 
-	getDefaultTSConfig(appId: string): string {
+	getDefaultTSConfig(appId: string, appPath: string): string {
 		return `import { NativeScriptConfig } from '@nativescript/core';
 
     export default {
       id: '${appId}',
+      appPath: '${appPath}'
       appResourcesPath: 'App_Resources',
       android: {
         v8Flags: '--expose_gc',


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
After creating a new project based on a template, we write the default config. In some cases, the `appPath` is different for a template. 

## What is the new behavior?
Default config writes `appPath` based on what folder exists in the template project.
Possible appPaths: `app`, `src`.

Fixes #5465

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
