### PR TITLE
feat: ensure App_Resources exists before running

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -18,6 +18,7 @@ import {
 	IProjectConfigService,
 	IProjectData,
 	IProjectDataService,
+	IProjectService,
 } from "../definitions/project";
 import {
 	INodeModulesDependenciesBuilder,
@@ -64,7 +65,8 @@ export class PrepareController extends EventEmitter {
 		private $watchIgnoreListService: IWatchIgnoreListService,
 		private $analyticsService: IAnalyticsService,
 		private $markingModeService: IMarkingModeService,
-		private $projectConfigService: IProjectConfigService
+		private $projectConfigService: IProjectConfigService,
+		private $projectService: IProjectService
 	) {
 		super();
 	}
@@ -127,6 +129,7 @@ export class PrepareController extends EventEmitter {
 		prepareData: IPrepareData,
 		projectData: IProjectData
 	): Promise<IPrepareResultData> {
+		await this.$projectService.ensureAppResourcesExist(projectData.projectDir);
 		await this.$platformController.addPlatformIfNeeded(
 			prepareData,
 			projectData

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -88,6 +88,13 @@ interface IProjectService {
 	 * @returns {boolean} returns true if the project is valid NativeScript project.
 	 */
 	isValidNativeScriptProject(pathToProject?: string): boolean;
+
+	/**
+	 * Checks if App_Resources exists, or pulls down a fresh set
+	 * from the default template otherwise.
+	 * @param {string} projectDir
+	 */
+	ensureAppResourcesExist(projectDir: string): Promise<void>;
 }
 
 interface INsConfigPlaform {

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -224,7 +224,7 @@ export class ProjectService implements IProjectService {
 	}
 
 	@performanceLog()
-	private async ensureAppResourcesExist(projectDir: string): Promise<void> {
+	public async ensureAppResourcesExist(projectDir: string): Promise<void> {
 		const projectData = this.$projectDataService.getProjectData(projectDir);
 		const appResourcesDestinationPath = projectData.getAppResourcesDirectoryPath(
 			projectDir

--- a/test/controllers/prepare-controller.ts
+++ b/test/controllers/prepare-controller.ts
@@ -19,6 +19,7 @@ const prepareData = {
 let isCompileWithWatchCalled = false;
 let isCompileWithoutWatchCalled = false;
 let isNativePrepareCalled = false;
+let isEnsuringAppResourcesExist = false;
 let emittedEventNames: string[] = [];
 let emittedEventData: any[] = [];
 
@@ -64,6 +65,12 @@ function createTestInjector(data: { hasNativeChanges: boolean }): IInjector {
 	});
 
 	injector.register("tempService", TempServiceStub);
+	injector.register("projectService", {
+		ensureAppResourcesExist(projectDir: string): Promise<void> {
+			isEnsuringAppResourcesExist = true;
+			return;
+		},
+	});
 
 	const prepareController: PrepareController = injector.resolve(
 		"prepareController"
@@ -84,6 +91,7 @@ describe("prepareController", () => {
 		isNativePrepareCalled = false;
 		isCompileWithWatchCalled = false;
 		isCompileWithoutWatchCalled = false;
+		isEnsuringAppResourcesExist = false;
 
 		emittedEventNames = [];
 		emittedEventData = [];
@@ -102,6 +110,7 @@ describe("prepareController", () => {
 
 					assert.isTrue(isCompileWithWatchCalled);
 					assert.isTrue(isNativePrepareCalled);
+					assert.isTrue(isEnsuringAppResourcesExist);
 				});
 			});
 			it(`should respect native changes that are made before the initial preparation of the project had been done for ${platform}`, async () => {
@@ -161,6 +170,7 @@ describe("prepareController", () => {
 				assert.isTrue(isNativePrepareCalled);
 				assert.isTrue(isCompileWithoutWatchCalled);
 				assert.isFalse(isCompileWithWatchCalled);
+				assert.isTrue(isEnsuringAppResourcesExist);
 			});
 		});
 	});

--- a/test/project-commands.ts
+++ b/test/project-commands.ts
@@ -96,6 +96,10 @@ class ProjectServiceMock implements IProjectService {
 	isValidNativeScriptProject(pathToProject?: string): boolean {
 		return true;
 	}
+
+	ensureAppResourcesExist(projectDir: string): Promise<void> {
+		return;
+	}
 }
 
 class ProjectNameValidatorMock implements IProjectNameValidator {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
If the project does not have an App_Resources, the build will fail/error out.

## What is the new behavior?
If the project does not have an App_Resources, defaults are pulled from the base template from npm before continuing the build.


