### PR TITLE
fix(unit-test-runner): node 18 binding family

### DIFF
--- a/lib/services/test-execution-service.ts
+++ b/lib/services/test-execution-service.ts
@@ -164,9 +164,11 @@ export class TestExecutionService implements ITestExecutionService {
 		const ips = Object.keys(nics)
 			.map(
 				(nicName) =>
-					nics[nicName].filter((binding: any) => binding.family === "IPv4")[0]
+					nics[nicName].filter(
+						(binding: any) => binding.family === "IPv4" || binding.family === 4
+					)[0]
 			)
-			.filter((binding) => binding)
+			.filter((binding) => !!binding)
 			.map((binding) => binding.address);
 
 		const config = {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base

## What is the current behavior?

Usage of unit test runner v3+ with Node 18 would fail.

## What is the new behavior?

Usage of unit test runner v3+ with Node 18 will operate normally.