### PR TITLE
chore(help): move from tns to ns in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ cd nativescript-cli
 npm run setup
 ```
 
-To use the locally built CLI instead `tns` you can call `PATH_TO_CLI_FOLDER/bin/tns`. For example:
+To use the locally built CLI instead of `ns` you can call `PATH_TO_CLI_FOLDER/bin/ns`. For example:
 `PATH_TO_CLI_FOLDER/bin/ns run ios|android`
 
 [Back to Top][1]

--- a/docs/man_pages/cloud/cloud-setup.md
+++ b/docs/man_pages/cloud/cloud-setup.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns cloud setup
+title: ns cloud setup
 position: 5
 ---<% } %>
 
-# tns cloud setup
+# ns cloud setup
 
 ### Description
 
@@ -13,13 +13,13 @@ Install the `nativescript-cloud extension` to configure your environment for clo
 
 Usage | Synopsis
 ------|-------
-Install the `nativescript-cloud extension` | `$ tns cloud setup`
-Log in for cloud builds (will open browser login form) | `$ tns login`
-Log in for cloud builds (through the CLI) | `$ tns dev-login <username> <password>`
-Accept EULA agreement | `$ tns accept eula`
-Perform iOS cloud build | `$ tns cloud build ios --accountId=<accountId>`
-Perform Android cloud build | `$ tns cloud build android --accountId=<accountId>`
-View accountId (after logging in) | `$ tns account`
+Install the `nativescript-cloud extension` | `$ ns cloud setup`
+Log in for cloud builds (will open browser login form) | `$ ns login`
+Log in for cloud builds (through the CLI) | `$ ns dev-login <username> <password>`
+Accept EULA agreement | `$ ns accept eula`
+Perform iOS cloud build | `$ ns cloud build ios --accountId=<accountId>`
+Perform Android cloud build | `$ ns cloud build android --accountId=<accountId>`
+View accountId (after logging in) | `$ ns account`
 
 
 ### Related Commands

--- a/docs/man_pages/device/device-android.md
+++ b/docs/man_pages/device/device-android.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns device android
+title: ns device android
 position: 1
 ---<% } %>
 
-# tns device android
+# ns device android
 
 ### Description
 
@@ -13,7 +13,7 @@ Lists all recognized connected Android physical and running virtual devices with
 
 Usage | Synopsis
 ------|-------
-General | `$ tns device android [--timeout <Milliseconds>]`
+General | `$ ns device android [--timeout <Milliseconds>]`
 
 ### Options
 

--- a/docs/man_pages/device/device-ios.md
+++ b/docs/man_pages/device/device-ios.md
@@ -1,21 +1,21 @@
 <% if (isJekyll) { %>---
-title: tns device ios
+title: ns device ios
 position: 2
 ---<% } %>
 
-# tns device ios
+# ns device ios
 
 ### Description
 
 Lists all recognized connected iOS devices with serial number and index.
 
-<% if(isConsole && (isLinux)) { %>WARNING: You can run this command only on Windows and macOS systems. To view the complete help for this command, run `$ tns help device ios`<% } %>
+<% if(isConsole && (isLinux)) { %>WARNING: You can run this command only on Windows and macOS systems. To view the complete help for this command, run `$ ns help device ios`<% } %>
 
 ### Commands
 
 Usage | Synopsis
 ------|-------
-General | `$ tns device ios [--timeout <Milliseconds>]`
+General | `$ ns device ios [--timeout <Milliseconds>]`
 
 <% if((isConsole && (isWindows || isMacOS)) || isHtml) { %>  
 
@@ -26,7 +26,7 @@ General | `$ tns device ios [--timeout <Milliseconds>]`
 
 ### Command Limitations
 
-* You can run `$ tns device ios` on Windows and OS X systems.
+* You can run `$ ns device ios` on Windows and OS X systems.
 
 ### Related Commands
 

--- a/docs/man_pages/device/device-list-applications.md
+++ b/docs/man_pages/device/device-list-applications.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns device list-applications
+title: ns device list-applications
 position: 3
 ---<% } %>
 
-# tns device list-applications
+# ns device list-applications
 
 ### Description
 
@@ -13,11 +13,11 @@ Lists the installed applications on all connected Android <% if(isWindows || isM
 
 Usage | Synopsis
 ------|-------
-General | `$ tns device list-applications [--device <Device ID>]`
+General | `$ ns device list-applications [--device <Device ID>]`
 
 ### Options
 
-* `--device` - If multiple devices are connected, sets the device for which you want to list all currently installed applications. `<Device ID>` is the device index or identifier as listed by the `$ tns device` command.
+* `--device` - If multiple devices are connected, sets the device for which you want to list all currently installed applications. `<Device ID>` is the device index or identifier as listed by the `$ ns device` command.
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/device/device-log.md
+++ b/docs/man_pages/device/device-log.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns device log
+title: ns device log
 position: 4
 ---<% } %>
 
-# tns device log
+# ns device log
 
 ### Description
 
@@ -13,11 +13,11 @@ Opens the device log stream for a selected connected Android <% if(isWindows || 
 
 Usage | Synopsis
 ------|-------
-General | `$ tns device log [--device <Device ID>]`
+General | `$ ns device log [--device <Device ID>]`
 
 ### Options
 
-* `--device` - If multiple devices are connected, sets the device for which you want to stream the log in the console. `<Device ID>` is the device index or identifier as listed by the `$ tns device` command.
+* `--device` - If multiple devices are connected, sets the device for which you want to stream the log in the console. `<Device ID>` is the device index or identifier as listed by the `$ ns device` command.
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/device/device-run.md
+++ b/docs/man_pages/device/device-run.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns device run
+title: ns device run
 position: 5
 ---<% } %>
 
-# tns device run
+# ns device run
 
 ### Description
 
@@ -15,15 +15,15 @@ Runs the selected application on a connected Android <% if(isMacOS) { %>or iOS <
 
 Usage | Synopsis
 ------|-------
-General | `$ tns device run <Application ID> [--device <Device ID>]`
+General | `$ ns device run <Application ID> [--device <Device ID>]`
 
 ### Options
 
-* `--device` - If multiple devices are connected, sets the device on which you want to run the app. `<Device ID>` is the device index or identifier as listed by the `$ tns device` command.
+* `--device` - If multiple devices are connected, sets the device on which you want to run the app. `<Device ID>` is the device index or identifier as listed by the `$ ns device` command.
 
 ### Arguments
 
-* `<Application ID>` is the application identifier as listed by `$ tns device list-applications`.
+* `<Application ID>` is the application identifier as listed by `$ ns device list-applications`.
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/device/device.md
+++ b/docs/man_pages/device/device.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns device
+title: ns device
 position: 6
 ---<% } %>
 
-# tns device
+# ns device
 
 ### Description
 
@@ -13,7 +13,7 @@ Lists all recognized connected Android <% if(isWindows || isMacOS) { %>or iOS de
 
 Usage | Synopsis
 ------|---------
-General | `$ tns device [<Command>]`
+General | `$ ns device [<Command>]`
 
 ### Arguments
 
@@ -28,11 +28,11 @@ General | `$ tns device [<Command>]`
 
 ### Command Limitations
 
-* You can run `$ tns device ios` on Windows and macOS systems.
+* You can run `$ ns device ios` on Windows and macOS systems.
 
 ### Aliases
 
-* You can use `$ tns devices` as an alias for `$ tns device`.
+* You can use `$ ns devices` as an alias for `$ ns device`.
 
 ### Related Commands
 

--- a/docs/man_pages/env-configuration/setup.md
+++ b/docs/man_pages/env-configuration/setup.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns setup
+title: ns setup
 position: 5
 ---<% } %>
 
-# tns setup
+# ns setup
 
 ### Description
 
@@ -13,7 +13,7 @@ Run the setup script to automatically install the NativeScript dependencies and 
 
 Usage | Synopsis
 ------|-------
-Run the setup script | `$ tns setup`
+Run the setup script | `$ ns setup`
 
 ### Related Commands
 

--- a/docs/man_pages/general/autocomplete-disable.md
+++ b/docs/man_pages/general/autocomplete-disable.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns autocomplete disable
+title: ns autocomplete disable
 position: 1
 ---<% } %>
 
-# tns autocomplete disable
+# ns autocomplete disable
 
 ### Description
 
@@ -15,7 +15,7 @@ Disables command-line completion for bash and zsh shells. You need to restart th
 
 Usage | Synopsis
 ------|-------
-General | `$ tns autocomplete disable`
+General | `$ ns autocomplete disable`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/autocomplete-enable.md
+++ b/docs/man_pages/general/autocomplete-enable.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns autocomplete enable
+title: ns autocomplete enable
 position: 2
 ---<% } %>
 
-# tns autocomplete enable
+# ns autocomplete enable
 
 ### Description
 
@@ -15,7 +15,7 @@ Enables command-line completion for bash and zsh shells. You need to restart the
 
 Usage | Synopsis
 ------|-------
-General | `$ tns autocomplete enable`
+General | `$ ns autocomplete enable`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/autocomplete-status.md
+++ b/docs/man_pages/general/autocomplete-status.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns autocomplete status
+title: ns autocomplete status
 position: 3
 ---<% } %>
 
-# tns autocomplete status
+# ns autocomplete status
 
 ### Description
 
@@ -13,7 +13,7 @@ Prints your current command-line completion settings.
 
 Usage | Synopsis
 ------|-------
-General | `$ tns autocomplete status`
+General | `$ ns autocomplete status`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/autocomplete.md
+++ b/docs/man_pages/general/autocomplete.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns autocomplete
+title: ns autocomplete
 position: 4
 ---<% } %>
 
-# tns autocomplete
+# ns autocomplete
 
 ### Description
 
@@ -15,10 +15,10 @@ Prints your current command-line completion settings. If disabled, prompts you t
 
 Usage | Synopsis
 ------|-------
-General | `$ tns autocomplete [<Command>]`
-Get settings | `$ tns autocomplete status`
-Enable | `$ tns autocomplete enable`
-Disable | `$ tns autocomplete disable`
+General | `$ ns autocomplete [<Command>]`
+Get settings | `$ ns autocomplete status`
+Enable | `$ ns autocomplete enable`
+Disable | `$ ns autocomplete disable`
 
 ### Arguments
 

--- a/docs/man_pages/general/error-reporting.md
+++ b/docs/man_pages/general/error-reporting.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns error-reporting
+title: ns error-reporting
 position: 6
 ---<% } %>
 
-# tns error-reporting
+# ns error-reporting
 
 ### Description
 
@@ -13,7 +13,7 @@ Configures anonymous error reporting for the NativeScript CLI. All data gathered
 
 Usage | Synopsis
 ------|-------
-General | `$ tns error-reporting [<Command>]`
+General | `$ ns error-reporting [<Command>]`
 
 ### Arguments
 

--- a/docs/man_pages/general/extension-install.md
+++ b/docs/man_pages/general/extension-install.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns extension install
+title: ns extension install
 position: 7
 ---<% } %>
 
-# tns extension install
+# ns extension install
 
 ### Description
 
@@ -13,7 +13,7 @@ Installs specified extension. Each extension adds additional functionality that'
 
 Usage | Synopsis
 ------|-------
-General | `$ tns extension install <Extension>`
+General | `$ ns extension install <Extension>`
 
 ### Arguments
 

--- a/docs/man_pages/general/extension-uninstall.md
+++ b/docs/man_pages/general/extension-uninstall.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns extension uninstall
+title: ns extension uninstall
 position: 8
 ---<% } %>
 
-# tns extension uninstall
+# ns extension uninstall
 
 ### Description
 
@@ -13,7 +13,7 @@ Uninstalls the specified extension, after which you will no longer be able to us
 
 Usage | Synopsis
 ------|-------
-General | `$ tns extension uninstall <Extension>`
+General | `$ ns extension uninstall <Extension>`
 
 ### Arguments
 

--- a/docs/man_pages/general/extension.md
+++ b/docs/man_pages/general/extension.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns extension
+title: ns extension
 position: 9
 ---<% } %>
 
-# tns extension
+# ns extension
 
 ### Description
 
@@ -13,7 +13,7 @@ Prints information about all installed extensions.
 
 Usage | Synopsis
 ------|-------
-General | `$ tns extension`
+General | `$ ns extension`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/help.md
+++ b/docs/man_pages/general/help.md
@@ -1,26 +1,26 @@
 <% if (isJekyll) { %>---
-title: tns help
+title: ns help
 position: 10
 ---<% } %>
 
-# tns help
+# ns help
 
 ### Description
 
 Opens the command reference for all commands in your browser or shows information about the selected command in the browser.
 
-To list all commands available in the console, run `$ tns -h`.
-To print information about a selected command in the console, run `$ tns <Command> -h`.
+To list all commands available in the console, run `$ ns -h`.
+To print information about a selected command in the console, run `$ ns <Command> -h`.
 
 ### Commands
 
 Usage | Synopsis
 ------|-------
-General | `$ tns help [<Command>]`
+General | `$ ns help [<Command>]`
 
 ### Arguments
 
-* `<Command>` is any of the available commands as listed by `$ tns help` or `$ tns -h`
+* `<Command>` is any of the available commands as listed by `$ ns help` or `$ ns -h`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/info.md
+++ b/docs/man_pages/general/info.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns info
+title: ns info
 position: 11
 ---<% } %>
 
-# tns info
+# ns info
 
 ### Description
 
@@ -13,7 +13,7 @@ Displays version information about the NativeScript CLI, core modules, and runti
 
 Usage | Synopsis
 ------|-------
-General | `$ tns info`
+General | `$ ns info`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/migrate.md
+++ b/docs/man_pages/general/migrate.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns migrate
+title: ns migrate
 position: 15
 ---<% } %>
 
-# tns migrate
+# ns migrate
 
 ### Description
 
@@ -65,7 +65,7 @@ The following dependencies will be updated if needed:
 
 Usage | Synopsis
 ------|-------
-General | `$ tns migrate`
+General | `$ ns migrate`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/package-manager-get.md
+++ b/docs/man_pages/general/package-manager-get.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns package-manager get
+title: ns package-manager get
 position: 19
 ---<% } %>
 
-# tns package-manager get
+# ns package-manager get
 
 ### Description
 
@@ -13,7 +13,7 @@ Prints the value of the current package manager.
 
 Usage | Synopsis
 ------|-------
-General | `$ tns package-manager get`
+General | `$ ns package-manager get`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/package-manager-set.md
+++ b/docs/man_pages/general/package-manager-set.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns package-manager set
+title: ns package-manager set
 position: 18
 ---<% } %>
 
-# tns package-manager set
+# ns package-manager set
 
 ### Description
 
@@ -13,7 +13,7 @@ Enables the specified package manager for the NativeScript CLI. Supported values
 
 Usage | Synopsis
 ------|-------
-General | `$ tns package-manager set <PackageManager>`
+General | `$ ns package-manager set <PackageManager>`
 
 ### Arguments
 

--- a/docs/man_pages/general/package-manager.md
+++ b/docs/man_pages/general/package-manager.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns package-manager get
+title: ns package-manager get
 position: 19
 ---<% } %>
 
-# tns package-manager get
+# ns package-manager get
 
 ### Description
 
@@ -13,7 +13,7 @@ Prints the value of the current package manager.
 
 Usage | Synopsis
 ------|-------
-General | `$ tns package-manager get`
+General | `$ ns package-manager get`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/proxy-clear.md
+++ b/docs/man_pages/general/proxy-clear.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns proxy clear
+title: ns proxy clear
 position: 12
 ---<% } %>
 
-# tns proxy clear
+# ns proxy clear
 
 ### Description
 
@@ -13,7 +13,7 @@ Clears the currently configured proxy settings of the NativeScript CLI.
 
 Usage | Synopsis
 ------|-------
-General | `$ tns proxy clear`
+General | `$ ns proxy clear`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/proxy-set.md
+++ b/docs/man_pages/general/proxy-set.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns proxy set
+title: ns proxy set
 position: 13
 ---<% } %>
 
-# tns proxy set
+# ns proxy set
 
 ### Description
 
@@ -13,7 +13,7 @@ Sets the proxy settings of the NativeScript CLI.
 
 Usage | Synopsis
 ------|-------
-General | `$ tns proxy set [<Url> <% if(isWindows) {%>[<Username> [<Password>]]<%}%>]`
+General | `$ ns proxy set [<Url> <% if(isWindows) {%>[<Username> [<Password>]]<%}%>]`
 
 ### Options
 

--- a/docs/man_pages/general/proxy.md
+++ b/docs/man_pages/general/proxy.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns proxy
+title: ns proxy
 position: 14
 ---<% } %>
 
-# tns proxy
+# ns proxy
 
 ### Description
 
@@ -13,7 +13,7 @@ Displays the current proxy settings of the NativeScript CLI.
 
 Usage | Synopsis
 ------|-------
-General | `$ tns proxy [<Command>]`
+General | `$ ns proxy [<Command>]`
 
 ### Arguments
 `<Command>` extends the `proxy` command. You can set the following values for this attribute:

--- a/docs/man_pages/general/update.md
+++ b/docs/man_pages/general/update.md
@@ -1,18 +1,18 @@
 <% if (isJekyll) { %>---
-title: tns update
+title: ns update
 position: 16
 ---<% } %>
 
-# tns update
+# ns update
 
 ### Description
 
 Updates the project with the latest versions of iOS/Android runtimes, cross-platform modules and "@nativescript/webpack".
 In order to get the latest development release instead, pass `next` as argument:
-`tns update next`
+`ns update next`
 
 You can also switch to specific version by passing it to the command:
-`tns update 5.0.0`
+`ns update 5.0.0`
 
 **NOTE:** The provided version should be an existing version of the project template for this project type.
 
@@ -20,7 +20,7 @@ You can also switch to specific version by passing it to the command:
 
 Usage | Synopsis
 ------|-------
-General | `$ tns update`
+General | `$ ns update`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/general/usage-reporting.md
+++ b/docs/man_pages/general/usage-reporting.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns usage-reporting
+title: ns usage-reporting
 position: 17
 ---<% } %>
 
-# tns usage-reporting
+# ns usage-reporting
 
 ### Description
 
@@ -13,7 +13,7 @@ Configures anonymous usage reporting for the NativeScript CLI. All data gathered
 
 Usage | Synopsis
 ------|-------
-General | `$ tns usage-reporting [<Command>]`
+General | `$ ns usage-reporting [<Command>]`
 
 ### Arguments
 

--- a/docs/man_pages/lib-management/plugin-add.md
+++ b/docs/man_pages/lib-management/plugin-add.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns plugin add
+title: ns plugin add
 position: 1
 ---<% } %>
 
-# tns plugin add
+# ns plugin add
 
 ### Description
 
@@ -14,8 +14,8 @@ position: 1
 
 Usage | Synopsis
 ------|-------
-General | `$ tns plugin add <Plugin>`
-Alias | `$ tns plugin install <Plugin>`
+General | `$ ns plugin add <Plugin>`
+Alias | `$ ns plugin install <Plugin>`
 
 ### Arguments
 

--- a/docs/man_pages/lib-management/plugin-build.md
+++ b/docs/man_pages/lib-management/plugin-build.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns plugin build
+title: ns plugin build
 position: 8
 ---<% } %>
 
-# tns plugin build
+# ns plugin build
 
 ### Description
 
@@ -14,7 +14,7 @@ position: 8
 
 Usage | Synopsis
 ------|-------
-General | `$ tns plugin build`
+General | `$ ns plugin build`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/lib-management/plugin-create.md
+++ b/docs/man_pages/lib-management/plugin-create.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns plugin create
+title: ns plugin create
 position: 1
 ---<% } %>
 
-# tns plugin create
+# ns plugin create
 
 ### Description
 
@@ -23,8 +23,8 @@ The project is setup for easy commit in Github, which is why the command will as
 
 Usage | Synopsis
 ---|---
-Create from the default plugin seed | `$ tns plugin create <Plugin Repository Name> [--path <Directory>]`
-Create from a custom plugin seed | `$ tns plugin create <Plugin Repository Name> [--path <Directory>] --template <Template>`
+Create from the default plugin seed | `$ ns plugin create <Plugin Repository Name> [--path <Directory>]`
+Create from a custom plugin seed | `$ ns plugin create <Plugin Repository Name> [--path <Directory>] --template <Template>`
 
 ### Options
 
@@ -33,15 +33,15 @@ Create from a custom plugin seed | `$ tns plugin create <Plugin Repository Name>
 * `--pluginName` - Used to set the default file and class names in the plugin source.
 * `--includeTypeScriptDemo` - Specifies if TypeScript demo should be created. Default value is `y` (i.e. `demo` will be created), in case you do not want to create this demo, pass `--includeTypeScriptDemo=n`
 * `--includeAngularDemo` - Specifies if Angular demo should be created. Default value is `y` (i.e. `demo-angular` will be created), in case you do not want to create this demo, pass `--includeAngularDemo=n`
