### PR TITLE
feat: `config` option

### DIFF
--- a/docs/man_pages/start.md
+++ b/docs/man_pages/start.md
@@ -75,5 +75,6 @@ Option | Description
 -------|---------
 --help, -h, /? | Prints help about the selected command in the console.
 --path `<Directory>` | Specifies the directory that contains the project. If not set, the project is searched for in the current directory and all directories above it.
+--config | Specifies the name of the Nativescript configuration file to load (relative to the project directory). The default is.
 --version | Prints the client version.
 --log trace | Prints a detailed diagnostic log for the execution of the current command.

--- a/docs/man_pages/start.md
+++ b/docs/man_pages/start.md
@@ -75,6 +75,6 @@ Option | Description
 -------|---------
 --help, -h, /? | Prints help about the selected command in the console.
 --path `<Directory>` | Specifies the directory that contains the project. If not set, the project is searched for in the current directory and all directories above it.
---config | Specifies the name of the Nativescript configuration file to load (relative to the project directory). The default is.
+--config | Specifies the name of the Nativescript configuration file to load (relative to the project directory). The default is `nativescript.config.ts` or `nativescript.config.js` (as a fallback).
 --version | Prints the client version.
 --log trace | Prints a detailed diagnostic log for the execution of the current command.

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -616,10 +616,10 @@ interface IOptions
 	/**
 	 * Project Configuration
 	 */
-	config: string[];
 	log: string;
 	verbose: boolean;
 	path: string;
