### PR TITLE
feat: --gradlePath argument support

### DIFF
--- a/lib/commands/plugin/build-plugin.ts
+++ b/lib/commands/plugin/build-plugin.ts
@@ -52,6 +52,7 @@ export class BuildPluginCommand implements ICommand {
 		);
 
 		const options: IPluginBuildOptions = {
+			gradlePath: this.$options.gradle,
 			aarOutputDir: platformsAndroidPath,
 			platformsAndroidDirPath: platformsAndroidPath,
 			pluginName: pluginName,

--- a/lib/commands/plugin/build-plugin.ts
+++ b/lib/commands/plugin/build-plugin.ts
@@ -52,7 +52,7 @@ export class BuildPluginCommand implements ICommand {
 		);
 
 		const options: IPluginBuildOptions = {
-			gradlePath: this.$options.gradle,
+			gradlePath: this.$options.gradlePath,
 			aarOutputDir: platformsAndroidPath,
 			platformsAndroidDirPath: platformsAndroidPath,
 			pluginName: pluginName,

--- a/lib/data/build-data.ts
+++ b/lib/data/build-data.ts
@@ -47,6 +47,7 @@ export class AndroidBuildData extends BuildData {
 	public keyStoreAliasPassword: string;
 	public keyStorePassword: string;
 	public androidBundle: boolean;
+	public gradlePath: string;
 
 	constructor(projectDir: string, platform: string, data: any) {
 		super(projectDir, platform, data);
@@ -56,5 +57,6 @@ export class AndroidBuildData extends BuildData {
 		this.keyStoreAliasPassword = data.keyStoreAliasPassword;
 		this.keyStorePassword = data.keyStorePassword;
 		this.androidBundle = data.androidBundle || data.aab;
+		this.gradlePath = data.gradle;
 	}
 }

--- a/lib/data/build-data.ts
+++ b/lib/data/build-data.ts
@@ -57,6 +57,6 @@ export class AndroidBuildData extends BuildData {
 		this.keyStoreAliasPassword = data.keyStoreAliasPassword;
 		this.keyStorePassword = data.keyStorePassword;
 		this.androidBundle = data.androidBundle || data.aab;
-		this.gradlePath = data.gradle;
+		this.gradlePath = data.gradlePath;
 	}
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -579,6 +579,10 @@ interface IAndroidBundleOptions {
 	aab: boolean;
 }
 
+interface IAndroidOptions {
+	gradle: string;
+}
+
 interface ITypingsOptions {
 	jar: string;
 	aar: string;
@@ -598,6 +602,7 @@ interface IOptions
 		IClean,
 		IProvision,
 		ITeamIdentifier,
+		IAndroidOptions,
 		IAndroidReleaseOptions,
 		IAndroidBundleOptions,
 		INpmInstallConfigurationOptions,

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -580,7 +580,7 @@ interface IAndroidBundleOptions {
 }
 
 interface IAndroidOptions {
-	gradle: string;
+	gradlePath: string;
 }
 
 interface ITypingsOptions {

--- a/lib/definitions/android-plugin-migrator.d.ts
+++ b/lib/definitions/android-plugin-migrator.d.ts
@@ -10,6 +10,7 @@ interface IAndroidBuildOptions {
 	pluginName: string;
 	aarOutputDir: string;
 	tempPluginDirPath: string;
+	gradlePath?: string;
 }
 
 interface IAndroidPluginBuildService {
@@ -37,4 +38,10 @@ interface IBuildAndroidPluginData extends Partial<IProjectDir> {
 	 * Information about tools that will be used to build the plugin, for example compile SDK version, build tools version, etc.
 	 */
 	androidToolsInfo?: IAndroidToolsInfoData;
+
+	/**
+	 * Optional custom Gradle path.
+	 */
+	gradlePath?: string,
+
 }

--- a/lib/definitions/android-plugin-migrator.d.ts
+++ b/lib/definitions/android-plugin-migrator.d.ts
@@ -42,6 +42,5 @@ interface IBuildAndroidPluginData extends Partial<IProjectDir> {
 	/**
 	 * Optional custom Gradle path.
 	 */
-	gradlePath?: string,
-
+	gradlePath?: string;
 }

--- a/lib/definitions/build.d.ts
+++ b/lib/definitions/build.d.ts
@@ -30,8 +30,8 @@ interface IAndroidBuildData
 	extends IBuildData,
 		IAndroidSigningData,
 		IHasAndroidBundle {
-			gradlePath?: string;
-		}
+	gradlePath?: string;
+}
 
 interface IAndroidSigningData {
 	keyStoreAlias: string;

--- a/lib/definitions/build.d.ts
+++ b/lib/definitions/build.d.ts
@@ -29,7 +29,9 @@ interface IiOSBuildData extends IBuildData {
 interface IAndroidBuildData
 	extends IBuildData,
 		IAndroidSigningData,
-		IHasAndroidBundle {}
+		IHasAndroidBundle {
+			gradlePath?: string;
+		}
 
 interface IAndroidSigningData {
 	keyStoreAlias: string;

--- a/lib/definitions/gradle.d.ts
+++ b/lib/definitions/gradle.d.ts
@@ -13,6 +13,7 @@ interface IGradleCommandOptions {
 	message?: string;
 	stdio?: string;
 	spawnOptions?: ISpawnFromEventOptions;
+	gradlePath?: string;
 }
 
 interface IGradleBuildService {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -215,6 +215,7 @@ export class Options {
 				default: false,
 				hasSensitiveValue: false,
 			},
+			gradle: { type: OptionType.String, hasSensitiveValue: false },
 			aab: { type: OptionType.Boolean, hasSensitiveValue: false },
 			performance: { type: OptionType.Object, hasSensitiveValue: true },
 			appleApplicationSpecificPassword: {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -215,7 +215,7 @@ export class Options {
 				default: false,
 				hasSensitiveValue: false,
 			},
-			gradle: { type: OptionType.String, hasSensitiveValue: false },
+			gradlePath: { type: OptionType.String, hasSensitiveValue: false },
 			aab: { type: OptionType.Boolean, hasSensitiveValue: false },
 			performance: { type: OptionType.Object, hasSensitiveValue: true },
 			appleApplicationSpecificPassword: {

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -716,7 +716,9 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			);
 		}
 
-		const gradlew = pluginBuildSettings.gradlePath ?? (this.$hostInfo.isWindows ? "gradlew.bat" : "./gradlew");
+		const gradlew =
+			pluginBuildSettings.gradlePath ??
+			(this.$hostInfo.isWindows ? "gradlew.bat" : "./gradlew");
 
 		const localArgs = [
 			"-p",

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -260,6 +260,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 				options.projectDir
 			);
 			await this.buildPlugin({
+				gradlePath: options.gradlePath,
 				pluginDir: pluginTempDir,
 				pluginName: options.pluginName,
 				projectDir: options.projectDir,
@@ -715,7 +716,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			);
 		}
 
-		const gradlew = this.$hostInfo.isWindows ? "gradlew.bat" : "./gradlew";
+		const gradlew = pluginBuildSettings.gradlePath ?? (this.$hostInfo.isWindows ? "gradlew.bat" : "./gradlew");
 
 		const localArgs = [
 			"-p",

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -61,6 +61,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		$fs: IFileSystem,
 		private $logger: ILogger,
 		$projectDataService: IProjectDataService,
+		private $options: IOptions,
 		private $injector: IInjector,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $androidPluginBuildService: IAndroidPluginBuildService,
@@ -603,6 +604,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		);
 		if (this.$fs.exists(pluginPlatformsFolderPath)) {
 			const options: IPluginBuildOptions = {
+				gradlePath: this.$options.gradle,
 				projectDir: projectData.projectDir,
 				pluginName: pluginData.name,
 				platformsAndroidDirPath: pluginPlatformsFolderPath,

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -604,7 +604,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		);
 		if (this.$fs.exists(pluginPlatformsFolderPath)) {
 			const options: IPluginBuildOptions = {
-				gradlePath: this.$options.gradle,
+				gradlePath: this.$options.gradlePath,
 				projectDir: projectData.projectDir,
 				pluginName: pluginData.name,
 				platformsAndroidDirPath: pluginPlatformsFolderPath,

--- a/lib/services/android/gradle-build-service.ts
+++ b/lib/services/android/gradle-build-service.ts
@@ -36,6 +36,7 @@ export class GradleBuildService
 			cwd: projectRoot,
 			message: "Gradle build...",
 			stdio: buildData.buildOutputStdio,
+			gradlePath: buildData.gradlePath,
 			spawnOptions,
 		};
 
@@ -60,6 +61,7 @@ export class GradleBuildService
 		const gradleCommandOptions = {
 			cwd: projectRoot,
 			message: "Gradle clean...",
+			gradlePath: buildData.gradlePath,
 		};
 		await this.$gradleCommandService.executeCommand(
 			cleanTaskArgs,

--- a/lib/services/android/gradle-command-service.ts
+++ b/lib/services/android/gradle-command-service.ts
@@ -27,9 +27,9 @@ export class GradleCommandService implements IGradleCommandService {
 		this.$logger.info(message);
 
 		const childProcessOptions = { cwd, stdio: stdio || "inherit" };
-		const gradleExecutable = options.gradlePath ?? (this.$hostInfo.isWindows
-			? "gradlew.bat"
-			: "./gradlew");
+		const gradleExecutable =
+			options.gradlePath ??
+			(this.$hostInfo.isWindows ? "gradlew.bat" : "./gradlew");
 
 		const result = await this.executeCommandSafe(
 			gradleExecutable,

--- a/lib/services/android/gradle-command-service.ts
+++ b/lib/services/android/gradle-command-service.ts
@@ -27,9 +27,9 @@ export class GradleCommandService implements IGradleCommandService {
 		this.$logger.info(message);
 
 		const childProcessOptions = { cwd, stdio: stdio || "inherit" };
-		const gradleExecutable = this.$hostInfo.isWindows
+		const gradleExecutable = options.gradlePath ?? (this.$hostInfo.isWindows
 			? "gradlew.bat"
-			: "./gradlew";
+			: "./gradlew");
 
 		const result = await this.executeCommandSafe(
 			gradleExecutable,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "glob": "7.1.6",
         "ios-device-lib": "0.9.2",
         "ios-mobileprovision-finder": "1.0.11",
-        "ios-sim-portable": "4.2.4",
+        "ios-sim-portable": "4.2.5",
         "istextorbinary": "5.9.0",
         "jimp": "0.14.0",
         "libnpmconfig": "1.2.1",
@@ -6315,9 +6315,9 @@
       }
     },
     "node_modules/ios-sim-portable": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.2.4.tgz",
-      "integrity": "sha512-TqgrBp3omXkKwXEHVpLxo3+uJqi6XTLdXpL/YGlXdQ0fL7RYySmqkVQcc98vea/eQMpR9ImTGxyAsKerW/819A==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.2.5.tgz",
+      "integrity": "sha512-2xuE60u+cjSwDoj3rXeN7PbuVtCDTZUhY5vkWWjlJj/TlWuLJMFEx9lgr5OGuYv7jRldpqD/nwGhtOdM2llKHw==",
       "dependencies": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "~1.4.0",
@@ -18169,9 +18169,9 @@
       }
     },
     "ios-sim-portable": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.2.4.tgz",
-      "integrity": "sha512-TqgrBp3omXkKwXEHVpLxo3+uJqi6XTLdXpL/YGlXdQ0fL7RYySmqkVQcc98vea/eQMpR9ImTGxyAsKerW/819A==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.2.5.tgz",
+      "integrity": "sha512-2xuE60u+cjSwDoj3rXeN7PbuVtCDTZUhY5vkWWjlJj/TlWuLJMFEx9lgr5OGuYv7jRldpqD/nwGhtOdM2llKHw==",
       "requires": {
         "bplist-parser": "https://github.com/telerik/node-bplist-parser/tarball/master",
         "colors": "~1.4.0",

--- a/test/services/android-project-service.ts
+++ b/test/services/android-project-service.ts
@@ -41,6 +41,7 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("androidPluginBuildService", {});
 	testInjector.register("errors", stubs.ErrorsStub);
 	testInjector.register("logger", stubs.LoggerStub);
+	testInjector.register("options", {});
 	testInjector.register("projectData", stubs.ProjectDataStub);
 	testInjector.register("androidToolsInfo", {
 		getToolsInfo: () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3607,10 +3607,10 @@
     "plist" "^2.0.1"
     "yargs" "^6.5.0"
 
-"ios-sim-portable@4.2.4":
-  "integrity" "sha512-TqgrBp3omXkKwXEHVpLxo3+uJqi6XTLdXpL/YGlXdQ0fL7RYySmqkVQcc98vea/eQMpR9ImTGxyAsKerW/819A=="
-  "resolved" "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.2.4.tgz"
-  "version" "4.2.4"
+"ios-sim-portable@4.2.5":
+  "integrity" "sha512-2xuE60u+cjSwDoj3rXeN7PbuVtCDTZUhY5vkWWjlJj/TlWuLJMFEx9lgr5OGuYv7jRldpqD/nwGhtOdM2llKHw=="
+  "resolved" "https://registry.npmjs.org/ios-sim-portable/-/ios-sim-portable-4.2.5.tgz"
+  "version" "4.2.5"
   dependencies:
     "bplist-parser" "https://github.com/telerik/node-bplist-parser/tarball/master"
     "colors" "~1.4.0"


### PR DESCRIPTION
This simple PR add `--gradle` option to specify a custom gradle binary path
Solves https://github.com/NativeScript/nativescript-cli/issues/5550 

EDIT: renamed the option to `gradlePath`. makes more sense as i am about to add gradle option for args