-* `--template` - Specifies the custom seed archive, which you want to use to create your plugin. If `--template` is not set, the NativeScript CLI creates the plugin from the default NativeScript Plugin Seed. `<Template>` can be a URL or a local path to a `.tar.gz` file with the contents of a seed repository.<% if(isHtml) { %> This must be a clone of the [NativeScript Plugin Seed](https://github.com/NativeScript/nativescript-plugin-seed) and must contain a `src` directory with a package.json file and a script at `src/scripts/postclone.js`. After the archive is extracted, the postclone script will be executed with the username (`gitHubUsername`) and plugin name (`pluginName`) parameters given to the `tns plugin create` command prompts. For more information, visit the default plugin seed repository and [examine the source script](https://github.com/NativeScript/nativescript-plugin-seed/blob/master/src/scripts/postclone.js) there. Examples:
+* `--template` - Specifies the custom seed archive, which you want to use to create your plugin. If `--template` is not set, the NativeScript CLI creates the plugin from the default NativeScript Plugin Seed. `<Template>` can be a URL or a local path to a `.tar.gz` file with the contents of a seed repository.<% if(isHtml) { %> This must be a clone of the [NativeScript Plugin Seed](https://github.com/NativeScript/nativescript-plugin-seed) and must contain a `src` directory with a package.json file and a script at `src/scripts/postclone.js`. After the archive is extracted, the postclone script will be executed with the username (`gitHubUsername`) and plugin name (`pluginName`) parameters given to the `ns plugin create` command prompts. For more information, visit the default plugin seed repository and [examine the source script](https://github.com/NativeScript/nativescript-plugin-seed/blob/master/src/scripts/postclone.js) there. Examples:
 
   * Using a local file:
 
-    `tns plugin create nativescript-testplugin --template ../seeds/seed1.tar.gz`
+    `ns plugin create nativescript-testplugin --template ../seeds/seed1.tar.gz`
 
   * Using a `.tar.gz` file from a tag called `v4.0` in a Github repository:
 
-    `tns plugin create nativescript-testplugin --template https://github.com/NativeScript/nativescript-plugin-seed/archive/v.4.0.tar.gz`<% } %>
+    `ns plugin create nativescript-testplugin --template https://github.com/NativeScript/nativescript-plugin-seed/archive/v.4.0.tar.gz`<% } %>
 
 ### Arguments
 

--- a/docs/man_pages/lib-management/plugin-install.md
+++ b/docs/man_pages/lib-management/plugin-install.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns plugin install
+title: ns plugin install
 position: 3
 ---<% } %>
 
-# tns plugin install
+# ns plugin install
 
 ### Description
 
@@ -14,8 +14,8 @@ position: 3
 
 Usage | Synopsis
 ------|-------
-General | `$ tns plugin install <Plugin>`
-Alias | `$ tns plugin add <Plugin>`
+General | `$ ns plugin install <Plugin>`
+Alias | `$ ns plugin add <Plugin>`
 
 ### Arguments
 

--- a/docs/man_pages/lib-management/plugin-remove.md
+++ b/docs/man_pages/lib-management/plugin-remove.md
@@ -1,20 +1,20 @@
 <% if (isJekyll) { %>---
-title: tns plugin remove
+title: ns plugin remove
 position: 4
 ---<% } %>
 
-# tns plugin remove
+# ns plugin remove
 
 ### Description
 
 <% if(isConsole) { %>Uninstalls a plugin by its name.<% } %>
-<% if(isHtml) { %>Removes the specified plugin and its dependencies from the local `node_modules` folder and the `dependencies` section in `package.json`. This operation does not remove the plugin from the installed platforms and you need to run `$ tns prepare` to finish uninstalling the plugin.<% } %>
+<% if(isHtml) { %>Removes the specified plugin and its dependencies from the local `node_modules` folder and the `dependencies` section in `package.json`. This operation does not remove the plugin from the installed platforms and you need to run `$ ns prepare` to finish uninstalling the plugin.<% } %>
 
 ### Commands
 
 Usage | Synopsis
 ------|-------
-General | `$ tns plugin remove <Plugin>`
+General | `$ ns plugin remove <Plugin>`
 
 ### Arguments
 

--- a/docs/man_pages/lib-management/plugin-update.md
+++ b/docs/man_pages/lib-management/plugin-update.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns plugin update
+title: ns plugin update
 position: 7
 ---<% } %>
 
