### PR TITLE
fix: hmr doesn't work properly in paths with the character '.'

### DIFF
--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -551,18 +551,17 @@ export class WebpackCompilerService
 			path.join(platformData.appDestinationDirectoryPath, "app", asset)
 		);
 
-		// console.log({ staleFiles });
-
 		// extract last hash from emitted filenames
 		const lastHash = (() => {
-			const fileWithLastHash = files.find((fileName: string) =>
+			const absoluteFileNameWithLastHash = files.find((fileName: string) =>
 				fileName.endsWith("hot-update.js")
 			);
-
-			if (!fileWithLastHash) {
+			
+			if (!absoluteFileNameWithLastHash) {
 				return null;
 			}
-			const matches = fileWithLastHash.match(/\.(.+).hot-update\.js/);
+			const fileNameWithLastHash = path.basename(absoluteFileNameWithLastHash);
+			const matches = fileNameWithLastHash.match(/\.(.+).hot-update\.js/);
 
 			if (matches) {
 				return matches[1];


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The hmr doesn't work properly in paths with the character '.'. Steps to reproduce: 

1. Create folder named **a.b-t14.32**
2. Enter on the **a.b-t14.32** folder
3. Create a ns project using angular template inside 
4. Run "ns run ios"
5. Change the app.ts file and save the changes.

Actual result:

    The app doesn't restart

Expected result:

    The app restart.


## What is the new behavior?
<!-- Describe the changes. -->

After change the app.ts file and save the changes the app restarts properly. 




## Issue 

The issue was happening on the wepack compiler service. The hash value wasn't being computed properly.

Before fix:
![before-fix](https://user-images.githubusercontent.com/5738416/204059689-f82f7f0f-2bc4-48a0-814a-63494e6b13aa.png)

After fix:
![after-fix](https://user-images.githubusercontent.com/5738416/204059778-72ab1fa3-8aed-4fa3-bafc-d6116779673a.png)



