### PR TITLE
perf: validate update version before backup

### DIFF
--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -90,12 +90,13 @@ export class UpdateController
 		);
 
 		try {
-			for (const updatableDependency of UpdateController.updatableDependencies) {
-				await this.getVersionFromTag(
-					updatableDependency.name,
-					updateOptions.version
-				);
-			}
+			// this is a preventive check to make sure the passed version exists before doing any backups, however
+			// the update can still fail if the specified tag doesn't exist in one of the updatableDependencies
+			// at this stage we only care to check a single dependency to catch invalid versions early.
+			await this.getVersionFromTag(
+				UpdateController.updatableDependencies[0].name,
+				updateOptions.version
+			);
 		} catch (error) {
 			this.$errors.fail(
 				`${UpdateController.updateFailMessage} Reason is: ${error.message}`

--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -88,6 +88,20 @@ export class UpdateController
 		const projectData = this.$projectDataService.getProjectData(
 			updateOptions.projectDir
 		);
+
+		try {
+			for (const updatableDependency of UpdateController.updatableDependencies) {
+				await this.getVersionFromTag(
+					updatableDependency.name,
+					updateOptions.version
+				);
+			}
+		} catch (error) {
+			this.$errors.fail(
+				`${UpdateController.updateFailMessage} Reason is: ${error.message}`
+			);
+		}
+
 		const backupDir = path.join(
 			updateOptions.projectDir,
 			UpdateController.backupFolder


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The CLI catches error for invalid version in the argument after cleaning/backing up while update.

## What is the new behavior?
The CLI throws error immediately at update if the version in the argument is incorrect.

Fixes #3669

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