-# tns plugin update
+# ns plugin update
 
 ### Description
 
@@ -14,7 +14,7 @@ position: 7
 
 Usage | Synopsis
 ------|-------
-General | `$ tns plugin update <Plugin(s)>`
+General | `$ ns plugin update <Plugin(s)>`
 
 ### Arguments
 

--- a/docs/man_pages/lib-management/plugin.md
+++ b/docs/man_pages/lib-management/plugin.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns plugin
+title: ns plugin
 position: 10
 ---<% } %>
 
-# tns plugin
+# ns plugin
 
 ### Description
 
@@ -13,8 +13,8 @@ Lets you manage the plugins for your project.
 
 Usage | Synopsis
 ---|---
-List plugins | `$ tns plugin`
-Manage plugins | `$ tns plugin <Command>`
+List plugins | `$ ns plugin`
+Manage plugins | `$ ns plugin <Command>`
 
 ### Arguments
 

--- a/docs/man_pages/project/configuration/generate.md
+++ b/docs/man_pages/project/configuration/generate.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns generate
+title: ns generate
 position: 9
 ---<% } %>
 
-# tns generate
+# ns generate
 
 ### Description
 
@@ -13,7 +13,7 @@ Modifies the project by executing a specified schematic to it.
 
 Usage | Synopsis
 ------|-------
-General | `$ tns generate <Schematic Name> [--collection <Collection>] [option=value]`
+General | `$ ns generate <Schematic Name> [--collection <Collection>] [option=value]`
 
 ### Options
 

--- a/docs/man_pages/project/configuration/install.md
+++ b/docs/man_pages/project/configuration/install.md
@@ -1,25 +1,25 @@
 <% if (isJekyll) { %>---
-title: tns install
+title: ns install
 position: 1
 ---<% } %>
 
-# tns install
+# ns install
 
 ### Description
 
 Installs all dependencies described in a valid `package.json` or installs a selected NativeScript development module as a dev dependency.
 
 <% if(isHtml) { %>
-The `package.json` file must be a valid `package.json` describing the configuration of a NativeScript project. If missing or corrupted, you can recreate the file by running `$ tns init` in the directory of a NativeScript project.
+The `package.json` file must be a valid `package.json` describing the configuration of a NativeScript project. If missing or corrupted, you can recreate the file by running `$ ns init` in the directory of a NativeScript project.
 <% } %>
 
 ### Commands
 
 Usage | Synopsis
 ---|---
-Install all dependencies | `$ tns install [--path]`
-Install a selected npm module | `$ tns install <Module>`
-Enable TypeScript support | `$ tns install typescript`
+Install all dependencies | `$ ns install [--path]`
+Install a selected npm module | `$ ns install <Module>`
+Enable TypeScript support | `$ ns install typescript`
 
 ### Options
 

--- a/docs/man_pages/project/configuration/platform-add.md
+++ b/docs/man_pages/project/configuration/platform-add.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns platform add
+title: ns platform add
 position: 2
 ---<% } %>
 
-# tns platform add
+# ns platform add
 
 ### Description
 
@@ -13,10 +13,10 @@ Configures the current project to target the selected platform. <% if(isHtml) { 
 
 Usage | Synopsis
 ------|-------
-Android latest runtime | `$ tns platform add android [--framework-path <File Path>]`
-Android selected runtime | `$ tns platform add android[@<Version>] [--framework-path <File Path>] `
-<% if (isMacOS) { %>iOS latest runtime | `$ tns platform add ios [--framework-path <File Path>]`
-iOS selected runtime | `$ tns platform add ios[@<Version>] [--framework-path <File Path>] `<% } %>
+Android latest runtime | `$ ns platform add android [--framework-path <File Path>]`
+Android selected runtime | `$ ns platform add android[@<Version>] [--framework-path <File Path>] `
+<% if (isMacOS) { %>iOS latest runtime | `$ ns platform add ios [--framework-path <File Path>]`
+iOS selected runtime | `$ ns platform add ios[@<Version>] [--framework-path <File Path>] `<% } %>
 
 ### Options
 
@@ -25,14 +25,14 @@ iOS selected runtime | `$ tns platform add ios[@<Version>] [--framework-path <Fi
 ### Arguments
 
 * `<Version>` is any available version of the respective platform runtime published in npm. <% if(isHtml) { %>If `@<Version>` is not specified, the NativeScript CLI installs the latest stable runtime for the selected platform.
-To list all available versions for Android, run `$ npm view tns-android versions`
-To list only experimental versions for Android, run `$ npm view tns-android dist-tags`
-To list all available versions for iOS, run `$ npm view tns-ios versions`
-To list only experimental versions for iOS, run `$ npm view tns-ios dist-tags`
+To list all available versions for Android, run `$ npm view @nativescript/android versions`
+To list only experimental versions for Android, run `$ npm view @nativescript/android dist-tags`
+To list all available versions for iOS, run `$ npm view @nativescript/ios versions`
+To list only experimental versions for iOS, run `$ npm view @nativescript/ios dist-tags`
 
 ### Command Limitations
 
-* You can run `$ tns platform add ios` only on macOS systems.
+* You can run `$ ns platform add ios` only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/project/configuration/platform-clean.md
+++ b/docs/man_pages/project/configuration/platform-clean.md
@@ -26,7 +26,7 @@ Usage | Synopsis
 ### Command Limitations
 
 * You can run `$ ns platform clean ios` only on macOS systems.
-* Clean command will not preserve your current installed platform version but will download and install latest platform version. If you are using clean with custom version of the runtime, specify the version in the command ns clean ios@2.1.0 or ns clean ios --frameworkPath <path-to-tgz>
+* Clean command will not preserve your current installed platform version but will download and install latest platform version. If you are using clean with custom version of the runtime, specify the version in the command `ns clean ios@2.1.0` or `ns clean ios --frameworkPath <path-to-tgz>`.
 
 ### Related Commands
 

--- a/docs/man_pages/project/configuration/platform-clean.md
+++ b/docs/man_pages/project/configuration/platform-clean.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns platform clean
+title: ns platform clean
 position: 3
 ---<% } %>
 
-# tns platform clean
+# ns platform clean
 
 ### Description
 
@@ -13,8 +13,8 @@ Removes and adds the selected platform to the project currently targets. <% if(i
 
 Usage | Synopsis
 ------|-------
-<% if((isConsole && isMacOS) || isHtml) { %>General | `$ tns platform clean <Platform>`<% } %>
-<% if(isConsole && (isLinux || isWindows)) { %>General | `$ tns platform clean android`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>General | `$ ns platform clean <Platform>`<% } %>
+<% if(isConsole && (isLinux || isWindows)) { %>General | `$ ns platform clean android`<% } %>
 
 <% if(isMacOS) { %>### Arguments
 `<Platform>` is the target mobile platform that you want to clean in your project. You can set the following target platforms.
@@ -25,8 +25,8 @@ Usage | Synopsis
 
 ### Command Limitations
 
-* You can run `$ tns platform clean ios` only on macOS systems.
-* Clean command will not preserve your current installed platform version but will download and install latest platform version. If you are using clean with custom version of the runtime, specify the version in the command tns clean ios@2.1.0 or tns clean ios --frameworkPath <path-to-tgz>
+* You can run `$ ns platform clean ios` only on macOS systems.
+* Clean command will not preserve your current installed platform version but will download and install latest platform version. If you are using clean with custom version of the runtime, specify the version in the command ns clean ios@2.1.0 or ns clean ios --frameworkPath <path-to-tgz>
 
 ### Related Commands
 

--- a/docs/man_pages/project/configuration/platform-remove.md
+++ b/docs/man_pages/project/configuration/platform-remove.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns platform remove
+title: ns platform remove
 position: 4
 ---<% } %>
 
-# tns platform remove
+# ns platform remove
 
 ### Description
 
@@ -15,8 +15,8 @@ Removes the selected platform from the platforms that the project currently targ
 
 Usage | Synopsis
 ------|-------
-<% if((isConsole && isMacOS) || isHtml) { %>General | `$ tns platform remove <Platform>`<% } %>
-<% if(isConsole && (isLinux || isWindows)) { %>General | `$ tns platform remove android`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>General | `$ ns platform remove <Platform>`<% } %>
+<% if(isConsole && (isLinux || isWindows)) { %>General | `$ ns platform remove android`<% } %>
 
 <% if(isMacOS) { %>### Arguments
 `<Platform>` is the target mobile platform that you want to remove from your project. You can set the following target platforms.
@@ -27,7 +27,7 @@ Usage | Synopsis
 
 ### Command Limitations
 
-* You can run `$ tns platform remove ios` only on macOS systems.
+* You can run `$ ns platform remove ios` only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/project/configuration/platform-update.md
+++ b/docs/man_pages/project/configuration/platform-update.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns platform update
+title: ns platform update
 position: 5
 ---<% } %>
 
-# tns platform update
+# ns platform update
 
 ### Description
 
@@ -13,10 +13,10 @@ Updates the NativeScript runtime for the specified platform. <% if(isMacOS) { %>
 
 Usage | Synopsis
 ------|-------
-Android latest runtime |`$ tns platform update android`
-Android selected runtime | `$ tns platform update android@<Version>`
-<% if(isMacOS) { %>iOS latest runtime | `$ tns platform update ios`
-iOS selected runtime | `$ tns platform update ios@<Version>` <% } %> 
+Android latest runtime |`$ ns platform update android`
+Android selected runtime | `$ ns platform update android@<Version>`
+<% if(isMacOS) { %>iOS latest runtime | `$ ns platform update ios`
+iOS selected runtime | `$ ns platform update ios@<Version>` <% } %> 
 
 ### Arguments
 
@@ -24,14 +24,14 @@ iOS selected runtime | `$ tns platform update ios@<Version>` <% } %>
 	* `android` - Updates the Android runtime.
 	* `ios` - Updates the iOS runtime.<% } %>
 * `<Version>` is any available version of the respective platform runtime published in npm. <% if(isHtml) { %>If `@<Version>` is not specified, the NativeScript CLI installs the latest stable runtime for the selected platform.  
-To list all available versions for Android, run `$ npm view tns-android versions`  
-To list only experimental versions for android, run `$ npm view tns-android dist-tags`  
-To list all available versions for iOS, run `$ npm view tns-ios versions`  
-To list only experimental versions for ios, run `$ npm view tns-ios dist-tags` 
+To list all available versions for Android, run `$ npm view @nativescript/android versions`
+To list only experimental versions for Android, run `$ npm view @nativescript/android dist-tags`
+To list all available versions for iOS, run `$ npm view @nativescript/ios versions`
+To list only experimental versions for iOS, run `$ npm view @nativescript/ios dist-tags`
 
 ### Command Limitations
 
-* You can run `$ tns platform update ios` only on macOS systems.
+* You can run `$ ns platform update ios` only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/project/configuration/platform.md
+++ b/docs/man_pages/project/configuration/platform.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns platform
+title: ns platform
 position: 6
 ---<% } %>
 
-# tns platform
+# ns platform
 
 ### Description
 
@@ -13,7 +13,7 @@ Lists all platforms that the project currently targets. You can build and deploy
 
 Usage | Synopsis
 ---|---
-General | `$ tns platform list`
+General | `$ ns platform list`
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/project/configuration/prepare.md
+++ b/docs/man_pages/project/configuration/prepare.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns prepare
+title: ns prepare
 position: 7
 ---<% } %>
 
-# tns prepare
+# ns prepare
 
 ### Description
 
@@ -19,7 +19,7 @@ When running this command the HMR (Hot Module Replacement) is not enabled by def
 
 Usage | Synopsis
 ------|-------
-<% if((isConsole && isMacOS) || isHtml) { %>General | `$ tns prepare <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ tns prepare android`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>General | `$ ns prepare <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ ns prepare android`<% } %>
 
 <% if(isMacOS) { %>### Arguments
 `<Platform>` is the target mobile platform for which you want to prepare your project. You can set the following target platforms.
@@ -29,13 +29,13 @@ Usage | Synopsis
 ### Options
 
 * `--hmr` - Enables the hot module replacement (HMR) feature.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>
 
 ### Command Limitations
 
-* You can run `$ tns prepare ios` only on macOS systems.
+* You can run `$ ns prepare ios` only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/project/configuration/resources/resources-generate-icons.md
+++ b/docs/man_pages/project/configuration/resources/resources-generate-icons.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns resources generate icons
+title: ns resources generate icons
 position: 11
 ---<% } %>
 
-# tns resources generate icons
+# ns resources generate icons
 
 ### Description
 
@@ -13,11 +13,11 @@ Generates all icons for Android and iOS platforms and places the generated image
 
 Usage | Synopsis
 ------|-------
-`$ tns resources generate icons <Path to image>` | Generate all icons for Android and iOS based on the specified image.
+`$ ns resources generate icons <Path to image>` | Generate all icons for Android and iOS based on the specified image.
 
 ### Options
 
-* `--background` Sets the background color of the icon. When no color is specified, a default value of `transparent` is used. `<Color>` is a valid color and can be represented with string, like `white`, `black`, `blue`, or with HEX representation, for example `#FFFFFF`, `#000000`, `#0000FF`. NOTE: As the `#` is special symbol in some terminals, make sure to place the value in quotes, for example `$ tns resources generate icons ../myImage.png --background "#FF00FF"`.
+* `--background` Sets the background color of the icon. When no color is specified, a default value of `transparent` is used. `<Color>` is a valid color and can be represented with string, like `white`, `black`, `blue`, or with HEX representation, for example `#FFFFFF`, `#000000`, `#0000FF`. NOTE: As the `#` is special symbol in some terminals, make sure to place the value in quotes, for example `$ ns resources generate icons ../myImage.png --background "#FF00FF"`.
 
 ### Arguments
 

--- a/docs/man_pages/project/configuration/resources/resources-generate-splashes.md
+++ b/docs/man_pages/project/configuration/resources/resources-generate-splashes.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns resources generate splashes
+title: ns resources generate splashes
 position: 12
 ---<% } %>
 
