### PR TITLE
feat: allow tests to run on monorepos

### DIFF
--- a/lib/services/karma-execution.ts
+++ b/lib/services/karma-execution.ts
@@ -2,9 +2,10 @@ import * as path from "path";
 
 process.on("message", (data: any) => {
 	if (data.karmaConfig) {
-		const pathToKarma = path.join(
-			data.karmaConfig.projectDir,
-			"node_modules/karma"
+		const pathToKarma = path.dirname(
+			require.resolve("karma/package.json", {
+				paths: [data.karmaConfig.projectDir],
+			})
 		);
 		const KarmaServer = require(path.join(pathToKarma, "lib/server"));
 		const karma = new KarmaServer(data.karmaConfig, (exitCode: number) => {

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -139,13 +139,20 @@ export class TestExecutionService implements ITestExecutionService {
 		projectData: IProjectData
 	): Promise<boolean> {
 		let canStartKarmaServer = true;
-		const requiredDependencies = ["karma", "@nativescript/unit-test-runner"];
+		const requiredDependencies = ["@nativescript/unit-test-runner"]; // we need @nativescript/unit-test-runner at the local level because of hooks!
 		_.each(requiredDependencies, (dep) => {
 			if (!projectData.dependencies[dep] && !projectData.devDependencies[dep]) {
 				canStartKarmaServer = false;
 				return;
 			}
 		});
+		try {
+			require.resolve("karma/package.json", {
+				paths: [projectData.projectDir],
+			});
+		} catch (ignore) {
+			canStartKarmaServer = false;
+		}
 
 		return canStartKarmaServer;
 	}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
If you have a monorepo you can't run tests because it requires karma to be at the app level, which also requires you to install a lot of extra stuff at the local level (including webpack).

## What is the new behavior?
Use a parent karma if possible.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
