### PR TITLE
feat: `--gradleArgs` option to pass gradle parameters

### DIFF
--- a/lib/commands/plugin/build-plugin.ts
+++ b/lib/commands/plugin/build-plugin.ts
@@ -53,7 +53,7 @@ export class BuildPluginCommand implements ICommand {
 
 		const options: IPluginBuildOptions = {
 			gradlePath: this.$options.gradlePath,
-			gradleArgs: this.$options.gradle,
+			gradleArgs: this.$options.gradleArgs,
 			aarOutputDir: platformsAndroidPath,
 			platformsAndroidDirPath: platformsAndroidPath,
 			pluginName: pluginName,

--- a/lib/commands/plugin/build-plugin.ts
+++ b/lib/commands/plugin/build-plugin.ts
@@ -53,6 +53,7 @@ export class BuildPluginCommand implements ICommand {
 
 		const options: IPluginBuildOptions = {
 			gradlePath: this.$options.gradlePath,
+			gradleArgs: this.$options.gradle,
 			aarOutputDir: platformsAndroidPath,
 			platformsAndroidDirPath: platformsAndroidPath,
 			pluginName: pluginName,

--- a/lib/data/build-data.ts
+++ b/lib/data/build-data.ts
@@ -48,6 +48,7 @@ export class AndroidBuildData extends BuildData {
 	public keyStorePassword: string;
 	public androidBundle: boolean;
 	public gradlePath: string;
+	public gradleArgs: string;
 
 	constructor(projectDir: string, platform: string, data: any) {
 		super(projectDir, platform, data);
@@ -58,5 +59,6 @@ export class AndroidBuildData extends BuildData {
 		this.keyStorePassword = data.keyStorePassword;
 		this.androidBundle = data.androidBundle || data.aab;
 		this.gradlePath = data.gradlePath;
+		this.gradleArgs = data.gradle;
 	}
 }

--- a/lib/data/build-data.ts
+++ b/lib/data/build-data.ts
@@ -59,6 +59,6 @@ export class AndroidBuildData extends BuildData {
 		this.keyStorePassword = data.keyStorePassword;
 		this.androidBundle = data.androidBundle || data.aab;
 		this.gradlePath = data.gradlePath;
-		this.gradleArgs = data.gradle;
+		this.gradleArgs = data.gradleArgs;
 	}
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -581,6 +581,7 @@ interface IAndroidBundleOptions {
 
 interface IAndroidOptions {
 	gradlePath: string;
+	gradle: string;
 }
 
 interface ITypingsOptions {

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -581,7 +581,7 @@ interface IAndroidBundleOptions {
 
 interface IAndroidOptions {
 	gradlePath: string;
-	gradle: string;
+	gradleArgs: string;
 }
 
 interface ITypingsOptions {

--- a/lib/definitions/android-plugin-migrator.d.ts
+++ b/lib/definitions/android-plugin-migrator.d.ts
@@ -11,6 +11,7 @@ interface IAndroidBuildOptions {
 	aarOutputDir: string;
 	tempPluginDirPath: string;
 	gradlePath?: string;
+	gradleArgs?: string;
 }
 
 interface IAndroidPluginBuildService {
@@ -43,4 +44,9 @@ interface IBuildAndroidPluginData extends Partial<IProjectDir> {
 	 * Optional custom Gradle path.
 	 */
 	gradlePath?: string;
+	
+	/** 
+	 * Optional custom Gradle arguments.
+	 */
+	 gradleArgs?: string,
 }

--- a/lib/definitions/build.d.ts
+++ b/lib/definitions/build.d.ts
@@ -31,6 +31,7 @@ interface IAndroidBuildData
 		IAndroidSigningData,
 		IHasAndroidBundle {
 	gradlePath?: string;
+	gradleArgs?: string;
 }
 
 interface IAndroidSigningData {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -216,6 +216,7 @@ export class Options {
 				hasSensitiveValue: false,
 			},
 			gradlePath: { type: OptionType.String, hasSensitiveValue: false },
+			gradle: { type: OptionType.String, hasSensitiveValue: false },
 			aab: { type: OptionType.Boolean, hasSensitiveValue: false },
 			performance: { type: OptionType.Object, hasSensitiveValue: true },
 			appleApplicationSpecificPassword: {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -216,7 +216,7 @@ export class Options {
 				hasSensitiveValue: false,
 			},
 			gradlePath: { type: OptionType.String, hasSensitiveValue: false },
-			gradle: { type: OptionType.String, hasSensitiveValue: false },
+			gradleArgs: { type: OptionType.String, hasSensitiveValue: false },
 			aab: { type: OptionType.Boolean, hasSensitiveValue: false },
 			performance: { type: OptionType.Object, hasSensitiveValue: true },
 			appleApplicationSpecificPassword: {

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -261,6 +261,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			);
 			await this.buildPlugin({
 				gradlePath: options.gradlePath,
+				gradleArgs: options.gradleArgs,
 				pluginDir: pluginTempDir,
 				pluginName: options.pluginName,
 				projectDir: options.projectDir,
@@ -727,6 +728,9 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			`-PcompileSdk=android-${pluginBuildSettings.androidToolsInfo.compileSdkVersion}`,
 			`-PbuildToolsVersion=${pluginBuildSettings.androidToolsInfo.buildToolsVersion}`,
 		];
+		if (pluginBuildSettings.gradleArgs) {
+			localArgs.push(pluginBuildSettings.gradleArgs);
+		}
 
 		if (this.$logger.getLevel() === "INFO") {
 			localArgs.push("--quiet");

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -605,6 +605,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		if (this.$fs.exists(pluginPlatformsFolderPath)) {
 			const options: IPluginBuildOptions = {
 				gradlePath: this.$options.gradlePath,
+				gradleArgs: this.$options.gradle,
 				projectDir: projectData.projectDir,
 				pluginName: pluginData.name,
 				platformsAndroidDirPath: pluginPlatformsFolderPath,

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -605,7 +605,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		if (this.$fs.exists(pluginPlatformsFolderPath)) {
 			const options: IPluginBuildOptions = {
 				gradlePath: this.$options.gradlePath,
-				gradleArgs: this.$options.gradle,
+				gradleArgs: this.$options.gradleArgs,
 				projectDir: projectData.projectDir,
 				pluginName: pluginData.name,
 				platformsAndroidDirPath: pluginPlatformsFolderPath,

--- a/lib/services/android/gradle-build-args-service.ts
+++ b/lib/services/android/gradle-build-args-service.ts
@@ -64,6 +64,9 @@ export class GradleBuildArgsService implements IGradleBuildArgsService {
 			`-PappPath=${this.$projectData.getAppDirectoryPath()}`,
 			`-PappResourcesPath=${this.$projectData.getAppResourcesDirectoryPath()}`
 		);
+		if (buildData.gradleArgs) {
+			args.push(buildData.gradleArgs);
+		}
 
 		if (buildData.release) {
 			args.push(


### PR DESCRIPTION
In the same vibe as `gradlePath` this allows to pass gradle command parameters.
One note is that they have to be double quoted like this `--gradle '"-PsplitEnabled"'` or using `=` like this `--gradle="-PsplitEnabled"`
This is due to how `yargs` parses arguments