### PR TITLE
fix: ios log filtering

### DIFF
--- a/lib/services/ios-log-filter.ts
+++ b/lib/services/ios-log-filter.ts
@@ -3,7 +3,7 @@ import { injector } from "../common/yok";
 export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 	// Used to recognize output related to the current project
 	// This looks for artifacts like: AppName[22432] or AppName(SomeTextHere)[23123]
-	private appOutputRegex: RegExp = /([^\s\(\)]+)(?:\([^\s]+\))?\[[0-9]+\]/;
+	private appOutputRegex: RegExp = /([^\s\(\)]+)(?:\(([^\s]+)\))?\[[0-9]+\]/;
 
 	// Used to trim the passed messages to a simpler output
 	// Example:
@@ -19,7 +19,7 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 	// (RunningBoardServices) [com.apple.runningboard:connection] Identity resolved as application<...>
 	//  ^^^^^^^^^^^^^^^^^^^^
 	// we then use this to filter out non-NativeScript lines
-	protected postFilterRegex: RegExp = /^\((.+)\)/;
+	protected postFilterRegex: RegExp = /^\((.+)\) \[com\.apple.+\]/;
 
 	private filterActive: boolean = true;
 
@@ -67,6 +67,10 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 				// of this filter may be used accross multiple projects.
 				const projectName = loggingOptions && loggingOptions.projectName;
 				this.filterActive = matchResult[1] !== projectName;
+
+				if (matchResult?.[2]) {
+					this.filterActive ||= matchResult[2] !== "NativeScript";
+				}
 			}
 
 			if (this.filterActive) {

--- a/lib/services/ios-log-filter.ts
+++ b/lib/services/ios-log-filter.ts
@@ -13,6 +13,14 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 		`^.*(?:<Notice>:|<Error>:|<Warning>:|\\(NativeScript\\)|${this.appOutputRegex.source}:){1}`
 	);
 
+	// Used to post filter messages that slip through but are not coming from NativeScript itself.
+	// Looks text in parenthesis at the beginning
+	// Example:
+	// (RunningBoardServices) [com.apple.runningboard:connection] Identity resolved as application<...>
+	//  ^^^^^^^^^^^^^^^^^^^^
+	// we then use this to filter out non-NativeScript lines
+	protected postFilterRegex: RegExp = /^\((.+)\)/;
+
 	private filterActive: boolean = true;
 
 	private partialLine: string = null;
@@ -71,6 +79,13 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 			}
 
 			currentLine = currentLine.trim();
+
+			// post filtering: (<anything>) check if <anything> is not "NativeScript"
+			const postFilterMatch = this.postFilterRegex.exec(currentLine);
+			if (postFilterMatch && postFilterMatch?.[1] !== "NativeScript") {
+				continue;
+			}
+
 			output += currentLine + "\n";
 		}
 

--- a/lib/services/ios-log-filter.ts
+++ b/lib/services/ios-log-filter.ts
@@ -14,10 +14,10 @@ export class IOSLogFilter implements Mobile.IPlatformLogFilter {
 	);
 
 	// Used to post filter messages that slip through but are not coming from NativeScript itself.
-	// Looks text in parenthesis at the beginning
+	// Looks for text in parenthesis at the beginning
 	// Example:
 	// (RunningBoardServices) [com.apple.runningboard:connection] Identity resolved as application<...>
-	//  ^^^^^^^^^^^^^^^^^^^^
+	// ^(~~capture group~~~)^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 	// we then use this to filter out non-NativeScript lines
 	protected postFilterRegex: RegExp = /^\((.+)\) \[com\.apple.+\]/;
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Some non-nativescript logs are shown when running, especially on a real device.

## What is the new behavior?
Only NativeScript logs (js) are shown.

fixes #3544
fixes #3727
fixes #5003
fixes #5310
fixes #5626 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
