### PR TITLE
perf: initialize project data if needed

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -165,6 +165,7 @@ interface IProjectData extends ICreateProjectData {
 	infoPlistPath: string;
 	buildXcconfigPath: string;
 	podfilePath: string;
+	initialized?: boolean;
 	/**
 	 * Defines if the project is a code sharing one.
 	 * Value is true when project has nativescript.config and it has `shared: true` in it.

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -98,6 +98,7 @@ export class ProjectData implements IProjectData {
 	public isShared: boolean;
 	public previewAppSchema: string;
 	public webpackConfigPath: string;
+	public initialized: boolean;
 
 	constructor(
 		private $fs: IFileSystem,
@@ -125,7 +126,10 @@ export class ProjectData implements IProjectData {
 			if (this.$fs.exists(projectFilePath)) {
 				const packageJsonContent = this.$fs.readText(projectFilePath);
 
-				this.initializeProjectDataFromContent(packageJsonContent, projectDir);
+				if (!this.initialized) {
+					this.initializeProjectDataFromContent(packageJsonContent, projectDir);
+					this.initialized = true;
+				}
 			}
 
 			return;

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -117,7 +117,7 @@ export class ProjectData implements IProjectData {
 	}
 
 	public initializeProjectData(projectDir?: string): void {
-		if (!this.initialized) {
+		if (this.initialized) {
 			return;
 		}
 		projectDir = projectDir || this.$projectHelper.projectDir;

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -117,6 +117,9 @@ export class ProjectData implements IProjectData {
 	}
 
 	public initializeProjectData(projectDir?: string): void {
+		if (!this.initialized) {
+			return;
+		}
 		projectDir = projectDir || this.$projectHelper.projectDir;
 
 		// If no project found, projectDir should be null
@@ -126,10 +129,8 @@ export class ProjectData implements IProjectData {
 			if (this.$fs.exists(projectFilePath)) {
 				const packageJsonContent = this.$fs.readText(projectFilePath);
 
-				if (!this.initialized) {
-					this.initializeProjectDataFromContent(packageJsonContent, projectDir);
-					this.initialized = true;
-				}
+				this.initializeProjectDataFromContent(packageJsonContent, projectDir);
+				this.initialized = true;
 			}
 
 			return;

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -119,8 +119,10 @@ export class ProjectDataService implements IProjectDataService {
 		this.projectDataCache[projectDir] =
 			this.projectDataCache[projectDir] ||
 			this.$injector.resolve<IProjectData>(ProjectData);
-		this.projectDataCache[projectDir].initializeProjectData(projectDir);
-
+		if (!this.projectDataCache[projectDir].initialized) {
+			this.projectDataCache[projectDir].initializeProjectData(projectDir);
+			this.projectDataCache[projectDir].initialized = true;
+		}
 		return this.projectDataCache[projectDir];
 	}
 

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -119,10 +119,7 @@ export class ProjectDataService implements IProjectDataService {
 		this.projectDataCache[projectDir] =
 			this.projectDataCache[projectDir] ||
 			this.$injector.resolve<IProjectData>(ProjectData);
-		if (!this.projectDataCache[projectDir].initialized) {
-			this.projectDataCache[projectDir].initializeProjectData(projectDir);
-			this.projectDataCache[projectDir].initialized = true;
-		}
+		this.projectDataCache[projectDir].initializeProjectData(projectDir);
 		return this.projectDataCache[projectDir];
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`projectData` gets re-initialized over and over again and the cache has no effect.

## What is the new behavior?
Initialize `projectData` only if it hasn't been initialized yet.

Fixes #5398

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
