### PR TITLE
feat(ios): always override xcconfig with user values

### DIFF
--- a/lib/services/xcconfig-service.ts
+++ b/lib/services/xcconfig-service.ts
@@ -43,12 +43,12 @@ export class XcconfigService implements IXcconfigService {
 		const escapedSourceFile = sourceFile.replace(/'/g, "\\'");
 
 		const mergeScript = `require 'xcodeproj';
-		sourceConfig = Xcodeproj::Config.new('${escapedDestinationFile}')
-		targetConfig = Xcodeproj::Config.new('${escapedSourceFile}')
-		if(sourceConfig.attributes.key?('IPHONEOS_DEPLOYMENT_TARGET') && targetConfig.attributes.key?('IPHONEOS_DEPLOYMENT_TARGET'))
-			sourceConfig.attributes.delete('IPHONEOS_DEPLOYMENT_TARGET')
+		userConfig = Xcodeproj::Config.new('${escapedDestinationFile}')
+		existingConfig = Xcodeproj::Config.new('${escapedSourceFile}')
+		userConfig.attributes.each do |key,|
+  			existingConfig.attributes.delete(key) if (userConfig.attributes.key?(key) && existingConfig.attributes.key?(key))
 		end
-		sourceConfig.merge(targetConfig).save_as(Pathname.new('${escapedDestinationFile}'))`;
+		userConfig.merge(existingConfig).save_as(Pathname.new('${escapedDestinationFile}'))`;
 		await this.$childProcess.exec(`ruby -e "${mergeScript}"`);
 	}
 


### PR DESCRIPTION

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Values in the user's build.xcconfig are sometimes concatenated to the base values from the iOS template

## What is the new behavior?
build.xcconfig always takes precedence over default values (no merging)
