### PR TITLE
feat: Added support for generating android adaptive icons

### DIFF
--- a/docs/man_pages/project/configuration/resources/resources-generate-icons.md
+++ b/docs/man_pages/project/configuration/resources/resources-generate-icons.md
@@ -15,6 +15,10 @@ Usage | Synopsis
 ------|-------
 `$ tns resources generate icons <Path to image>` | Generate all icons for Android and iOS based on the specified image.
 
+### Options
+
+* `--background` Sets the background color of the icon. When no color is specified, a default value of `transparent` is used. `<Color>` is a valid color and can be represented with string, like `white`, `black`, `blue`, or with HEX representation, for example `#FFFFFF`, `#000000`, `#0000FF`. NOTE: As the `#` is special symbol in some terminals, make sure to place the value in quotes, for example `$ tns resources generate icons ../myImage.png --background "#FF00FF"`.
+
 ### Arguments
 
 * `<Path to image>` is a valid path to an image that will be used to generate all icons.

--- a/lib/commands/generate-assets.ts
+++ b/lib/commands/generate-assets.ts
@@ -61,6 +61,7 @@ export class GenerateIconsCommand
 	): Promise<void> {
 		await this.$assetsGenerationService.generateIcons({
 			imagePath,
+			background,
 			projectDir: this.$projectData.projectDir,
 		});
 	}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -1144,12 +1144,7 @@ interface IResourceGenerationData extends IProjectDir {
 	 * @param {string} platform Specify for which platform to generate assets. If not defined will generate for all platforms
 	 */
 	platform?: string;
-}
 
