### PR TITLE
feat: allow plugin blacklist metadata

### DIFF
--- a/lib/definitions/metadata-filtering-service.d.ts
+++ b/lib/definitions/metadata-filtering-service.d.ts
@@ -28,6 +28,10 @@ interface INativeApiUsagePluginConfiguration {
 	 * Defines APIs which are used by the plugin and which should be whitelisted by the application using this plugin.
 	 */
 	uses: string[];
+	/**
+	 * Defines APIs which can be safely ignored by this plugin
+	 */
+	blacklist?: string[];
 }
 
 /**

--- a/lib/services/metadata-filtering-service.ts
+++ b/lib/services/metadata-filtering-service.ts
@@ -116,7 +116,40 @@ export class MetadataFilteringService implements IMetadataFilteringService {
 		);
 		if (nativeApiConfiguration) {
 			const blacklistedItems: string[] = nativeApiConfiguration.blacklist || [];
-
+			if (nativeApiConfiguration["whitelist-plugins-usages"]) {
+				const plugins = this.$pluginsService.getAllProductionPlugins(
+					projectData,
+					platform
+				);
+				for (const pluginData of plugins) {
+					const pathToPlatformsDir = pluginData.pluginPlatformsFolderPath(
+						platform
+					);
+					const pathToPluginsMetadataConfig = path.join(
+						pathToPlatformsDir,
+						MetadataFilteringConstants.NATIVE_API_USAGE_FILE_NAME
+					);
+					if (this.$fs.exists(pathToPluginsMetadataConfig)) {
+						const pluginConfig: INativeApiUsagePluginConfiguration =
+							this.$fs.readJson(pathToPluginsMetadataConfig) || {};
+						this.$logger.trace(
+							`Adding content of ${pathToPluginsMetadataConfig} to whitelisted items of metadata filtering: ${JSON.stringify(
+								pluginConfig,
+								null,
+								2
+							)}`
+						);
+						const itemsToAdd = pluginConfig.blacklist || [];
+						blacklistedItems.push(
+							`// Added from: ${pathToPluginsMetadataConfig}`
+						);
+						blacklistedItems.push(...itemsToAdd);
+						blacklistedItems.push(
+							`// Finished part from ${pathToPluginsMetadataConfig}${os.EOL}`
+						);
+					}
+				}
+			}
 			if (blacklistedItems.length) {
 				this.$fs.writeFile(pathToBlacklistFile, blacklistedItems.join(os.EOL));
 			}


### PR DESCRIPTION
This pull request allows plugins `native-api-usage.json` to provide blacklist  (useful for example to prevent huge .R to be included)