### PR TITLE
chore: fix issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -104,7 +104,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: '&nbsp;'
+      label: ''
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -104,7 +104,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: 'Please accept these terms'
+      label: Please accept these terms
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -102,9 +102,9 @@ body:
 
         ---
   - type: checkboxes
-    label: Terms
     id: terms
     attributes:
+      label: false
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -104,7 +104,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: &nbsp;
+      label: '&nbsp;'
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -104,7 +104,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: ' '
+      label: 'Please accept these terms'
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -102,6 +102,7 @@ body:
 
         ---
   - type: checkboxes
+    label: Terms
     id: terms
     attributes:
       options:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -104,7 +104,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: ''
+      label: ' '
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -104,7 +104,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: Terms
+      label: &nbsp;
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -104,7 +104,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
-      label: false
+      label: Terms
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -63,6 +63,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
+      label: Please accept these terms
       options:
         - label: I have searched the [existing issues](https://github.com/NativeScript/nativescript-cli/issues) as well as [StackOverflow](https://stackoverflow.com/questions/tagged/nativescript) and this has not been posted before
           required: true


### PR DESCRIPTION
GitHub recently made the `label` fields required for the checkboxes.