### PR TITLE
feat: initialize git repo on project create

### DIFF
--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -26,6 +26,7 @@ import {
 	IStringDictionary,
 } from "../common/declarations";
 import * as _ from "lodash";
+import * as shelljs from "shelljs";
 import { injector } from "../common/yok";
 
 export class ProjectService implements IProjectService {
@@ -102,6 +103,10 @@ export class ProjectService implements IProjectService {
 			appId: appId,
 			projectName,
 		});
+
+		shelljs.exec(`git init ${projectDir}`);
+		shelljs.exec(`git -C ${projectDir} add --all`);
+		shelljs.exec(`git -C ${projectDir} commit -m "Initialize new project"`);
 
 		this.$logger.info();
 		this.$logger.printMarkdown(

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -108,7 +108,7 @@ export class ProjectService implements IProjectService {
 		try {
 			await this.$childProcess.exec(`git init ${projectDir}`);
 			await this.$childProcess.exec(`git -C ${projectDir} add --all`);
-			await this.$childProcess.exec(`git -C ${projectDir} commit -m "init"`);
+			await this.$childProcess.exec(`git -C ${projectDir} commit --no-verify -m "init"`);
 		} catch (err) {
 			this.$logger.trace(
 				"Unable to initialize git repository. Error is: ",

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -24,9 +24,9 @@ import {
 	IFileSystem,
 	IProjectHelper,
 	IStringDictionary,
+	IChildProcess,
 } from "../common/declarations";
 import * as _ from "lodash";
-import * as shelljs from "shelljs";
 import { injector } from "../common/yok";
 
 export class ProjectService implements IProjectService {
@@ -43,7 +43,8 @@ export class ProjectService implements IProjectService {
 		private $projectNameService: IProjectNameService,
 		private $projectTemplatesService: IProjectTemplatesService,
 		private $tempService: ITempService,
-		private $staticConfig: IStaticConfig
+		private $staticConfig: IStaticConfig,
+		private $childProcess: IChildProcess
 	) {}
 
 	public async validateProjectName(opts: {
@@ -104,9 +105,16 @@ export class ProjectService implements IProjectService {
 			projectName,
 		});
 
-		shelljs.exec(`git init ${projectDir}`);
-		shelljs.exec(`git -C ${projectDir} add --all`);
-		shelljs.exec(`git -C ${projectDir} commit -m "Initialize new project"`);
+		try {
+			await this.$childProcess.exec(`git init ${projectDir}`);
+			await this.$childProcess.exec(`git -C ${projectDir} add --all`);
+			await this.$childProcess.exec(`git -C ${projectDir} commit -m "init"`);
+		} catch (err) {
+			this.$logger.trace(
+				"Unable to initialize git repository. Error is: ",
+				err
+			);
+		}
 
 		this.$logger.info();
 		this.$logger.printMarkdown(

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -123,7 +123,7 @@ describe("projectService", () => {
 				[
 					`git init ${projectDir}`,
 					`git -C ${projectDir} add --all`,
-					`git -C ${projectDir} commit -m "init"`,
+					`git -C ${projectDir} commit --no-verify -m "init"`,
 				]
 			);
 		});

--- a/test/project-service.ts
+++ b/test/project-service.ts
@@ -87,6 +87,13 @@ describe("projectService", () => {
 				extractPackage: () => Promise.resolve(),
 			});
 			testInjector.register("tempService", TempServiceStub);
+			const executedCommands: string[] = [];
+			testInjector.register("childProcess", {
+				_getExecutedCommands: () => executedCommands,
+				exec: (executedCommand: string) => {
+					executedCommands.push(executedCommand);
+				},
+			});
 
 			return testInjector;
 		};
@@ -98,16 +105,27 @@ describe("projectService", () => {
 			const projectService = testInjector.resolve<IProjectService>(
 				ProjectServiceLib.ProjectService
 			);
+			const projectDir = path.join(dirToCreateProject, projectName);
 			const projectCreationData = await projectService.createProject({
 				projectName: projectName,
 				pathToProject: dirToCreateProject,
 				force: true,
 				template: constants.RESERVED_TEMPLATE_NAMES["default"],
 			});
+
 			assert.deepStrictEqual(projectCreationData, {
 				projectName,
-				projectDir: path.join(dirToCreateProject, projectName),
+				projectDir,
 			});
+
+			assert.deepEqual(
+				testInjector.resolve("childProcess")._getExecutedCommands(),
+				[
+					`git init ${projectDir}`,
+					`git -C ${projectDir} add --all`,
+					`git -C ${projectDir} commit -m "init"`,
+				]
+			);
 		});
 
 		it("fails when invalid name is passed when projectNameService fails", async () => {
@@ -188,6 +206,7 @@ describe("projectService", () => {
 				downloadAndExtract: () => Promise.resolve(),
 			});
 			testInjector.register("tempService", TempServiceStub);
+			testInjector.register("childProcess", {});
 
 			return testInjector;
 		};


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
When running `ns create` a fresh project, the CLI initializes a new git repository and commits the initial files.

Implements #5467

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
