### PR TITLE
fix(publish): Various apple publish/sign in fixes.

### DIFF
--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -48,28 +48,25 @@ export class PublishIOS implements ICommand {
 			args[0] ||
 			(await this.$prompter.getString("Apple ID", { allowEmpty: false }));
 
-		let password;
-		let user;
-		if (true) {
-			password =
-				args[1] || (await this.$prompter.getPassword("Apple ID password"));
+		const password =
+			args[1] || (await this.$prompter.getPassword("Apple ID password"));
 
-			user = await this.$applePortalSessionService.createUserSession(
-				{ username, password },
-				{
-					applicationSpecificPassword: this.$options
-						.appleApplicationSpecificPassword,
-					sessionBase64: this.$options.appleSessionBase64,
-					requireInteractiveConsole: true,
-					requireApplicationSpecificPassword: true,
-				}
-			);
-			if (!user.areCredentialsValid) {
-				this.$errors.fail(
-					`Invalid username and password combination. Used '${username}' as the username.`
-				);
+		const user = await this.$applePortalSessionService.createUserSession(
+			{ username, password },
+			{
+				applicationSpecificPassword: this.$options
+					.appleApplicationSpecificPassword,
+				sessionBase64: this.$options.appleSessionBase64,
+				requireInteractiveConsole: true,
+				requireApplicationSpecificPassword: true,
 			}
+		);
+		if (!user.areCredentialsValid) {
+			this.$errors.fail(
+				`Invalid username and password combination. Used '${username}' as the username.`
+			);
 		}
+
 		const mobileProvisionIdentifier = this.$options.provision ?? args[2];
 
 		let ipaFilePath = this.$options.ipa

--- a/lib/commands/appstore-upload.ts
+++ b/lib/commands/appstore-upload.ts
@@ -40,31 +40,37 @@ export class PublishIOS implements ICommand {
 	}
 
 	public async execute(args: string[]): Promise<void> {
-		await this.$itmsTransporterService.validate();
+		await this.$itmsTransporterService.validate(
+			this.$options.appleApplicationSpecificPassword
+		);
 
 		const username =
 			args[0] ||
 			(await this.$prompter.getString("Apple ID", { allowEmpty: false }));
-		const password =
-			args[1] || (await this.$prompter.getPassword("Apple ID password"));
-		const mobileProvisionIdentifier = args[2];
-		const codeSignIdentity = args[3];
 
-		const user = await this.$applePortalSessionService.createUserSession(
-			{ username, password },
-			{
-				applicationSpecificPassword: this.$options
-					.appleApplicationSpecificPassword,
-				sessionBase64: this.$options.appleSessionBase64,
-				requireInteractiveConsole: true,
-				requireApplicationSpecificPassword: true,
-			}
-		);
-		if (!user.areCredentialsValid) {
-			this.$errors.fail(
-				`Invalid username and password combination. Used '${username}' as the username.`
+		let password;
+		let user;
+		if (true) {
+			password =
+				args[1] || (await this.$prompter.getPassword("Apple ID password"));
+
+			user = await this.$applePortalSessionService.createUserSession(
+				{ username, password },
+				{
+					applicationSpecificPassword: this.$options
+						.appleApplicationSpecificPassword,
+					sessionBase64: this.$options.appleSessionBase64,
+					requireInteractiveConsole: true,
+					requireApplicationSpecificPassword: true,
+				}
 			);
+			if (!user.areCredentialsValid) {
+				this.$errors.fail(
+					`Invalid username and password combination. Used '${username}' as the username.`
+				);
+			}
 		}
+		const mobileProvisionIdentifier = this.$options.provision ?? args[2];
 
 		let ipaFilePath = this.$options.ipa
 			? path.resolve(this.$options.ipa)
@@ -76,25 +82,21 @@ export class PublishIOS implements ICommand {
 			);
 		}
 
-		if (!codeSignIdentity && !ipaFilePath) {
-			this.$logger.warn(
-				"No code sign identity set. A default code sign identity will be used. You can set one in app/App_Resources/iOS/build.xcconfig"
-			);
-		}
-
 		this.$options.release = true;
 
 		if (!ipaFilePath) {
 			const platform = this.$devicePlatformsConstants.iOS.toLowerCase();
 			// No .ipa path provided, build .ipa on out own.
-			if (mobileProvisionIdentifier || codeSignIdentity) {
+			if (mobileProvisionIdentifier) {
 				// This is not very correct as if we build multiple targets we will try to sign all of them using the signing identity here.
 				this.$logger.info(
-					"Building .ipa with the selected mobile provision and/or certificate."
+					"Building .ipa with the selected mobile provision and/or certificate. " +
+						mobileProvisionIdentifier
 				);
 
 				// As we need to build the package for device
 				this.$options.forDevice = true;
+				this.$options.provision = mobileProvisionIdentifier;
 
 				const buildData = new IOSBuildData(
 					this.$projectData.projectDir,
@@ -124,6 +126,7 @@ export class PublishIOS implements ICommand {
 			ipaFilePath,
 			shouldExtractIpa: !!this.$options.ipa,
 			verboseLogging: this.$logger.getLevel() === "TRACE",
+			teamId: this.$options.teamId,
 		});
 	}
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -158,6 +158,7 @@ export class ITMSConstants {
 	};
 	static iTMSExecutableName = "iTMSTransporter";
 	static iTMSDirectoryName = "itms";
+	static altoolExecutableName = "altool";
 }
 
 class ItunesConnectApplicationTypesClass

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -765,13 +765,18 @@ interface IITMSData {
 	 * @type {string}
 	 */
 	verboseLogging?: boolean;
+	/**
+	 * Specifies the team id
+	 * @type {string}
+	 */
+	teamId?: string;
 }
 
 /**
  * Used for communicating with Xcode iTMS Transporter tool.
  */
 interface IITMSTransporterService {
-	validate(): Promise<void>;
+	validate(appSpecificPassword?: string): Promise<void>;
 	/**
 	 * Uploads an .ipa package to iTunes Connect.
 	 * @param  {IITMSData}     data Data needed to upload the package

--- a/lib/services/apple-portal/apple-portal-session-service.ts
+++ b/lib/services/apple-portal/apple-portal-session-service.ts
@@ -264,12 +264,12 @@ For more details how to set up your environment, please execute "tns publish ios
 				`Please enter the ${parsedAuthResponse.securityCode.length} digit code`,
 				{ allowEmpty: false }
 			);
-			var body: any = {
+			const body: any = {
 				securityCode: {
 					code: token.toString(),
 				},
 			};
-			var url = `https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode`;
+			let url = `https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode`;
 
 			if (isSMS) {
 				// No trusted devices means it must be sms.
@@ -313,8 +313,8 @@ function makeHashCash(bits: string, challenge: string): string {
 	const version = 1;
 
 	const dateString = getHashCanDateString();
-	var result: string;
-	for (var counter = 0; ; counter++) {
+	let result: string;
+	for (let counter = 0; ; counter++) {
 		const hc = [version, bits, dateString, challenge, `:${counter}`].join(":");
 
 		const shasumData = crypto.createHash("sha1");
@@ -343,8 +343,8 @@ function padTo2Digits(num: number) {
 }
 
 function checkBits(bits: number, digest: Buffer) {
-	var result = true;
-	for (var i = 0; i < bits; ++i) {
+	let result = true;
+	for (let i = 0; i < bits; ++i) {
 		result = checkBit(i, digest);
 		if (!result) break;
 	}

--- a/lib/services/apple-portal/apple-portal-session-service.ts
+++ b/lib/services/apple-portal/apple-portal-session-service.ts
@@ -8,6 +8,7 @@ import {
 	IAppleLoginResult,
 	IApplePortalSessionService,
 } from "./definitions";
+import * as crypto from "crypto";
 
 export class ApplePortalSessionService implements IApplePortalSessionService {
 	private loginConfigEndpoint =
@@ -38,7 +39,8 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 				await this.handleTwoFactorAuthentication(
 					loginResult.scnt,
 					loginResult.xAppleIdSessionId,
-					authServiceKey
+					authServiceKey,
+					loginResult.hashcash
 				);
 			}
 
@@ -114,6 +116,7 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 			xAppleIdSessionId: <string>null,
 			isTwoFactorAuthenticationEnabled: false,
 			areCredentialsValid: true,
+			hashcash: <string>null,
 		};
 
 		if (opts && opts.sessionBase64) {
@@ -130,6 +133,12 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 				await this.loginCore(credentials);
 			} catch (err) {
 				const statusCode = err && err.response && err.response.status;
+
+				const bits = err?.response?.headers["x-apple-hc-bits"];
+				const challenge = err?.response?.headers["x-apple-hc-challenge"];
+				const hashcash = makeHashCash(bits, challenge);
+				result.hashcash = hashcash;
+
 				result.areCredentialsValid = statusCode !== 401 && statusCode !== 403;
 				result.isTwoFactorAuthenticationEnabled = statusCode === 409;
 
@@ -216,12 +225,14 @@ For more details how to set up your environment, please execute "tns publish ios
 	private async handleTwoFactorAuthentication(
 		scnt: string,
 		xAppleIdSessionId: string,
-		authServiceKey: string
+		authServiceKey: string,
+		hashcash: string
 	): Promise<void> {
 		const headers = {
 			scnt: scnt,
 			"X-Apple-Id-Session-Id": xAppleIdSessionId,
 			"X-Apple-Widget-Key": authServiceKey,
+			"X-Apple-HC": hashcash,
 			Accept: "application/json",
 		};
 		const authResponse = await this.$httpClient.httpRequest({
@@ -231,21 +242,48 @@ For more details how to set up your environment, please execute "tns publish ios
 		});
 
 		const data = JSON.parse(authResponse.body);
-		if (data.trustedPhoneNumbers && data.trustedPhoneNumbers.length) {
+
+		const isSMS =
+			data.trustedPhoneNumbers &&
+			data.trustedPhoneNumbers.length === 1 &&
+			data.noTrustedDevices; // 1 device and no trusted devices means sms was automatically sent.
+		const multiSMS =
+			data.trustedPhoneNumbers &&
+			data.trustedPhoneNumbers.length !== 1 &&
+			data.noTrustedDevices; // Not handling more than 1 sms device and no trusted devices.
+
+		let token: string;
+
+		if (
+			data.trustedPhoneNumbers &&
+			data.trustedPhoneNumbers.length &&
+			!multiSMS
+		) {
 			const parsedAuthResponse = JSON.parse(authResponse.body);
-			const token = await this.$prompter.getString(
+			token = await this.$prompter.getString(
 				`Please enter the ${parsedAuthResponse.securityCode.length} digit code`,
 				{ allowEmpty: false }
 			);
+			var body: any = {
+				securityCode: {
+					code: token.toString(),
+				},
+			};
+			var url = `https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode`;
+
+			if (isSMS) {
+				// No trusted devices means it must be sms.
+				body.mode = "sms";
+				body.phoneNumber = {
+					id: data.trustedPhoneNumbers[0].id,
+				};
+				url = `https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode`;
+			}
 
 			await this.$httpClient.httpRequest({
-				url: `https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode`,
+				url,
 				method: "POST",
-				body: {
-					securityCode: {
-						code: token.toString(),
-					},
-				},
+				body,
 				headers: { ...headers, "Content-Type": "application/json" },
 			});
 
@@ -258,6 +296,10 @@ For more details how to set up your environment, please execute "tns publish ios
 			this.$applePortalCookieService.updateUserSessionCookie(
 				authTrustResponse.headers["set-cookie"]
 			);
+		} else if (multiSMS) {
+			this.$errors.fail(
+				`The NativeScript CLI does not support SMS authenticaton with multiple registered phone numbers.`
+			);
 		} else {
 			this.$errors.fail(
 				`Although response from Apple indicated activated Two-step Verification or Two-factor Authentication, NativeScript CLI don't know how to handle this response: ${data}`
@@ -266,3 +308,52 @@ For more details how to set up your environment, please execute "tns publish ios
 	}
 }
 injector.register("applePortalSessionService", ApplePortalSessionService);
+
+function makeHashCash(bits: string, challenge: string): string {
+	const version = 1;
+
+	const dateString = getHashCanDateString();
+	var result: string;
+	for (var counter = 0; ; counter++) {
+		const hc = [version, bits, dateString, challenge, `:${counter}`].join(":");
+
+		const shasumData = crypto.createHash("sha1");
+
+		shasumData.update(hc);
+		const digest = shasumData.digest();
+		if (checkBits(+bits, digest)) {
+			result = hc;
+			break;
+		}
+	}
+	return result;
+}
+
+function getHashCanDateString(): string {
+	const now = new Date();
+
+	return `${now.getFullYear()}${padTo2Digits(now.getMonth() + 1)}${padTo2Digits(
+		now.getDate()
+	)}${padTo2Digits(now.getHours())}${padTo2Digits(
+		now.getMinutes()
+	)}${padTo2Digits(now.getSeconds())}`;
+}
+function padTo2Digits(num: number) {
+	return num.toString().padStart(2, "0");
+}
+
+function checkBits(bits: number, digest: Buffer) {
+	var result = true;
+	for (var i = 0; i < bits; ++i) {
+		result = checkBit(i, digest);
+		if (!result) break;
+	}
+	return result;
+}
+
+function checkBit(position: number, buffer: Buffer): boolean {
+	const bitOffset = position & 7; // in byte
+	const byteIndex = position >> 3; // in buffer
+	const bit = (buffer[byteIndex] >> bitOffset) & 1;
+	return bit === 0;
+}

--- a/lib/services/apple-portal/definitions.d.ts
+++ b/lib/services/apple-portal/definitions.d.ts
@@ -39,6 +39,7 @@ interface IAppleLoginResult {
 	xAppleIdSessionId: string;
 	isTwoFactorAuthenticationEnabled: boolean;
 	areCredentialsValid: boolean;
+	hashcash: string;
 }
 
 interface IApplePortalUserDetail extends IAppleLoginResult {

--- a/lib/services/itmstransporter-service.ts
+++ b/lib/services/itmstransporter-service.ts
@@ -33,16 +33,38 @@ export class ITMSTransporterService implements IITMSTransporterService {
 		return this.$injector.resolve("projectData");
 	}
 
-	public async validate(): Promise<void> {
+	public async validate(appSpecificPassword?: string): Promise<void> {
 		const itmsTransporterPath = await this.getITMSTransporterPath();
-		if (!this.$fs.exists(itmsTransporterPath)) {
-			this.$errors.fail(
-				"iTMS Transporter not found on this machine - make sure your Xcode installation is not damaged."
-			);
+		var version = await this.$xcodeSelectService.getXcodeVersion();
+		if (+version.major < 14) {
+			if (!this.$fs.exists(itmsTransporterPath)) {
+				this.$errors.fail(
+					"iTMS Transporter not found on this machine - make sure your Xcode installation is not damaged."
+				);
+			}
+		} else {
+			const altoolPath = await this.getAltoolPath();
+			if (!this.$fs.exists(altoolPath)) {
+				this.$errors.fail(
+					"altool not found on this machine - make sure your Xcode installation is not damaged."
+				);
+			}
+			if (!appSpecificPassword) {
+				this.$errors.fail(
+					"An app-specific password is required from xCode versions 14 and above, Use the --appleApplicationSpecificPassword to supply it."
+				);
+			}
 		}
 	}
-
 	public async upload(data: IITMSData): Promise<void> {
+		var version = await this.$xcodeSelectService.getXcodeVersion();
+		if (+version.major < 14) {
+			await this.upload_iTMSTransporter(data);
+		} else {
+			await this.upload_altool(data);
+		}
+	}
+	public async upload_iTMSTransporter(data: IITMSData): Promise<void> {
 		const itmsTransporterPath = await this.getITMSTransporterPath();
 		const ipaFileName = "app.ipa";
 		const itmsDirectory = await this.$tempService.mkdirSync("itms-");
@@ -97,6 +119,46 @@ export class ITMSTransporterService implements IITMSTransporterService {
 			"close",
 			{ stdio: "inherit" }
 		);
+	}
+
+	public async upload_altool(data: IITMSData): Promise<void> {
+		const altoolPath = await this.getAltoolPath();
+		const ipaFileName = "app.ipa";
+		const itmsDirectory = await this.$tempService.mkdirSync("itms-");
+		const innerDirectory = path.join(itmsDirectory, "mybundle.itmsp");
+		const ipaFileLocation = path.join(innerDirectory, ipaFileName);
+
+		this.$fs.createDirectory(innerDirectory);
+
+		this.$fs.copyFile(data.ipaFilePath, ipaFileLocation);
+
+		const password = data.applicationSpecificPassword;
+
+		const args = [
+			"--upload-app",
+			"-t",
+			"ios",
+			"-f",
+			ipaFileLocation,
+			"-u",
+			data.credentials.username,
+			"-p",
+			password,
+			"-k 100000",
+		];
+
+		if (data.teamId) {
+			args.push("--asc-provider");
+			args.push(data.teamId);
+		}
+		console.log("****Verbose loggin is ", data.verboseLogging);
+		if (data.verboseLogging) {
+			args.push("--verbose");
+		}
+
+		await this.$childProcess.spawnFromEvent(altoolPath, args, "close", {
+			stdio: "inherit",
+		});
 	}
 
 	private async getBundleIdentifier(data: IITMSData): Promise<string> {
@@ -154,6 +216,22 @@ export class ITMSTransporterService implements IITMSTransporterService {
 		}
 
 		return this.$projectData.projectIdentifiers.ios;
+	}
+
+	@cache()
+	private async getAltoolPath(): Promise<string> {
+		const xcodePath = await this.$xcodeSelectService.getContentsDirectoryPath();
+		let itmsTransporterPath = path.join(
+			xcodePath,
+			"..",
+			"Contents",
+			"Developer",
+			"usr",
+			"bin",
+			ITMSConstants.altoolExecutableName
+		);
+
+		return itmsTransporterPath;
 	}
 
 	@cache()

--- a/lib/services/itmstransporter-service.ts
+++ b/lib/services/itmstransporter-service.ts
@@ -151,7 +151,7 @@ export class ITMSTransporterService implements IITMSTransporterService {
 			args.push("--asc-provider");
 			args.push(data.teamId);
 		}
-		console.log("****Verbose loggin is ", data.verboseLogging);
+
 		if (data.verboseLogging) {
 			args.push("--verbose");
 		}

--- a/lib/services/itmstransporter-service.ts
+++ b/lib/services/itmstransporter-service.ts
@@ -35,7 +35,7 @@ export class ITMSTransporterService implements IITMSTransporterService {
 
 	public async validate(appSpecificPassword?: string): Promise<void> {
 		const itmsTransporterPath = await this.getITMSTransporterPath();
-		var version = await this.$xcodeSelectService.getXcodeVersion();
+		const version = await this.$xcodeSelectService.getXcodeVersion();
 		if (+version.major < 14) {
 			if (!this.$fs.exists(itmsTransporterPath)) {
 				this.$errors.fail(
@@ -57,7 +57,7 @@ export class ITMSTransporterService implements IITMSTransporterService {
 		}
 	}
 	public async upload(data: IITMSData): Promise<void> {
-		var version = await this.$xcodeSelectService.getXcodeVersion();
+		const version = await this.$xcodeSelectService.getXcodeVersion();
 		if (+version.major < 14) {
 			await this.upload_iTMSTransporter(data);
 		} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nativescript",
-  "version": "8.3.3",
+  "version": "8.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nativescript",
-      "version": "8.3.3",
+      "version": "8.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently any command that tries to login to apple with a username/passwrod will fail and lock the apple account.
e.g. `ns publish ios`. fastlane issue: https://github.com/fastlane/fastlane/issues/21071.

Current implementation does not support SMS verification. (#5714)

On Xcode >= 14 publish will fail because of the removal of iTMSTransporter. (#5704)

## What is the new behavior?
The Hashcash header is implemented allowing login.
The simple 1 phone registered SMS case is supported.
Now uses altool to push ipa if xcode>=14.

fixes #5714
fixes #5704.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
