### PR TITLE
feat: default template version based on cli major

### DIFF
--- a/test/project-templates-service.ts
+++ b/test/project-templates-service.ts
@@ -16,7 +16,6 @@ import { IAnalyticsService, IFileSystem } from "../lib/common/declarations";
 import { IEventActionData } from "../lib/common/definitions/google-analytics";
 
 const nativeScriptValidatedTemplatePath = "nsValidatedTemplatePath";
-const compatibleTemplateVersion = "1.2.3";
 
 function createTestInjector(
 	configuration: {
@@ -33,6 +32,7 @@ function createTestInjector(
 		exists: (pathToCheck: string) => false,
 		readJson: (pathToFile: string) => configuration.packageJsonContent || {},
 	});
+	injector.register("staticConfig", { version: "8.0.0" });
 
 	class NpmStub extends stubs.NodePackageManagerStub {
 		public async install(
@@ -69,9 +69,6 @@ function createTestInjector(
 			}
 
 			return Promise.resolve(nativeScriptValidatedTemplatePath);
-		}
-		async getLatestCompatibleVersionSafe(packageName: string): Promise<string> {
-			return compatibleTemplateVersion;
 		}
 	}
 
@@ -275,7 +272,7 @@ describe("project-templates-service", () => {
 				{
 					name: "is correct when scoped package name without version is passed",
 					templateName: "@nativescript/vue-template",
-					expectedVersion: compatibleTemplateVersion,
+					expectedVersion: "^8.0.0",
 					expectedTemplateName: "@nativescript/vue-template",
 				},
 				{


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
`ns create` will use the same template major version as the CLI. 

Fixes #5515.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
