### PR TITLE
feat: include-settings.gradle plugin

### DIFF
--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -408,7 +408,8 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		);
 		const allGradleTemplateFiles = path.join(gradleTemplatePath, "*");
 		const buildGradlePath = path.join(pluginTempDir, "build.gradle");
-
+		const settingsGradlePath = path.join(pluginTempDir, "settings.gradle");
+		
 		this.$fs.copyFile(allGradleTemplateFiles, pluginTempDir);
 		this.addCompileDependencies(platformsAndroidDirPath, buildGradlePath);
 		const runtimeGradleVersions = await this.getRuntimeGradleVersions(
@@ -423,6 +424,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			runtimeGradleVersions.gradleAndroidPluginVersion
 		);
 		this.replaceFileContent(buildGradlePath, "{{pluginName}}", pluginName);
+		this.replaceFileContent(settingsGradlePath, "{{pluginName}}", pluginName);
 	}
 
 	private async getRuntimeGradleVersions(

--- a/vendor/gradle-plugin/settings.gradle
+++ b/vendor/gradle-plugin/settings.gradle
@@ -1,1 +1,25 @@
+import groovy.json.JsonSlurper
 
+def USER_PROJECT_ROOT = "$rootDir/../../../"
+def PLATFORMS_ANDROID = "platforms/android"
+def PLUGIN_NAME = "{{pluginName}}"
+
+def dependenciesJson = file("${USER_PROJECT_ROOT}/${PLATFORMS_ANDROID}/dependencies.json")
+def appDependencies = new JsonSlurper().parseText(dependenciesJson.text)
+def pluginData = appDependencies.find { it.name == PLUGIN_NAME }
+def nativescriptDependencies = appDependencies.findAll{pluginData.name == it.name}
+
+def getDepPlatformDir = { dep ->
+        file("$USER_PROJECT_ROOT/$PLATFORMS_ANDROID/${dep.directory}/$PLATFORMS_ANDROID")
+}
+
+def applyIncludeSettingsGradlePlugin = {
+     nativescriptDependencies.each { dep ->
+            def includeSettingsGradlePath = "${getDepPlatformDir(dep)}/include-settings.gradle"
+            if (file(includeSettingsGradlePath).exists()) {
+                apply from: includeSettingsGradlePath
+            }
+    }
+}
+
+applyIncludeSettingsGradlePlugin()


### PR DESCRIPTION
As plugins are built in an isolated tempPlugin folder, it is currently not possible to link local projects in plugin builds similar to iOS. The following PR adds a `include-settings.gradle` plugin which can be used to link local android projects in plugin builds.

Related PR in android-runtime for app level settings.gradle plugin: https://github.com/NativeScript/android-runtime/pull/1731