### PR TITLE
fix: android plugins now built using same “gradle” as apps

### DIFF
--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -144,40 +144,6 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		return promise;
 	}
 
-	private getIncludeGradleCompileDependenciesScope(
-		includeGradleFileContent: string
-	): Array<string> {
-		const indexOfDependenciesScope = includeGradleFileContent.indexOf(
-			"dependencies"
-		);
-		const result: Array<string> = [];
-
-		if (indexOfDependenciesScope === -1) {
-			return result;
-		}
-
-		const indexOfRepositoriesScope = includeGradleFileContent.indexOf(
-			"repositories"
-		);
-
-		let repositoriesScope = "";
-		if (indexOfRepositoriesScope >= 0) {
-			repositoriesScope = this.getScope(
-				"repositories",
-				includeGradleFileContent
-			);
-			result.push(repositoriesScope);
-		}
-
-		const dependenciesScope = this.getScope(
-			"dependencies",
-			includeGradleFileContent
-		);
-		result.push(dependenciesScope);
-
-		return result;
-	}
-
 	private getScope(scopeName: string, content: string): string {
 		const indexOfScopeName = content.indexOf(scopeName);
 		const openingBracket = "{";
@@ -410,17 +376,12 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		const buildGradlePath = path.join(pluginTempDir, "build.gradle");
 
 		this.$fs.copyFile(allGradleTemplateFiles, pluginTempDir);
-		this.addCompileDependencies(platformsAndroidDirPath, buildGradlePath);
 		const runtimeGradleVersions = await this.getRuntimeGradleVersions(
 			projectDir
 		);
 		this.replaceGradleVersion(
 			pluginTempDir,
 			runtimeGradleVersions.gradleVersion
-		);
-		this.replaceGradleAndroidPluginVersion(
-			buildGradlePath,
-			runtimeGradleVersions.gradleAndroidPluginVersion
 		);
 		this.replaceFileContent(buildGradlePath, "{{pluginName}}", pluginName);
 	}
@@ -640,22 +601,6 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		);
 	}
 
