### PR TITLE
feat(logs): improve android logging

### DIFF
--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -179,11 +179,15 @@ declare global {
 		interface ILogcatStartOptions {
 			deviceIdentifier: string;
 			pid?: string;
+			appId?: string;
 			keepSingleProcess?: boolean;
 		}
 
 		interface ILogcatHelper {
-			start(options: ILogcatStartOptions): Promise<void>;
+			start(
+				options: ILogcatStartOptions,
+				onAppRestarted?: () => void
+			): Promise<void>;
 			stop(deviceIdentifier: string): void;
 			dump(deviceIdentifier: string): Promise<void>;
 		}
@@ -222,6 +226,13 @@ declare global {
 			 * @param {string} pid The Process ID of the currently running application for which we need the logs.
 			 */
 			setApplicationPidForDevice(deviceIdentifier: string, pid: string): void;
+
+			/**
+			 * Sets the application id of the application on the specified device.
+			 * @param {string} deviceIdentifier The unique identifier of the device.
+			 * @param {string} appId The Process ID of the currently running application for which we need the logs.
+			 */
+			setApplicationIdForDevice(deviceIdentifier: string, appId: string): void;
 
 			/**
 			 * Sets the project name of the application on the specified device.
@@ -264,6 +275,10 @@ declare global {
 			 * The project name.
 			 */
 			projectName?: string;
+			/**
+			 *	The application id of the current app.
+			 */
+			applicationId?: string;
 		}
 
 		/**

--- a/lib/common/mobile/android/android-debug-bridge.ts
+++ b/lib/common/mobile/android/android-debug-bridge.ts
@@ -55,7 +55,6 @@ export class AndroidDebugBridge implements Mobile.IAndroidDebugBridge {
 			childProcessOptions,
 			{ throwError: false }
 		);
-
 		const errors = this.$androidDebugBridgeResultHandler.checkForErrors(result);
 
 		if (errors && errors.length > 0) {

--- a/lib/common/mobile/android/android-log-filter.ts
+++ b/lib/common/mobile/android/android-log-filter.ts
@@ -7,7 +7,8 @@ export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
 
 	// sample line is "11-23 12:39:07.310  1584  1597 I art     : Background sticky concurrent mark sweep GC freed 21966(1780KB) AllocSpace objects, 4(80KB) LOS objects, 77% free, 840KB/3MB, paused 4.018ms total 158.629ms"
 	// or '12-28 10:45:08.020  3329  3329 W chromium: [WARNING:data_reduction_proxy_settings.cc(328)] SPDY proxy OFF at startup'
-	private static API_LEVEL_23_LINE_REGEX = /.+?\s+?(?:[A-Z]\s+?)([A-Za-z \.]+?)\s*?\: (.*)/;
+	private static API_LEVEL_23_LINE_REGEX =
+		/.+?\s+?(?:[A-Z]\s+?)([A-Za-z \.]+?)\s*?\: (.*)/;
 
 	constructor(private $loggingLevels: Mobile.ILoggingLevels) {}
 
@@ -23,7 +24,9 @@ export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
 			);
 			if (log) {
 				if (log.tag) {
-					return `${log.tag}: ${log.message}` + EOL;
+					return (
+						`${log.tag === "JS" ? "" : `${log.tag}: `}${log.message}` + EOL
+					);
 				} else {
 					return log.message + EOL;
 				}
@@ -35,33 +38,18 @@ export class AndroidLogFilter implements Mobile.IPlatformLogFilter {
 		return data + EOL;
 	}
 
-	private getConsoleLogFromLine(lineText: string, pid: string): any {
-		// filter log line if it does not belong to the current application process id
-		if (pid && lineText.indexOf(pid) < 0) {
+	getConsoleLogFromLine(lineText: string, pid: string) {
+		if (pid && lineText.indexOf(pid) === -1) {
 			return null;
 		}
 
-		// Messages with category TNS.Native and TNS.Java will be printed by runtime to Logcat only when `__enableVerboseLogging()` is called in the application.
-		const acceptedTags = [
-			"chromium",
-			"Web Console",
-			"JS",
-			"ActivityManager",
-			"System.err",
-			"TNS.Native",
-			"TNS.Java",
-		];
-
-		let consoleLogMessage: { tag?: string; message: string };
-
+		let consoleLogMessage;
 		const match =
 			lineText.match(AndroidLogFilter.LINE_REGEX) ||
 			lineText.match(AndroidLogFilter.API_LEVEL_23_LINE_REGEX);
-
-		if (match && acceptedTags.indexOf(match[1].trim()) !== -1) {
+		if (match) {
 			consoleLogMessage = { tag: match[1].trim(), message: match[2] };
 		}
-
 		return consoleLogMessage;
 	}
 }

--- a/lib/common/mobile/device-log-provider-base.ts
+++ b/lib/common/mobile/device-log-provider-base.ts
@@ -4,7 +4,8 @@ import { IDictionary } from "../declarations";
 
 export abstract class DeviceLogProviderBase
 	extends EventEmitter
-	implements Mobile.IDeviceLogProvider {
+	implements Mobile.IDeviceLogProvider
+{
 	protected devicesLogOptions: IDictionary<Mobile.IDeviceLogOptions> = {};
 
 	constructor(
@@ -50,6 +51,15 @@ export abstract class DeviceLogProviderBase
 		);
 	}
 
+	public setApplicationIdForDevice(deviceIdentifier: string, appId: string) {
+		this.setDeviceLogOptionsProperty(
+			deviceIdentifier,
+			(deviceLogOptions: Mobile.IDeviceLogOptions) =>
+				deviceLogOptions.applicationId,
+			appId
+		);
+	}
+
 	public setProjectNameForDevice(
 		deviceIdentifier: string,
 		projectName: string
@@ -86,6 +96,13 @@ export abstract class DeviceLogProviderBase
 		return (
 			this.devicesLogOptions[deviceIdentifier] &&
 			this.devicesLogOptions[deviceIdentifier].applicationPid
+		);
+	}
+
+	getApplicationIdForDevice(deviceIdentifier: string) {
+		return (
+			this.devicesLogOptions[deviceIdentifier] &&
+			this.devicesLogOptions[deviceIdentifier].applicationId
 		);
 	}
 

--- a/lib/common/test/unit-tests/stubs.ts
+++ b/lib/common/test/unit-tests/stubs.ts
@@ -141,7 +141,8 @@ export class SettingsService implements ISettingsService {
 }
 
 export class AndroidProcessServiceStub
-	implements Mobile.IAndroidProcessService {
+	implements Mobile.IAndroidProcessService
+{
 	public MapAbstractToTcpPortResult = "stub";
 	public GetDebuggableAppsResult: Mobile.IDeviceApplicationInformation[] = [];
 	public GetMappedAbstractToTcpPortsResult: IDictionary<number> = {};
@@ -212,9 +213,11 @@ export class LogcatHelperStub implements Mobile.ILogcatHelper {
 
 export class DeviceLogProviderStub
 	extends EventEmitter
-	implements Mobile.IDeviceLogProvider {
+	implements Mobile.IDeviceLogProvider
+{
 	public logger = new CommonLoggerStub();
 	public currentDevicePids: IStringDictionary = {};
+	public currentDeviceAppIds: IStringDictionary = {};
 	public currentDeviceProjectNames: IStringDictionary = {};
 	public currentDeviceProjectDirs: IStringDictionary = {};
 
@@ -230,6 +233,10 @@ export class DeviceLogProviderStub
 
 	setApplicationPidForDevice(deviceIdentifier: string, pid: string): void {
 		this.currentDevicePids[deviceIdentifier] = pid;
+	}
+
+	setApplicationIdForDevice(deviceIdentifier: string, appId: string): void {
+		this.currentDeviceAppIds[deviceIdentifier] = appId;
 	}
 
 	setProjectNameForDevice(deviceIdentifier: string, projectName: string): void {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Logging on android stops working if the app is restarted. This happens mainly due to logging directly linked with app PID. When app restarts, the pid changes and logs stop.

## What is the new behavior?
I wanted to completely ditch PID for something else on android but I realized there are good reasons to keep using PID as it helps us filter logs precisely for the current app. In the new approach we restart adb logcat with the new PID if the app is restarts automatically. This we we always keep the CLI in sync with the current PID of the running NativeScript app.

This PR also makes logging much more performant on android by using native android filters of TAGs of concern instead of filtering on the host device.

- Removed `JS:` from logs
- Logging works on app restart
- Improved logging performance on android and reduced the filtering needed on host device

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
