### PR TITLE
feat(profiling): generate chrome compatible timeline data

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -154,6 +154,10 @@ injector.require(
 	"./services/android-device-debug-service"
 );
 
+injector.require(
+	"timelineProfilerService",
+	"./services/timeline-profiler-service"
+);
 injector.require("userSettingsService", "./services/user-settings-service");
 injector.requirePublic(
 	"analyticsSettingsService",

--- a/lib/common/mobile/device-log-provider.ts
+++ b/lib/common/mobile/device-log-provider.ts
@@ -6,11 +6,14 @@ import * as chalk from "chalk";
 import { LoggerConfigData } from "../../constants";
 import { IOptions } from "../../declarations";
 
+import { ITimelineProfilerService } from "../../services/timeline-profiler-service";
+
 export class DeviceLogProvider extends DeviceLogProviderBase {
 	constructor(
 		protected $logFilter: Mobile.ILogFilter,
 		protected $logger: ILogger,
 		protected $logSourceMapService: Mobile.ILogSourceMapService,
+		protected $timelineProfilerService: ITimelineProfilerService,
 		protected $options: IOptions
 	) {
 		super($logFilter, $logger, $logSourceMapService);
@@ -29,7 +32,9 @@ export class DeviceLogProvider extends DeviceLogProviderBase {
 			data,
 			loggingOptions
 		);
+
 		if (data) {
+			this.$timelineProfilerService.processLogData(data, deviceIdentifier);
 			this.logDataCore(data, deviceIdentifier);
 			this.emit(DEVICE_LOG_EVENT_NAME, lineText, deviceIdentifier, platform);
 		}

--- a/lib/common/test/unit-tests/mobile/device-log-provider.ts
+++ b/lib/common/test/unit-tests/mobile/device-log-provider.ts
@@ -76,6 +76,10 @@ const createTestInjector = (): IInjector => {
 		},
 	});
 
+	testInjector.register("timelineProfilerService", {
+		processLogData() {},
+	});
+
 	const logger = testInjector.resolve<CommonLoggerStub>("logger");
 	logger.info = (...args: any[]): void => {
 		args = args.filter((arg) => Object.keys(arg).indexOf("skipNewLine") === -1);

--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -22,20 +22,20 @@ installUncaughtExceptionListener(
 );
 
 const logger: ILogger = injector.resolve("logger");
-const originalProcessOn = process.on;
+// const originalProcessOn = process.on;
 
-process.on = (event: string, listener: any): any => {
-	if (event === "SIGINT") {
-		logger.trace(
-			`Trying to handle SIGINT event. CLI overrides this behavior and does not allow handling SIGINT as this causes issues with Ctrl + C in terminal.`
-		);
-		const msg = "The stackTrace of the location trying to handle SIGINT is:";
-		const stackTrace = new Error(msg).stack || "";
-		logger.trace(stackTrace.replace(`Error: ${msg}`, msg));
-	} else {
-		return originalProcessOn.apply(process, [event, listener]);
-	}
-};
+// process.on = (event: string, listener: any): any => {
+// 	if (event === "SIGINT") {
+// 		logger.trace(
+// 			`Trying to handle SIGINT event. CLI overrides this behavior and does not allow handling SIGINT as this causes issues with Ctrl + C in terminal.`
+// 		);
+// 		const msg = "The stackTrace of the location trying to handle SIGINT is:";
+// 		const stackTrace = new Error(msg).stack || "";
+// 		logger.trace(stackTrace.replace(`Error: ${msg}`, msg));
+// 	} else {
+// 		return originalProcessOn.apply(process, [event, listener]);
+// 	}
+// };
 
 /* tslint:disable:no-floating-promises */
 (async () => {

--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -22,20 +22,20 @@ installUncaughtExceptionListener(
 );
 
 const logger: ILogger = injector.resolve("logger");
-// const originalProcessOn = process.on;
+const originalProcessOn = process.on;
 
-// process.on = (event: string, listener: any): any => {
-// 	if (event === "SIGINT") {
-// 		logger.trace(
-// 			`Trying to handle SIGINT event. CLI overrides this behavior and does not allow handling SIGINT as this causes issues with Ctrl + C in terminal.`
-// 		);
-// 		const msg = "The stackTrace of the location trying to handle SIGINT is:";
-// 		const stackTrace = new Error(msg).stack || "";
-// 		logger.trace(stackTrace.replace(`Error: ${msg}`, msg));
-// 	} else {
-// 		return originalProcessOn.apply(process, [event, listener]);
-// 	}
-// };
+process.on = (event: string, listener: any): any => {
+	if (event === "SIGINT") {
+		logger.trace(
+			`Trying to handle SIGINT event. CLI overrides this behavior and does not allow handling SIGINT as this causes issues with Ctrl + C in terminal.`
+		);
+		const msg = "The stackTrace of the location trying to handle SIGINT is:";
+		const stackTrace = new Error(msg).stack || "";
+		logger.trace(stackTrace.replace(`Error: ${msg}`, msg));
+	} else {
+		return originalProcessOn.apply(process, [event, listener]);
+	}
+};
 
 /* tslint:disable:no-floating-promises */
 (async () => {

--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -22,7 +22,7 @@ installUncaughtExceptionListener(
 );
 
 const logger: ILogger = injector.resolve("logger");
-const originalProcessOn = process.on;
+export const originalProcessOn = process.on.bind(process);
 
 process.on = (event: string, listener: any): any => {
 	if (event === "SIGINT") {
@@ -33,7 +33,7 @@ process.on = (event: string, listener: any): any => {
 		const stackTrace = new Error(msg).stack || "";
 		logger.trace(stackTrace.replace(`Error: ${msg}`, msg));
 	} else {
-		return originalProcessOn.apply(process, [event, listener]);
+		return originalProcessOn(event, listener);
 	}
 };
 

--- a/lib/services/timeline-profiler-service.ts
+++ b/lib/services/timeline-profiler-service.ts
@@ -3,6 +3,7 @@ import { cache } from "../common/decorators";
 import { injector } from "../common/yok";
 import { IProjectConfigService } from "../definitions/project";
 import * as path from "path";
+import { originalProcessOn } from "../nativescript-cli";
 
 export interface ITimelineProfilerService {
 	processLogData(data: string, deviceIdentifier: string): void;
@@ -32,22 +33,27 @@ interface DeviceTimeline {
 }
 
 export class TimelineProfilerService implements ITimelineProfilerService {
-	private timelines: Map<string, DeviceTimeline>;
+	private timelines: Map<string, DeviceTimeline> = new Map();
+	private attachedExitHandler: boolean = false;
 	constructor(
 		private $projectConfigService: IProjectConfigService,
 		private $fs: IFileSystem,
 		private $logger: ILogger
-	) {
-		this.timelines = new Map();
+	) {}
 
-		process.on("exit", this.writeTimelines.bind(this));
-		process.on("SIGINT", this.writeTimelines.bind(this));
+	private attachExitHanlder() {
+		if (!this.attachedExitHandler) {
+			this.$logger.info('attached "SIGINT" handler to write timeline data.');
+			originalProcessOn("SIGINT", this.writeTimelines.bind(this));
+			this.attachedExitHandler = true;
+		}
 	}
 
 	public processLogData(data: string, deviceIdentifier: string) {
 		if (!this.isEnabled()) {
 			return;
 		}
+		this.attachExitHanlder();
 
 		if (!this.timelines.has(deviceIdentifier)) {
 			this.timelines.set(deviceIdentifier, {
@@ -97,15 +103,17 @@ export class TimelineProfilerService implements ITimelineProfilerService {
 	}
 
 	private writeTimelines() {
-		if (this.isEnabled()) {
-			this.$logger.info("Writing timeline data to json...");
-			this.timelines.forEach((deviceTimeline, deviceIdentifier) => {
-				this.$fs.writeJson(
-					path.resolve(process.cwd(), `timeline-${deviceIdentifier}.json`),
-					deviceTimeline.timeline
-				);
-			});
-		}
+		this.$logger.info("\n\nWriting timeline data to json...");
+		this.timelines.forEach((deviceTimeline, deviceIdentifier) => {
+			const deviceTimelineFileName = `timeline-${deviceIdentifier}.json`;
+			this.$fs.writeJson(
+				path.resolve(process.cwd(), deviceTimelineFileName),
+				deviceTimeline.timeline
+			);
+			this.$logger.info(
+				`Timeline data for device ${deviceIdentifier} written to ${deviceTimelineFileName}`
+			);
+		});
 
 		process.exit();
 	}

--- a/lib/services/timeline-profiler-service.ts
+++ b/lib/services/timeline-profiler-service.ts
@@ -1,0 +1,114 @@
+import { IFileSystem } from "../common/declarations";
+import { cache } from "../common/decorators";
+import { injector } from "../common/yok";
+import { IProjectConfigService } from "../definitions/project";
+import * as path from "path";
+
+export interface ITimelineProfilerService {
+	processLogData(data: string, deviceIdentifier: string): void;
+}
+
+const TIMELINE_LOG_RE = /Timeline:\s*(\d*.?\d*ms:\s*)?([^\:]*\:)?(.*)\((\d*.?\d*)ms\.?\s*-\s*(\d*.\d*)ms\.?\)/;
+
+enum ChromeTraceEventPhase {
+	BEGIN = "B",
+	END = "E",
+	INSTANT = "i",
+	COMPLETE = "X",
+}
+
+interface ChromeTraceEvent {
+	ts: number;
+	pid: number;
+	tid: number;
+	/** event phase */
+	ph?: ChromeTraceEventPhase | string;
+	[otherData: string]: any;
+}
+
+interface DeviceTimeline {
+	startPoint: number;
+	timeline: ChromeTraceEvent[];
+}
+
+export class TimelineProfilerService implements ITimelineProfilerService {
+	private timelines: Map<string, DeviceTimeline>;
+	constructor(
+		private $projectConfigService: IProjectConfigService,
+		private $fs: IFileSystem,
+		private $logger: ILogger
+	) {
+		this.timelines = new Map();
+
+		process.on("exit", this.writeTimelines.bind(this));
+		process.on("SIGINT", this.writeTimelines.bind(this));
+	}
+
+	public processLogData(data: string, deviceIdentifier: string) {
+		if (!this.isEnabled()) {
+			return;
+		}
+
+		if (!this.timelines.has(deviceIdentifier)) {
+			this.timelines.set(deviceIdentifier, {
+				startPoint: null,
+				timeline: [],
+			});
+		}
+
+		const deviceTimeline = this.timelines.get(deviceIdentifier);
+
+		data.split("\n").forEach((line) => {
+			const trace = this.toTrace(line.trim());
+			if (trace) {
+				deviceTimeline.startPoint ??= trace.from;
+				deviceTimeline.timeline.push(trace);
+			}
+		});
+	}
+
+	@cache()
+	private isEnabled() {
+		return this.$projectConfigService.getValue("profiling") === "timeline";
+	}
+
+	private toTrace(text: string): ChromeTraceEvent | undefined {
+		const result = text.match(TIMELINE_LOG_RE);
+		if (!result) {
+			return;
+		}
+
+		const trace = {
+			domain: result[2]?.trim().replace(":", ""),
+			name: result[3].trim(),
+			from: parseFloat(result[4]),
+			to: parseFloat(result[5]),
+		};
+
+		return {
+			pid: 1,
+			tid: 1,
+			ts: trace.from * 1000,
+			dur: (trace.to - trace.from) * 1000,
+			name: trace.name,
+			cat: trace.domain ?? "default",
+			ph: ChromeTraceEventPhase.COMPLETE,
+		};
+	}
+
+	private writeTimelines() {
+		if (this.isEnabled()) {
+			this.$logger.info("Writing timeline data to json...");
+			this.timelines.forEach((deviceTimeline, deviceIdentifier) => {
+				this.$fs.writeJson(
+					path.resolve(process.cwd(), `timeline-${deviceIdentifier}.json`),
+					deviceTimeline.timeline
+				);
+			});
+		}
+
+		process.exit();
+	}
+}
+
+injector.register("timelineProfilerService", TimelineProfilerService);

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -129,6 +129,7 @@ function createTestInjector(
 	testInjector.register("messages", Messages);
 	testInjector.register("mobileHelper", MobileHelper);
 	testInjector.register("deviceLogProvider", DeviceLogProvider);
+	testInjector.register("timelineProfilerService", {});
 	testInjector.register("logFilter", LogFilter);
 	testInjector.register("loggingLevels", LoggingLevels);
 	testInjector.register("utils", Utils);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Profiling requires installing an external tool (`timeline-view`) and piping the output of a run command into it to generate a timeline html view.

## What is the new behavior?
A timeline json file is generated automatically when timeline profiling is enabled (`profiling: "timeline"` in the nativescript config). The file is saved when the run is canceled with `ctrl+c`. The output json can be loaded into chrome devtools -> Performance and loading the json.

---

~~Commented out the `SIGINT` handling override - as it prevented listening for it for writing the timeline jsons - however this might cause side effects, so a different approach might be required.~~

~~For example and idle timeout, if no new traces come in within X seconds, it's automatically saved.~~

~~Another approach is listening for a keypress (for example `s` for "stop") and then stopping the timeline.~~

~~Other...?~~

Found a different approach by getting around the `SIGINT` prevention **only** when profiling.

