### PR TITLE
fix(ios-publish) Changes in Apple API to set Team Id

### DIFF
--- a/lib/services/apple-portal/apple-portal-application-service.ts
+++ b/lib/services/apple-portal/apple-portal-application-service.ts
@@ -23,7 +23,7 @@ export class ApplePortalApplicationService
 		let result: IApplePortalApplicationSummary[] = [];
 
 		for (const account of user.associatedAccounts) {
-			const contentProviderId = account.contentProvider.contentProviderPublicId;
+			const contentProviderId = account.contentProvider.contentProviderId;
 			const applications = await this.getApplicationsByProvider(
 				contentProviderId
 			);
@@ -34,7 +34,7 @@ export class ApplePortalApplicationService
 	}
 
 	public async getApplicationsByProvider(
-		contentProviderId: string
+		contentProviderId: number
 	): Promise<IApplePortalApplication> {
 		const webSessionCookie = await this.$applePortalSessionService.createWebSession(
 			contentProviderId

--- a/lib/services/apple-portal/apple-portal-session-service.ts
+++ b/lib/services/apple-portal/apple-portal-session-service.ts
@@ -79,22 +79,13 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 		return result;
 	}
 
-	public async createWebSession(contentProviderId: string): Promise<string> {
+	public async createWebSession(contentProviderId: number): Promise<string> {
 		const webSessionResponse = await this.$httpClient.httpRequest({
-			url:
-				"https://appstoreconnect.apple.com/olympus/v1/providerSwitchRequests",
+			url: "https://appstoreconnect.apple.com/olympus/v1/session",
 			method: "POST",
 			body: {
-				data: {
-					type: "providerSwitchRequests",
-					relationships: {
-						provider: {
-							data: {
-								type: "providers",
-								id: contentProviderId,
-							},
-						},
-					},
+				provider: {
+					providerId: contentProviderId,
 				},
 			},
 			headers: {
@@ -102,6 +93,7 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 				"Accept-Encoding": "gzip, deflate, br",
 				"X-Csrf-Itc": "itc",
 				"Content-Type": "application/json;charset=UTF-8",
+				"X-Requested-With": "olympus-ui",
 				Cookie: this.$applePortalCookieService.getUserSessionCookie(),
 			},
 		});

--- a/lib/services/apple-portal/definitions.d.ts
+++ b/lib/services/apple-portal/definitions.d.ts
@@ -1,7 +1,7 @@
 import { ICredentials } from "../../common/declarations";
 
 interface IApplePortalSessionService {
-	createWebSession(contentProviderId: string): Promise<string>;
+	createWebSession(contentProviderId: number): Promise<string>;
 	createUserSession(
 		credentials: ICredentials,
 		opts?: IAppleCreateUserSessionOptions
@@ -19,7 +19,7 @@ interface IApplePortalApplicationService {
 		user: IApplePortalUserDetail
 	): Promise<IApplePortalApplicationSummary[]>;
 	getApplicationsByProvider(
-		contentProviderId: string
+		contentProviderId: number
 	): Promise<IApplePortalApplication>;
 	getApplicationByBundleId(
 		user: IApplePortalUserDetail,


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Current cli fails with 401 with ```ns publish ...``` and ```ns appstore``` becuase of changes in apple api

## What is the new behavior?
Ported over the changes from fastlane and called a different api to set the correct team id so the commands work again.



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
