### PR TITLE
feat(extensions): add extension podfile and setup extension with provision

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -335,6 +335,8 @@ export type SupportedPlatform = PlatformTypes.ios | PlatformTypes.android;
 
 export const PODFILE_NAME = "Podfile";
 
+export const EXTENSION_PROVISIONING_FILENAME = "provisioning.json";
+
 export class IosProjectConstants {
 	public static XcodeProjExtName = ".xcodeproj";
 	public static XcodeSchemeExtName = ".xcscheme";

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -530,6 +530,10 @@ interface IProvision {
 	provision: string;
 }
 
+interface IProvisioningJSON {
+	[identifier: string]: string;
+}
+
 interface ITeamIdentifier {
 	teamId: string;
 }

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -652,6 +652,11 @@ interface ICocoaPodsService {
 		platformData: IPlatformData
 	): Promise<void>;
 
+	applyPodfileFromExtensions(
+		projectData: IProjectData,
+		platformData: IPlatformData
+	): Promise<void>;
+
 	/**
 	 * Prepares the Podfile content of a plugin and merges it in the project's Podfile.
 	 * @param {string} moduleName The module which the Podfile is from.

--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -21,6 +21,7 @@ import {
 } from "../common/declarations";
 import { injector } from "../common/yok";
 import { XcodeSelectService } from "../common/services/xcode-select-service";
+import * as constants from "../constants";
 
 export class CocoaPodsService implements ICocoaPodsService {
 	private static PODFILE_POST_INSTALL_SECTION_NAME = "post_install";
@@ -197,6 +198,71 @@ end`.trim();
 
 		// clean up
 		this.$fs.deleteFile(exclusionsPodfile);
+	}
+
+	public async applyPodfileFromExtensions(
+		projectData: IProjectData,
+		platformData: IPlatformData
+	) {
+		const extensionFolderPath = path.join(
+			projectData.getAppResourcesDirectoryPath(),
+			constants.iOSAppResourcesFolderName,
+			constants.NATIVE_EXTENSION_FOLDER
+		);
+		const projectPodfilePath = this.getProjectPodfilePath(
+			platformData.projectRoot
+		);
+
+		if (
+			!this.$fs.exists(extensionFolderPath) ||
+			!this.$fs.exists(projectPodfilePath)
+		) {
+			return;
+		}
+
+		let projectPodFileContent = this.$fs.readText(projectPodfilePath);
+
+		const extensionsPodfile = this.$fs
+			.readDirectory(extensionFolderPath)
+			.filter((name) => {
+				const extensionPath = path.join(extensionFolderPath, name);
+				const stats = this.$fs.getFsStats(extensionPath);
+				return stats.isDirectory() && !name.startsWith(".");
+			})
+			.map((name) => ({
+				targetName: name,
+				podfilePath: path.join(
+					extensionFolderPath,
+					name,
+					constants.PODFILE_NAME
+				),
+			}));
+
+		extensionsPodfile.forEach(({ targetName, podfilePath }) => {
+			// Remove the data between #Begin Podfile and #EndPodfile
+			const regExpToRemove = new RegExp(
+				`${this.getExtensionPodfileHeader(
+					podfilePath,
+					targetName
+				)}[\\s\\S]*?${this.getExtensionPodfileEnd()}`,
+				"mg"
+			);
+			projectPodFileContent = projectPodFileContent.replace(regExpToRemove, "");
+
+			if (this.$fs.exists(podfilePath)) {
+				const podfileContentWithoutTarget = this.$fs.readText(podfilePath);
+				const podFileContent =
+					this.getExtensionPodfileHeader(podfilePath, targetName) +
+					EOL +
+					podfileContentWithoutTarget +
+					EOL +
+					this.getExtensionPodfileEnd();
+
+				projectPodFileContent += EOL + podFileContent;
+			}
+		});
+
+		this.$fs.writeFile(projectPodfilePath, projectPodFileContent);
 	}
 
 	public async applyPodfileToProject(
@@ -491,9 +557,22 @@ end`.trim();
 		pluginPodFilePath = pluginPodFilePath.replace(/\+/g, "\\+");
 		return `# Begin Podfile - ${pluginPodFilePath}`;
 	}
+	private getExtensionPodfileHeader(
+		extensionPodFilePath: string,
+		targetName: string
+	): string {
+		const targetHeader = `target "${targetName.trim()}" do`;
+		return `${this.getPluginPodfileHeader(
+			extensionPodFilePath
+		)}${EOL}${targetHeader}`;
+	}
 
 	private getPluginPodfileEnd(): string {
 		return `# End Podfile${EOL}`;
+	}
+
+	private getExtensionPodfileEnd(): string {
+		return `end${EOL}${this.getPluginPodfileEnd()}`;
 	}
 
 	private getPostInstallHookHeader() {

--- a/lib/services/cocoapods-service.ts
+++ b/lib/services/cocoapods-service.ts
@@ -122,9 +122,10 @@ ${versionResolutionHint}`);
 		);
 		const podFolder = path.join(platformData.projectRoot, podFilesRootDirName);
 		if (this.$fs.exists(podFolder)) {
-			const pluginsXcconfigFilePaths = this.$xcconfigService.getPluginsXcconfigFilePaths(
-				platformData.projectRoot
-			);
+			const pluginsXcconfigFilePaths =
+				this.$xcconfigService.getPluginsXcconfigFilePaths(
+					platformData.projectRoot
+				);
 			for (const configuration in pluginsXcconfigFilePaths) {
 				const pluginsXcconfigFilePath = pluginsXcconfigFilePaths[configuration];
 				const podXcconfigFilePath = path.join(
@@ -282,16 +283,13 @@ end`.trim();
 			return;
 		}
 
-		const {
-			podfileContent,
-			replacedFunctions,
-			podfilePlatformData,
-		} = this.buildPodfileContent(
-			podfilePath,
-			moduleName,
-			projectData,
-			platformData
-		);
+		const { podfileContent, replacedFunctions, podfilePlatformData } =
+			this.buildPodfileContent(
+				podfilePath,
+				moduleName,
+				projectData,
+				platformData
+			);
 		const pathToProjectPodfile = this.getProjectPodfilePath(nativeProjectPath);
 		const projectPodfileContent = this.$fs.exists(pathToProjectPodfile)
 			? this.$fs.readText(pathToProjectPodfile).trim()
@@ -363,11 +361,12 @@ end`.trim();
 				moduleName,
 				projectPodFileContent
 			);
-			projectPodFileContent = this.$cocoaPodsPlatformManager.removePlatformSection(
-				moduleName,
-				projectPodFileContent,
-				podfilePath
-			);
+			projectPodFileContent =
+				this.$cocoaPodsPlatformManager.removePlatformSection(
+					moduleName,
+					projectPodFileContent,
+					podfilePath
+				);
 
 			const defaultPodfileBeginning = this.getPodfileHeader(
 				projectData.projectName
@@ -557,6 +556,11 @@ end`.trim();
 		pluginPodFilePath = pluginPodFilePath.replace(/\+/g, "\\+");
 		return `# Begin Podfile - ${pluginPodFilePath}`;
 	}
+
+	private getPluginPodfileEnd(): string {
+		return `# End Podfile${EOL}`;
+	}
+
 	private getExtensionPodfileHeader(
 		extensionPodFilePath: string,
 		targetName: string
@@ -565,10 +569,6 @@ end`.trim();
 		return `${this.getPluginPodfileHeader(
 			extensionPodFilePath
 		)}${EOL}${targetHeader}`;
-	}
-
-	private getPluginPodfileEnd(): string {
-		return `# End Podfile${EOL}`;
 	}
 
 	private getExtensionPodfileEnd(): string {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -567,6 +567,12 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	): Promise<void> {
 		const projectRoot = path.join(projectData.platformsDir, "ios");
 		const platformData = this.getPlatformData(projectData);
+
+		const pluginsData = this.getAllProductionPlugins(projectData);
+		const pbxProjPath = this.getPbxProjPath(projectData);
+		this.$iOSExtensionsService.removeExtensions({ pbxProjPath });
+		await this.addExtensions(projectData, pluginsData);
+
 		const resourcesDirectoryPath = projectData.getAppResourcesDirectoryPath();
 
 		const provision = prepareData && prepareData.provision;
@@ -653,7 +659,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			);
 		}
 
-		const pbxProjPath = this.getPbxProjPath(projectData);
 		this.$iOSWatchAppService.removeWatchApp({ pbxProjPath });
 		const addedWatchApp = await this.$iOSWatchAppService.addWatchAppFromPath({
 			watchAppFolderPath: path.join(
@@ -960,6 +965,11 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			platformData
 		);
 
+		await this.$cocoapodsService.applyPodfileFromExtensions(
+			projectData,
+			platformData
+		);
+
 		const projectPodfilePath = this.$cocoapodsService.getProjectPodfilePath(
 			platformData.projectRoot
 		);
@@ -983,10 +993,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		}
 
 		await this.$spmService.applySPMPackages(platformData, projectData);
-
-		const pbxProjPath = this.getPbxProjPath(projectData);
-		this.$iOSExtensionsService.removeExtensions({ pbxProjPath });
-		await this.addExtensions(projectData, pluginsData);
 	}
 
 	public beforePrepareAllPlugins(

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -259,14 +259,13 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			return;
 		}
 
-		const checkEnvironmentRequirementsOutput = await this.$platformEnvironmentRequirements.checkEnvironmentRequirements(
-			{
+		const checkEnvironmentRequirementsOutput =
+			await this.$platformEnvironmentRequirements.checkEnvironmentRequirements({
 				platform: this.getPlatformData(projectData).normalizedPlatformName,
 				projectDir: projectData.projectDir,
 				options,
 				notConfiguredEnvOptions,
-			}
-		);
+			});
 
 		if (
 			checkEnvironmentRequirementsOutput &&
@@ -682,9 +681,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		const projectAppResourcesPath = projectData.getAppResourcesDirectoryPath(
 			projectData.projectDir
 		);
-		const platformsAppResourcesPath = this.getAppResourcesDestinationDirectoryPath(
-			projectData
-		);
+		const platformsAppResourcesPath =
+			this.getAppResourcesDestinationDirectoryPath(projectData);
 
 		this.$fs.deleteDirectory(platformsAppResourcesPath);
 		this.$fs.ensureDirectoryExists(platformsAppResourcesPath);
@@ -964,7 +962,6 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			projectData,
 			platformData
 		);
-
 		await this.$cocoapodsService.applyPodfileFromExtensions(
 			projectData,
 			platformData
@@ -1037,9 +1034,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				if (hasTeamId) {
 					if (signing && signing.style === "Automatic") {
 						if (signing.team !== teamId) {
-							const teamIdsForName = await this.$iOSProvisionService.getTeamIdsWithName(
-								teamId
-							);
+							const teamIdsForName =
+								await this.$iOSProvisionService.getTeamIdsWithName(teamId);
 							if (!teamIdsForName.some((id) => id === signing.team)) {
 								changesInfo.signingChanged = true;
 							}
@@ -1185,14 +1181,13 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 		);
 		const platformData = this.getPlatformData(projectData);
 		const pbxProjPath = this.getPbxProjPath(projectData);
-		const addedExtensionsFromResources = await this.$iOSExtensionsService.addExtensionsFromPath(
-			{
+		const addedExtensionsFromResources =
+			await this.$iOSExtensionsService.addExtensionsFromPath({
 				extensionsFolderPath: resorcesExtensionsPath,
 				projectData,
 				platformData,
 				pbxProjPath,
-			}
-		);
+			});
 		let addedExtensionsFromPlugins = false;
 		for (const pluginIndex in pluginsData) {
 			const pluginData = pluginsData[pluginIndex];
@@ -1204,14 +1199,13 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				pluginPlatformsFolderPath,
 				constants.NATIVE_EXTENSION_FOLDER
 			);
-			const addedExtensionFromPlugin = await this.$iOSExtensionsService.addExtensionsFromPath(
-				{
+			const addedExtensionFromPlugin =
+				await this.$iOSExtensionsService.addExtensionsFromPath({
 					extensionsFolderPath: extensionPath,
 					projectData,
 					platformData,
 					pbxProjPath,
-				}
-			);
+				});
 			addedExtensionsFromPlugins =
 				addedExtensionsFromPlugins || addedExtensionFromPlugin;
 		}
@@ -1466,9 +1460,10 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 					tempEntitlementsDir,
 					"set-entitlements.xcconfig"
 				);
-				const entitlementsRelativePath = this.$iOSEntitlementsService.getPlatformsEntitlementsRelativePath(
-					projectData
-				);
+				const entitlementsRelativePath =
+					this.$iOSEntitlementsService.getPlatformsEntitlementsRelativePath(
+						projectData
+					);
 				this.$fs.writeFile(
 					tempEntitlementsFilePath,
 					`CODE_SIGN_ENTITLEMENTS = ${entitlementsRelativePath}${EOL}`
@@ -1497,8 +1492,8 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 			this.getPlatformData(projectData).normalizedPlatformName,
 			this.getPlatformData(projectData).configurationFileName
 		);
-		const mergedPlistPath = this.getPlatformData(projectData)
-			.configurationFilePath;
+		const mergedPlistPath =
+			this.getPlatformData(projectData).configurationFilePath;
 
 		if (!this.$fs.exists(infoPlistPath) || !this.$fs.exists(mergedPlistPath)) {
 			return;

--- a/lib/services/ios/export-options-plist-service.ts
+++ b/lib/services/ios/export-options-plist-service.ts
@@ -5,6 +5,7 @@ import { IFileSystem } from "../../common/declarations";
 import { injector } from "../../common/yok";
 import { ITempService } from "../../definitions/temp-service";
 import * as constants from "../../constants";
+import { IProvisioningJSON } from "../../declarations";
 
 export class ExportOptionsPlistService implements IExportOptionsPlistService {
 	constructor(
@@ -16,17 +17,14 @@ export class ExportOptionsPlistService implements IExportOptionsPlistService {
 	private getExtensionProvisions() {
 		const provisioningJSONPath = path.join(
 			this.$projectData.getAppResourcesDirectoryPath(),
-			"iOS",
+			constants.iOSAppResourcesFolderName,
 			constants.NATIVE_EXTENSION_FOLDER,
-			"provisioning.json"
+			constants.EXTENSION_PROVISIONING_FILENAME
 		);
 		if (!this.$fs.exists(provisioningJSONPath)) {
 			return "";
 		}
 
-		interface IProvisioningJSON {
-			[identifier: string]: string;
-		}
 		const provisioningJSON = this.$fs.readJson(
 			provisioningJSONPath
 		) as IProvisioningJSON;

--- a/lib/services/ios/ios-signing-service.ts
+++ b/lib/services/ios/ios-signing-service.ts
@@ -52,9 +52,9 @@ export class IOSSigningService implements IiOSSigningService {
 			(!signing || signing.style !== "Manual")
 		) {
 			xcode.setManualSigningStyle(projectData.projectName);
-			this.getExtensionsName(projectData).forEach((name) =>
-				xcode.setManualSigningStyle(name)
-			);
+			this.getExtensionNames(projectData).forEach((name) => {
+				xcode.setManualSigningStyle(name);
+			});
 			xcode.save();
 		} else if (
 			!iOSBuildData.provision &&
@@ -83,9 +83,8 @@ export class IOSSigningService implements IiOSSigningService {
 		if (signing && signing.style === "Automatic") {
 			if (signing.team !== teamId) {
 				// Maybe the provided team is name such as "Telerik AD" and we need to convert it to CH******37
-				const teamIdsForName = await this.$iOSProvisionService.getTeamIdsWithName(
-					teamId
-				);
+				const teamIdsForName =
+					await this.$iOSProvisionService.getTeamIdsWithName(teamId);
 				if (!teamIdsForName.some((id) => id === signing.team)) {
 					shouldUpdateXcode = true;
 				}
@@ -114,9 +113,9 @@ export class IOSSigningService implements IiOSSigningService {
 				],
 				teamId
 			);
-			this.getExtensionsName(projectData).forEach((name) =>
-				xcode.setAutomaticSigningStyle(name, teamId)
-			);
+			this.getExtensionNames(projectData).forEach((name) => {
+				xcode.setAutomaticSigningStyle(name, teamId);
+			});
 
 			xcode.save();
 
@@ -199,7 +198,7 @@ export class IOSSigningService implements IiOSSigningService {
 		}
 	}
 
-	private getExtensionsName(projectData: IProjectData) {
+	private getExtensionNames(projectData: IProjectData) {
 		const extensionFolderPath = path.join(
 			projectData.getAppResourcesDirectoryPath(),
 			constants.iOSAppResourcesFolderName,
@@ -207,15 +206,14 @@ export class IOSSigningService implements IiOSSigningService {
 		);
 
 		if (this.$fs.exists(extensionFolderPath)) {
-			const extensionsName = this.$fs
+			const extensionNames = this.$fs
 				.readDirectory(extensionFolderPath)
 				.filter((fileName) => {
 					const extensionPath = path.join(extensionFolderPath, fileName);
 					const stats = this.$fs.getFsStats(extensionPath);
 					return stats.isDirectory() && !fileName.startsWith(".");
 				});
-
-			return extensionsName;
+			return extensionNames;
 		}
 		return [];
 	}
@@ -233,12 +231,12 @@ export class IOSSigningService implements IiOSSigningService {
 				provisioningJSONPath
 			) as IProvisioningJSON;
 
-			const extensionsName = this.getExtensionsName(projectData);
+			const extensionNames = this.getExtensionNames(projectData);
 
 			const provisioning = Object.entries(provisioningJSON).map(
 				async ([id, provision]) => {
 					const name = id.split(".").at(-1);
-					if (extensionsName.includes(name)) {
+					if (extensionNames.includes(name)) {
 						const configuration = await this.getManualSigningConfiguration(
 							projectData,
 							provision

--- a/lib/services/ios/ios-signing-service.ts
+++ b/lib/services/ios/ios-signing-service.ts
@@ -8,11 +8,16 @@ import {
 import * as helpers from "../../common/helpers";
 import { IOSProvisionService } from "../ios-provision-service";
 import { IOSBuildData } from "../../data/build-data";
-import { IXcconfigService, IXcprojService } from "../../declarations";
+import {
+	IProvisioningJSON,
+	IXcconfigService,
+	IXcprojService,
+} from "../../declarations";
 import { IProjectData } from "../../definitions/project";
 import { IErrors, IFileSystem } from "../../common/declarations";
 import * as _ from "lodash";
 import { injector } from "../../common/yok";
+import * as constants from "../../constants";
 
 export class IOSSigningService implements IiOSSigningService {
 	constructor(
@@ -47,6 +52,9 @@ export class IOSSigningService implements IiOSSigningService {
 			(!signing || signing.style !== "Manual")
 		) {
 			xcode.setManualSigningStyle(projectData.projectName);
+			this.getExtensionsName(projectData).forEach((name) =>
+				xcode.setManualSigningStyle(name)
+			);
 			xcode.save();
 		} else if (
 			!iOSBuildData.provision &&
@@ -106,6 +114,10 @@ export class IOSSigningService implements IiOSSigningService {
 				],
 				teamId
 			);
+			this.getExtensionsName(projectData).forEach((name) =>
+				xcode.setAutomaticSigningStyle(name, teamId)
+			);
+
 			xcode.save();
 
 			this.$logger.trace(`Set Automatic signing style and team id ${teamId}.`);
@@ -146,59 +158,142 @@ export class IOSSigningService implements IiOSSigningService {
 		}
 
 		if (shouldUpdateXcode) {
-			const pickStart = Date.now();
-			const mobileprovision =
-				mobileProvisionData ||
-				(await this.$iOSProvisionService.pick(
-					provision,
-					projectData.projectIdentifiers.ios
-				));
-			const pickEnd = Date.now();
-			this.$logger.trace(
-				"Searched and " +
-					(mobileprovision ? "found" : "failed to find ") +
-					" matching provisioning profile. (" +
-					(pickEnd - pickStart) +
-					"ms.)"
+			const projectSigningConfig = await this.getManualSigningConfiguration(
+				projectData,
+				provision,
+				mobileProvisionData
 			);
-			if (!mobileprovision) {
-				this.$errors.fail(
-					"Failed to find mobile provision with UUID or Name: " + provision
-				);
-			}
-			const configuration = {
-				team:
-					mobileprovision.TeamIdentifier &&
-					mobileprovision.TeamIdentifier.length > 0
-						? mobileprovision.TeamIdentifier[0]
-						: undefined,
-				uuid: mobileprovision.UUID,
-				name: mobileprovision.Name,
-				identity:
-					mobileprovision.Type === "Development"
-						? "iPhone Developer"
-						: "iPhone Distribution",
-			};
-			xcode.setManualSigningStyle(projectData.projectName, configuration);
+			xcode.setManualSigningStyle(
+				projectData.projectName,
+				projectSigningConfig
+			);
 			xcode.setManualSigningStyleByTargetProductTypesList(
 				[
 					IOSNativeTargetProductTypes.appExtension,
 					IOSNativeTargetProductTypes.watchApp,
 					IOSNativeTargetProductTypes.watchExtension,
 				],
-				configuration
+				projectSigningConfig
 			);
-			xcode.save();
 
-			// this.cache(uuid);
 			this.$logger.trace(
-				`Set Manual signing style and provisioning profile: ${mobileprovision.Name} (${mobileprovision.UUID})`
+				`Set Manual signing style and provisioning profile: ${projectSigningConfig.name} (${projectSigningConfig.uuid})`
 			);
+
+			const extensionSigningConfig = await Promise.all(
+				this.getExtensionsManualSigningConfiguration(projectData)
+			);
+			extensionSigningConfig.forEach(({ name, configuration }) => {
+				xcode.setManualSigningStyle(name, configuration);
+				this.$logger.trace(
+					`Set Manual signing style and provisioning profile: ${configuration.name} (${configuration.uuid})`
+				);
+			});
+
+			xcode.save();
+			// this.cache(uuid);
 		} else {
 			this.$logger.trace(
 				`The specified provisioning profile is already set in the Xcode: ${provision}`
 			);
 		}
+	}
+
+	private getExtensionsName(projectData: IProjectData) {
+		const extensionFolderPath = path.join(
+			projectData.getAppResourcesDirectoryPath(),
+			constants.iOSAppResourcesFolderName,
+			constants.NATIVE_EXTENSION_FOLDER
+		);
+
+		if (this.$fs.exists(extensionFolderPath)) {
+			const extensionsName = this.$fs
+				.readDirectory(extensionFolderPath)
+				.filter((fileName) => {
+					const extensionPath = path.join(extensionFolderPath, fileName);
+					const stats = this.$fs.getFsStats(extensionPath);
+					return stats.isDirectory() && !fileName.startsWith(".");
+				});
+
+			return extensionsName;
+		}
+		return [];
+	}
+
+	private getExtensionsManualSigningConfiguration(projectData: IProjectData) {
+		const provisioningJSONPath = path.join(
+			projectData.getAppResourcesDirectoryPath(),
+			constants.iOSAppResourcesFolderName,
+			constants.NATIVE_EXTENSION_FOLDER,
+			constants.EXTENSION_PROVISIONING_FILENAME
+		);
+
+		if (this.$fs.exists(provisioningJSONPath)) {
+			const provisioningJSON = this.$fs.readJson(
+				provisioningJSONPath
+			) as IProvisioningJSON;
+
+			const extensionsName = this.getExtensionsName(projectData);
+
+			const provisioning = Object.entries(provisioningJSON).map(
+				async ([id, provision]) => {
+					const name = id.split(".").at(-1);
+					if (extensionsName.includes(name)) {
+						const configuration = await this.getManualSigningConfiguration(
+							projectData,
+							provision
+						);
+						return { name, configuration };
+					}
+					return null;
+				}
+			);
+
+			return provisioning;
+		}
+
+		return [];
+	}
+
+	private async getManualSigningConfiguration(
+		projectData: IProjectData,
+		provision: string,
+		mobileProvisionData?: mobileProvisionFinder.provision.MobileProvision
+	) {
+		const pickStart = Date.now();
+		const mobileprovision =
+			mobileProvisionData ||
+			(await this.$iOSProvisionService.pick(
+				provision,
+				projectData.projectIdentifiers.ios
+			));
+		const pickEnd = Date.now();
+		this.$logger.trace(
+			"Searched and " +
+				(mobileprovision ? "found" : "failed to find ") +
+				" matching provisioning profile. (" +
+				(pickEnd - pickStart) +
+				"ms.)"
+		);
+		if (!mobileprovision) {
+			this.$errors.fail(
+				"Failed to find mobile provision with UUID or Name: " + provision
+			);
+		}
+		const configuration = {
+			team:
+				mobileprovision.TeamIdentifier &&
+				mobileprovision.TeamIdentifier.length > 0
+					? mobileprovision.TeamIdentifier[0]
+					: undefined,
+			uuid: mobileprovision.UUID,
+			name: mobileprovision.Name,
+			identity:
+				mobileprovision.Type === "Development"
+					? "iPhone Developer"
+					: "iPhone Distribution",
+		};
+		return configuration;
 	}
 
 	private getBuildXCConfigFilePath(projectData: IProjectData): string {

--- a/test/services/ios/ios-signing-service.ts
+++ b/test/services/ios/ios-signing-service.ts
@@ -22,6 +22,7 @@ const projectData: any = {
 	projectIdentifiers: {
 		ios: "org.nativescript.testApp",
 	},
+	getAppResourcesDirectoryPath: () => "app-resources/path",
 };
 const NativeScriptDev = {
 	Name: "NativeScriptDev",
@@ -59,6 +60,8 @@ const NativeScriptAdHoc = {
 	ProvisionsAllDevices: true,
 	Type: "Distribution",
 };
+
+let provisioningJSON: Record<string, any> | undefined;
 
 class XcodeMock implements IXcodeMock {
 	public isSetManualSigningStyleCalled = false;
@@ -115,7 +118,20 @@ function setup(data: {
 
 	const injector = new Yok();
 	injector.register("errors", Errors);
-	injector.register("fs", {});
+
+	provisioningJSON = undefined;
+	injector.register("fs", {
+		exists(path: string) {
+			return false;
+		},
+		readDirectory: (path: string): string[] => [],
+		readJson() {
+			return provisioningJSON ?? {};
+		},
+		getFsStats(path: string) {
+			return <any>{ isDirectory: () => false };
+		},
+	});
 	injector.register("iOSProvisionService", {
 		getTeamIdsWithName: () => teamIdsForName || [],
 		pick: async (uuidOrName: string, projId: string) => {


### PR DESCRIPTION

This PR fixes the following open issue
https://github.com/NativeScript/nativescript-cli/issues/5520
https://github.com/NativeScript/nativescript-cli/issues/5244

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
- Currently, the NativeScript CLI does not support Podfiles for extensions. The final Podfile is wrapped with the main application target. However, extensions require their own unique targets.

- Additionally, it is currently not possible to build the iOS app with an extension and a provided team ID or provision.


## What is the new behavior?
- With this update, developers can now create a Podfile in each extension folder, similar to how they would for the main app. During the build process, the CLI will generate a new target with the extension name and merge it with the existing final Podfile. As a result, the Podfile, after the build, will contain plugins, App-Resources, and extension Podfiles.

- Extension signing will inherit the signing style and team ID from the main app. If the build command contains the provision, the extension will also be signed with the provided provisions from the provisioning.json file located in the extension folder.

