### PR TITLE
fix: setup docs links

### DIFF
--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -92,7 +92,7 @@ export class PlatformEnvironmentRequirements
 
 		return (
 			`Verify that your environment is configured according to the system requirements described at\n` +
-			`https://docs.nativescript.org/setup${anchor}.`
+			`https://docs.nativescript.org/setup/${os}${anchor}.`
 		);
 	}
 }

--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -88,11 +88,11 @@ export class PlatformEnvironmentRequirements
 			darwin: "macos",
 		} as any)[process.platform];
 
-		const anchor = platform ? `#${os}-${platform.toLowerCase()}` : "";
+		const anchor = platform ? `/${os}#${platform.toLowerCase()}` : "";
 
 		return (
 			`Verify that your environment is configured according to the system requirements described at\n` +
-			`https://docs.nativescript.org/environment-setup.html${anchor}.`
+			`https://docs.nativescript.org/setup${anchor}.`
 		);
 	}
 }

--- a/lib/services/platform-environment-requirements.ts
+++ b/lib/services/platform-environment-requirements.ts
@@ -88,7 +88,7 @@ export class PlatformEnvironmentRequirements
 			darwin: "macos",
 		} as any)[process.platform];
 
-		const anchor = platform ? `/${os}#${platform.toLowerCase()}` : "";
+		const anchor = platform ? `#setting-up-${os}-for-${platform.toLowerCase()}` : "";
 
 		return (
 			`Verify that your environment is configured according to the system requirements described at\n` +

--- a/packages/doctor/src/constants.ts
+++ b/packages/doctor/src/constants.ts
@@ -6,7 +6,7 @@ export class Constants {
 		Constants.IOS_PLATFORM_NAME,
 	];
 	public static SYSTEM_REQUIREMENTS_LINKS =
-		"https://docs.nativescript.org/environment-setup.html";
+		"https://docs.nativescript.org/setup";
 	public static INFO_TYPE_NAME = "info";
 	public static WARNING_TYPE_NAME = "warning";
 


### PR DESCRIPTION
when it has an error due to the environment, we have the error
```
Your environment is not configured properly and you will not be able to execute local builds.
Verify that your environment is configured according to the system requirements described at
https://docs.nativescript.org/environment-setup.html#macos-ios.
```

This does not correspond to the new documentation, since before we had everything on the same page and now on separate pages

Also this PR needs more changes, since we need
```
/setup/macos#setting-up-macos-for-ios

rather

/environment-setup.html#macos-ios
```
Here we can add the change to put
```
const anchor = platform ? `/${os}#setting-up-${os}-for-${platform.toLowerCase()}` : "";
```

Or we can change in the documentation

```
/setup/macos#setting-up-macos-for-ios

To

/setup/macos#ios
```