### PR TITLE
fix: handle permissions error on directory creation

### DIFF
--- a/lib/common/file-system.ts
+++ b/lib/common/file-system.ts
@@ -200,7 +200,16 @@ export class FileSystem implements IFileSystem {
 	}
 
 	public createDirectory(path: string): void {
-		mkdirp.sync(path);
+		try {
+			mkdirp.sync(path);
+		} catch (error) {
+			const $errors = this.$injector.resolve("errors");
+			let errorMessage = `Unable to create directory ${path}. \nError is: ${error}.`;
+			if (error.code === "EACCES") {
+				errorMessage += "\n\nYou may need to call the command with 'sudo'.";
+			}
+			$errors.fail(errorMessage);
+		}
 	}
 
 	public readDirectory(path: string): string[] {
@@ -372,15 +381,8 @@ export class FileSystem implements IFileSystem {
 	}
 
 	public ensureDirectoryExists(directoryPath: string): void {
-		try {
-			if (!this.exists(directoryPath)) {
-				this.createDirectory(directoryPath);
-			}
-		} catch (error) {
-			const $errors = this.$injector.resolve("errors");
-			$errors.fail(
-				`Unable to generate CLI documentation.\n\nUnable to write to a system directory (${directoryPath}).\n\nYou may need to call the command with 'sudo'.`
-			);
+		if (!this.exists(directoryPath)) {
+			this.createDirectory(directoryPath);
 		}
 	}
 

--- a/lib/common/file-system.ts
+++ b/lib/common/file-system.ts
@@ -372,8 +372,15 @@ export class FileSystem implements IFileSystem {
 	}
 
 	public ensureDirectoryExists(directoryPath: string): void {
-		if (!this.exists(directoryPath)) {
-			this.createDirectory(directoryPath);
+		try {
+			if (!this.exists(directoryPath)) {
+				this.createDirectory(directoryPath);
+			}
+		} catch (error) {
+			const $errors = this.$injector.resolve("errors");
+			$errors.fail(
+				`Unable to generate CLI documentation.\n\nUnable to write to a system directory (${directoryPath}).\n\nYou may need to call the command with 'sudo'.`
+			);
 		}
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
If node is not properly installed documentation generating might fail, caused by node and the packages are in a system protected folder. The CLI does not have permission to create directory in system folders.

## What is the new behavior?
In case of node and packages are in a system protected folder, the documentation generation logs an error with help, how to run the command.

Fixes #5445

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