+	config: string;
 	version: boolean;
 	help: boolean;
 	json: boolean;

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -145,6 +145,7 @@ interface INsConfig {
 	webpackConfigPath?: string;
 	ios?: INsConfigIOS;
 	android?: INsConfigAndroid;
+	ignoredNativeDependencies?: string[];
 }
 
 interface IProjectData extends ICreateProjectData {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -30,6 +30,7 @@ export class Options {
 		profileDir: { type: OptionType.String, hasSensitiveValue: true },
 		analyticsClient: { type: OptionType.String, hasSensitiveValue: false },
 		path: { type: OptionType.String, alias: "p", hasSensitiveValue: true },
+		config: { type: OptionType.String, alias: "c", hasSensitiveValue: true },
 		// This will parse all non-hyphenated values as strings.
 		_: { type: OptionType.String, hasSensitiveValue: false },
 	};

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -88,6 +88,7 @@ export class ProjectData implements IProjectData {
 	public appResourcesDirectoryPath: string;
 	public dependencies: any;
 	public devDependencies: IStringDictionary;
+	public ignoredDependencies: string[];
 	public projectType: string;
 	public androidManifestPath: string;
 	public infoPlistPath: string;
@@ -172,6 +173,7 @@ export class ProjectData implements IProjectData {
 			this.devDependencies = packageJsonData.devDependencies;
 			this.projectType = this.getProjectType();
 			this.nsConfig = nsConfig;
+			this.ignoredDependencies = nsConfig.ignoredNativeDependencies;
 			this.appDirectoryPath = this.getAppDirectoryPath();
 			this.appResourcesDirectoryPath = this.getAppResourcesDirectoryPath();
 			this.androidManifestPath = this.getPathToAndroidManifest(

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -173,7 +173,7 @@ export class ProjectData implements IProjectData {
 			this.devDependencies = packageJsonData.devDependencies;
 			this.projectType = this.getProjectType();
 			this.nsConfig = nsConfig;
-			this.ignoredDependencies = nsConfig.ignoredNativeDependencies;
+			this.ignoredDependencies = nsConfig?.ignoredNativeDependencies;
 			this.appDirectoryPath = this.getAppDirectoryPath();
 			this.appResourcesDirectoryPath = this.getAppResourcesDirectoryPath();
 			this.androidManifestPath = this.getPathToAndroidManifest(

--- a/lib/services/project-config-service.ts
+++ b/lib/services/project-config-service.ts
@@ -31,7 +31,6 @@ import { cache, exported } from "../common/decorators";
 import { IOptions } from "../declarations";
 import semver = require("semver/preload");
 import { ICleanupService } from "../definitions/cleanup-service";
-import * as FsLib from "../../lib/common/file-system";
 
 export class ProjectConfigService implements IProjectConfigService {
 	private forceUsingNewConfig: boolean = false;
@@ -98,26 +97,26 @@ export default {
 		let JSConfigPath;
 		let TSConfigPath;
 		const configFilename = this.$options.config;
+		// allow overriding config name with --config (or -c)
 		if (configFilename) {
-			const fullPath = this.$fs.isRelativePath(configFilename) ? path.join(
-				projectDir || this.projectHelper.projectDir,
-				configFilename
-			) :  configFilename;
-			if (configFilename.endsWith('.ts')) {
+			const fullPath = this.$fs.isRelativePath(configFilename)
+				? path.join(projectDir || this.projectHelper.projectDir, configFilename)
+				: configFilename;
+			if (configFilename.endsWith(".ts")) {
 				TSConfigPath = fullPath;
-			} else if (configFilename.endsWith('.js')) {
+			} else if (configFilename.endsWith(".js")) {
 				JSConfigPath = fullPath;
 			} else {
 				// the user might have passed the name without extension
-				TSConfigPath = fullPath + '.ts';
-				JSConfigPath =fullPath + '.js';
+				TSConfigPath = fullPath + ".ts";
+				JSConfigPath = fullPath + ".js";
 			}
 		} else {
-			 JSConfigPath = path.join(
+			JSConfigPath = path.join(
 				projectDir || this.projectHelper.projectDir,
 				CONFIG_FILE_NAME_JS
 			);
-			 TSConfigPath = path.join(
+			TSConfigPath = path.join(
 				projectDir || this.projectHelper.projectDir,
 				CONFIG_FILE_NAME_TS
 			);
@@ -126,7 +125,6 @@ export default {
 			projectDir || this.projectHelper.projectDir,
 			CONFIG_NS_FILE_NAME
 		);
-		
 
 		const hasTSConfig = this.$fs.exists(TSConfigPath);
 		const hasJSConfig = this.$fs.exists(JSConfigPath);

--- a/lib/services/project-config-service.ts
+++ b/lib/services/project-config-service.ts
@@ -113,8 +113,9 @@ export default {
 			),
 		];
 
-		// allow overriding config name with --config (or -c)
-		const configFilename = this.$options.config;
+		// allow overriding config name with env variable or --config (or -c)
+		const configFilename =
+			process.env.NATIVESCRIPT_CONFIG_NAME ?? this.$options.config;
 		if (configFilename) {
 			const fullPath = this.$fs.isRelativePath(configFilename)
 				? path.join(projectDir || this.projectHelper.projectDir, configFilename)

--- a/lib/services/project-config-service.ts
+++ b/lib/services/project-config-service.ts
@@ -31,6 +31,7 @@ import { cache, exported } from "../common/decorators";
 import { IOptions } from "../declarations";
 import semver = require("semver/preload");
 import { ICleanupService } from "../definitions/cleanup-service";
+import * as FsLib from "../../lib/common/file-system";
 
 export class ProjectConfigService implements IProjectConfigService {
 	private forceUsingNewConfig: boolean = false;
@@ -94,18 +95,38 @@ export default {
 	}
 
 	public detectProjectConfigs(projectDir?: string): IProjectConfigInformation {
-		const JSConfigPath = path.join(
-			projectDir || this.projectHelper.projectDir,
-			CONFIG_FILE_NAME_JS
-		);
-		const TSConfigPath = path.join(
-			projectDir || this.projectHelper.projectDir,
-			CONFIG_FILE_NAME_TS
-		);
+		let JSConfigPath;
+		let TSConfigPath;
+		const configFilename = this.$options.config;
+		if (configFilename) {
+			const fullPath = this.$fs.isRelativePath(configFilename) ? path.join(
+				projectDir || this.projectHelper.projectDir,
+				configFilename
+			) :  configFilename;
+			if (configFilename.endsWith('.ts')) {
+				TSConfigPath = fullPath;
+			} else if (configFilename.endsWith('.js')) {
+				JSConfigPath = fullPath;
+			} else {
+				// the user might have passed the name without extension
+				TSConfigPath = fullPath + '.ts';
+				JSConfigPath =fullPath + '.js';
+			}
+		} else {
+			 JSConfigPath = path.join(
+				projectDir || this.projectHelper.projectDir,
+				CONFIG_FILE_NAME_JS
+			);
+			 TSConfigPath = path.join(
+				projectDir || this.projectHelper.projectDir,
+				CONFIG_FILE_NAME_TS
+			);
+		}
 		const NSConfigPath = path.join(
 			projectDir || this.projectHelper.projectDir,
 			CONFIG_NS_FILE_NAME
 		);
+		
 
 		const hasTSConfig = this.$fs.exists(TSConfigPath);
 		const hasJSConfig = this.$fs.exists(JSConfigPath);

--- a/lib/services/project-config-service.ts
+++ b/lib/services/project-config-service.ts
@@ -197,16 +197,6 @@ export default {
 		const hasNSConfig = !!paths.NSConfigPath;
 		const usingNSConfig = !(hasTSConfig || hasJSConfig);
 
-		console.log({
-			hasTSConfig,
-			hasJSConfig,
-			hasNSConfig,
-			usingNSConfig,
-			TSConfigPath: paths.TSConfigPath,
-			JSConfigPath: paths.JSConfigPath,
-			NSConfigPath: paths.NSConfigPath,
-		});
-
 		if (hasTSConfig && hasJSConfig) {
 			this.$logger.warn(
 				`You have both a ${CONFIG_FILE_NAME_JS} and ${CONFIG_FILE_NAME_TS} file. Defaulting to ${CONFIG_FILE_NAME_TS}.`

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -13,6 +13,7 @@ import {
 import {
 	IPackageManager,
 	IPackageInstallationManager,
+	IOptions,
 } from "../../declarations";
 import { IPlatformData } from "../../definitions/platform";
 import { IProjectData } from "../../definitions/project";
@@ -48,6 +49,7 @@ export class WebpackCompilerService
 	private expectedHashes: IStringDictionary = {};
 
 	constructor(
+		private $options: IOptions,
 		private $errors: IErrors,
 		private $childProcess: IChildProcess,
 		public $fs: IFileSystem,
@@ -368,6 +370,13 @@ export class WebpackCompilerService
 
 		envData.verbose = envData.verbose || this.$logger.isVerbose();
 		envData.production = envData.production || prepareData.release;
+
+		// add the config file name to the env data so the webpack process can read the
+		// correct config file when resolving the CLI lib and the config service
+		// we are explicityly setting it to false to force using the defaults
+		envData.config =
+			process.env.NATIVESCRIPT_CONFIG_NAME ?? this.$options.config ?? "false";
+
 		// The snapshot generation is wrongly located in the Webpack plugin.
 		// It should be moved in the Native Prepare of the CLI or a Gradle task in the Runtime.
 		// As a workaround, we skip the mksnapshot, xxd and android-ndk calls based on skipNativePrepare.

--- a/test/options.ts
+++ b/test/options.ts
@@ -107,6 +107,24 @@ describe("options", () => {
 			assert.isTrue(isExecutionStopped);
 		});
 
+		it("does not break execution when valid option has correct value", () => {
+			process.argv.push("--config");
+			process.argv.push("SomeFilename");
+			const options = createOptions(testInjector);
+			options.validateOptions();
+			process.argv.pop();
+			process.argv.pop();
+			assert.isFalse(isExecutionStopped);
+		});
+
+		it("breaks execution when valid option has empty string value", () => {
+			process.argv.push("--config");
+			const options = createOptions(testInjector);
+			options.validateOptions();
+			process.argv.pop();
+			assert.isTrue(isExecutionStopped);
+		});
+
 		it("breaks execution when valid option has value with spaces only", () => {
 			process.argv.push("--path");
 			process.argv.push("  ");

--- a/test/services/project-config-service.ts
+++ b/test/services/project-config-service.ts
@@ -45,6 +45,8 @@ const createTestInjector = (
 
 		readJson: (filePath: string): any => null,
 
+		isRelativePath: (filePath: string): any => true,
+
 		enumerateFilesInDirectorySync: (
 			directoryPath: string,
 			filterCallback?: (_file: string, _stat: IFsStats) => boolean,
@@ -139,6 +141,82 @@ describe("projectConfigService", () => {
 
 			const actualValue = projectConfigService.getValue("android.v8Flags");
 			assert.deepStrictEqual(actualValue, "--expose-gc");
+		});
+
+		it("can read a named JS config file when passing --config", async () => {
+			const testInjector = createTestInjector(
+				(filename) => sampleJSConfig,
+				(filePath) => basename(filePath) === "custom.config.js"
+			);
+
+			// mock "--config custom.config.js"
+			const options: Options = testInjector.resolve("options") as Options;
+			// @ts-ignore
+			options.config = "custom.config.js";
+
+			const projectConfigService: IProjectConfigService = testInjector.resolve(
+				"projectConfigService"
+			);
+
+			const actualValue = projectConfigService.getValue("id");
+			assert.deepStrictEqual(actualValue, "io.test.app");
+		});
+
+		it("can read a named TS config file when passing --config", async () => {
+			const testInjector = createTestInjector(
+				(filename) => sampleTSConfig,
+				(filePath) => basename(filePath) === "custom.config.ts"
+			);
+
+			// mock "--config custom.config.ts"
+			const options: Options = testInjector.resolve("options") as Options;
+			// @ts-ignore
+			options.config = "custom.config.ts";
+
+			const projectConfigService: IProjectConfigService = testInjector.resolve(
+				"projectConfigService"
+			);
+
+			const actualValue = projectConfigService.getValue("id");
+			assert.deepStrictEqual(actualValue, "io.test.app");
+		});
+
+		it("can read a named JS config file when passing --config without extension", async () => {
+			const testInjector = createTestInjector(
+				(filename) => sampleJSConfig,
+				(filePath) => basename(filePath) === "custom.config.js"
+			);
+
+			// mock "--config custom.config"
+			const options: Options = testInjector.resolve("options") as Options;
+			// @ts-ignore
+			options.config = "custom.config";
+
+			const projectConfigService: IProjectConfigService = testInjector.resolve(
+				"projectConfigService"
+			);
+
+			const actualValue = projectConfigService.getValue("id");
+			assert.deepStrictEqual(actualValue, "io.test.app");
+		});
+
+		it("can read a named TS config file when passing --config without extension", async () => {
+			const testInjector = createTestInjector(
+				(filename) => sampleTSConfig,
+				(filePath) => basename(filePath) === "custom.config.ts"
+			);
+
+			// mock "--config custom.config"
+			const options: Options = testInjector.resolve("options") as Options;
+			// @ts-ignore
+			options.config = "custom.config";
+
+			const projectConfigService: IProjectConfigService = testInjector.resolve(
+				"projectConfigService"
+			);
+
+			const actualValue = projectConfigService.getValue("id");
+			assert.deepStrictEqual(actualValue, "io.test.app");
 		});
 
 		// it("Throws error if no config file found", () => {

--- a/test/services/webpack/webpack-compiler-service.ts
+++ b/test/services/webpack/webpack-compiler-service.ts
@@ -27,6 +27,7 @@ function createTestInjector(): IInjector {
 	testInjector.register("childProcess", {});
 	testInjector.register("hooksService", {});
 	testInjector.register("hostInfo", {});
+	testInjector.register("options", {});
 	testInjector.register("logger", {});
 	testInjector.register("errors", ErrorsStub);
 	testInjector.register("packageInstallationManager", {});


### PR DESCRIPTION
to set custom `nativescript.config` file name (relative, absolute, with or without .ts or .js)

read `ignoredNativeDependencies` from `nativescript.config``nativescript.config`

I added a test. What is weird to me is that some tests are failing.But i cant see how they could pass, like this one https://github.com/farfromrefug/nativescript-cli/blob/cdf912ecdbd01c34ab405df2e9e39268f982d71f/test/tools/node-modules/node-modules-dependencies-builder.ts#L536
