### PR TITLE
fix: migrate failing because options passed to clean are null

### DIFF
--- a/lib/services/project-cleanup-service.ts
+++ b/lib/services/project-cleanup-service.ts
@@ -27,10 +27,10 @@ export class ProjectCleanupService implements IProjectCleanupService {
 		options?: IProjectCleanupOptions
 	): Promise<IProjectCleanupResult> {
 		this.spinner = this.$terminalSpinnerService.createSpinner({
-			isSilent: options.silent,
+			isSilent: options?.silent,
 		});
 
-		let stats = options.stats ? new Map<string, number>() : false;
+		let stats = options?.stats ? new Map<string, number>() : false;
 
 		let success = true;
 		for (const pathToClean of pathsToClean) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: c.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ns migrate fails with 
``
TypeError: Cannot read properties of undefined (reading 'silent')
    at ProjectCleanupService.<anonymous> (/Users/jcassidy/.nvm/versions/node/v18.13.0/lib/node_modules/nativescript/lib/services/project-cleanup-service.js:25:35)
``
## What is the new behavior?
<!-- Describe the changes. -->

Added null checks.

migrate works.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
