### PR TITLE
feat: more informative android compile SDK messages

### DIFF
--- a/packages/doctor/src/android-tools-info.ts
+++ b/packages/doctor/src/android-tools-info.ts
@@ -98,15 +98,15 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 		const errors: NativeScriptDoctor.IWarning[] = [];
 		const toolsInfoData = this.getToolsInfo(config);
 		const isAndroidHomeValid = this.isAndroidHomeValid();
-		const supportsOnlyMinRequiredCompileTarget =
-			this.getMaxSupportedCompileVersion(config) ===
-			AndroidToolsInfo.MIN_REQUIRED_COMPILE_TARGET;
-
 		if (!toolsInfoData.compileSdkVersion) {
+			const supportedTargetsForAndroidRuntime = this.getSupportedTargets(config.projectDir)
 			errors.push({
-				warning: `Cannot find a compatible Android SDK for compilation. To be able to build for Android, install Android SDK ${
-					AndroidToolsInfo.MIN_REQUIRED_COMPILE_TARGET
-				}${supportsOnlyMinRequiredCompileTarget ? "" : " or later"}.`,
+				warning: [
+					`Cannot find a compatible Android SDK for compilation.`,
+					`To be able to build for Android with your current android runtime, install one of the following supported Android SDK targets:`,
+					...supportedTargetsForAndroidRuntime.map(target => `  ${target}`),
+					`Supported targets vary based on what android runtime you have installed. Currently your app uses @nativescript/android ${this.getRuntimeVersion({ projectDir: config.projectDir })}`
+				].join('\n'),
 				additionalInformation: `Run \`\$ ${this.getPathToSdkManagementTool()}\` to manage your Android SDK versions.`,
 				platforms: [Constants.ANDROID_PLATFORM_NAME],
 			});


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
![image](https://user-images.githubusercontent.com/18545667/199410454-f04598fb-6cab-409f-8347-131c2cb7acb1.png)

CLI produces an incorrect error message that does not indicate that the reason for being unable to find a compatible android SDK version has anything to do with the range of android SDK versions which are interoperable with your current android runtime version. This will leave the user confused if they have a newer android SDK version installed than the most recent one (especially when the CLI is currently telling them to install "version x **or later**") which is compatible with their current android runtime version e.g. @nativescript/android version 8.1.1 + Android SDK version 31.

## What is the new behavior?
![image](https://user-images.githubusercontent.com/18545667/199410556-cff06bce-ceac-48c2-8909-680476d1a0a7.png)

The error message produced when unable to find an Android SDK version compatible with your android runtime version will list out the android SDK versions compatible with your runtime version, and specifically mention `Supported targets vary based on what android runtime you have installed. Currently your app uses @nativescript/android x.x.x`