-# tns resources generate splashes
+# ns resources generate splashes
 
 ### Description
 
@@ -13,11 +13,11 @@ Generates all splashscreens for Android and iOS platforms and places the generat
 
 Usage | Synopsis
 ------|-------
-`$ tns resources generate splashes <Path to image> [--background <Color>]` | Generate all splashscreens for Android and iOS based on the specified image.
+`$ ns resources generate splashes <Path to image> [--background <Color>]` | Generate all splashscreens for Android and iOS based on the specified image.
 
 ### Options
 
-* `--background` Sets the background color of the splashscreen. When no color is specified, a default value of `white` is used. `<Color>` is a valid color and can be represented with string, like `white`, `black`, `blue`, or with HEX representation, for example `#FFFFFF`, `#000000`, `#0000FF`. NOTE: As the `#` is special symbol in some terminals, make sure to place the value in quotes, for example `$ tns resources generate splashes ../myImage.png --background "#FF00FF"`.
+* `--background` Sets the background color of the splashscreen. When no color is specified, a default value of `white` is used. `<Color>` is a valid color and can be represented with string, like `white`, `black`, `blue`, or with HEX representation, for example `#FFFFFF`, `#000000`, `#0000FF`. NOTE: As the `#` is special symbol in some terminals, make sure to place the value in quotes, for example `$ ns resources generate splashes ../myImage.png --background "#FF00FF"`.
 
 ### Arguments
 

--- a/docs/man_pages/project/configuration/resources/resources-update.md
+++ b/docs/man_pages/project/configuration/resources/resources-update.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns resources update
+title: ns resources update
 position: 10
 ---<% } %>
 
-# tns resources update
+# ns resources update
 
 ### Description
 
@@ -17,12 +17,12 @@ Updates the App_Resources/<platform>'s internal folder structure to conform to t
 
 Usage | Synopsis
 ------|-------
-`$ tns resources update` | Defaults to executing `$ tns resources update android`. Updates the App_Resources/Android's folder structure.
-`$ tns resources update android` | Updates the App_Resources/Android's folder structure.
+`$ ns resources update` | Defaults to executing `$ ns resources update android`. Updates the App_Resources/Android's folder structure.
+`$ ns resources update android` | Updates the App_Resources/Android's folder structure.
 
 ### Command Limitations
 
-* The command works only for the directory structure under `App_Resources/Android`. Running `$ tns resources-update ios` will have no effect.
+* The command works only for the directory structure under `App_Resources/Android`. Running `$ ns resources-update ios` will have no effect.
 
 ### Related Commands
 

--- a/docs/man_pages/project/creation/create.md
+++ b/docs/man_pages/project/creation/create.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns create
+title: ns create
 position: 1
 ---<% } %>
 
-# tns create
+# ns create
 
 ### Description
 
