### PR TITLE
fix: correctly merge IPHONEOS_DEPLOYMENT_TARGET in xcconfigs

### DIFF
--- a/lib/services/xcconfig-service.ts
+++ b/lib/services/xcconfig-service.ts
@@ -42,7 +42,13 @@ export class XcconfigService implements IXcconfigService {
 		const escapedDestinationFile = destinationFile.replace(/'/g, "\\'");
 		const escapedSourceFile = sourceFile.replace(/'/g, "\\'");
 
-		const mergeScript = `require 'xcodeproj'; Xcodeproj::Config.new('${escapedDestinationFile}').merge(Xcodeproj::Config.new('${escapedSourceFile}')).save_as(Pathname.new('${escapedDestinationFile}'))`;
+		const mergeScript = `require 'xcodeproj';
+		sourceConfig = Xcodeproj::Config.new('${escapedDestinationFile}')
+		targetConfig = Xcodeproj::Config.new('${escapedSourceFile}')
+		if(sourceConfig.attributes.key?('IPHONEOS_DEPLOYMENT_TARGET') && targetConfig.attributes.key?('IPHONEOS_DEPLOYMENT_TARGET'))
+			sourceConfig.attributes.delete('IPHONEOS_DEPLOYMENT_TARGET')
+		end
+		sourceConfig.merge(targetConfig).save_as(Pathname.new('${escapedDestinationFile}'))`;
 		await this.$childProcess.exec(`ruby -e "${mergeScript}"`);
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When using `xcodeproj` merge, it'll merge properties like:

```
// file 1
IPHONEOS_DEPLOYMENT_TARGET= 10.0;
// file 2
IPHONEOS_DEPLOYMENT_TARGET= 14.0;

//output
IPHONEOS_DEPLOYMENT_TARGET= 10.0; 14.0;
```

This causes an issue with Xcode 14.3 where this property is now being set for plugins as well

## What is the new behavior?
If both configs have `IPHONEOS_DEPLOYMENT_TARGET`, then we override instead of append

Fixes https://github.com/triniwiz/nativescript-plugins/issues/176