### PR TITLE
feat: only install corresponding abi package when possible

### DIFF
--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -99,6 +99,12 @@ declare global {
 			 * For iOS simulators - same as the identifier.
 			 */
 			imageIdentifier?: string;
+
+			/**
+			 *  Optional property describing the architecture of the device
+			 *  Available for Android only
+			 */
+			 abis?: string[];
 		}
 
 		interface IDeviceError extends Error, IDeviceIdentifier {}

--- a/lib/common/mobile/android/android-device.ts
+++ b/lib/common/mobile/android/android-device.ts
@@ -13,6 +13,9 @@ interface IAndroidDeviceDetails {
 	name: string;
 	release: string;
 	brand: string;
+	'cpu.abi': string;
+	'cpu.abilist64': string;
+	'cpu.abilist32': string;
 }
 
 interface IAdbDeviceStatusInfo {
@@ -96,6 +99,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 			identifier: this.identifier,
 			displayName: details.name,
 			model: details.model,
+			abis: details['cpu.abilist64'].split(',').concat(details['cpu.abilist32'].split(',')),
 			version,
 			vendor: details.brand,
 			platform: this.$devicePlatformsConstants.Android,

--- a/lib/controllers/build-controller.ts
+++ b/lib/controllers/build-controller.ts
@@ -116,7 +116,7 @@ export class BuildController extends EventEmitter implements IBuildController {
 		);
 
 		if (buildData.copyTo) {
-			this.$buildArtefactsService.copyLatestAppPackage(
+			this.$buildArtefactsService.copyAppPackages(
 				buildData.copyTo,
 				platformData,
 				buildData

--- a/lib/controllers/deploy-controller.ts
+++ b/lib/controllers/deploy-controller.ts
@@ -23,11 +23,10 @@ export class DeployController {
 				},
 			};
 			await this.$prepareController.prepare(prepareData);
-			const packageFilePath = await deviceDescriptor.buildAction();
+			await deviceDescriptor.buildAction();
 			await this.$deviceInstallAppService.installOnDevice(
 				device,
-				{ ...deviceDescriptor.buildData, buildForDevice: !device.isEmulator },
-				packageFilePath
+				{ ...deviceDescriptor.buildData, buildForDevice: !device.isEmulator }
 			);
 		};
 

--- a/lib/controllers/run-controller.ts
+++ b/lib/controllers/run-controller.ts
@@ -473,7 +473,6 @@ export class RunController extends EventEmitter implements IRunController {
 		deviceDescriptors: ILiveSyncDeviceDescriptor[]
 	): Promise<void> {
 		const rebuiltInformation: IDictionary<{
-			packageFilePath: string;
 			platform: string;
 			isEmulator: boolean;
 		}> = {};
@@ -509,8 +508,6 @@ export class RunController extends EventEmitter implements IRunController {
 			);
 
 			try {
-				let packageFilePath: string = null;
-
 				// Case where we have three devices attached, a change that requires build is found,
 				// we'll rebuild the app only for the first device, but we should install new package on all three devices.
 				if (
@@ -521,24 +518,19 @@ export class RunController extends EventEmitter implements IRunController {
 						rebuiltInformation[platformData.platformNameLowerCase]
 							.isEmulator === device.isEmulator)
 				) {
-					packageFilePath =
-						rebuiltInformation[platformData.platformNameLowerCase]
-							.packageFilePath;
 					await this.$deviceInstallAppService.installOnDevice(
 						device,
-						buildData,
-						packageFilePath
+						buildData
 					);
 				} else {
 					const shouldBuild =
 						prepareResultData.hasNativeChanges ||
 						(await this.$buildController.shouldBuild(buildData));
 					if (shouldBuild) {
-						packageFilePath = await deviceDescriptor.buildAction();
+						await deviceDescriptor.buildAction();
 						rebuiltInformation[platformData.platformNameLowerCase] = {
 							isEmulator: device.isEmulator,
-							platform: platformData.platformNameLowerCase,
-							packageFilePath,
+							platform: platformData.platformNameLowerCase
 						};
 					} else {
 						await this.$analyticsService.trackEventActionInGoogleAnalytics({
@@ -550,8 +542,7 @@ export class RunController extends EventEmitter implements IRunController {
 
 					await this.$deviceInstallAppService.installOnDeviceIfNeeded(
 						device,
-						buildData,
-						packageFilePath
+						buildData
 					);
 				}
 
@@ -710,9 +701,7 @@ export class RunController extends EventEmitter implements IRunController {
 
 					await this.$deviceInstallAppService.installOnDevice(
 						device,
-						deviceDescriptor.buildData,
-						rebuiltInformation[platformData.platformNameLowerCase]
-							.packageFilePath
+						deviceDescriptor.buildData
 					);
 					await platformLiveSyncService.syncAfterInstall(device, watchInfo);
 					await this.refreshApplication(

--- a/lib/definitions/build.d.ts
+++ b/lib/definitions/build.d.ts
@@ -58,7 +58,7 @@ interface IBuildArtefactsService {
 		platformData: IPlatformData,
 		buildOutputOptions: IBuildOutputOptions
 	): Promise<string>;
-	copyLatestAppPackage(
+	copyAppPackages(
 		targetPath: string,
 		platformData: IPlatformData,
 		buildOutputOptions: IBuildOutputOptions

--- a/lib/definitions/run.d.ts
+++ b/lib/definitions/run.d.ts
@@ -28,13 +28,11 @@ declare global {
 	interface IDeviceInstallAppService {
 		installOnDevice(
 			device: Mobile.IDevice,
-			buildData: IBuildData,
-			packageFile?: string
+			buildData: IBuildData
 		): Promise<void>;
 		installOnDeviceIfNeeded(
 			device: Mobile.IDevice,
-			buildData: IBuildData,
-			packageFile?: string
+			buildData: IBuildData
 		): Promise<void>;
 		shouldInstall(
 			device: Mobile.IDevice,

--- a/lib/services/device/device-install-app-service.ts
+++ b/lib/services/device/device-install-app-service.ts
@@ -28,8 +28,7 @@ export class DeviceInstallAppService {
 
 	public async installOnDevice(
 		device: Mobile.IDevice,
-		buildData: IBuildData,
-		packageFile?: string
+		buildData: IBuildData
 	): Promise<void> {
 		this.$logger.info(
 			`Installing on device ${device.deviceInfo.identifier}...`
@@ -49,12 +48,38 @@ export class DeviceInstallAppService {
 			device,
 			projectDir: projectData.projectDir,
 		});
+		const buildOutputOptions = platformData.getValidBuildOutputData(buildData);
+		const outputPath = buildData.outputPath || platformData.getBuildOutputPath(buildData);
+		const packages = await this.$buildArtefactsService.getAllAppPackages(
+			outputPath,
+			buildOutputOptions
+		);
+		let packageFile;
+		if (packages.length === 1) {
+			// will always be the case on iOS
+			packageFile = packages[0].packageName;
+		} else if (device.deviceInfo.abis) {
+			device.deviceInfo.abis.every(abi=>{
+				const index = packages.findIndex(p => p.packageName.indexOf(abi) !== -1);
+				if (index !== -1) {
+					packageFile = packages[index].packageName;
+					return false;
+				}
+				return true;
+			})
+		} else {
+			//we did not find corresponding abi let's try universal
+			const index = packages.findIndex(p => p.packageName.indexOf('universal') !== -1);
+			if (index !== -1) {
+				packageFile = packages[index].packageName;
+			}
+		}
 
 		if (!packageFile) {
-			packageFile = await this.$buildArtefactsService.getLatestAppPackagePath(
-				platformData,
-				buildData
+			this.$logger.error(
+				`Could not find a package corresponding to the device with identifier '${device.deviceInfo.identifier}'.`
 			);
+			return;
 		}
 
 		await platformData.platformProjectService.cleanDeviceTempFolder(
@@ -88,18 +113,17 @@ export class DeviceInstallAppService {
 		}
 
 		this.$logger.info(
-			`Successfully installed on device with identifier '${device.deviceInfo.identifier}'.`
+			`Successfully installed on device with identifier '${device.deviceInfo.identifier} using package ${packageFile}'.`
 		);
 	}
 
 	public async installOnDeviceIfNeeded(
 		device: Mobile.IDevice,
-		buildData: IBuildData,
-		packageFile?: string
+		buildData: IBuildData
 	): Promise<void> {
 		const shouldInstall = await this.shouldInstall(device, buildData);
 		if (shouldInstall) {
-			await this.installOnDevice(device, buildData, packageFile);
+			await this.installOnDevice(device, buildData);
 		}
 	}
 


### PR DESCRIPTION
This PR changes the way the `installOnDevice` works.
The idea is to be compatible with apk split on android.
The reason for this is multiple:
* much smaller apps on device/emulator. It gets really boring to get warning about emulator not having enough space.
* it is the first step to other features like only build device ABI

The way it works is this:
* track device abis (might be multiple as a 64 device almost always accept 32bit apks). 
* When deploying see how many `.apk` files were built:
      - 1: always install this one
      - >1: if 64bit abi or 32bit abi package found use this one
      - >1: if not look for universal one found use this one
      - otherwise => error
 
I also applied the same rule for `copy copyLatestAppPackage To` (thus renamed to `copyAppPackages `)
* if `copyTo` is an existing directory or a path which does not end with `aab|ipa|apk` copy all packages to `copyTo` as a directory
* if `copyTo` is a file name
    - if only one package in output dir then copy it
    - copy only `universal` package if existing

There is one thing bugging be for which i have not found a solution. Because of [this](https://github.com/NativeScript/nativescript-cli/blob/master/lib/controllers/build-controller.ts#L113) line if there are multiple packages there will be warning about it which is wrong in its meaning when using `run`. Might also be wrong in other cases and we can simply remove the warning ...