@@ -22,7 +22,7 @@ Custom template | `$ ns create [<App Name>] [--path <Directory>] [--appid <App I
 ### Options
 
 * `--path` - Specifies the directory where you want to create the project, if different from the current directory. `<Directory>` is the absolute path to an empty directory in which you want to create the project.
-* `--appid` - Sets the application identifier of your project. `<App ID>` is the value of the application identifier and it must meet the specific requirements of each platform that you want to target. If not specified, the application identifier is set to `org.nativescript.<App name>`.<% if(isConsole) { %> For more information about the `<App ID>` requirements, run `$ tns help create`.<% } %><% if(isHtml) { %> The application identifier must be a domain name in reverse. For projects that target Android, you can use uppercase or lowercase letters, numbers, and underscores in the strings of the reversed domain name, separated by a dot. Strings must be separated by a dot and must start with a letter. For example: `com.nativescript.My_Andro1d_App`. For projects that target iOS, you can use uppercase or lowercase letters, numbers, and hyphens in the strings of the reversed domain name. Strings must be separated by a dot. For example: `com.nativescript.My-i0s-App`.
+* `--appid` - Sets the application identifier of your project. `<App ID>` is the value of the application identifier and it must meet the specific requirements of each platform that you want to target. If not specified, the application identifier is set to `org.nativescript.<App name>`.<% if(isConsole) { %> For more information about the `<App ID>` requirements, run `$ ns help create`.<% } %><% if(isHtml) { %> The application identifier must be a domain name in reverse. For projects that target Android, you can use uppercase or lowercase letters, numbers, and underscores in the strings of the reversed domain name, separated by a dot. Strings must be separated by a dot and must start with a letter. For example: `com.nativescript.My_Andro1d_App`. For projects that target iOS, you can use uppercase or lowercase letters, numbers, and hyphens in the strings of the reversed domain name. Strings must be separated by a dot. For example: `com.nativescript.My-i0s-App`.
 * `--template` - Specifies a valid npm package which you want to use as a base to create your project. If `--template` is not set, the NativeScript CLI will ask you to pick one from a predefined list afterwards.<% if(isHtml) { %> If one or more application assets are missing from the `App_Resources` directory in the package, the CLI adds them using the assets available in the default hello-world template.<% } %> `<Template>` can be the name of a package in the npm registry, a local path or a GitHub URL to a directory, or a `.tar.gz` archive containing a `package.json` file. The contents of the package will be copied to the `app` directory of your project.<% } %>
 * `--js`, `--javascript` - Sets the template for your project to the JavaScript template.
 * `--ts`, `--tsc`, `--typescript` - Sets the template for your project to the TypeScript template.
@@ -31,7 +31,7 @@ Custom template | `$ ns create [<App Name>] [--path <Directory>] [--appid <App I
 
 ### Arguments
 
-`<App Name>` is the name of project and must meet the requirements of each platform that you want to target. If not specified in the initial command, the NativeScript CLI will ask you for it afterwards.<% if(isConsole) { %> For more information about the `<App Name>` requirements, run `$ tns help create`.<% } %><% if(isHtml) { %> For projects that target Android, you can use uppercase or lowercase letters, numbers, and underscores. The name must start with a letter. For projects that target iOS, you can use uppercase or lowercase letters, numbers, and hyphens.
+`<App Name>` is the name of project and must meet the requirements of each platform that you want to target. If not specified in the initial command, the NativeScript CLI will ask you for it afterwards.<% if(isConsole) { %> For more information about the `<App Name>` requirements, run `$ ns help create`.<% } %><% if(isHtml) { %> For projects that target Android, you can use uppercase or lowercase letters, numbers, and underscores. The name must start with a letter. For projects that target iOS, you can use uppercase or lowercase letters, numbers, and hyphens.
 <% } %>
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/build-android.md
+++ b/docs/man_pages/project/testing/build-android.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns build android
+title: ns build android
 position: 1
 ---<% } %>
 
-# tns build android
+# ns build android
 
 ### Description
 
@@ -13,7 +13,7 @@ Builds the project for Android and produces an APK that you can manually deploy 
 
 Usage | Synopsis
 ---|---
-General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--static-bindings] [--copy-to <File Path>] [--env.*]] [--aab]`
+General | `$ ns build android [--compileSdk <API Level>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--static-bindings] [--copy-to <File Path>] [--env.*]] [--aab]`
 
 ### Options
 
@@ -34,7 +34,7 @@ General | `$ tns build android [--compileSdk <API Level>] [--key-store-path <Fil
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the build will produce an Android App Bundle(`.aab`) file.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 * `--path <Directory>` - Specifies the directory that contains the project. If not set, the project is searched for in the current directory and all directories above it.
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/build-ios.md
+++ b/docs/man_pages/project/testing/build-ios.md
@@ -1,15 +1,15 @@
 <% if (isJekyll) { %>---
-title: tns build ios
+title: ns build ios
 position: 2
 ---<% } %>
 
-# tns build ios
+# ns build ios
 
 ### Description
 
 Builds the project for iOS and produces an `APP` or `IPA` that you can manually deploy in the iOS Simulator or on a device.
 
-<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help build ios`<% } %>
+<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ ns help build ios`<% } %>
 <% if((isConsole && isMacOS) || isHtml) { %>
 <% if(isHtml) { %>> <% } %>IMPORTANT: Before building for iOS device, verify that you have configured a valid pair of certificate and provisioning profile on your macOS system. <% if(isHtml) { %>For more information, see the [Code Signing](https://developer.apple.com/support/code-signing/) and [Maintain Signing Assets](https://help.apple.com/xcode/mac/current/#/dev3a05256b8) sections from the Apple Developer documentation.<% } %>
 
@@ -17,7 +17,7 @@ Builds the project for iOS and produces an `APP` or `IPA` that you can manually 
 
 Usage | Synopsis
 ---|---
-General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [--provision [<UUID/name>]] [--env.*]]`
+General | `$ ns build ios [--for-device] [--release] [--copy-to <File Path>] [--provision [<UUID/name>]] [--env.*]]`
 
 ### Options
 
@@ -33,7 +33,7 @@ General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [-
     *   `--env.report` - creates a Webpack report inside a `report` folder in the root folder.
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 * `--path <Directory>` - Specifies the directory that contains the project. If not set, the project is searched for in the current directory and all directories above it.
 
 <% } %>
@@ -42,7 +42,7 @@ General | `$ tns build ios [--for-device] [--release] [--copy-to <File Path>] [-
 
 ### Command Limitations
 
-* You can run the `$ tns build ios` command only on macOS systems.
+* You can run the `$ ns build ios` command only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/project/testing/build.md
+++ b/docs/man_pages/project/testing/build.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns build
+title: ns build
 position: 3
 ---<% } %>
 
-# tns build
+# ns build
 
 ### Description
 
@@ -19,7 +19,7 @@ When running this command the HMR (Hot Module Replacement) is not enabled by def
 
 Usage | Synopsis
 ---|---
-<% if((isConsole && isMacOS) || isHtml) { %>General | `$ tns build <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ tns build android`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>General | `$ ns build <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ ns build android`<% } %>
 
 <% if((isConsole && isMacOS) || isHtml) { %>### Arguments
 `<Platform>` is the target mobile platform for which you want to build your project. You can set the following target platforms.
@@ -30,7 +30,7 @@ Usage | Synopsis
 
 * `--justlaunch` - If set, does not print the application output in the console.
 * `--release` -If set, produces a release build by running webpack in production mode and native build in release mode. Otherwise, produces a debug build.
-* `--device` - Specifies a connected device/emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device <Platform> --available-devices` command.
+* `--device` - Specifies a connected device/emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ ns device <Platform> --available-devices` command.
 * `--hmr` - Enables the hot module replacement (HMR) feature.
 * `--env.*` - Specifies additional flags that the bundler may process. Can be passed multiple times. Supported additional flags:
     *   `--env.aot` - creates Ahead-Of-Time build (Angular only).
@@ -41,7 +41,7 @@ Usage | Synopsis
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/project/testing/debug-android.md
+++ b/docs/man_pages/project/testing/debug-android.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns debug android
+title: ns debug android
 position: 4
 ---<% } %>
 
-# tns debug android
+# ns debug android
 
 ### Description 
 
@@ -13,15 +13,15 @@ Initiates a debugging session for your project on a connected Android device or 
 
 Usage | Synopsis
 ---|---
-Deploy on device/emulator, run the app and generate a Chrome DevTools link for debugging | `$ tns debug android [--device <Device ID>] [--timeout <timeout>] [--aab]`
-Deploy on device/emulator, run the app and stop at the first code statement | `$ tns debug android --debug-brk [--device <Device ID>] [--timeout <timeout>] [--aab]`
-Deploy in the native emulator, run the app and stop at the first code statement | `$ tns debug android --debug-brk --emulator [--timeout <timeout>] [--aab]`
-Attach the debug tools to a running app on device/emulator | `$ tns debug android --start [--device <Device ID>] [--timeout <timeout>] [--aab]`
-Attach the debug tools to a running app in the native emulator | `$ tns debug android --start --emulator [--timeout <timeout>] [--aab]`
+Deploy on device/emulator, run the app and generate a Chrome DevTools link for debugging | `$ ns debug android [--device <Device ID>] [--timeout <timeout>] [--aab]`
+Deploy on device/emulator, run the app and stop at the first code statement | `$ ns debug android --debug-brk [--device <Device ID>] [--timeout <timeout>] [--aab]`
+Deploy in the native emulator, run the app and stop at the first code statement | `$ ns debug android --debug-brk --emulator [--timeout <timeout>] [--aab]`
+Attach the debug tools to a running app on device/emulator | `$ ns debug android --start [--device <Device ID>] [--timeout <timeout>] [--aab]`
+Attach the debug tools to a running app in the native emulator | `$ ns debug android --start --emulator [--timeout <timeout>] [--aab]`
 
 ### Options
 
-* `--device` - Specifies a connected device/emulator on which to debug the app. `<Device ID>` is the device identifier or name of the target device as listed by the `$ tns device android` command.
+* `--device` - Specifies a connected device/emulator on which to debug the app. `<Device ID>` is the device identifier or name of the target device as listed by the `$ ns device android` command.
 * `--emulator` - Specifies that you want to debug the app in the native Android emulator.
 * `--debug-brk` - Prepares, builds and deploys the application package on a device/emulator, generates a link for Chrome Developer Tools and stops at the first code statement.
 * `--start` - Attaches the debug tools to a deployed and running app.
@@ -38,7 +38,7 @@ Attach the debug tools to a running app in the native emulator | `$ tns debug an
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/project/testing/debug-ios.md
+++ b/docs/man_pages/project/testing/debug-ios.md
@@ -1,15 +1,15 @@
 <% if (isJekyll) { %>---
-title: tns debug ios
+title: ns debug ios
 position: 5
 ---<% } %>
 
-# tns debug ios
+# ns debug ios
 
 ### Description
 
 Initiates a debugging session for your project on a connected iOS device or in the iOS simulator. When necessary, the command will prepare, build, deploy and launch the app before starting the debug session. While debugging, the output from the application is printed in the console and any changes made to your code are synchronizes with the deployed app. <% if(isHtml) { %>Any debugging traffic is forwarded to port 8080 (or the next available one) from the device to the local machine.<% } %>
 
-<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help debug ios`<% } %>
+<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ ns help debug ios`<% } %>
 <% if((isConsole && isMacOS) || isHtml) { %>
 <% if(isHtml) { %>> <% } %>IMPORTANT: Before building for iOS device, verify that you have configured a valid pair of certificate and provisioning profile on your macOS system. <% if(isHtml) { %>For more information, see the [Code Signing](https://developer.apple.com/support/code-signing/) and [Maintain Signing Assets](https://help.apple.com/xcode/mac/current/#/dev3a05256b8) sections from the Apple Developer documentation.<% } %>
 
@@ -17,15 +17,15 @@ Initiates a debugging session for your project on a connected iOS device or in t
 
 Usage | Synopsis
 ---|---
-Deploy on device/emulator, run the app, attach a debugger and generate a Chrome DevTools link for debugging | `$ tns debug ios`
-Deploy on device/simulator, run the app and stop at the first code statement | `$ tns debug ios --debug-brk [--device <Device ID>] [--no-client]`
-Deploy in the iOS simulator, run the app and stop at the first code statement | `$ tns debug ios --debug-brk --emulator [--no-client]`
-Attach the debug tools to a running app on specified device or simulator| `$ tns debug ios --start [--device <Device ID>] [--no-client]`
-Attach the debug tools to a running app in the iOS simulator | `$ tns debug ios --start --emulator [--no-client]`
+Deploy on device/emulator, run the app, attach a debugger and generate a Chrome DevTools link for debugging | `$ ns debug ios`
+Deploy on device/simulator, run the app and stop at the first code statement | `$ ns debug ios --debug-brk [--device <Device ID>] [--no-client]`
+Deploy in the iOS simulator, run the app and stop at the first code statement | `$ ns debug ios --debug-brk --emulator [--no-client]`
+Attach the debug tools to a running app on specified device or simulator| `$ ns debug ios --start [--device <Device ID>] [--no-client]`
+Attach the debug tools to a running app in the iOS simulator | `$ ns debug ios --start --emulator [--no-client]`
 
 ### Options
 
-* `--device` - Specifies a connected device or iOS simulator on which to run the app. `<Device ID>` is the device identifier of the target device as listed by the `$ tns device ios` command.
+* `--device` - Specifies a connected device or iOS simulator on which to run the app. `<Device ID>` is the device identifier of the target device as listed by the `$ ns device ios` command.
 * `--emulator` - Indicates that you want to debug your app in the iOS simulator.
 * `--debug-brk` - Prepares, builds and deploys the application package on a device or in a simulator, runs the app, launches the developer tools of your Safari browser and stops at the first code statement.
 * `--start` - Attaches the debug tools to a deployed and running app and launches the developer tools of your Safari browser.
@@ -36,14 +36,14 @@ Attach the debug tools to a running app in the iOS simulator | `$ tns debug ios 
 * `--no-hmr` - Disables Hot Module Replacement (HMR). In this case, when a change in the code is applied, CLI will transfer the modified files and restart the application.
 * `--chrome` - Deprecated - default behavior uses '--chrome' implicitly. Allows debugging in Chrome Developer Tools. If set, Safari Web Inspector is not started and debugging is attached to Chrome Developer Tools.
 * `--inspector` - If set, the developer tools in the Safari Web Inspector are used for debugging the application.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% } %>
 <% if(isHtml) { %>
 
 ### Command Limitations
 
-* You can run `$ tns debug ios` only on macOS systems.
+* You can run `$ ns debug ios` only on macOS systems.
 * You must have Google Chrome installed on your machine.
 * If you want to debug in the iOS simulator, you must have the latest versions of Xcode installed on your machine.
 

--- a/docs/man_pages/project/testing/debug.md
+++ b/docs/man_pages/project/testing/debug.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns debug
+title: ns debug
 position: 6
 ---<% } %>
 
