### PR TITLE
feat: allow to ignore native dependencies

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -375,7 +375,7 @@ export class PrepareController extends EventEmitter {
 		projectData: IProjectData
 	): Promise<string[]> {
 		const dependencies = this.$nodeModulesDependenciesBuilder
-			.getProductionDependencies(projectData.projectDir)
+			.getProductionDependencies(projectData.projectDir, projectData.dependenciesToIgnore)
 			.filter((dep) => dep.nativescript);
 		const pluginsNativeDirectories = dependencies.map((dep) =>
 			path.join(

--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -375,7 +375,7 @@ export class PrepareController extends EventEmitter {
 		projectData: IProjectData
 	): Promise<string[]> {
 		const dependencies = this.$nodeModulesDependenciesBuilder
-			.getProductionDependencies(projectData.projectDir, projectData.dependenciesToIgnore)
+			.getProductionDependencies(projectData.projectDir, projectData.ignoredDependencies)
 			.filter((dep) => dep.nativescript);
 		const pluginsNativeDirectories = dependencies.map((dep) =>
 			path.join(

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -78,7 +78,7 @@ interface IPrepareNodeModulesData {
 }
 
 interface INodeModulesDependenciesBuilder {
-	getProductionDependencies(projectPath: string): IDependencyData[];
+	getProductionDependencies(projectPath: string, ignore?: string[]): IDependencyData[];
 }
 
 interface IBuildInfo {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -153,7 +153,7 @@ interface IProjectData extends ICreateProjectData {
 	projectId: string;
 	projectIdentifiers?: Mobile.IProjectIdentifier;
 	dependencies: any;
-	dependenciesToIgnore?: string[];
+	ignoredDependencies?: string[];
 	devDependencies: IStringDictionary;
 	appDirectoryPath: string;
 	appResourcesDirectoryPath: string;

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -153,6 +153,7 @@ interface IProjectData extends ICreateProjectData {
 	projectId: string;
 	projectIdentifiers?: Mobile.IProjectIdentifier;
 	dependencies: any;
+	dependenciesToIgnore?: string[];
 	devDependencies: IStringDictionary;
 	appDirectoryPath: string;
 	appResourcesDirectoryPath: string;

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -352,7 +352,7 @@ export class PluginsService implements IPluginsService {
 		dependencies =
 			dependencies ||
 			this.$nodeModulesDependenciesBuilder.getProductionDependencies(
-				projectData.projectDir, projectData.dependenciesToIgnore
+				projectData.projectDir, projectData.ignoredDependencies
 			);
 
 		if (_.isEmpty(dependencies)) {

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -352,7 +352,7 @@ export class PluginsService implements IPluginsService {
 		dependencies =
 			dependencies ||
 			this.$nodeModulesDependenciesBuilder.getProductionDependencies(
-				projectData.projectDir
+				projectData.projectDir, projectData.dependenciesToIgnore
 			);
 
 		if (_.isEmpty(dependencies)) {

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -93,7 +93,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			);
 
 			this.$nodeModulesDependenciesBuilder
-				.getProductionDependencies(projectData.projectDir, projectData.dependenciesToIgnore)
+				.getProductionDependencies(projectData.projectDir, projectData.ignoredDependencies)
 				.filter(
 					(dep) =>
 						dep.nativescript &&

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -93,7 +93,7 @@ export class ProjectChangesService implements IProjectChangesService {
 			);
 
 			this.$nodeModulesDependenciesBuilder
-				.getProductionDependencies(projectData.projectDir)
+				.getProductionDependencies(projectData.projectDir, projectData.dependenciesToIgnore)
 				.filter(
 					(dep) =>
 						dep.nativescript &&

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -19,7 +19,7 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		projectData,
 	}: IPrepareNodeModulesData): Promise<void> {
 		const dependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(
-			projectData.projectDir, projectData.dependenciesToIgnore
+			projectData.projectDir, projectData.ignoredDependencies
 		);
 		await platformData.platformProjectService.beforePrepareAllPlugins(
 			projectData,

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -19,7 +19,7 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 		projectData,
 	}: IPrepareNodeModulesData): Promise<void> {
 		const dependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(
-			projectData.projectDir
+			projectData.projectDir, projectData.dependenciesToIgnore
 		);
 		await platformData.platformProjectService.beforePrepareAllPlugins(
 			projectData,

--- a/lib/tools/node-modules/node-modules-dependencies-builder.ts
+++ b/lib/tools/node-modules/node-modules-dependencies-builder.ts
@@ -20,7 +20,7 @@ export class NodeModulesDependenciesBuilder
 	implements INodeModulesDependenciesBuilder {
 	public constructor(private $fs: IFileSystem) {}
 
-	public getProductionDependencies(projectPath: string): IDependencyData[] {
+	public getProductionDependencies(projectPath: string, ignore?:string[]): IDependencyData[] {
 		const rootNodeModulesPath = path.join(
 			projectPath,
 			NODE_MODULES_FOLDER_NAME
@@ -83,7 +83,9 @@ export class NodeModulesDependenciesBuilder
 				resolvedDependencies.push(resolvedDependency);
 			}
 		}
-
+		if (ignore && ignore.length > 0) {
+			return resolvedDependencies.filter(d => ignore.indexOf(d.name) === -1);
+		}
 		return resolvedDependencies;
 	}
 

--- a/test/tools/node-modules/node-modules-dependencies-builder.ts
+++ b/test/tools/node-modules/node-modules-dependencies-builder.ts
@@ -790,6 +790,46 @@ describe("nodeModulesDependenciesBuilder", () => {
 
 				assert.deepStrictEqual(actualResult, expectedResult);
 			});
+
+			it("ignoring dependencies", async () => {
+				// The test validates the following dependency tree, when npm 3+ is used.
+				// <project dir>
+				// ├── firstPackage@1.0.0
+				// ├── secondPackage@1.1.0
+				// └── thirdPackage@1.2.0
+
+				const rootDeps: IDependencyInfo[] = [
+					generateDependency(firstPackage, "1.0.0", 0, null),
+					generateDependency(secondPackage, "1.1.0", 0, null),
+					generateDependency(thirdPackage, "1.2.0", 0, null),
+				];
+
+				const nodeModulesDependenciesBuilder = generateTest(rootDeps);
+				const actualResult = await nodeModulesDependenciesBuilder.getProductionDependencies(
+					pathToProject, [firstPackage]
+				);
+
+				const expectedResult: IDependencyData[] = [
+					getNodeModuleInfoForExpecteDependency(
+						secondPackage,
+						0,
+						null,
+						null,
+						null,
+						"1.1.0"
+					),
+					getNodeModuleInfoForExpecteDependency(
+						thirdPackage,
+						0,
+						null,
+						null,
+						null,
+						"1.2.0"
+					),
+				];
+
+				assert.deepStrictEqual(actualResult, expectedResult);
+			});
 		});
 	});
 });


### PR DESCRIPTION
Along with that we simply need to have a cli parameter and an option in nativescript.config
 @rigor789 could you help with the cli params? not sure where to do that.
 
 Also i think we could even add ignored dependencies through the webpack config right? I dont remember how but we can modify the project data from there?
 
 With this people can simply make it so that some deps are only used in dev (like vue-dev-tools and socketio) while not being present in production.
 
 You can also make different releases for Google Play and Fdroid (what i am going for) where one would use non open source libs and the other would not (flavors on android)