### PR TITLE
remove duplicate plugins data

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -359,7 +359,9 @@ export class PluginsService implements IPluginsService {
 		);
 		const pluginData = productionPlugins.map((plugin) =>
 			this.convertToPluginData(plugin, projectData.projectDir)
-		);
+		).filter(function(item, pos, self) {
+			return self.findIndex(p=>p.name === item.name) == pos;
+		});
 		return pluginData;
 	}
 

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -283,22 +283,27 @@ export class PluginsService implements IPluginsService {
 			_.keys(packageJsonContent.devDependencies)
 		);
 
-		const notInstalledDependencies = allDependencies.map(dep => {
-		  try {
-		    this.$logger.trace(`Checking if ${dep} is installed...`);
-		    require.resolve(`${dep}/package.json`, {
-		      paths: [projectData.projectDir]
-        })
+		const notInstalledDependencies = allDependencies
+			.map((dep) => {
+				try {
+					this.$logger.trace(`Checking if ${dep} is installed...`);
+					require.resolve(`${dep}/package.json`, {
+						paths: [projectData.projectDir],
+					});
 
-        // return false if the dependency is installed - we'll filter out boolean values
-        // and end up with an array of dep names that are not installed if we end up
-        // inside the catch block.
-        return false;
-      } catch(err) {
-		    this.$logger.trace(`Error while checking if ${dep} is installed. Error is: `, err)
-		    return dep;
-      }
-    }).filter(Boolean);
+					// return false if the dependency is installed - we'll filter out boolean values
+					// and end up with an array of dep names that are not installed if we end up
+					// inside the catch block.
+					return false;
+				} catch (err) {
+					this.$logger.trace(
+						`Error while checking if ${dep} is installed. Error is: `,
+						err
+					);
+					return dep;
+				}
+			})
+			.filter(Boolean);
 
 		if (this.$options.force || notInstalledDependencies.length) {
 			this.$logger.trace(
@@ -342,7 +347,8 @@ export class PluginsService implements IPluginsService {
 		dependencies =
 			dependencies ||
 			this.$nodeModulesDependenciesBuilder.getProductionDependencies(
-				projectData.projectDir, projectData.ignoredDependencies
+				projectData.projectDir,
+				projectData.ignoredDependencies
 			);
 
 		if (_.isEmpty(dependencies)) {
@@ -357,12 +363,14 @@ export class PluginsService implements IPluginsService {
 			projectData.projectDir,
 			platform
 		);
-		const pluginData = productionPlugins.map((plugin) =>
-			this.convertToPluginData(plugin, projectData.projectDir)
-		).filter(function(item, pos, self) {
-			return self.findIndex(p=>p.name === item.name) == pos;
-		});
-		return pluginData;
+		return productionPlugins
+			.map((plugin) => this.convertToPluginData(plugin, projectData.projectDir))
+			.filter((item, idx, self) => {
+				// Filter out duplicates to speed up build times by not building the same dependency
+				// multiple times. One possible downside is that if there are different versions
+				// of the same native dependency only the first one in the array will be built
+				return self.findIndex((p) => p.name === item.name) === idx;
+			});
 	}
 
 	public getDependenciesFromPackageJson(


### PR DESCRIPTION
This happens when multiple deps have another common dependencies.
This fix has one direct consequences which makes app build faster. 
Before this native plugins where built multiple times.
As an example for [this](https://github.com/nativescript-community/ui-material-components/tree/master/demo-vue) app using my material components.
Before this commit :
```js
pluginsData 37 [
  '@nativescript-community/css-theme',
  '@nativescript-community/text',
  '@nativescript-community/ui-material-activityindicator',
  '@nativescript-community/ui-material-bottom-navigation',
  '@nativescript-community/ui-material-bottomnavigationbar',
  '@nativescript-community/ui-material-bottomsheet',
  '@nativescript-community/ui-material-button',
  '@nativescript-community/ui-material-cardview',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-dialogs',
  '@nativescript-community/ui-material-floatingactionbutton',
  '@nativescript-community/ui-material-progress',
  '@nativescript-community/ui-material-ripple',
  '@nativescript-community/ui-material-slider',
  '@nativescript-community/ui-material-snackbar',
  '@nativescript-community/ui-material-speeddial',
  '@nativescript-community/ui-material-tabs',
  '@nativescript-community/ui-material-textfield',
  '@nativescript-community/ui-material-textview',
  '@nativescript/core',
  '@nativescript/iqkeyboardmanager',
  '@nativescript/theme',
  'nativescript-vue',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/text',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-textfield',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/text',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/text'
]
```
After this plugin:
```js
pluginsData 23 [
  '@nativescript-community/css-theme',
  '@nativescript-community/text',
  '@nativescript-community/ui-material-activityindicator',
  '@nativescript-community/ui-material-bottom-navigation',
  '@nativescript-community/ui-material-bottomnavigationbar',
  '@nativescript-community/ui-material-bottomsheet',
  '@nativescript-community/ui-material-button',
  '@nativescript-community/ui-material-cardview',
  '@nativescript-community/ui-material-core',
  '@nativescript-community/ui-material-dialogs',
  '@nativescript-community/ui-material-floatingactionbutton',
  '@nativescript-community/ui-material-progress',
  '@nativescript-community/ui-material-ripple',
  '@nativescript-community/ui-material-slider',
  '@nativescript-community/ui-material-snackbar',
  '@nativescript-community/ui-material-speeddial',
  '@nativescript-community/ui-material-tabs',
  '@nativescript-community/ui-material-textfield',
  '@nativescript-community/ui-material-textview',
  '@nativescript/core',
  '@nativescript/iqkeyboardmanager',
  '@nativescript/theme',
  'nativescript-vue'
]
```
It means the native build of the app plugins  got reduced by 60%

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