-# tns debug
+# ns debug
 
 ### Description
 
@@ -35,7 +35,7 @@ When running this command with `--debug-brk` any file change will cause a restar
 
 Usage | Synopsis
 ---|---
-<% if((isConsole && isMacOS) || isHtml) { %>General | `$ tns debug <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ tns debug android`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>General | `$ ns debug <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ ns debug android`<% } %>
 
 <% if((isConsole && isMacOS) || isHtml) { %>### Arguments
 `<Platform>` is the target mobile platform for which you want to debug your project. You can set the following target platforms:
@@ -46,7 +46,7 @@ Usage | Synopsis
 
 ### Command Limitations
 
-* You can run `$ tns debug ios` only on macOS systems.
+* You can run `$ ns debug ios` only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/project/testing/deploy.md
+++ b/docs/man_pages/project/testing/deploy.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns deploy
+title: ns deploy
 position: 7
 ---<% } %>
 
-# tns deploy
+# ns deploy
 
 ### Description
 
@@ -16,17 +16,17 @@ Prepares, builds and deploys the project to a connected device or native emulato
 
 Usage | Synopsis
 ---|---
-Deploy on Android | `$ tns deploy android [--device <Device ID>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--aab]`
-<% if(isMacOS) { %>Deploy on iOS | `$ tns deploy ios [--device <Device ID>] [--release]`<% } %>
+Deploy on Android | `$ ns deploy android [--device <Device ID>] [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--aab]`
+<% if(isMacOS) { %>Deploy on iOS | `$ ns deploy ios [--device <Device ID>] [--release]`<% } %>
 
 ### Options for iOS
 
-* `--device` - Deploys the project on the specified connected physical or virtual device. `<Device ID>` is the index or name of the target device as listed by the `$ tns devices` command.
+* `--device` - Deploys the project on the specified connected physical or virtual device. `<Device ID>` is the index or name of the target device as listed by the `$ ns devices` command.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build.<% } %>
 
 ### Options<% if(isMacOS) { %> for Android<% } %>
 
-* `--device` - Deploys the project on the specified connected physical or virtual device. `<Device ID>` is the index or name of the target device as listed by the `$ tns devices` command.
+* `--device` - Deploys the project on the specified connected physical or virtual device. `<Device ID>` is the index or name of the target device as listed by the `$ ns devices` command.
 * `--clean` - If set, forces the complete rebuild of the native application.
 * `--release` - If set, produces a release build. Otherwise, produces a debug build. When set, you must also specify the `--key-store-*` options.
 * `--key-store-path` - Specifies the file path to the keystore file (P12) which you want to use to code sign your APK. You can use the `--key-store-*` options along with `--release` to produce a signed release build. You need to specify all `--key-store-*` options.
@@ -42,13 +42,13 @@ Deploy on Android | `$ tns deploy android [--device <Device ID>] [--key-store-pa
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>
 
 ### Command Limitations
 
-* You can run `$ tns deploy ios` only on macOS systems.
+* You can run `$ ns deploy ios` only on macOS systems.
 * When the `--release` flag is set for an Android build, you must also specify all `--key-store-*` options.
 
 ### Related Commands

--- a/docs/man_pages/project/testing/dev-test-android.md
+++ b/docs/man_pages/project/testing/dev-test-android.md
@@ -3,18 +3,18 @@ test android
 
 Usage | Synopsis
 ------|-------
-Run tests on all connected devices | `$ tns test android [--watch] [--debug-brk]`
-Run tests on a selected device | `$ tns test android --device <Device ID> [--watch] [--debug-brk]`
+Run tests on all connected devices | `$ ns test android [--watch] [--debug-brk]`
+Run tests on a selected device | `$ ns test android --device <Device ID> [--watch] [--debug-brk]`
 
-Runs the tests in your project on connected Android devices and running native emulators.<% if(isConsole) { %> Your project must already be configured for unit testing by running `$ tns test init`.<% } %>
+Runs the tests in your project on connected Android devices and running native emulators.<% if(isConsole) { %> Your project must already be configured for unit testing by running `$ ns test init`.<% } %>
 
 ### Options
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device and tests are re-run.
-* `--device` - Specifies the serial number or the index of the connected device on which to run the tests. To list all connected devices, grouped by platform, run `$ tns device`
+* `--device` - Specifies the serial number or the index of the connected device on which to run the tests. To list all connected devices, grouped by platform, run `$ ns device`
 * `--debug-brk` - Runs the tests under the debugger. The debugger will break just before your tests are executed, so you have a chance to place breakpoints.
 
 ### Attributes
-* `<Device ID>` is the device index or identifier as listed by `$ tns device`
+* `<Device ID>` is the device index or identifier as listed by `$ ns device`
 
 <% if(isHtml) { %>
 ### Prerequisites

--- a/docs/man_pages/project/testing/dev-test-ios.md
+++ b/docs/man_pages/project/testing/dev-test-ios.md
@@ -3,23 +3,23 @@ test ios
 
 Usage | Synopsis
 ------|-------
-Run tests on all connected devices | `$ tns test ios [--watch] [--debug-brk]`
-Run tests on a selected device | `$ tns test ios --device <Device ID> [--watch] [--debug-brk]`
-Run tests in the iOS Simulator | `$ tns test ios --emulator [--watch] [--debug-brk]`
+Run tests on all connected devices | `$ ns test ios [--watch] [--debug-brk]`
+Run tests on a selected device | `$ ns test ios --device <Device ID> [--watch] [--debug-brk]`
+Run tests in the iOS Simulator | `$ ns test ios --emulator [--watch] [--debug-brk]`
 
-Runs the tests in your project on connected iOS devices or the iOS Simulator.<% if(isConsole && isMacOS) { %> Your project must already be configured for unit testing by running `$ tns test init`.<% } %>
+Runs the tests in your project on connected iOS devices or the iOS Simulator.<% if(isConsole && isMacOS) { %> Your project must already be configured for unit testing by running `$ ns test init`.<% } %>
 
-<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ tns help test ios`<% } %> 
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on OS X systems. To view the complete help for this command, run `$ ns help test ios`<% } %> 
 
 <% if((isConsole && isMacOS) || isHtml) { %>
 ### Options
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device and tests are re-ran.
-* `--device` - Specifies the serial number or the index of the connected device on which you want to run tests. To list all connected devices, grouped by platform, run `$ tns device`. You cannot set `--device` and `--emulator` simultaneously.
+* `--device` - Specifies the serial number or the index of the connected device on which you want to run tests. To list all connected devices, grouped by platform, run `$ ns device`. You cannot set `--device` and `--emulator` simultaneously.
 * `--emulator` - Runs tests on the iOS Simulator. You cannot set `--device` and `--emulator` simultaneously.
 * `--debug-brk` - Runs the tests under the debugger. The debugger will break just before your tests are executed, so you have a chance to place breakpoints.
 
 ### Attributes
-* `<Device ID>` is the device index or identifier as listed by `$ tns device`<% } %>
+* `<Device ID>` is the device index or identifier as listed by `$ ns device`<% } %>
 
 <% if(isHtml) { %>
 ### Prerequisites

--- a/docs/man_pages/project/testing/preview.md
+++ b/docs/man_pages/project/testing/preview.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns preview
+title: ns preview
 position: 1
 ---<% } %>
 
-# tns preview
+# ns preview
 
 ### Description
 
@@ -19,12 +19,12 @@ After scanning the QR code with the scanner provided in the NativeScript Playgro
 
 Usage | Synopsis
 ---|---
-Generates a QR code that can be scanned by the NativeScript PlayGround app | `tns preview`
+Generates a QR code that can be scanned by the NativeScript PlayGround app | `ns preview`
 
 ### Options
 
 * `--no-hmr` - Disables Hot Module Replacement (HMR). In this case, when a change in the code is applied, CLI will transfer the modified files and restart the application.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns run android
+title: ns run android
 position: 10
 ---<% } %>
 
-# tns run android
+# ns run android
 
 ### Description
 
