### PR TITLE
fix: use correct path to emulator executable

### DIFF
--- a/lib/common/mobile/android/android-virtual-device-service.ts
+++ b/lib/common/mobile/android/android-virtual-device-service.ts
@@ -331,7 +331,7 @@ export class AndroidVirtualDeviceService
 	private getConfigurationError(): string {
 		const pathToEmulatorExecutable = this.$hostInfo.isWindows
 			? `${this.pathToEmulatorExecutable}.exe`
-			: this.pathToAndroidExecutable;
+			: this.pathToEmulatorExecutable;
 		if (!this.$fs.exists(pathToEmulatorExecutable)) {
 			return "Unable to find the path to emulator executable and will not be able to start the emulator. Searched paths: [$ANDROID_HOME/tools/emulator, $ANDROID_HOME/emulator/emulator]";
 		}


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
We're checking for the `sdk/tools/android` instead of `sdk/emulator/emulator/`

## What is the new behavior?
We check for `sdk/emulator/emulator`
