### PR TITLE
fix(doctor): improve target and sdk compatibility detection on <8.2

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -313,9 +313,10 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			}
 		);
 
-		this.$androidToolsInfo.validateTargetSdk({
+		this.$androidToolsInfo.validateInfo({
 			showWarningsAsErrors: true,
 			projectDir: projectData.projectDir,
+			validateTargetSdk: true,
 		});
 
 		return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@nativescript/doctor": "2.0.7",
+        "@nativescript/doctor": "2.0.8",
         "@nativescript/schematics-executor": "0.0.2",
         "@rigor789/resolve-package-path": "^1.0.5",
         "axios": "^0.21.1",
@@ -692,9 +692,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "node_modules/@nativescript/doctor": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@nativescript/doctor/-/doctor-2.0.7.tgz",
-      "integrity": "sha512-Pd3NlFGXN+SC03sBC/pj/9t5v5h7bh2xnbjbXHCo1MTjjm6fpLGFSxlCZRPPFgDIisf4OqGmEeIglNpy7CbyZg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@nativescript/doctor/-/doctor-2.0.8.tgz",
+      "integrity": "sha512-/jVGBBBBY2BX1IwriDyXHNi0ZNAkSuzdDQuGY3nUl3BDLu5AM+FFg4qCG3D9IW664WLbA1KbJQd+HUSjRHM/ZQ==",
       "dependencies": {
         "lodash": "4.17.21",
         "osenv": "0.1.5",
@@ -13607,9 +13607,9 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
     },
     "@nativescript/doctor": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@nativescript/doctor/-/doctor-2.0.7.tgz",
-      "integrity": "sha512-Pd3NlFGXN+SC03sBC/pj/9t5v5h7bh2xnbjbXHCo1MTjjm6fpLGFSxlCZRPPFgDIisf4OqGmEeIglNpy7CbyZg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@nativescript/doctor/-/doctor-2.0.8.tgz",
+      "integrity": "sha512-/jVGBBBBY2BX1IwriDyXHNi0ZNAkSuzdDQuGY3nUl3BDLu5AM+FFg4qCG3D9IW664WLbA1KbJQd+HUSjRHM/ZQ==",
       "requires": {
         "lodash": "4.17.21",
         "osenv": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "mobile"
   ],
   "dependencies": {
-    "@nativescript/doctor": "2.0.7",
+    "@nativescript/doctor": "2.0.8",
     "@nativescript/schematics-executor": "0.0.2",
     "@rigor789/resolve-package-path": "^1.0.5",
     "axios": "^0.21.1",

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/doctor",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Library that helps identifying if the environment can be used for development of {N} apps.",
   "main": "src/index.js",
   "types": "./typings/nativescript-doctor.d.ts",

--- a/packages/doctor/src/android-tools-info.ts
+++ b/packages/doctor/src/android-tools-info.ts
@@ -128,15 +128,16 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 				message = `You have to install version ${versionRangeMatches[1]}.`;
 			}
 
-			let invalidBuildToolsAdditionalMsg = `Run \`\$ ${this.getPathToSdkManagementTool()}\` from your command-line to install required \`Android Build Tools\`.`;
+			// let invalidBuildToolsAdditionalMsg = `Run \`\$ ${this.getPathToSdkManagementTool()}\` from your command-line to install required \`Android Build Tools\`.`;
+			let invalidBuildToolsAdditionalMsg = `Install the required build-tools through Android Studio.`;
 			if (!isAndroidHomeValid) {
 				invalidBuildToolsAdditionalMsg +=
-					" In case you already have them installed, make sure `ANDROID_HOME` environment variable is set correctly.";
+					" In case you already have them installed, make sure the `ANDROID_HOME` environment variable is set correctly.";
 			}
 
 			errors.push({
 				warning:
-					"You need to have the Android SDK Build-tools installed on your system. " +
+					"No compatible version of the Android SDK Build-tools are installed on your system. " +
 					message,
 				additionalInformation: invalidBuildToolsAdditionalMsg,
 				platforms: [Constants.ANDROID_PLATFORM_NAME],

--- a/packages/doctor/src/android-tools-info.ts
+++ b/packages/doctor/src/android-tools-info.ts
@@ -36,6 +36,11 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 			const indexOfSdk29 = baseTargets.indexOf("android-29");
 			baseTargets = baseTargets.slice(0, indexOfSdk29);
 		}
+		if (runtimeVersion && semver.lt(semver.coerce(runtimeVersion), "8.2.0")) {
+			baseTargets.sort();
+			const indexOfSdk32 = baseTargets.indexOf("android-32");
+			baseTargets = baseTargets.slice(0, indexOfSdk32);
+		}
 
 		return baseTargets;
 	}
@@ -503,7 +508,13 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 	}
 
 	private getMaxSupportedVersion(projectDir: string): number {
-		const supportedTargets = this.getSupportedTargets(projectDir);
+		let supportedTargets = this.getSupportedTargets(projectDir);
+		const runtimeVersion = this.getRuntimeVersion({ projectDir });
+		if (semver.lt(semver.coerce(runtimeVersion), "8.2.0")) {
+			supportedTargets = supportedTargets.filter(
+				(target) => this.parseAndroidSdkString(target) <= 30
+			);
+		}
 		return this.parseAndroidSdkString(
 			supportedTargets.sort()[supportedTargets.length - 1]
 		);

--- a/packages/doctor/src/android-tools-info.ts
+++ b/packages/doctor/src/android-tools-info.ts
@@ -31,15 +31,19 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 			"android-32",
 		];
 
-		if (runtimeVersion && semver.lt(semver.coerce(runtimeVersion), "6.1.0")) {
-			baseTargets.sort();
-			const indexOfSdk29 = baseTargets.indexOf("android-29");
-			baseTargets = baseTargets.slice(0, indexOfSdk29);
-		}
-		if (runtimeVersion && semver.lt(semver.coerce(runtimeVersion), "8.2.0")) {
-			baseTargets.sort();
-			const indexOfSdk32 = baseTargets.indexOf("android-32");
-			baseTargets = baseTargets.slice(0, indexOfSdk32);
+		const isRuntimeVersionLessThan = (targetVersion: string) => {
+			return (
+				runtimeVersion &&
+				semver.lt(semver.coerce(runtimeVersion), targetVersion)
+			);
+		};
+
+		if (isRuntimeVersionLessThan("6.1.0")) {
+			// limit baseTargets to android-17 - android-28 if the runtime is < 6.1.0
+			baseTargets = baseTargets.slice(0, baseTargets.indexOf("android-29"));
+		} else if (isRuntimeVersionLessThan("8.2.0")) {
+			// limit baseTargets to android-17 - android-30 if the runtime is < 8.2.0
+			baseTargets = baseTargets.slice(0, baseTargets.indexOf("android-31"));
 		}
 
 		return baseTargets;
@@ -508,13 +512,8 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 	}
 
 	private getMaxSupportedVersion(projectDir: string): number {
-		let supportedTargets = this.getSupportedTargets(projectDir);
-		const runtimeVersion = this.getRuntimeVersion({ projectDir });
-		if (semver.lt(semver.coerce(runtimeVersion), "8.2.0")) {
-			supportedTargets = supportedTargets.filter(
-				(target) => this.parseAndroidSdkString(target) <= 30
-			);
-		}
+		const supportedTargets = this.getSupportedTargets(projectDir);
+
 		return this.parseAndroidSdkString(
 			supportedTargets.sort()[supportedTargets.length - 1]
 		);

--- a/packages/doctor/test/android-tools-info.ts
+++ b/packages/doctor/test/android-tools-info.ts
@@ -47,9 +47,25 @@ describe("androidToolsInfo", () => {
 			},
 			readDirectory: (path: string) => {
 				if (path.indexOf("build-tools") >= 0) {
-					return ["20.0.0", "27.0.3", "28.0.3", "29.0.1"];
+					return [
+						"20.0.0",
+						"27.0.3",
+						"28.0.3",
+						"29.0.1",
+						"30.0.0",
+						"31.0.0",
+						"32.0.0",
+					];
 				} else {
-					return ["android-16", "android-27", "android-28", "android-29"];
+					return [
+						"android-16",
+						"android-27",
+						"android-28",
+						"android-29",
+						"android-30",
+						"android-31",
+						"android-32",
+					];
 				}
 			},
 		};
@@ -58,34 +74,68 @@ describe("androidToolsInfo", () => {
 		return new AndroidToolsInfo(childProcess, fs, hostInfo, helpers);
 	};
 
-	describe("getToolsInfo", () => {
-		it("runtime 6.0.0", () => {
+	describe("getToolsInfo -> compileSdkVersion", () => {
+		it("runtime 6.0.0 - 28", () => {
 			const androidToolsInfo = getAndroidToolsInfo("6.0.0");
 			const toolsInfo = androidToolsInfo.getToolsInfo({ projectDir: "test" });
 
 			assert.equal(toolsInfo.compileSdkVersion, 28);
 		});
 
-		it("runtime 6.1.0", () => {
+		it("runtime 6.1.0 - 30", () => {
 			const androidToolsInfo = getAndroidToolsInfo("6.1.0");
 			const toolsInfo = androidToolsInfo.getToolsInfo({ projectDir: "test" });
 
-			assert.equal(toolsInfo.compileSdkVersion, 29);
+			assert.equal(toolsInfo.compileSdkVersion, 30);
+		});
+
+		it("runtime 8.1.1 - 30", () => {
+			const androidToolsInfo = getAndroidToolsInfo("8.1.1");
+			const toolsInfo = androidToolsInfo.getToolsInfo({ projectDir: "test" });
+
+			assert.equal(toolsInfo.compileSdkVersion, 30);
+		});
+
+		it("runtime 8.2.0 - 32", () => {
+			const androidToolsInfo = getAndroidToolsInfo("8.2.0");
+			const toolsInfo = androidToolsInfo.getToolsInfo({ projectDir: "test" });
+
+			assert.equal(toolsInfo.compileSdkVersion, 32);
 		});
 	});
 
 	describe("supportedAndroidSdks", () => {
-		it("should support android-17 - android-32", () => {
-			const min = 17;
-			const max = 32;
+		const assertSupportedRange = (
+			runtimeVersion: string,
+			min: number,
+			max: number
+		) => {
 			let cnt = 0;
-			const androidToolsInfo = getAndroidToolsInfo("6.5.0");
+			const androidToolsInfo = getAndroidToolsInfo(runtimeVersion);
 			const supportedTargets = androidToolsInfo.getSupportedTargets("test");
 			for (let i = 0; i < supportedTargets.length; i++) {
 				assert.equal(supportedTargets[i], `android-${min + i}`);
 				cnt = min + i;
 			}
 			assert.equal(cnt, max);
+		};
+
+		it("runtime 6.0.0 should support android-17 - android-28", () => {
+			const min = 17;
+			const max = 28;
+			assertSupportedRange("6.0.0", min, max);
+		});
+
+		it("runtime 8.1.0 should support android-17 - android-30", () => {
+			const min = 17;
+			const max = 30;
+			assertSupportedRange("8.1.0", min, max);
+		});
+
+		it("runtime 8.2.0 should support android-17 - android-32", () => {
+			const min = 17;
+			const max = 32;
+			assertSupportedRange("8.2.0", min, max);
 		});
 	});
 
@@ -293,6 +343,52 @@ describe("androidToolsInfo", () => {
 				});
 			}
 		);
+	});
+
+	describe("validataMaxSupportedTargetSdk", () => {
+		const testCases = [
+			{
+				runtimeVersion: "8.1.0",
+				targetSdk: 30,
+				expectWarning: false,
+			},
+			{
+				runtimeVersion: "8.1.0",
+				targetSdk: 31,
+				expectWarning: true,
+			},
+			{
+				runtimeVersion: "8.1.0",
+				targetSdk: 32,
+				expectWarning: true,
+			},
+			{
+				runtimeVersion: "8.2.0",
+				targetSdk: 32,
+				expectWarning: false,
+			},
+		];
+
+		testCases.forEach(({ runtimeVersion, targetSdk, expectWarning }) => {
+			it(`for runtime ${runtimeVersion} - and targetSdk ${targetSdk}`, () => {
+				const androidToolsInfo = getAndroidToolsInfo(runtimeVersion);
+				const actualWarnings = androidToolsInfo.validataMaxSupportedTargetSdk({
+					projectDir: "test",
+					targetSdk,
+				});
+				let expectedWarnings: NativeScriptDoctor.IWarning[] = [];
+
+				if (expectWarning) {
+					expectedWarnings.push({
+						additionalInformation: "",
+						platforms: ["Android"],
+						warning: `Support for the selected Android target SDK android-${targetSdk} is not verified. Your Android app might not work as expected.`,
+					});
+				}
+
+				assert.deepEqual(actualWarnings, expectedWarnings);
+			});
+		});
 	});
 
 	after(() => {

--- a/packages/doctor/tsconfig.json
+++ b/packages/doctor/tsconfig.json
@@ -5,6 +5,7 @@
 	},
 	"include": [
 		"src/",
-		"test/"
+		"test/",
+		"typings/"
 	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,10 +340,10 @@
   "resolved" "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz"
   "version" "1.1.1"
 
-"@nativescript/doctor@2.0.7":
-  "integrity" "sha512-Pd3NlFGXN+SC03sBC/pj/9t5v5h7bh2xnbjbXHCo1MTjjm6fpLGFSxlCZRPPFgDIisf4OqGmEeIglNpy7CbyZg=="
-  "resolved" "https://registry.npmjs.org/@nativescript/doctor/-/doctor-2.0.7.tgz"
-  "version" "2.0.7"
+"@nativescript/doctor@2.0.8":
+  "integrity" "sha512-/jVGBBBBY2BX1IwriDyXHNi0ZNAkSuzdDQuGY3nUl3BDLu5AM+FFg4qCG3D9IW664WLbA1KbJQd+HUSjRHM/ZQ=="
+  "resolved" "https://registry.npmjs.org/@nativescript/doctor/-/doctor-2.0.8.tgz"
+  "version" "2.0.8"
   dependencies:
     "lodash" "4.17.21"
     "osenv" "0.1.5"


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?

Building with build-tools 31 or 32 on `@nativescript/android` < 8.2 fails.

## What is the new behavior?

Building on < 8.2 now tries to use a supported targetSdk, compileSdk and buildToolsVersion, or otherwise fails with a message indicating the issue (missing build-tools in the correct range).


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