@@ -17,13 +17,13 @@ When running this command without passing `--release` flag, the HMR (Hot Module 
 
 Usage | Synopsis
 ---|---
-Run on all connected devices and running emulators | `$ tns run android [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--env.*]] [--aab]`
-Run on a selected connected device or running emulator. Will start emulator with specified `Device Identifier`, if not already running. | `$ tns run android --device <Device ID> [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--env.*]] [--aab]`
-Start a default emulator if none are running, or run application on all connected emulators. | `$ tns run android --emulator [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--env.*]] [--aab]`
+Run on all connected devices and running emulators | `$ ns run android [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--env.*]] [--aab]`
+Run on a selected connected device or running emulator. Will start emulator with specified `Device Identifier`, if not already running. | `$ ns run android --device <Device ID> [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--env.*]] [--aab]`
+Start a default emulator if none are running, or run application on all connected emulators. | `$ ns run android --emulator [--key-store-path <File Path> --key-store-password <Password> --key-store-alias <Name> --key-store-alias-password <Password>] [--release] [--justlaunch] [--env.*]] [--aab]`
 
 ### Options
 
-* `--device` - Specifies a connected device or emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device android --available-devices` command.
+* `--device` - Specifies a connected device or emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ ns device android --available-devices` command.
 * `--emulator` - If set, runs the app in all available and configured Android emulators. It will start an emulator if none are already running.
 * `--justlaunch` - If set, does not print the application output in the console.
 * `--clean` - If set, forces the complete rebuild of the native application.
@@ -43,7 +43,7 @@ Start a default emulator if none are running, or run application on all connecte
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/project/testing/run-ios.md
+++ b/docs/man_pages/project/testing/run-ios.md
@@ -1,15 +1,15 @@
 <% if (isJekyll) { %>---
-title: tns run ios
+title: ns run ios
 position: 11
 ---<% } %>
 
-# tns run ios
+# ns run ios
 
 ### Description
 
 Runs your project on a connected iOS device or in the iOS Simulator, if configured. This is shorthand for prepare, build and deploy. While your app is running, prints the output from the application in the console and watches for changes in your code. Once a change is detected, it synchronizes the change with all selected devices and restarts/refreshes the application.
 
-<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help run ios`<% } %>
+<% if(isConsole && (isWindows || isLinux)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ ns help run ios`<% } %>
 <% if((isConsole && isMacOS) || isHtml) { %>
 <% if(isHtml) { %>> <% } %>IMPORTANT: Before building for iOS device, verify that you have configured a valid pair of certificate and provisioning profile on your macOS system. <% if(isHtml) { %>For more information, see the [Code Signing](https://developer.apple.com/support/code-signing/) and [Maintain Signing Assets](https://help.apple.com/xcode/mac/current/#/dev3a05256b8) sections from the Apple Developer documentation.<% } %>
 
@@ -21,15 +21,15 @@ When running this command without passing `--release` flag, the HMR (Hot Module 
 
 Usage | Synopsis
 ---|---
-Run on all connected devices | `$ tns run ios [--release] [--justlaunch] [--env.*]]`
-Run on a selected connected device. Will start simulator with specified `Device Identifier`, if not already running. | `$ tns run ios [--device <Device ID>] [--release] [--justlaunch] [--env.*]]`
-Start an emulator and run the app inside it | `$ tns run ios --emulator [--release] [--env.*]]`
-Start an emulator with specified device name and sdk | `$ tns run ios [--device <Device Name>] [--sdk <sdk>]`
-Start an emulator with specified device identifier and sdk | `$ tns run ios [--device <Device Identifier>] [--sdk <sdk>]`
+Run on all connected devices | `$ ns run ios [--release] [--justlaunch] [--env.*]]`
+Run on a selected connected device. Will start simulator with specified `Device Identifier`, if not already running. | `$ ns run ios [--device <Device ID>] [--release] [--justlaunch] [--env.*]]`
+Start an emulator and run the app inside it | `$ ns run ios --emulator [--release] [--env.*]]`
+Start an emulator with specified device name and sdk | `$ ns run ios [--device <Device Name>] [--sdk <sdk>]`
+Start an emulator with specified device identifier and sdk | `$ ns run ios [--device <Device Identifier>] [--sdk <sdk>]`
 
 ### Options
 
-* `--device` - Specifies a connected device/simulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device ios --available-devices` command.
+* `--device` - Specifies a connected device/simulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ ns device ios --available-devices` command.
 * `--emulator` - If set, runs the app in all available and configured ios simulators. It will start a simulator if none are already running.
 * `--sdk` - Specifies the target simulator's sdk.
 * `--justlaunch` - If set, does not print the application output in the console.
@@ -43,7 +43,7 @@ Start an emulator with specified device identifier and sdk | `$ tns run ios [--d
     *   `--env.report` - creates a Webpack report inside a `report` folder in the root folder.
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 ### Environment Variables
 
@@ -59,7 +59,7 @@ Before running the iOS Simulator, verify that your system meets the following re
 
 ### Command Limitations
 
-* You can run `$ tns run ios` only on macOS systems.
+* You can run `$ ns run ios` only on macOS systems.
 * You cannot use `--device` and `--emulator` simultaneously.
 
 ### Related Commands

--- a/docs/man_pages/project/testing/run.md
+++ b/docs/man_pages/project/testing/run.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns run
+title: ns run
 position: 12
 ---<% } %>
 
-# tns run
+# ns run
 
 ### Description
 
@@ -35,15 +35,15 @@ With **no** HMR:
 
 Usage | Synopsis
 ---|---
-Run on all connected devices | `$ tns run [--release] [--justlaunch]`
-Run on a selected connected device or running emulator. Will start emulator with specified `Device Identifier`, if not already running. | `$ tns run --device <Device ID> [--release] [--justlaunch]`
-<% if((isConsole && isMacOS) || isHtml) { %>Run on all connected devices of the specified `Platform` | `$ tns run <Platform> [--release] [--justlaunch]`<% } %>
+Run on all connected devices | `$ ns run [--release] [--justlaunch]`
+Run on a selected connected device or running emulator. Will start emulator with specified `Device Identifier`, if not already running. | `$ ns run --device <Device ID> [--release] [--justlaunch]`
+<% if((isConsole && isMacOS) || isHtml) { %>Run on all connected devices of the specified `Platform` | `$ ns run <Platform> [--release] [--justlaunch]`<% } %>
 
 ### Options
 
 * `--justlaunch` - If set, does not print the application output in the console.
 * `--release` - If set, produces a release build by running webpack in production mode and native build in release mode. Otherwise, produces a debug build.
-* `--device` - Specifies a connected device/emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ tns device <Platform> --available-devices` command.
+* `--device` - Specifies a connected device/emulator to start and run the app. `<Device ID>` is the index or `Device Identifier` of the target device as listed by the `$ ns device <Platform> --available-devices` command.
 * `--no-hmr` - Disables Hot Module Replacement (HMR). In this case, when a change in the code is applied, CLI will transfer the modified files and restart the application.
 * `--env.*` - Specifies additional flags that the bundler may process. Can be passed multiple times. Supported additional flags:
     *   `--env.aot` - creates Ahead-Of-Time build (Angular only).
@@ -54,7 +54,7 @@ Run on a selected connected device or running emulator. Will start emulator with
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 
 <% if((isConsole && isMacOS) || isHtml) { %>### Arguments

--- a/docs/man_pages/project/testing/test-android.md
+++ b/docs/man_pages/project/testing/test-android.md
@@ -1,25 +1,25 @@
 <% if (isJekyll) { %>---
-title: tns test android
+title: ns test android
 position: 20
 ---<% } %>
 
-# tns test android
+# ns test android
 
 ### Description
 
-Runs the tests in your project on connected Android devices and Android emulators.<% if(isConsole) { %> Your project must already be configured for unit testing by running `$ tns test init`.<% } %>
+Runs the tests in your project on connected Android devices and Android emulators.<% if(isConsole) { %> Your project must already be configured for unit testing by running `$ ns test init`.<% } %>
 
 ### Commands
 
 Usage | Synopsis
 ------|-------
-Run tests on all connected devices | `$ tns test android [--watch] [--debug-brk] [--aab]`
-Run tests on a selected device | `$ tns test android --device <Device ID> [--watch] [--debug-brk] [--aab]`
+Run tests on all connected devices | `$ ns test android [--watch] [--debug-brk] [--aab]`
+Run tests on a selected device | `$ ns test android --device <Device ID> [--watch] [--debug-brk] [--aab]`
 
 ### Options
 
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device and tests are re-run.
-* `--device` - Specifies the serial number or the index of the connected device on which to run the tests. To list all connected devices, grouped by platform, run `$ tns device`. `<Device ID>` is the device index or identifier as listed by the `$ tns device` command.
+* `--device` - Specifies the serial number or the index of the connected device on which to run the tests. To list all connected devices, grouped by platform, run `$ ns device`. `<Device ID>` is the device index or identifier as listed by the `$ ns device` command.
 * `--debug-brk` - Runs the tests under the debugger. The debugger will break just before your tests are executed, so you have a chance to place breakpoints.
 * `--env.*` - Specifies additional flags that the bundler may process. Can be passed multiple times. Supported additional flags:
     *   `--env.uglify` - provides basic obfuscation and smaller app size.
@@ -27,7 +27,7 @@ Run tests on a selected device | `$ tns test android --device <Device ID> [--wat
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>
 

--- a/docs/man_pages/project/testing/test-init.md
+++ b/docs/man_pages/project/testing/test-init.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns test init
+title: ns test init
 position: 21
 ---<% } %>
 
-# tns test init
+# ns test init
 
 ### Description
 
@@ -13,7 +13,7 @@ Configures your project for unit testing with a selected framework. This operati
 
 Usage | Synopsis
 ------|-------
-General | `$ tns test init [--framework <Framework>]`
+General | `$ ns test init [--framework <Framework>]`
 
 ### Options
 

--- a/docs/man_pages/project/testing/test-ios.md
+++ b/docs/man_pages/project/testing/test-ios.md
@@ -1,33 +1,33 @@
 <% if (isJekyll) { %>---
-title: tns test ios
+title: ns test ios
 position: 22
 ---<% } %>
 
-# tns test ios
+# ns test ios
 
 ### Description
 
-Runs the tests in your project on connected iOS devices or the iOS Simulator.<% if(isConsole && isMacOS) { %> Your project must already be configured for unit testing by running `$ tns test init`.<% } %>
+Runs the tests in your project on connected iOS devices or the iOS Simulator.<% if(isConsole && isMacOS) { %> Your project must already be configured for unit testing by running `$ ns test init`.<% } %>
 
-<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help test ios`<% } %> 
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ ns help test ios`<% } %> 
 
 ### Commands
 
 Usage | Synopsis
 ------|-------
-Run tests on all connected devices | `$ tns test ios [--watch] [--debug-brk]`
-Run tests on a selected device | `$ tns test ios --device <Device ID> [--watch] [--debug-brk]`
-Run tests in the iOS Simulator | `$ tns test ios --emulator [--watch] [--debug-brk]`
+Run tests on all connected devices | `$ ns test ios [--watch] [--debug-brk]`
+Run tests on a selected device | `$ ns test ios --device <Device ID> [--watch] [--debug-brk]`
+Run tests in the iOS Simulator | `$ ns test ios --emulator [--watch] [--debug-brk]`
 
 <% if((isConsole && isMacOS) || isHtml) { %>
 
 ### Options
 
 * `--watch` - If set, when you save changes to the project, changes are automatically synchronized to the connected device and tests are re-ran.
-* `--device` - Specifies the serial number or the index of the connected device on which you want to run tests. To list all connected devices, grouped by platform, run `$ tns device`. You cannot set `--device` and `--emulator` simultaneously. `<Device ID>` is the device index or identifier as listed by the `$ tns device` command.
+* `--device` - Specifies the serial number or the index of the connected device on which you want to run tests. To list all connected devices, grouped by platform, run `$ ns device`. You cannot set `--device` and `--emulator` simultaneously. `<Device ID>` is the device index or identifier as listed by the `$ ns device` command.
 * `--emulator` - Runs tests on the iOS Simulator. You cannot set `--device` and `--emulator` simultaneously.
 * `--debug-brk` - Runs the tests under the debugger. The debugger will break just before your tests are executed, so you have a chance to place breakpoints.
-* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `tns migrate`.
+* `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% } %>
 

--- a/docs/man_pages/project/testing/test.md
+++ b/docs/man_pages/project/testing/test.md
@@ -1,13 +1,13 @@
 <% if (isJekyll) { %>---
-title: tns test
+title: ns test
 position: 23
 ---<% } %>
 
-# tns test
+# ns test
 
 ### Description
 
-Runs unit tests on the selected mobile platform.<% if(isConsole) { %> Your project must already be configured for unit testing by running `$ tns test init`.<% } %>
+Runs unit tests on the selected mobile platform.<% if(isConsole) { %> Your project must already be configured for unit testing by running `$ ns test init`.<% } %>
 
 <% if(isHtml) { %>
 #### How file changes are handled
@@ -23,7 +23,7 @@ Runs unit tests on the selected mobile platform.<% if(isConsole) { %> Your proje
 
 Usage | Synopsis
 ------|-------
-<% if((isConsole && isMacOS) || isHtml) { %>General | `$ tns test <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ tns test android`<% } %>
+<% if((isConsole && isMacOS) || isHtml) { %>General | `$ ns test <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ ns test android`<% } %>
 
 <% if((isConsole && isMacOS) || isHtml) { %>### Arguments
 `<Platform>` is the target mobile platform on which you want to run the tests. You can set the following target platforms.

--- a/docs/man_pages/publishing/apple-login.md
+++ b/docs/man_pages/publishing/apple-login.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns apple-login
+title: ns apple-login
 position: 5
 ---<% } %>
 
-# tns apple-login
+# ns apple-login
 
 ### Description
 
@@ -13,7 +13,7 @@ Uses the provided Apple credentials to obtain Apple session which can be used wh
 
 Usage | Synopsis
 ---|---
-General | `$ tns apple-login [<Apple ID>] [<Password>]`
+General | `$ ns apple-login [<Apple ID>] [<Password>]`
 
 ### Arguments
 

--- a/docs/man_pages/publishing/appstore-upload.md
+++ b/docs/man_pages/publishing/appstore-upload.md
@@ -1,24 +1,24 @@
 <% if (isJekyll) { %>---
-title: tns appstore upload
+title: ns appstore upload
 position: 1
 ---<% } %>
 
-# tns appstore upload
+# ns appstore upload
 
 ### Description
 
 Uploads project to iTunes Connect. The command either issues a production build and uploads it to iTunes Connect, or uses an already built package to upload.
-The user will be prompted interactively for verification code when two-factor authentication enabled account is used. As on non-interactive console (CI), you will not be prompt for verification code. In this case, you need to generate a login session for your apple's account in advance using `tns apple-login` command. The generated value must be provided via the `--appleSessionBase64` option and is only valid for up to a month. Meaning you'll need to create a new session every month.
+The user will be prompted interactively for verification code when two-factor authentication enabled account is used. As on non-interactive console (CI), you will not be prompt for verification code. In this case, you need to generate a login session for your apple's account in advance using `ns apple-login` command. The generated value must be provided via the `--appleSessionBase64` option and is only valid for up to a month. Meaning you'll need to create a new session every month.
 
-<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help appstore upload`<% } %>
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ ns help appstore upload`<% } %>
 <% if((isConsole && isMacOS) || isHtml) { %>
 
 ### Commands
 
 Usage | Synopsis
 ---|---
-Build and upload package | `$ tns appstore upload [<Apple ID> [<Password> [<Mobile Provisioning Profile Identifier> [<Code Sign Identity>]]]]]`
-Upload package | `$ tns appstore upload [<Apple ID> [<Password>]] --ipa <Ipa File Path>`
+Build and upload package | `$ ns appstore upload [<Apple ID> [<Password> [<Mobile Provisioning Profile Identifier> [<Code Sign Identity>]]]]]`
+Upload package | `$ ns appstore upload [<Apple ID> [<Password>]] --ipa <Ipa File Path>`
 
 ### Options
 
@@ -36,7 +36,7 @@ Upload package | `$ tns appstore upload [<Apple ID> [<Password>]] --ipa <Ipa Fil
 
 ### Command Limitations
 
-* You can run `$ tns appstore upload` only on macOS systems.
+* You can run `$ ns appstore upload` only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/publishing/appstore.md
+++ b/docs/man_pages/publishing/appstore.md
@@ -1,9 +1,9 @@
 <% if (isJekyll) { %>---
-title: tns appstore
+title: ns appstore
 position: 2
 ---<% } %>
 
-# tns appstore
+# ns appstore
 
 ### Description
 
@@ -13,8 +13,8 @@ Lists all application records in iTunes Connect. The list contains name, version
 
 Usage | Synopsis
 ---|---
-List applications | `$ tns appstore [<Apple ID> [<Password>]]`
-<% if((isConsole && isMacOS) || isHtml) { %>Upload | `$ tns appstore upload`<% } %>
+List applications | `$ ns appstore [<Apple ID> [<Password>]]`
+<% if((isConsole && isMacOS) || isHtml) { %>Upload | `$ ns appstore upload`<% } %>
 
 ### Arguments
 
@@ -27,7 +27,7 @@ List applications | `$ tns appstore [<Apple ID> [<Password>]]`
 
 ### Command Limitations
 
-* You can run `$ tns appstore upload` only on macOS systems.
+* You can run `$ ns appstore upload` only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/publishing/publish-ios.md
+++ b/docs/man_pages/publishing/publish-ios.md
@@ -1,23 +1,23 @@
 <% if (isJekyll) { %>---
-title: tns publish ios
+title: ns publish ios
 position: 3
 ---<% } %>
 
-# tns publish ios
+# ns publish ios
 
 ### Description
 
 Uploads project to iTunes Connect. The command either issues a production build and uploads it to iTunes Connect, or uses an already built package to upload.
-The user will be prompted interactively for verification code when two-factor authentication enabled account is used. As on non-interactive console (CI), you will not be prompt for verification code. In this case, you need to generate a login session for your apple's account in advance using `tns apple-login` command. The generated value must be provided via the `--appleSessionBase64` option and is only valid for up to a month. Meaning you'll need to create a new session every month.
+The user will be prompted interactively for verification code when two-factor authentication enabled account is used. As on non-interactive console (CI), you will not be prompt for verification code. In this case, you need to generate a login session for your apple's account in advance using `ns apple-login` command. The generated value must be provided via the `--appleSessionBase64` option and is only valid for up to a month. Meaning you'll need to create a new session every month.
 
-<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help publish ios`<% } %>
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ ns help publish ios`<% } %>
 
 ### Commands
 
 Usage | Synopsis
 ---|---
-Build and upload package | `$ tns publish ios [<Apple ID> [<Password> [<Mobile Provisioning Profile Identifier> [<Code Sign Identity>]]]]]`
-Upload package | `$ tns publish ios [<Apple ID> [<Password>]] --ipa <Ipa File Path>`
+Build and upload package | `$ ns publish ios [<Apple ID> [<Password> [<Mobile Provisioning Profile Identifier> [<Code Sign Identity>]]]]]`
+Upload package | `$ ns publish ios [<Apple ID> [<Password>]] --ipa <Ipa File Path>`
 
 <% if((isConsole && isMacOS) || isHtml) { %>
 
@@ -38,7 +38,7 @@ Upload package | `$ tns publish ios [<Apple ID> [<Password>]] --ipa <Ipa File Pa
 
 ### Command Limitations
 
-* You can run `$ tns publish ios` only on macOS systems.
+* You can run `$ ns publish ios` only on macOS systems.
 
 ### Related Commands
 

--- a/docs/man_pages/publishing/publish.md
+++ b/docs/man_pages/publishing/publish.md
@@ -1,28 +1,28 @@
 <% if (isJekyll) { %>---
-title: tns publish
+title: ns publish
 position: 4
 ---<% } %>
 
-# tns publish
+# ns publish
 
 ### Description
 
 Uploads project to an application store.
 
-<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ tns help publish ios`<% } %>
+<% if(isConsole && (isLinux || isWindows)) { %>WARNING: You can run this command only on macOS systems. To view the complete help for this command, run `$ ns help publish ios`<% } %>
 
 ### Commands
 
 Usage | Synopsis
 ---|---
-General | `$ tns publish ios`
+General | `$ ns publish ios`
 
 <% if(isHtml) { %>
 
 ### Command Limitations
 
-* You can run `$ tns publish` only on macOS systems.
-* Currently, you can use `$ tns publish` only to publish iOS applications.
+* You can run `$ ns publish` only on macOS systems.
+* Currently, you can use `$ ns publish` only to publish iOS applications.
 
 ### Related Commands
 

--- a/docs/man_pages/start.md
+++ b/docs/man_pages/start.md
@@ -7,8 +7,9 @@ position: 1
 
 Usage | Synopsis
 ------|-------
-General | `$ tns <Command> [Command Parameters] [--command <Options>]`
+General | `$ ns <Command> [Command Parameters] [--command <Options>]`
 Alias | `$ nativescript <Command> [Command Parameters] [--command <Options>]`
+Alias | `$ tns <Command> [Command Parameters] [--command <Options>]`
 
 ## General Commands
 

--- a/lib/services/apple-portal/apple-portal-session-service.ts
+++ b/lib/services/apple-portal/apple-portal-session-service.ts
@@ -58,8 +58,7 @@ export class ApplePortalSessionService implements IApplePortalSessionService {
 		}
 
 		const userDetailsResponse = await this.$httpClient.httpRequest({
-			url:
-				"https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/user/detail",
+			url: "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/user/detail",
 			method: "GET",
 			headers: {
 				"Content-Type": "application/json",
@@ -162,7 +161,7 @@ This password will be used for the iTunes Transporter, which is used to upload y
 				) {
 					this.$errors
 						.fail(`Your account has two-factor authentication enabled, but your console is not interactive.
-For more details how to set up your environment, please execute "tns publish ios --help".`);
+For more details how to set up your environment, please execute "ns publish ios --help".`);
 				}
 
 				const headers = (err && err.response && err.response.headers) || {};

