### PR TITLE
feat: allow passing command line arguments running an app in the iOS Simulator

### DIFF
--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -45,6 +45,10 @@ Start an emulator with specified device identifier and sdk | `$ tns run ios [--d
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
 
+### Environment Variables
+
+* `IOS_SIMULATOR_RUN_ARGS` - specifies extra command line arguments to pass to the application when running on the iOS Simulator. E.g. `$ IOS_SIMULATOR_RUN_ARGS=-FIRDebugEnabled tns device run ios`.
+
 <% } %>
 <% if(isHtml) { %>
 

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -47,7 +47,7 @@ Start an emulator with specified device identifier and sdk | `$ tns run ios [--d
 
 ### Environment Variables
 
-* `IOS_SIMULATOR_RUN_ARGS` - specifies extra command line arguments to pass to the application when running on the iOS Simulator. E.g. `$ IOS_SIMULATOR_RUN_ARGS=-FIRDebugEnabled tns device run ios`.
+* `IOS_SIMULATOR_RUN_ARGS` - specifies extra command line arguments to pass to the application when running on the iOS Simulator. E.g. `$ IOS_SIMULATOR_RUN_ARGS=-FIRDebugEnabled ns device run ios`.
 
 <% } %>
 <% if(isHtml) { %>

--- a/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-application-manager.ts
@@ -71,11 +71,14 @@ export class IOSSimulatorApplicationManager extends ApplicationManagerBase {
 	public async startApplication(
 		appData: Mobile.IStartApplicationData
 	): Promise<void> {
+		const args = process.env.IOS_SIMULATOR_RUN_ARGS || "";
 		const options = appData.waitForDebugger
 			? {
 					waitForDebugger: true,
-					args: "--nativescript-debug-brk",
+					args: `--nativescript-debug-brk ${args}`.trim(),
 			  }
+			: args
+			? { args }
 			: {};
 		await this.setDeviceLogData(appData);
 		const launchResult = await this.iosSim.startApplication(


### PR DESCRIPTION
The `IOS_SIMULATOR_RUN_ARGS` environment variable allows specific command line arguments to be passed to the simulator when running an app.

This is _extremely_ useful when working (for example) with Firebase and having to debug events or other internals:

https://firebase.google.com/docs/analytics/debugview

The command line arguments `-FIRDebugEnabled` and `-FIRDebugDisabled` control the behaviour of Firebase in combination with its realtime event debugging console.

With this patch, enabling debugging is as easy as calling:

```bash
IOS_SIMULATOR_RUN_ARGS=-FIRDebugEnabled ns run ios
```
