### PR TITLE
fix: write project settings to gradle.properties

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -127,7 +127,10 @@ export class PrepareController extends EventEmitter {
 		prepareData: IPrepareData,
 		projectData: IProjectData
 	): Promise<IPrepareResultData> {
-		await this.$platformController.addPlatformIfNeeded(prepareData);
+		await this.$platformController.addPlatformIfNeeded(
+			prepareData,
+			projectData
+		);
 		await this.trackRuntimeVersion(prepareData.platform, projectData);
 
 		this.$logger.info("Preparing project...");
@@ -375,7 +378,10 @@ export class PrepareController extends EventEmitter {
 		projectData: IProjectData
 	): Promise<string[]> {
 		const dependencies = this.$nodeModulesDependenciesBuilder
-			.getProductionDependencies(projectData.projectDir, projectData.ignoredDependencies)
+			.getProductionDependencies(
+				projectData.projectDir,
+				projectData.ignoredDependencies
+			)
 			.filter((dep) => dep.nativescript);
 		const pluginsNativeDirectories = dependencies.map((dep) =>
 			path.join(

--- a/lib/definitions/platform.d.ts
+++ b/lib/definitions/platform.d.ts
@@ -78,7 +78,10 @@ interface IPrepareNodeModulesData {
 }
 
 interface INodeModulesDependenciesBuilder {
-	getProductionDependencies(projectPath: string, ignore?: string[]): IDependencyData[];
+	getProductionDependencies(
+		projectPath: string,
+		ignore?: string[]
+	): IDependencyData[];
 }
 
 interface IBuildInfo {
@@ -118,8 +121,14 @@ interface IAddPlatformData extends IControllerDataBase {
 }
 
 interface IPlatformController {
-	addPlatform(addPlatformData: IAddPlatformData): Promise<void>;
-	addPlatformIfNeeded(addPlatformData: IAddPlatformData): Promise<void>;
+	addPlatform(
+		addPlatformData: IAddPlatformData,
+		projectData?: IProjectData
+	): Promise<void>;
+	addPlatformIfNeeded(
+		addPlatformData: IAddPlatformData,
+		projectData?: IProjectData
+	): Promise<void>;
 }
 
 interface IAddPlatformService {


### PR DESCRIPTION


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Running the `platforms/android` project in AndroidStudio does not quite work without editing the run configurations to include appPath and appResourcesPath settings.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->
The missing settings are written to `gradle.properties` after adding the platform.

