### PR TITLE
fix(migrate): create polyfills.ts if missing for angular projects

### DIFF
--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -40,6 +40,7 @@ import { IInjector } from "../common/definitions/yok";
 import { injector } from "../common/yok";
 import { IJsonFileSettingsService } from "../common/definitions/json-file-settings-service";
 import { SupportedConfigValues } from "../tools/config-manipulation/config-transformer";
+import * as temp from "temp";
 
 // const wait: (ms: number) => Promise<void> = (ms: number = 1000) =>
 // 	new Promise((resolve) => setTimeout(resolve, ms));
@@ -432,12 +433,29 @@ export class MigrateController
 
 		this.spinner.succeed("Project dependencies have been updated");
 
+		const isAngular = this.hasDependency(
+			{
+				packageName: "@nativescript/angular",
+			},
+			projectData
+		);
+
+		// ensure polyfills.ts exists in angular projects
+		let polyfillsPath;
+		if (isAngular) {
+			polyfillsPath = await this.checkOrCreatePolyfillsTS(projectData);
+		}
+
 		// update tsconfig
 		const tsConfigPath = path.resolve(projectDir, "tsconfig.json");
 		if (this.$fs.exists(tsConfigPath)) {
 			this.spinner.info(`Updating ${"tsconfig.json".yellow}`);
 
-			await this.migrateTSConfig(tsConfigPath);
+			await this.migrateTSConfig({
+				tsConfigPath,
+				isAngular,
+				polyfillsPath,
+			});
 
 			this.spinner.succeed(`Updated ${"tsconfig.json".yellow}`);
 		}
@@ -1189,7 +1207,15 @@ export class MigrateController
 		return dependencies;
 	}
 
-	private async migrateTSConfig(tsConfigPath: string): Promise<boolean> {
+	private async migrateTSConfig({
+		tsConfigPath,
+		isAngular,
+		polyfillsPath,
+	}: {
+		tsConfigPath: string;
+		isAngular: boolean;
+		polyfillsPath?: string;
+	}): Promise<boolean> {
 		try {
 			const configContents = this.$fs.readJson(tsConfigPath);
 
@@ -1205,6 +1231,18 @@ export class MigrateController
 				...new Set([...(configContents.compilerOptions.lib || []), "es2017"]),
 			];
 
+			if (isAngular) {
+				// make sure polyfills.ts is in files
+				if (configContents.files) {
+					configContents.files = [
+						...new Set([
+							...(configContents.files || []),
+							polyfillsPath ?? "./src/polyfills.ts",
+						]),
+					];
+				}
+			}
+
 			this.$fs.writeJson(tsConfigPath, configContents);
 
 			return true;
@@ -1212,6 +1250,48 @@ export class MigrateController
 			this.$logger.trace("Failed to migrate tsconfig.json. Error is: ", error);
 			return false;
 		}
+	}
+
+	private async checkOrCreatePolyfillsTS(
+		projectData: IProjectData
+	): Promise<string> {
+		const { projectDir, appDirectoryPath } = projectData;
+
+		const possiblePaths = [
+			`${appDirectoryPath}/polyfills.ts`,
+			`./src/polyfills.ts`,
+			`./app/polyfills.ts`,
+		].map((possiblePath) => path.resolve(projectDir, possiblePath));
+
+		let polyfillsPath = possiblePaths.find((possiblePath) => {
+			return this.$fs.exists(possiblePath);
+		});
+
+		if (polyfillsPath) {
+			return "./" + path.relative(projectDir, polyfillsPath);
+		}
+
+		const tempDir = temp.mkdirSync({
+			prefix: "migrate-angular-polyfills",
+		});
+
+		// get from default angular template
+		await this.$pacoteService.extractPackage(
+			constants.RESERVED_TEMPLATE_NAMES["angular"],
+			tempDir
+		);
+
+		this.$fs.copyFile(
+			path.resolve(tempDir, "src/polyfills.ts"),
+			possiblePaths[0]
+		);
+
+		// clean up temp project
+		this.$fs.deleteDirectory(tempDir);
+
+		this.spinner.succeed(`Created fresh ${"polyfills.ts".cyan}`);
+
+		return "./" + path.relative(projectDir, possiblePaths[0]);
 	}
 
 	private async migrateNativeScriptAngular(): Promise<IMigrationDependency[]> {
@@ -1281,6 +1361,12 @@ export class MigrateController
 			},
 
 			// devDependencies
+			{
+				packageName: "@angular/cli",
+				minVersion,
+				desiredVersion,
+				isDev: true,
+			},
 			{
 				packageName: "@angular/compiler-cli",
 				minVersion,


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
