### PR TITLE
Fixed breakline on clean command

### DIFF
--- a/lib/commands/clean.ts
+++ b/lib/commands/clean.ts
@@ -17,7 +17,7 @@ export class CleanCommand implements ICommand {
 
 	public async execute(args: string[]): Promise<void> {
 		const spinner = this.$terminalSpinnerService.createSpinner();
-		spinner.start("Cleaning project...");
+		spinner.start("Cleaning project...\n");
 
 		const pathsToClean = [
 			constants.HOOKS_DIR_NAME,


### PR DESCRIPTION
Fixed the information texts when using the clean command. The 'Cleanining project...' and 'Cleaned directory hooks' are showing at the same line