--- a/lib/services/build-artifacts-service.ts
+++ b/lib/services/build-artifacts-service.ts
@@ -32,7 +32,7 @@ export class BuildArtifactsService implements IBuildArtifactsService {
 
 		if (!packageFile || !this.$fs.exists(packageFile)) {
 			this.$errors.fail(
-				`Unable to find built application. Try 'tns build ${platformData.platformNameLowerCase}'.`
+				`Unable to find built application. Try 'ns build ${platformData.platformNameLowerCase}'.`
 			);
 		}
 

--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -179,8 +179,8 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 		);
 		const { doRefresh, timeout, operationId } = options;
 		const id = operationId || this.generateOperationIdentifier();
-		const operationPromise: Promise<IAndroidLivesyncSyncOperationResult> = new Promise(
-			(resolve, reject) => {
+		const operationPromise: Promise<IAndroidLivesyncSyncOperationResult> =
+			new Promise((resolve, reject) => {
 				if (!this.verifyActiveConnection(reject)) {
 					return;
 				}
@@ -217,8 +217,7 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 					socketId,
 					timeoutId,
 				};
-			}
-		);
+			});
 
 		return operationPromise;
 	}
@@ -411,10 +410,11 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 						clearTimeout(this.pendingConnectionData.socketTimer);
 					}
 
-					const applicationPid = await this.$androidProcessService.getAppProcessId(
-						configuration.deviceIdentifier,
-						configuration.appIdentifier
-					);
+					const applicationPid =
+						await this.$androidProcessService.getAppProcessId(
+							configuration.deviceIdentifier,
+							configuration.appIdentifier
+						);
 					if (!applicationPid) {
 						this.$logger.trace(
 							"In Android LiveSync tool, lastKnownError is: ",
@@ -428,7 +428,7 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 						this.$logger.info(
 							color.cyan(
 								`This issue may be caused by:
-	* crash at startup (try \`tns debug android --debug-brk\` to check why it crashes)
+	* crash at startup (try \`ns debug android --debug-brk\` to check why it crashes)
 	* different application identifier in your package.json and in your gradle files (check your identifier in \`package.json\` and in all *.gradle files in your App_Resources directory)
 	* device is locked
 	* manual closing of the application`
@@ -563,9 +563,7 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 		return error;
 	}
 
-	private getFilePathData(
-		filePath: string
-	): {
+	private getFilePathData(filePath: string): {
 		relativeFilePath: string;
 		filePathLengthBytes: number;
 		filePathLengthString: string;

--- a/packages/doctor/README.md
+++ b/packages/doctor/README.md
@@ -409,7 +409,7 @@ Library that helps identifying if the environment can be used for development of
 		isCocoaPodsWorkingCorrectly: boolean;
 
 		/**
-		 * NativeScript CLI version string, as returned by `tns --version`.
+		 * NativeScript CLI version string, as returned by `ns --version`.
 		 * @type {string}
 		 */
 		nativeScriptCliVersion: string;


### PR DESCRIPTION
Also from tns-android or tns-ios to @nativescript/android or @nativescript/ios.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Content displayed by help is in the form `tns <command>`.

## What is the new behavior?
Changes help content to `ns <command>`

Also some minor grammar and changing the references in help from `tns-android/io` to `@NativeScript/ns`.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