-/**
- * Describes the data needed for splash screens generation
- */
-interface ISplashesGenerationData extends IResourceGenerationData {
 	/**
 	 * @param {string} background Background color that will be used for background. Defaults to #FFFFFF
 	 */
@@ -1169,11 +1164,11 @@ interface IAssetsGenerationService {
 
 	/**
 	 * Generate splash screens for iOS and Android
-	 * @param {ISplashesGenerationData} splashesGenerationData Provides the data needed for splash screens generation
+	 * @param {IResourceGenerationData} splashesGenerationData Provides the data needed for splash screens generation
 	 * @returns {Promise<void>}
 	 */
 	generateSplashScreens(
-		splashesGenerationData: ISplashesGenerationData
+		splashesGenerationData: IResourceGenerationData
 	): Promise<void>;
 }
 

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -407,6 +407,10 @@ interface IAssetItem {
 	resizeOperation?: string;
 	overlayImageScale?: number;
 	rgba?: boolean;
+
+	// additional operations for special cases
+	operation?: "delete" | "writeXMLColor";
+	data?: any;
 }
 
 interface IAssetSubGroup {
@@ -438,6 +442,7 @@ interface IImageDefinitionGroup {
 interface IImageDefinitionsStructure {
 	ios: IImageDefinitionGroup;
 	android: IImageDefinitionGroup;
+	android_legacy: IImageDefinitionGroup;
 }
 
 interface ITemplateData {

--- a/lib/services/assets-generation/assets-generation-service.ts
+++ b/lib/services/assets-generation/assets-generation-service.ts
@@ -65,7 +65,7 @@ export class AssetsGenerationService implements IAssetsGenerationService {
 		generationData: IResourceGenerationData,
 		propertiesToEnumerate: string[]
 	): Promise<void> {
-		// generationData.background = generationData.background || "white";
+		const background = generationData.background || "white";
 		const assetsStructure = await this.$projectDataService.getAssetsStructure(
 			generationData
 		);
@@ -174,7 +174,7 @@ export class AssetsGenerationService implements IAssetsGenerationService {
 						imageResize
 					);
 					image = this.generateImage(
-						generationData.background,
+						background,
 						width,
 						height,
 						outputPath,
@@ -182,12 +182,7 @@ export class AssetsGenerationService implements IAssetsGenerationService {
 					);
 					break;
 				case Operations.Blank:
-					image = this.generateImage(
-						generationData.background,
-						width,
-						height,
-						outputPath
-					);
+					image = this.generateImage(background, width, height, outputPath);
 					break;
 				case Operations.Resize:
 					image = await this.resize(generationData.imagePath, width, height);

--- a/lib/services/assets-generation/assets-generation-service.ts
+++ b/lib/services/assets-generation/assets-generation-service.ts
@@ -20,6 +20,7 @@ export const enum Operations {
 	OverlayWith = "overlayWith",
 	Blank = "blank",
 	Resize = "resize",
+	OuterScale = "outerScale",
 }
 
 export class AssetsGenerationService implements IAssetsGenerationService {
@@ -150,6 +151,22 @@ export class AssetsGenerationService implements IAssetsGenerationService {
 					break;
 				case Operations.Resize:
 					image = await this.resize(generationData.imagePath, width, height);
+					break;
+				case Operations.OuterScale:
+					// Resize image without applying scale
+					image = await this.resize(
+						generationData.imagePath,
+						assetItem.width,
+						assetItem.height
+					);
+					// The scale will apply to the underlying layer of the generated image
+					image = this.generateImage(
+						"#00000000",
+						width,
+						height,
+						outputPath,
+						image
+					);
 					break;
 				default:
 					throw new Error(`Invalid image generation operation: ${operation}`);

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -236,7 +236,19 @@ export class ProjectDataService implements IProjectDataService {
 			? path.join(pathToAndroidDir, SRC_DIR, MAIN_DIR, RESOURCES_DIR)
 			: pathToAndroidDir;
 
-		const content = this.getImageDefinitions().android;
+		let useLegacy = false;
+		try {
+			const manifest = this.$fs.readText(
+				path.resolve(basePath, "../AndroidManifest.xml")
+			);
+			useLegacy = !manifest.includes(`android:icon="@mipmap/ic_launcher"`);
+		} catch (err) {
+			// ignore
+		}
+
+		const content = this.getImageDefinitions()[
+			useLegacy ? "android_legacy" : "android"
+		];
 
 		return {
 			icons: this.getAndroidAssetSubGroup(content.icons, basePath),
@@ -460,7 +472,9 @@ export class ProjectDataService implements IProjectDataService {
 				assetItem.filename
 			);
 			assetItem.path = imagePath;
-			assetItem.size = `${assetItem.width}${AssetConstants.sizeDelimiter}${assetItem.height}`;
+			if (assetItem.width && assetItem.height) {
+				assetItem.size = `${assetItem.width}${AssetConstants.sizeDelimiter}${assetItem.height}`;
+			}
 			assetSubGroup.images.push(assetItem);
 		});
 

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -236,18 +236,17 @@ export class ProjectDataService implements IProjectDataService {
 			? path.join(pathToAndroidDir, SRC_DIR, MAIN_DIR, RESOURCES_DIR)
 			: pathToAndroidDir;
 
-		const currentStructure = this.$fs.enumerateFilesInDirectorySync(basePath);
 		const content = this.getImageDefinitions().android;
 
 		return {
-			icons: this.getAndroidAssetSubGroup(content.icons, currentStructure),
+			icons: this.getAndroidAssetSubGroup(content.icons, basePath),
 			splashBackgrounds: this.getAndroidAssetSubGroup(
 				content.splashBackgrounds,
-				currentStructure
+				basePath
 			),
 			splashCenterImages: this.getAndroidAssetSubGroup(
 				content.splashCenterImages,
-				currentStructure
+				basePath
 			),
 			splashImages: null,
 		};
@@ -448,32 +447,21 @@ export class ProjectDataService implements IProjectDataService {
 
 	private getAndroidAssetSubGroup(
 		assetItems: IAssetItem[],
-		realPaths: string[]
+		basePath: string
 	): IAssetSubGroup {
 		const assetSubGroup: IAssetSubGroup = {
 			images: <any>[],
 		};
 
-		const normalizedPaths = _.map(realPaths, (p) => path.normalize(p));
 		_.each(assetItems, (assetItem) => {
-			const imagePath = path.join(assetItem.directory, assetItem.filename);
-
-			let found = false;
-			_.each(normalizedPaths, (currentNormalizedPath) => {
-				if (currentNormalizedPath.indexOf(path.normalize(imagePath)) !== -1) {
-					assetItem.path = currentNormalizedPath;
-					assetItem.size = `${assetItem.width}${AssetConstants.sizeDelimiter}${assetItem.height}`;
-					assetSubGroup.images.push(assetItem);
-					found = true;
-					return false;
-				}
-			});
-
-			if (!found) {
-				this.$logger.warn(
-					`Didn't find a matching old image definition for file ${imagePath}. This file will be skipped from resources generation.`
-				);
-			}
+			const imagePath = path.join(
+				basePath,
+				assetItem.directory,
+				assetItem.filename
+			);
+			assetItem.path = imagePath;
+			assetItem.size = `${assetItem.width}${AssetConstants.sizeDelimiter}${assetItem.height}`;
+			assetSubGroup.images.push(assetItem);
 		});
 
 		return assetSubGroup;

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -456,15 +456,24 @@ export class ProjectDataService implements IProjectDataService {
 
 		const normalizedPaths = _.map(realPaths, (p) => path.normalize(p));
 		_.each(assetItems, (assetItem) => {
+			const imagePath = path.join(assetItem.directory, assetItem.filename);
+
+			let found = false;
 			_.each(normalizedPaths, (currentNormalizedPath) => {
-				const imagePath = path.join(assetItem.directory, assetItem.filename);
 				if (currentNormalizedPath.indexOf(path.normalize(imagePath)) !== -1) {
 					assetItem.path = currentNormalizedPath;
 					assetItem.size = `${assetItem.width}${AssetConstants.sizeDelimiter}${assetItem.height}`;
 					assetSubGroup.images.push(assetItem);
+					found = true;
 					return false;
 				}
 			});
+
+			if (!found) {
+				this.$logger.warn(
+					`Didn't find a matching old image definition for file ${imagePath}. This file will be skipped from resources generation.`
+				);
+			}
 		});
 
 		return assetSubGroup;

--- a/resources/assets/image-definitions.json
+++ b/resources/assets/image-definitions.json
@@ -490,7 +490,7 @@
 				"filename": "ic_launcher_foreground.png",
 				"resizeOperation": "outerScale",
 				"scale": "1.5x"
-			},
+			}
 		],
 		"splashBackgrounds": [
 			{

--- a/resources/assets/image-definitions.json
+++ b/resources/assets/image-definitions.json
@@ -416,32 +416,38 @@
 			{
 				"width": 72,
 				"height": 72,
-				"directory": "mipmap-hdpi",
-				"filename": "ic_launcher.png"
+				"directory": "drawable-hdpi",
+				"filename": "icon.png"
+			},
+			{
+				"width": 36,
+				"height": 36,
+				"directory": "drawable-ldpi",
+				"filename": "icon.png"
 			},
 			{
 				"width": 48,
 				"height": 48,
-				"directory": "mipmap-mdpi",
-				"filename": "ic_launcher.png"
+				"directory": "drawable-mdpi",
+				"filename": "icon.png"
 			},
 			{
 				"width": 96,
 				"height": 96,
-				"directory": "mipmap-xhdpi",
-				"filename": "ic_launcher.png"
+				"directory": "drawable-xhdpi",
+				"filename": "icon.png"
 			},
 			{
 				"width": 144,
 				"height": 144,
-				"directory": "mipmap-xxhdpi",
-				"filename": "ic_launcher.png"
+				"directory": "drawable-xxhdpi",
+				"filename": "icon.png"
 			},
 			{
-				"width": 192,
-				"height": 192,
-				"directory": "mipmap-xxxhdpi",
-				"filename": "ic_launcher.png"
+				"width": 345,
+				"height": 345,
+				"directory": "drawable-xxxhdpi",
+				"filename": "icon.png"
 			},
 			{
 				"width": 108,
@@ -490,6 +496,36 @@
 				"filename": "ic_launcher_foreground.png",
 				"resizeOperation": "outerScale",
 				"scale": "1.5x"
+			},
+			{
+				"width": 72,
+				"height": 72,
+				"directory": "mipmap-hdpi",
+				"filename": "ic_launcher.png"
+			},
+			{
+				"width": 48,
+				"height": 48,
+				"directory": "mipmap-mdpi",
+				"filename": "ic_launcher.png"
+			},
+			{
+				"width": 96,
+				"height": 96,
+				"directory": "mipmap-xhdpi",
+				"filename": "ic_launcher.png"
+			},
+			{
+				"width": 144,
+				"height": 144,
+				"directory": "mipmap-xxhdpi",
+				"filename": "ic_launcher.png"
+			},
+			{
+				"width": 192,
+				"height": 192,
+				"directory": "mipmap-xxxhdpi",
+				"filename": "ic_launcher.png"
 			}
 		],
 		"splashBackgrounds": [

--- a/resources/assets/image-definitions.json
+++ b/resources/assets/image-definitions.json
@@ -416,39 +416,81 @@
 			{
 				"width": 72,
 				"height": 72,
-				"directory": "drawable-hdpi",
-				"filename": "icon.png"
-			},
-			{
-				"width": 36,
-				"height": 36,
-				"directory": "drawable-ldpi",
-				"filename": "icon.png"
+				"directory": "mipmap-hdpi",
+				"filename": "ic_launcher.png"
 			},
 			{
 				"width": 48,
 				"height": 48,
-				"directory": "drawable-mdpi",
-				"filename": "icon.png"
+				"directory": "mipmap-mdpi",
+				"filename": "ic_launcher.png"
 			},
 			{
 				"width": 96,
 				"height": 96,
-				"directory": "drawable-xhdpi",
-				"filename": "icon.png"
+				"directory": "mipmap-xhdpi",
+				"filename": "ic_launcher.png"
 			},
 			{
 				"width": 144,
 				"height": 144,
-				"directory": "drawable-xxhdpi",
-				"filename": "icon.png"
+				"directory": "mipmap-xxhdpi",
+				"filename": "ic_launcher.png"
 			},
 			{
-				"width": 345,
-				"height": 345,
+				"width": 192,
+				"height": 192,
+				"directory": "mipmap-xxxhdpi",
+				"filename": "ic_launcher.png"
+			},
+			{
+				"width": 108,
+				"height": 108,
+				"directory": "drawable-hdpi",
+				"filename": "ic_launcher_foreground.png",
+				"resizeOperation": "outerScale",
+				"scale": "1.5x"
+			},
+			{
+				"width": 54,
+				"height": 54,
+				"directory": "drawable-ldpi",
+				"filename": "ic_launcher_foreground.png",
+				"resizeOperation": "outerScale",
+				"scale": "1.5x"
+			},
+			{
+				"width": 72,
+				"height": 72,
+				"directory": "drawable-mdpi",
+				"filename": "ic_launcher_foreground.png",
+				"resizeOperation": "outerScale",
+				"scale": "1.5x"
+			},
+			{
+				"width": 144,
+				"height": 144,
+				"directory": "drawable-xhdpi",
+				"filename": "ic_launcher_foreground.png",
+				"resizeOperation": "outerScale",
+				"scale": "1.5x"
+			},
+			{
+				"width": 216,
+				"height": 216,
+				"directory": "drawable-xxhdpi",
+				"filename": "ic_launcher_foreground.png",
+				"resizeOperation": "outerScale",
+				"scale": "1.5x"
+			},
+			{
+				"width": 288,
+				"height": 288,
 				"directory": "drawable-xxxhdpi",
-				"filename": "icon.png"
-			}
+				"filename": "ic_launcher_foreground.png",
+				"resizeOperation": "outerScale",
+				"scale": "1.5x"
+			},
 		],
 		"splashBackgrounds": [
 			{

--- a/resources/assets/image-definitions.json
+++ b/resources/assets/image-definitions.json
@@ -411,43 +411,74 @@
 			}
 		]
 	},
-	"android": {
+	"android_legacy": {
 		"icons": [
 			{
 				"width": 72,
 				"height": 72,
 				"directory": "drawable-hdpi",
-				"filename": "icon.png"
+				"filename": "icon.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 36,
 				"height": 36,
 				"directory": "drawable-ldpi",
-				"filename": "icon.png"
+				"filename": "icon.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 48,
 				"height": 48,
 				"directory": "drawable-mdpi",
-				"filename": "icon.png"
+				"filename": "icon.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 96,
 				"height": 96,
 				"directory": "drawable-xhdpi",
-				"filename": "icon.png"
+				"filename": "icon.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 144,
 				"height": 144,
 				"directory": "drawable-xxhdpi",
-				"filename": "icon.png"
+				"filename": "icon.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 345,
 				"height": 345,
 				"directory": "drawable-xxxhdpi",
-				"filename": "icon.png"
+				"filename": "icon.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
+			}
+		]
+	},
+	"android": {
+		"icons": [
+			{
+				"directory": "drawable",
+				"filename": "ic_launcher_foreground.xml",
+				"operation": "delete"
+			},
+			{
+				"directory": "values",
+				"filename": "ic_launcher_background.xml",
+				"operation": "writeXMLColor",
+				"data": {
+					"colorName": "ic_launcher_background",
+					"fromKey": "background",
+					"default": "#FFFFFF"
+				}
 			},
 			{
 				"width": 108,
@@ -501,31 +532,41 @@
 				"width": 72,
 				"height": 72,
 				"directory": "mipmap-hdpi",
-				"filename": "ic_launcher.png"
+				"filename": "ic_launcher.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 48,
 				"height": 48,
 				"directory": "mipmap-mdpi",
-				"filename": "ic_launcher.png"
+				"filename": "ic_launcher.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 96,
 				"height": 96,
 				"directory": "mipmap-xhdpi",
-				"filename": "ic_launcher.png"
+				"filename": "ic_launcher.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 144,
 				"height": 144,
 				"directory": "mipmap-xxhdpi",
-				"filename": "ic_launcher.png"
+				"filename": "ic_launcher.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			},
 			{
 				"width": 192,
 				"height": 192,
 				"directory": "mipmap-xxxhdpi",
-				"filename": "ic_launcher.png"
+				"filename": "ic_launcher.png",
+				"resizeOperation": "overlayWith",
+				"scale": "1x"
 			}
 		],
 		"splashBackgrounds": [


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Command `ns resources generate icons <source image path>` cannot generate app launcher icons ever since the adaptive icons addition (ic_launcher). Right now, developers have no ways to generate android launcher icons apart from using Android Studio.

## What is the new behavior?
Command `ns resources generate icons <source image path>` will generate all needed icons.

According to google, adaptive icons have few requirements:

- Both layers must be sized at 108 x 108 dp.
- The inner 72 x 72 dp of the icon appears within the masked viewport.
- The system reserves the outer 18 dp on each of the 4 sides to create interesting visual effects, such as parallax or pulsing.

In order to comply with these requirements, I updated `image-definitions.json` using the following concept:

1. Source image will also be used to create an `ic_launcher_foreground` resized to 72 dp converted to pixels.
2. A new resize operation called `outerScale` was added to CLI. Using this operation, we can scale the outer part of the image (it's a bottom layer actually), which will become an opaque layer using hex `#00000000`.
3. Scale is set to 1.5x  to resize image (but not the inner content) to pixels that equal to 108dp according to device dpi. (72dp x 1.5 = 108dp)

Fixes/Implements/Closes #5571.