### PR TITLE
fix(test): exit test command if karma finishes execution

### DIFF
--- a/lib/commands/test.ts
+++ b/lib/commands/test.ts
@@ -89,6 +89,8 @@ abstract class TestCommandBase {
 			liveSyncInfo,
 			deviceDescriptors
 		);
+		// if we got here, it means karma exited with exit code 0 (success)
+		process.exit(0);
 	}
 
 	async canExecute(args: string[]): Promise<boolean> {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
the test command does not exit when karma exits with error code 0

## What is the new behavior?
cli exits with code 0 when karma finishes it's execution

Fixes #5617.
