### PR TITLE
fix: handle `gradleArgs` as an array option

### DIFF
--- a/lib/common/declarations.d.ts
+++ b/lib/common/declarations.d.ts
@@ -1311,6 +1311,11 @@ interface IDashedOption {
 	 * Specifies either a single option key (string), or an array of options that must be followed by option values.
 	 */
 	requiresArg?: any;
+
+	/**
+	 * Set to true to define the option as an array option https://github.com/yargs/yargs/blob/main/docs/api.md#array
+	 */
+	array?: any;
 }
 
 /**

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -581,7 +581,7 @@ interface IAndroidBundleOptions {
 
 interface IAndroidOptions {
 	gradlePath: string;
-	gradleArgs: string;
+	gradleArgs: string[];
 }
 
 interface ITypingsOptions {

--- a/lib/definitions/android-plugin-migrator.d.ts
+++ b/lib/definitions/android-plugin-migrator.d.ts
@@ -11,7 +11,7 @@ interface IAndroidBuildOptions {
 	aarOutputDir: string;
 	tempPluginDirPath: string;
 	gradlePath?: string;
-	gradleArgs?: string;
+	gradleArgs?: string[];
 }
 
 interface IAndroidPluginBuildService {
@@ -48,5 +48,5 @@ interface IBuildAndroidPluginData extends Partial<IProjectDir> {
 	/** 
 	 * Optional custom Gradle arguments.
 	 */
-	 gradleArgs?: string,
+	 gradleArgs?: string[],
 }

--- a/lib/definitions/build.d.ts
+++ b/lib/definitions/build.d.ts
@@ -31,7 +31,7 @@ interface IAndroidBuildData
 		IAndroidSigningData,
 		IHasAndroidBundle {
 	gradlePath?: string;
-	gradleArgs?: string;
+	gradleArgs?: string[];
 }
 
 interface IAndroidSigningData {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -217,7 +217,7 @@ export class Options {
 				hasSensitiveValue: false,
 			},
 			gradlePath: { type: OptionType.String, hasSensitiveValue: false },
-			gradleArgs: { type: OptionType.String, hasSensitiveValue: false },
+			gradleArgs: { type: OptionType.String, hasSensitiveValue: false, array: true },
 			aab: { type: OptionType.Boolean, hasSensitiveValue: false },
 			performance: { type: OptionType.Object, hasSensitiveValue: true },
 			appleApplicationSpecificPassword: {

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -732,7 +732,11 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			`-PappResourcesPath=${this.$projectData.getAppResourcesDirectoryPath()}`
 		];
 		if (pluginBuildSettings.gradleArgs) {
-			localArgs.push(pluginBuildSettings.gradleArgs);
+			const additionalArgs: string[] = []
+			pluginBuildSettings.gradleArgs.forEach(arg=>{
+				additionalArgs.push(...arg.split(' -P').map((a,i) => i === 0 ? a : `-P${a}`));
+			});
+			localArgs.push(...additionalArgs);
 		}
 
 		if (this.$logger.getLevel() === "INFO") {

--- a/lib/services/android/gradle-build-args-service.ts
+++ b/lib/services/android/gradle-build-args-service.ts
@@ -65,7 +65,11 @@ export class GradleBuildArgsService implements IGradleBuildArgsService {
 			`-PappResourcesPath=${this.$projectData.getAppResourcesDirectoryPath()}`
 		);
 		if (buildData.gradleArgs) {
-			args.push(buildData.gradleArgs);
+			const additionalArgs: string[] = []
+			buildData.gradleArgs.forEach(arg=>{
+				additionalArgs.push(...arg.split(' -P').map((a,i) => i === 0 ? a : `-P${a}`));
+			});
+			args.push(...additionalArgs);
 		}
 
 		if (buildData.release) {


### PR DESCRIPTION
This changes the way `gradleArgs` works. 
Now you can use either `--gradleArgs=-PsplitEnabled  --gradleArgs=-PabiFilters=arm64-v8a,armeabi-v7a` or `--gradleArgs=\"-PsplitEnabled -PabiFilters=arm64-v8a,armeabi-v7a\"` 

there is just duplicate code in the parsing handle multiple args in the same `gradleArgs` (necessary because otherwise gradle wont read them)