### PR TITLE
feat(extension): initial per-extension provisioning

### DIFF
--- a/test/services/ios/export-options-plist-service.ts
+++ b/test/services/ios/export-options-plist-service.ts
@@ -2,24 +2,47 @@ import { Yok } from "../../../lib/common/yok";
 import { ExportOptionsPlistService } from "../../../lib/services/ios/export-options-plist-service";
 import { assert } from "chai";
 import * as _ from "lodash";
-import { TempServiceStub } from "../../stubs";
+import { TempServiceStub, ProjectDataStub } from "../../stubs";
 
 let actualPlistTemplate: string = null;
 const projectName = "myProjectName";
 const projectRoot = "/my/test/project/platforms/ios";
 const archivePath = "/my/test/archive/path";
 
+let provisioningJSON: Record<string, any> | undefined;
+
 function createTestInjector() {
 	const injector = new Yok();
+	provisioningJSON = undefined;
 	injector.register("fs", {
+		exists(path: string) {
+			return path.endsWith("provisioning.json");
+		},
 		writeFile: (exportPath: string, plistTemplate: string) => {
 			actualPlistTemplate = plistTemplate;
+		},
+		readJson() {
+			return provisioningJSON ?? {};
 		},
 	});
 	injector.register("exportOptionsPlistService", ExportOptionsPlistService);
 	injector.register("tempService", TempServiceStub);
+	const projectData = new ProjectDataStub();
+	projectData.initializeProjectData(projectRoot);
+	projectData.projectName = projectName;
+
+	injector.register("projectData", projectData);
 
 	return injector;
+}
+
+function expectPlistTemplateToContain(template: string, expected: string) {
+	const trimmedTemplate = template.replace(/\s/g, "");
+	const trimmedExpected = expected.replace(/\s/g, "");
+	assert.isTrue(
+		trimmedTemplate.indexOf(trimmedExpected) !== -1,
+		`Expected plist template to contain:\n\n${expected}\n\nbut it was:\n\n${template}`
+	);
 }
 
 describe("ExportOptionsPlistService", () => {
@@ -33,21 +56,29 @@ describe("ExportOptionsPlistService", () => {
 				name: "should create export options plist with provision",
 				buildConfig: { provision: "myTestProvision" },
 				expectedPlist:
-					"<key>provisioningProfiles</key> <dict> 	<key>org.nativescript.myTestApp</key> 	<string>myTestProvision</string> </dict>",
+					"<key>provisioningProfiles</key><dict><key>org.nativescript.myTestApp</key><string>myTestProvision</string></dict>",
 			},
 			{
-				name:
-					"should create export options plist with mobileProvisionIdentifier",
+				name: "should create export options plist with mobileProvisionIdentifier",
 				buildConfig: { mobileProvisionIdentifier: "myTestProvision" },
 				expectedPlist:
-					"<key>provisioningProfiles</key> <dict> 	<key>org.nativescript.myTestApp</key> 	<string>myTestProvision</string> </dict>",
+					"<key>provisioningProfiles</key><dict><key>org.nativescript.myTestApp</key><string>myTestProvision</string></dict>",
 			},
 			{
-				name:
-					"should create export options plist with Production iCloudContainerEnvironment",
+				name: "should create export options plist with Production iCloudContainerEnvironment",
 				buildConfig: { iCloudContainerEnvironment: "Production" },
 				expectedPlist:
-					"<key>iCloudContainerEnvironment</key>     <string>Production</string>",
+					"<key>iCloudContainerEnvironment</key><string>Production</string>",
+			},
+			{
+				name: "should add extension provisioning profiles if there are any",
+				buildConfig: { provision: "myTestProvision" },
+				provisioningJSON: {
+					"org.nativescript.myTestApp.SampleExtension":
+						"mySampleExtensionTestProvision",
+				},
+				expectedPlist:
+					"<key>provisioningProfiles</key><dict><key>org.nativescript.myTestApp</key><string>myTestProvision</string><key>org.nativescript.myTestApp.SampleExtension</key><string>mySampleExtensionTestProvision</string></dict>",
 			},
 		];
 
@@ -57,6 +88,9 @@ describe("ExportOptionsPlistService", () => {
 				(provisionType) => {
 					it(testCase.name, async () => {
 						const injector = createTestInjector();
+						if (testCase.provisioningJSON) {
+							provisioningJSON = testCase.provisioningJSON;
+						}
 						const exportOptionsPlistService = injector.resolve(
 							"exportOptionsPlistService"
 						);
@@ -73,20 +107,23 @@ describe("ExportOptionsPlistService", () => {
 							testCase.buildConfig
 						);
 
-						const template = actualPlistTemplate.split("\n").join(" ");
-						assert.isTrue(
-							template.indexOf(
-								`<key>method</key> 	<string>${provisionType}</string>`
-							) > 0
+						expectPlistTemplateToContain(
+							actualPlistTemplate,
+							`<key>method</key><string>${provisionType}</string>`
 						);
-						assert.isTrue(
-							template.indexOf("<key>uploadBitcode</key>     <false/>") > 0
+						expectPlistTemplateToContain(
+							actualPlistTemplate,
+							`<key>uploadBitcode</key><false/>`
 						);
-						assert.isTrue(
-							template.indexOf("<key>compileBitcode</key>     <false/>") > 0
+						expectPlistTemplateToContain(
+							actualPlistTemplate,
+							`<key>compileBitcode</key><false/>`
 						);
 						if (testCase.expectedPlist) {
-							assert.isTrue(template.indexOf(testCase.expectedPlist) > 0);
+							expectPlistTemplateToContain(
+								actualPlistTemplate,
+								testCase.expectedPlist
+							);
 						}
 					});
 				}
@@ -103,25 +140,37 @@ describe("ExportOptionsPlistService", () => {
 				name: "should create export options plist with provision",
 				buildConfig: { provision: "myTestProvision" },
 				expectedPlist:
-					"<key>provisioningProfiles</key>     <dict>         <key>org.nativescript.myTestApp</key>         <string>myTestProvision</string>     </dict>",
+					"<key>provisioningProfiles</key><dict><key>org.nativescript.myTestApp</key><string>myTestProvision</string></dict>",
 			},
 			{
-				name:
-					"should create export options plist with mobileProvisionIdentifier",
+				name: "should create export options plist with mobileProvisionIdentifier",
 				buildConfig: { mobileProvisionIdentifier: "myTestProvision" },
 				expectedPlist:
-					"<key>provisioningProfiles</key>     <dict>         <key>org.nativescript.myTestApp</key>         <string>myTestProvision</string>     </dict>",
+					"<key>provisioningProfiles</key><dict><key>org.nativescript.myTestApp</key><string>myTestProvision</string></dict>",
 			},
 			{
 				name: "should create export options plist with teamID",
 				buildConfig: { teamId: "myTeamId" },
-				expectedPlist: "<key>teamID</key>     <string>myTeamId</string>",
+				expectedPlist: "<key>teamID</key><string>myTeamId</string>",
+			},
+			{
+				name: "should add extension provisioning profiles if there are any",
+				buildConfig: { provision: "myTestProvision" },
+				provisioningJSON: {
+					"org.nativescript.myTestApp.SampleExtension":
+						"mySampleExtensionTestProvision",
+				},
+				expectedPlist:
+					"<key>provisioningProfiles</key><dict><key>org.nativescript.myTestApp</key><string>myTestProvision</string><key>org.nativescript.myTestApp.SampleExtension</key><string>mySampleExtensionTestProvision</string></dict>",
 			},
 		];
 
 		_.each(testCases, (testCase) => {
 			it(testCase.name, async () => {
 				const injector = createTestInjector();
+				if (testCase.provisioningJSON) {
+					provisioningJSON = testCase.provisioningJSON;
+				}
 				const exportOptionsPlistService = injector.resolve(
 					"exportOptionsPlistService"
 				);
@@ -137,22 +186,28 @@ describe("ExportOptionsPlistService", () => {
 					testCase.buildConfig
 				);
 
-				const template = actualPlistTemplate.split("\n").join(" ");
-				assert.isTrue(
-					template.indexOf("<key>method</key>     <string>app-store</string>") >
-						0
+				expectPlistTemplateToContain(
+					actualPlistTemplate,
+					`<key>method</key><string>app-store</string>`
 				);
-				assert.isTrue(
-					template.indexOf("<key>uploadBitcode</key>     <false/>") > 0
+				expectPlistTemplateToContain(
+					actualPlistTemplate,
+					`<key>uploadBitcode</key><false/>`
 				);
-				assert.isTrue(
-					template.indexOf("<key>compileBitcode</key>     <false/>") > 0
+				expectPlistTemplateToContain(
+					actualPlistTemplate,
+					`<key>compileBitcode</key><false/>`
 				);
-				assert.isTrue(
-					template.indexOf("<key>uploadSymbols</key>     <false/>") > 0
+				expectPlistTemplateToContain(
+					actualPlistTemplate,
+					`<key>uploadSymbols</key><false/>`
 				);
+
 				if (testCase.expectedPlist) {
-					assert.isTrue(template.indexOf(testCase.expectedPlist) > 0);
+					expectPlistTemplateToContain(
+						actualPlistTemplate,
+						testCase.expectedPlist
+					);
 				}
 			});
 		});


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
