### PR TITLE
fix: race condition when getting iOS inspector port

### DIFF
--- a/lib/common/mobile/ios/simulator/ios-simulator-device.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-device.ts
@@ -99,6 +99,8 @@ export class IOSSimulator extends IOSDeviceBase implements Mobile.IiOSDevice {
 				.catch((e) => this.$logger.error(e));
 		}, 5e3);
 
+		// the internal retry-mechanism of getDebuggerPort will ensure the above 
+		// interval has a chance to execute multiple times
 		const port = await super.getDebuggerPort(appId).finally(() => {
 			clearInterval(postNotificationRetryInterval);
 		});

--- a/lib/common/mobile/ios/simulator/ios-simulator-device.ts
+++ b/lib/common/mobile/ios/simulator/ios-simulator-device.ts
@@ -87,7 +87,21 @@ export class IOSSimulator extends IOSDeviceBase implements Mobile.IiOSDevice {
 			attachRequestMessage,
 			this.deviceInfo.identifier
 		);
-		const port = await super.getDebuggerPort(appId);
+
+		// Retry posting the notification every five seconds, in case the AttachRequest
+		// event handler wasn't registered when the first one was sent
+		const postNotificationRetryInterval = setInterval(() => {
+			this.$iOSEmulatorServices
+				.postDarwinNotification(
+					attachRequestMessage,
+					this.deviceInfo.identifier
+				)
+				.catch((e) => this.$logger.error(e));
+		}, 5e3);
+
+		const port = await super.getDebuggerPort(appId).finally(() => {
+			clearInterval(postNotificationRetryInterval);
+		});
 		try {
 			socket = await helpers.connectEventuallyUntilTimeout(async () => {
 				return this.$iOSEmulatorServices.connectToPort({ port });


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it. #3701
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?

When running an iOS simulator app, the NativeScript CLI sends an `AttachRequest` notification to the application right after launch. If the runtime hasn't had time to set up the event handler for this notification yet, it's silently lost, and the CLI never gets the port number for debugging. This causes HMR to not work, and worse, the application auto-restarts after a minute. (The console shows the error "NativeScript debugger was not able to get inspector socket port")

This seems to be a race condition based on how quickly the iOS runtime sets up its event handler vs. how quickly the CLI sends the `AttachRequest` notification after launching the app. For some reason, I went from not experiencing this issue at all to experiencing it nearly 100% of the time when using the simulator on my Mac. (I haven't tested with an actual device. Also, I'm using the V8 iOS runtime.)

## What is the new behavior?

I set up a timer to re-send the `AttachRequest` notification once every 5 seconds until `getDebuggerPort()` either returns or throws an error. In my testing, I was able to resolve it by adding a simple one-second delay before sending `AttachRequest`, but this seems more robust.

Fixes/Implements/Closes #3701. (Seems to be the same issue.)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


Shouldn't be any.

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
