### PR TITLE
feat: compute and log build time

### DIFF
--- a/lib/controllers/build-controller.ts
+++ b/lib/controllers/build-controller.ts
@@ -43,6 +43,7 @@ export class BuildController extends EventEmitter implements IBuildController {
 
 	public async build(buildData: IBuildData): Promise<string> {
 		this.$logger.info("Building project...");
+		const startTime = performance.now();
 
 		const platform = buildData.platform.toLowerCase();
 		const projectData = this.$projectDataService.getProjectData(
@@ -102,7 +103,10 @@ export class BuildController extends EventEmitter implements IBuildController {
 			buildInfoFileDir
 		);
 
+		const endTime = performance.now();
 		this.$logger.info("Project successfully built.");
+		const buildTime = (endTime - startTime) / 1000;
+		this.$logger.info(`Build time: ${buildTime.toFixed(3)} s.`);
 
 		const result = await this.$buildArtefactsService.getLatestAppPackagePath(
 			platformData,

--- a/lib/controllers/build-controller.ts
+++ b/lib/controllers/build-controller.ts
@@ -104,8 +104,9 @@ export class BuildController extends EventEmitter implements IBuildController {
 		);
 
 		const endTime = performance.now();
-		this.$logger.info("Project successfully built.");
 		const buildTime = (endTime - startTime) / 1000;
+
+		this.$logger.info("Project successfully built.");
 		this.$logger.info(`Build time: ${buildTime.toFixed(3)} s.`);
 
 		const result = await this.$buildArtefactsService.getLatestAppPackagePath(


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Build time not shown in ios.

## What is the new behavior?
Build time is computed and logged irrespective of OS.

Fixes/Implements/Closes #2998.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