-	private replaceGradleAndroidPluginVersion(
-		buildGradlePath: string,
-		version: string
-	): void {
-		const gradleAndroidPluginVersionPlaceholder =
-			"{{runtimeAndroidPluginVersion}}";
-		const gradleAndroidPluginVersion =
-			version || AndroidBuildDefaults.GradleAndroidPluginVersion;
-
-		this.replaceFileContent(
-			buildGradlePath,
-			gradleAndroidPluginVersionPlaceholder,
-			gradleAndroidPluginVersion
-		);
-	}
-
 	private replaceFileContent(
 		filePath: string,
 		content: string,
@@ -665,29 +610,6 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		const contentRegex = new RegExp(content, "g");
 		const replacedFileContent = fileContent.replace(contentRegex, replacement);
 		this.$fs.writeFile(filePath, replacedFileContent);
-	}
-
-	private addCompileDependencies(
-		platformsAndroidDirPath: string,
-		buildGradlePath: string
-	): void {
-		const includeGradlePath = path.join(
-			platformsAndroidDirPath,
-			INCLUDE_GRADLE_NAME
-		);
-		if (this.$fs.exists(includeGradlePath)) {
-			const includeGradleContent = this.$fs.readText(includeGradlePath);
-			const compileDependencies = this.getIncludeGradleCompileDependenciesScope(
-				includeGradleContent
-			);
-
-			if (compileDependencies.length) {
-				this.$fs.appendFile(
-					buildGradlePath,
-					"\n" + compileDependencies.join("\n")
-				);
-			}
-		}
 	}
 
 	private copyAar(

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -8,85 +8,128 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 buildscript {
-    def getDepPlatformDir = { dep ->
-        file("${project.ext.USER_PROJECT_ROOT}/${project.ext.PLATFORMS_ANDROID}/${dep.directory}/$PLATFORMS_ANDROID")
-    }
-    def computeKotlinVersion = { -> project.hasProperty("kotlinVersion") ? kotlinVersion : "1.6.0" }
-    def kotlinVersion = computeKotlinVersion()
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:{{runtimeAndroidPluginVersion}}'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+    def initialize = { ->
+        // set up our logger
+        project.ext.outLogger = services.get(StyledTextOutputFactory).create("colouredOutputLogger")
+        outLogger.withStyle(Style.SuccessHeader).println "\t ~initialize"
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
 
-    // Set up styled logger
-    project.ext.getDepPlatformDir = getDepPlatformDir
-    project.ext.outLogger = services.get(StyledTextOutputFactory).create("colouredOutputLogger")
+        project.ext.USER_PROJECT_ROOT = "$rootDir/../../.."
+        project.ext.PLATFORMS_ANDROID = "platforms/android"
+        project.ext.PLUGIN_NAME = "{{pluginName}}"
+        
+        def userDir = "$USER_PROJECT_ROOT"
+        apply from: "$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/gradle-helpers/user_properties_reader.gradle"
+        apply from: "$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/gradle-helpers/paths.gradle"
+        rootProject.ext.userDefinedGradleProperties = getUserProperties("${getAppResourcesPath(USER_PROJECT_ROOT)}/Android")
 
-    project.ext.USER_PROJECT_ROOT = "$rootDir/../../.."
-    project.ext.PLATFORMS_ANDROID = "platforms/android"
-    project.ext.PLUGIN_NAME = "{{pluginName}}"
-
-    // the build script will not work with previous versions of the CLI (3.1 or earlier)
-    def dependenciesJson = file("${project.ext.USER_PROJECT_ROOT}/${project.ext.PLATFORMS_ANDROID}/dependencies.json")
-    def appDependencies = new JsonSlurper().parseText(dependenciesJson.text)
-    def pluginData = appDependencies.find { it.name == project.ext.PLUGIN_NAME }
-    project.ext.nativescriptDependencies = appDependencies.findAll{pluginData.dependencies.contains(it.name)}
-    project.ext.getAppPath = { ->
-        def relativePathToApp = "app"
-        def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
-        def nsConfig
-
-        if (nsConfigFile.exists()) {
-            nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+        loadPropertyFile("$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/gradle.properties")
+        loadPropertyFile("$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/additional_gradle.properties")
+        
+        if (rootProject.hasProperty("userDefinedGradleProperties")) {
+            rootProject.ext.userDefinedGradleProperties.each { entry ->
+                def propertyName = entry.getKey()
+                def propertyValue = entry.getValue()
+                project.ext.set(propertyName, propertyValue)
+            }
         }
 
-        if (project.hasProperty("appPath")) {
-            // when appPath is passed through -PappPath=/path/to/app
-            // the path could be relative or absolute - either case will work
-            relativePathToApp = appPath
-        } else if (nsConfig != null && nsConfig.appPath != null) {
-            relativePathToApp = nsConfig.appPath
+        def getDepPlatformDir = { dep ->
+            file("${project.ext.USER_PROJECT_ROOT}/${project.ext.PLATFORMS_ANDROID}/${dep.directory}/$PLATFORMS_ANDROID")
         }
 
-        project.ext.appPath = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToApp).toAbsolutePath()
+        // Set up styled logger
+        project.ext.getDepPlatformDir = getDepPlatformDir
+        project.ext.outLogger = services.get(StyledTextOutputFactory).create("colouredOutputLogger")
 
-        return project.ext.appPath
+
+        // the build script will not work with previous versions of the CLI (3.1 or earlier)
+        def dependenciesJson = file("${project.ext.USER_PROJECT_ROOT}/${project.ext.PLATFORMS_ANDROID}/dependencies.json")
+        def appDependencies = new JsonSlurper().parseText(dependenciesJson.text)
+        def pluginData = appDependencies.find { it.name == project.ext.PLUGIN_NAME }
+        project.ext.nativescriptDependencies = appDependencies.findAll{pluginData.dependencies.contains(it.name)}.plus([pluginData])
+        outLogger.withStyle(Style.SuccessHeader).println "\t ~ nativescriptDependencies ${nativescriptDependencies}"
+    
+
+        project.ext.getAppResourcesPath = { ->
+            def relativePathToAppResources
+            def absolutePathToAppResources
+            def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
+            def nsConfig
+
+            if (nsConfigFile.exists()) {
+                nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+            }
+
+            if (project.hasProperty("appResourcesPath")) {
+                // when appResourcesPath is passed through -PappResourcesPath=/path/to/App_Resources
+                // the path could be relative or absolute - either case will work
+                relativePathToAppResources = appResourcesPath
+                absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
+            } else if (nsConfig != null && nsConfig.appResourcesPath != null) {
+                relativePathToAppResources = nsConfig.appResourcesPath
+                absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
+            } else {
+                absolutePathToAppResources = "${getAppPath()}/App_Resources"
+            }
+
+            project.ext.appResourcesPath = absolutePathToAppResources
+
+            return absolutePathToAppResources
+        }
+
+
+        project.ext.getAppPath = { ->
+            def relativePathToApp = "app"
+            def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
+            def nsConfig
+
+            if (nsConfigFile.exists()) {
+                nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+            }
+
+            if (project.hasProperty("appPath")) {
+                // when appPath is passed through -PappPath=/path/to/app
+                // the path could be relative or absolute - either case will work
+                relativePathToApp = appPath
+            } else if (nsConfig != null && nsConfig.appPath != null) {
+                relativePathToApp = nsConfig.appPath
+            }
+
+            project.ext.appPath = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToApp).toAbsolutePath()
+
+            return project.ext.appPath
+        }
+
+        project.ext.getAppResourcesPath = { ->
+            def relativePathToAppResources
+            def absolutePathToAppResources
+            def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
+            def nsConfig
+
+            if (nsConfigFile.exists()) {
+                nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+            }
+
+            if (project.hasProperty("appResourcesPath")) {
+                // when appResourcesPath is passed through -PappResourcesPath=/path/to/App_Resources
+                // the path could be relative or absolute - either case will work
+                relativePathToAppResources = appResourcesPath
+                absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
+            } else if (nsConfig != null && nsConfig.appResourcesPath != null) {
+                relativePathToAppResources = nsConfig.appResourcesPath
+                absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
+            } else {
+                absolutePathToAppResources = "${getAppPath()}/App_Resources"
+            }
+
+            project.ext.appResourcesPath = absolutePathToAppResources
+
+            return absolutePathToAppResources
+        }
+
+
     }
-
-    project.ext.getAppResourcesPath = { ->
-        def relativePathToAppResources
-        def absolutePathToAppResources
-        def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
-        def nsConfig
-
-        if (nsConfigFile.exists()) {
-            nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
-        }
-
-        if (project.hasProperty("appResourcesPath")) {
-            // when appResourcesPath is passed through -PappResourcesPath=/path/to/App_Resources
-            // the path could be relative or absolute - either case will work
-            relativePathToAppResources = appResourcesPath
-            absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
-        } else if (nsConfig != null && nsConfig.appResourcesPath != null) {
-            relativePathToAppResources = nsConfig.appResourcesPath
-            absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
-        } else {
-            absolutePathToAppResources = "${getAppPath()}/App_Resources"
-        }
-
-        project.ext.appResourcesPath = absolutePathToAppResources
-
-        return absolutePathToAppResources
-    }
-
     def applyBuildScriptConfigurations = { ->
         def absolutePathToAppResources = getAppResourcesPath()
         def pathToBuildScriptGradle = "$absolutePathToAppResources/Android/buildscript.gradle"
@@ -112,7 +155,24 @@ buildscript {
             apply from: pathToPluginBuildScriptGradle, to: buildscript
         }
     }
+
+    initialize()
     applyBuildScriptConfigurations()
+
+    def computeKotlinVersion = { -> project.hasProperty("kotlinVersion") ? kotlinVersion : "${ns_default_kotlin_version}" }
+    def computeBuildToolsVersion = { -> project.hasProperty("androidBuildToolsVersion") ? androidBuildToolsVersion : "${NS_DEFAULT_ANDROID_BUILD_TOOLS_VERSION}" }
+    def kotlinVersion = computeKotlinVersion()
+    def androidBuildToolsVersion = computeBuildToolsVersion()
+
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:$androidBuildToolsVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.codehaus.groovy:groovy-all:3.0.8"
+    }
 
 }
 
