### PR TITLE
feat(spm): add support for local SPM packages

### DIFF
--- a/lib/services/ios/spm-service.ts
+++ b/lib/services/ios/spm-service.ts
@@ -5,6 +5,7 @@ import {
 	IosSPMPackageDefinition,
 } from "@rigor789/trapezedev-project";
 import { IPlatformData } from "../../definitions/platform";
+import path = require("path");
 
 export class SPMService implements ISPMService {
 	constructor(
@@ -54,6 +55,11 @@ export class SPMService implements ISPMService {
 
 			// todo: handle removing packages? Or just warn and require a clean?
 			for (const pkg of spmPackages) {
+				if ("path" in pkg) {
+					// resolve the path relative to the project root
+					this.$logger.trace("SPM: resolving path for package: ", pkg.path);
+					pkg.path = path.resolve(projectData.projectDir, pkg.path);
+				}
 				this.$logger.trace(`SPM: adding package ${pkg.name} to project.`, pkg);
 				await project.ios.addSPMPackage(projectData.projectName, pkg);
 			}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@nativescript/schematics-executor": "0.0.2",
     "@npmcli/move-file": "^2.0.0",
     "@rigor789/resolve-package-path": "1.0.5",
-    "@rigor789/trapezedev-project": "^7.1.0",
+    "@rigor789/trapezedev-project": "7.1.1",
     "archiver": "^5.3.1",
     "axios": "1.3.5",
     "byline": "5.0.0",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
There's no way to add local SPM packages.

## What is the new behavior?
Local SPM packages can be added using the new package definition:
```ts
SPMPacakges: [
  {
    name: 'LocalPackage',
    libs: ['LocalPackageLib'],
    path: './path/to/package' // can be relative to the config or absolute
  },
  {
    name: 'RemotePackage',
    libs: ['RemotePackageLib'],
    repositoryURL: 'remote repository url',
    version: '1.0.0'
  } 
]
```

Handling implemented in Trapeze PR: https://github.com/ionic-team/trapeze/pull/176#issuecomment-1642305248
