### PR TITLE
fix: running tests / http requests where no proxy configured

### DIFF
--- a/lib/common/http-client.ts
+++ b/lib/common/http-client.ts
@@ -6,6 +6,7 @@ import { injector } from "./yok";
 import axios from "axios";
 import { HttpStatusCodes } from "./constants";
 import * as tunnel from "tunnel";
+import { Agent } from "http";
 
 export class HttpClient implements Server.IHttpClient {
 	private static STUCK_REQUEST_ERROR_MESSAGE =
@@ -98,12 +99,15 @@ export class HttpClient implements Server.IHttpClient {
 
 		this.$logger.trace("httpRequest: %s", util.inspect(options));
 
-		const agent = tunnel.httpsOverHttp({
-			proxy: {
-				host: cliProxySettings.hostname,
-				port: parseInt(cliProxySettings.port),
-			},
-		});
+		const agent = cliProxySettings
+			? tunnel.httpsOverHttp({
+					proxy: {
+						host: cliProxySettings.hostname,
+						port: parseInt(cliProxySettings.port),
+					},
+			  })
+			: new Agent({ keepAlive: true }); // If no proxy use default.
+
 		const result = await axios({
 			url: options.url,
 			headers: options.headers,

--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -81,7 +81,7 @@ export class TestExecutionService implements ITestExecutionService {
 						liveSyncInfo.projectDir,
 						TestExecutionService.SOCKETIO_JS_FILE_NAME
 					),
-					socketIoJs
+					JSON.parse(socketIoJs)
 				);
 			}
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ X ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
ns test android is broken

## What is the new behavior?
ns test works

Fixes/Implements/Closes #5572 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