@@ -185,10 +245,15 @@ def applyBeforePluginGradleConfiguration() {
 
 task addDependenciesFromNativeScriptPlugins {
     nativescriptDependencies.each { dep ->
+        outLogger.withStyle(Style.SuccessHeader).println "\t +addDependenciesFromNativeScriptPlugins: " +  getDepPlatformDir(dep)
         def aarFiles = fileTree(dir: getDepPlatformDir(dep), include: ["**/*.aar"])
+        def currentDirname = file(project.buildscript.sourceFile).getParentFile().getName()
         aarFiles.each { aarFile ->
             def length = aarFile.name.length() - 4
             def fileName = aarFile.name[0..<length]
+            if(fileName == currentDirname) {
+                return
+            }
             outLogger.withStyle(Style.SuccessHeader).println "\t + adding aar plugin dependency: " + aarFile.getAbsolutePath()
             project.dependencies.add("implementation", [name: fileName, ext: "aar"])
         }

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -48,8 +48,6 @@ buildscript {
         def appDependencies = new JsonSlurper().parseText(dependenciesJson.text)
         def pluginData = appDependencies.find { it.name == project.ext.PLUGIN_NAME }
         project.ext.nativescriptDependencies = appDependencies.findAll{pluginData.dependencies.contains(it.name)}.plus([pluginData])
-        outLogger.withStyle(Style.SuccessHeader).println "\t ~ nativescriptDependencies ${nativescriptDependencies}"
-    
 
         project.ext.getAppResourcesPath = { ->
             def relativePathToAppResources
@@ -245,7 +243,6 @@ def applyBeforePluginGradleConfiguration() {
 
 task addDependenciesFromNativeScriptPlugins {
     nativescriptDependencies.each { dep ->
-        outLogger.withStyle(Style.SuccessHeader).println "\t +addDependenciesFromNativeScriptPlugins: " +  getDepPlatformDir(dep)
         def aarFiles = fileTree(dir: getDepPlatformDir(dep), include: ["**/*.aar"])
         def currentDirname = file(project.buildscript.sourceFile).getParentFile().getName()
         aarFiles.each { aarFile ->

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -72,6 +72,27 @@ buildscript {
             logger.warn "\t + failed to load gradle properties from \"$path\". Error is: ${ex.getMessage()}"
         }
     }
+    def getAppPath = { ->
+        def relativePathToApp = "app"
+        def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
+        def nsConfig
+
+        if (nsConfigFile.exists()) {
+            nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+        }
+
+        if (project.hasProperty("appPath")) {
+            // when appPath is passed through -PappPath=/path/to/app
+            // the path could be relative or absolute - either case will work
+            relativePathToApp = appPath
+        } else if (nsConfig != null && nsConfig.appPath != null) {
+            relativePathToApp = nsConfig.appPath
+        }
+
+        project.ext.appPath = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToApp).toAbsolutePath()
+
+        return project.ext.appPath
+    }
     def getAppResourcesPath = { ->
         def relativePathToAppResources
         def absolutePathToAppResources
@@ -99,28 +120,6 @@ buildscript {
         return absolutePathToAppResources
     }
 
-
-    def getAppPath = { ->
-        def relativePathToApp = "app"
-        def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
-        def nsConfig
-
-        if (nsConfigFile.exists()) {
-            nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
-        }
-
-        if (project.hasProperty("appPath")) {
-            // when appPath is passed through -PappPath=/path/to/app
-            // the path could be relative or absolute - either case will work
-            relativePathToApp = appPath
-        } else if (nsConfig != null && nsConfig.appPath != null) {
-            relativePathToApp = nsConfig.appPath
-        }
-
-        project.ext.appPath = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToApp).toAbsolutePath()
-
-        return project.ext.appPath
-    }
     def initialize = { ->
         // set up our logger
         project.ext.outLogger = services.get(StyledTextOutputFactory).create("colouredOutputLogger")
@@ -295,6 +294,7 @@ android {
         nativescriptDependencies.each { dep ->
             def includeGradlePath = "${getDepPlatformDir(dep)}/include.gradle"
             if (file(includeGradlePath).exists()) {
+                outLogger.withStyle(Style.SuccessHeader).println "\t + applying plugin include.gradle from dependency ${includeGradlePath}"
                 apply from: includeGradlePath
             }
         }
@@ -309,6 +309,10 @@ android {
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"
+    }
+    lintOptions {
+        checkReleaseBuilds false
+        abortOnError false
     }
 }
 

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -7,7 +7,71 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
+def loadPropertyFile = { path ->
+    try {
+        if(project.hasProperty("loadedProperties_${path}")) {
+            logger.info "\t + gradle properties already loaded. SKIPPING"
+        } else {
+            logger.info "\t + trying to load gradle properties from \"$path\""
+
+            Properties properties = new Properties()
+            properties.load(new FileInputStream("$path"))
+            properties.each { prop ->
+                logger.info "\t + [$path] setting ${prop.key} = ${prop.value}"
+                project.ext.set(prop.key, prop.value)
+            }
+            project.ext.set("loadedProperties_${path}", true)
+            
+            outLogger.withStyle(Style.SuccessHeader).println "\t + loaded gradle properties from \"$path\""
+        }
+    } catch(Exception ex) {
+        logger.warn "\t + failed to load gradle properties from \"$path\". Error is: ${ex.getMessage()}"
+    }
+}
+
 buildscript {
+    def GRADLE_PROPERTIES_FILENAME = "gradle.properties"
+
+    def getFile = { dir, filename ->
+        File file = new File("$dir$File.separator$filename")
+        file?.exists() ? file : null
+    }
+
+    def getPropertyFile = { dir ->
+        return getFile(dir, GRADLE_PROPERTIES_FILENAME)
+    }
+    def getUserProperties = { dir ->
+        def file = getPropertyFile(dir)
+        if (!file) {
+            return null
+        }
+
+        Properties properties = new Properties()
+        properties.load(file.newInputStream())
+
+        return properties
+    }
+    def loadPropertyFile = { path ->
+        try {
+            if(project.hasProperty("loadedProperties_${path}")) {
+                logger.info "\t + gradle properties already loaded. SKIPPING"
+            } else {
+                logger.info "\t + trying to load gradle properties from \"$path\""
+
+                Properties properties = new Properties()
+                properties.load(new FileInputStream("$path"))
+                properties.each { prop ->
+                    logger.info "\t + [$path] setting ${prop.key} = ${prop.value}"
+                    project.ext.set(prop.key, prop.value)
+                }
+                project.ext.set("loadedProperties_${path}", true)
+                
+                outLogger.withStyle(Style.SuccessHeader).println "\t + loaded gradle properties from \"$path\""
+            }
+        } catch(Exception ex) {
+            logger.warn "\t + failed to load gradle properties from \"$path\". Error is: ${ex.getMessage()}"
+        }
+    }
     def initialize = { ->
         // set up our logger
         project.ext.outLogger = services.get(StyledTextOutputFactory).create("colouredOutputLogger")
@@ -19,8 +83,6 @@ buildscript {
         project.ext.PLUGIN_NAME = "{{pluginName}}"
         
         def userDir = "$USER_PROJECT_ROOT"
-        apply from: "$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/gradle-helpers/user_properties_reader.gradle"
-        apply from: "$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/gradle-helpers/paths.gradle"
         rootProject.ext.userDefinedGradleProperties = getUserProperties("${getAppResourcesPath(USER_PROJECT_ROOT)}/Android")
 
         loadPropertyFile("$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/gradle.properties")

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -72,6 +72,55 @@ buildscript {
             logger.warn "\t + failed to load gradle properties from \"$path\". Error is: ${ex.getMessage()}"
         }
     }
+    def getAppResourcesPath = { ->
+        def relativePathToAppResources
+        def absolutePathToAppResources
+        def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
+        def nsConfig
+
+        if (nsConfigFile.exists()) {
+            nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+        }
+
+        if (project.hasProperty("appResourcesPath")) {
+            // when appResourcesPath is passed through -PappResourcesPath=/path/to/App_Resources
+            // the path could be relative or absolute - either case will work
+            relativePathToAppResources = appResourcesPath
+            absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
+        } else if (nsConfig != null && nsConfig.appResourcesPath != null) {
+            relativePathToAppResources = nsConfig.appResourcesPath
+            absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
+        } else {
+            absolutePathToAppResources = "${getAppPath()}/App_Resources"
+        }
+
+        project.ext.appResourcesPath = absolutePathToAppResources
+
+        return absolutePathToAppResources
+    }
+
+
+    def getAppPath = { ->
+        def relativePathToApp = "app"
+        def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
+        def nsConfig
+
+        if (nsConfigFile.exists()) {
+            nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+        }
+
+        if (project.hasProperty("appPath")) {
+            // when appPath is passed through -PappPath=/path/to/app
+            // the path could be relative or absolute - either case will work
+            relativePathToApp = appPath
+        } else if (nsConfig != null && nsConfig.appPath != null) {
+            relativePathToApp = nsConfig.appPath
+        }
+
+        project.ext.appPath = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToApp).toAbsolutePath()
+
+        return project.ext.appPath
+    }
     def initialize = { ->
         // set up our logger
         project.ext.outLogger = services.get(StyledTextOutputFactory).create("colouredOutputLogger")
@@ -83,7 +132,7 @@ buildscript {
         project.ext.PLUGIN_NAME = "{{pluginName}}"
         
         def userDir = "$USER_PROJECT_ROOT"
-        rootProject.ext.userDefinedGradleProperties = getUserProperties("${getAppResourcesPath(USER_PROJECT_ROOT)}/Android")
+        rootProject.ext.userDefinedGradleProperties = getUserProperties("${getAppResourcesPath()}/Android")
 
         loadPropertyFile("$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/gradle.properties")
         loadPropertyFile("$USER_PROJECT_ROOT/${project.ext.PLATFORMS_ANDROID}/additional_gradle.properties")
@@ -160,35 +209,6 @@ buildscript {
 
             return project.ext.appPath
         }
-
-        project.ext.getAppResourcesPath = { ->
-            def relativePathToAppResources
-            def absolutePathToAppResources
-            def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
-            def nsConfig
-
-            if (nsConfigFile.exists()) {
-                nsConfig = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
-            }
-
-            if (project.hasProperty("appResourcesPath")) {
-                // when appResourcesPath is passed through -PappResourcesPath=/path/to/App_Resources
-                // the path could be relative or absolute - either case will work
-                relativePathToAppResources = appResourcesPath
-                absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
-            } else if (nsConfig != null && nsConfig.appResourcesPath != null) {
-                relativePathToAppResources = nsConfig.appResourcesPath
-                absolutePathToAppResources = Paths.get(USER_PROJECT_ROOT).resolve(relativePathToAppResources).toAbsolutePath()
-            } else {
-                absolutePathToAppResources = "${getAppPath()}/App_Resources"
-            }
-
-            project.ext.appResourcesPath = absolutePathToAppResources
-
-            return absolutePathToAppResources
-        }
-
-
     }
     def applyBuildScriptConfigurations = { ->
         def absolutePathToAppResources = getAppResourcesPath()

--- a/vendor/gradle-plugin/gradle.properties
+++ b/vendor/gradle-plugin/gradle.properties
@@ -1,19 +1,4 @@
-# Project-wide Gradle settings.
-
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-#org.gradle.parallel=true
-
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
+# Nativescript CLI plugin build gradle properties
 org.gradle.jvmargs=-Xmx16384M
 
 android.enableJetifier=true


### PR DESCRIPTION
* copy paste for now. I think most could be refactored in the runtime and cli should include from there
* now kotlin, buildtools, … versions are define like in apps and use same defaults
* we dont modify the build.gradle for tempPlugin anymore. Instead we add the plugin as a native dep (to itself..) and just ignore the `aar` that we would build (which can already be there).
* now users can do almost anything they want in their plugin `include.gradle` and it will work (for example comments on the first line would break the build)
* now while building a tempPlugin we pickup any external aar we find the plugin `platforms` folder (main reason for this change)

