### PR TITLE
feat: support livesync in remote machine

### DIFF
--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -262,7 +262,7 @@ export class AndroidDeviceLiveSyncService
 
 			socket.connect(
 				this.port,
-				process.env.LIVESYNC_ADDR || "127.0.0.1",
+				process.env.NATIVESCRIPT_LIVESYNC_ADDRESS || "127.0.0.1",
 				() => {
 					socket.write(Buffer.from([0, 0, 0, 1, 1]));
 				}

--- a/lib/services/livesync/android-device-livesync-service.ts
+++ b/lib/services/livesync/android-device-livesync-service.ts
@@ -260,9 +260,13 @@ export class AndroidDeviceLiveSyncService
 			let isResolved = false;
 			const socket = new net.Socket();
 
-			socket.connect(this.port, "127.0.0.1", () => {
-				socket.write(Buffer.from([0, 0, 0, 1, 1]));
-			});
+			socket.connect(
+				this.port,
+				process.env.LIVESYNC_ADDR || "127.0.0.1",
+				() => {
+					socket.write(Buffer.from([0, 0, 0, 1, 1]));
+				}
+			);
 			socket.on("data", (data: any) => {
 				isResolved = true;
 				socket.destroy();

--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -76,7 +76,8 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 		}
 
 		if (!configuration.localHostAddress) {
-			configuration.localHostAddress = DEFAULT_LOCAL_HOST_ADDRESS;
+			configuration.localHostAddress =
+				process.env.LIVESYNC_ADDR || DEFAULT_LOCAL_HOST_ADDRESS;
 		}
 
 		const connectTimeout = configuration.connectTimeout || TRY_CONNECT_TIMEOUT;

--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -77,7 +77,7 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 
 		if (!configuration.localHostAddress) {
 			configuration.localHostAddress =
-				process.env.LIVESYNC_ADDR || DEFAULT_LOCAL_HOST_ADDRESS;
+				process.env.NATIVESCRIPT_LIVESYNC_ADDRESS || DEFAULT_LOCAL_HOST_ADDRESS;
 		}
 
 		const connectTimeout = configuration.connectTimeout || TRY_CONNECT_TIMEOUT;


### PR DESCRIPTION
adds support to wsl via `export LIVESYNC_ADDR=hostIpAddr`

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
livesync always tries to connect to localhost

## What is the new behavior?
you can provide the LIVESYNC_ADDR to override the default ip address for livesync

Implements #5450.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
