### PR TITLE
fix: hash plugin files after prepare

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -268,10 +268,15 @@ export class PluginsService implements IPluginsService {
 					pluginData,
 					projectData
 				);
+
+				const updatedPluginNativeHashes = await this.getPluginNativeHashes(
+					pluginPlatformsFolderPath
+				);
+
 				this.setPluginNativeHashes({
 					pathToPluginsBuildFile,
 					pluginData,
-					currentPluginNativeHashes,
+					currentPluginNativeHashes: updatedPluginNativeHashes,
 					allPluginsNativeHashes,
 				});
 			}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

NativeScript CLI hashes plugin files before preparing them, meaning that the next run of the CLI will have outdated hashes if the plugin changed any of its files during the prepare step.

This can lead to some cases of plugins not being prepared when they should because the known hashes (from `.ns-plugins-build-data.json`) match the hashes of a plugin that was not built yet.

This is notable when using yarn and some plugins from nativescript-community (_i.e._ [ui-lottie](https://github.com/nativescript-community/ui-lottie) and [ui-material-*](https://github.com/nativescript-community/ui-material-components)) because they don't ship a `.aar` in the tarball. After installing any dependency with yarn it'll reset the node_modules to a known state that will break the known hashes of the CLI.

Steps to reproduce:

```sh
git clone https://github.com/nativescript-community/ui-lottie.git
cd demo
yarn # not reproducible with npm unless manually messing with node_modules
ns run android
yarn add uuid # any package woks here, using uuid as example
ns run android # app crashes due to missing aar file
```

## What is the new behavior?
<!-- Describe the changes. -->

The CLI now hashes the plugin files after a successful prepare, meaning that it'll store the most recent file hashes for plugins that change their contents during this step.

A side-effect of this fix is that the CLI tracks more accurately which plugins need to be prepared after a yarn install even if they do ship their own `.aar` files as it now has a way for checking if the shipped `.aar` has the same hashes as the one previous compiled locally.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
