### PR TITLE
fix: remove cli-table aliasing

### DIFF
--- a/lib/common/helpers.ts
+++ b/lib/common/helpers.ts
@@ -15,7 +15,7 @@ import {
 } from "./declarations";
 import { IAndroidSigningData } from "../definitions/build";
 
-import * as Table from "cli-table";
+import * as Table from "cli-table3";
 const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/gm;
 
 export function stripComments(content: string): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "byline": "5.0.0",
         "chalk": "4.1.2",
         "chokidar": "3.5.3",
-        "cli-table": "npm:cli-table3@0.6.3",
+        "cli-table3": "0.6.3",
         "color": "4.2.3",
         "convert-source-map": "2.0.0",
         "detect-newline": "3.1.0",
@@ -2879,21 +2879,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-table": {
-      "name": "cli-table3",
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-table3": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "byline": "5.0.0",
     "chalk": "4.1.2",
     "chokidar": "3.5.3",
-    "cli-table": "npm:cli-table3@0.6.3",
+    "cli-table3": "0.6.3",
     "color": "4.2.3",
     "convert-source-map": "2.0.0",
     "detect-newline": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@npmcli/move-file": "^2.0.0",
     "@rigor789/resolve-package-path": "1.0.7",
     "@rigor789/trapezedev-project": "7.1.1",
-	"ansi-colors": "^4.1.3",
+    "ansi-colors": "^4.1.3",
     "archiver": "^5.3.1",
     "axios": "1.3.5",
     "byline": "5.0.0",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
We're aliasing `cli-table` to `cli-table3`. This causes issues with certain package managers.

## What is the new behavior?
We no longer alias `cli-table` and instead use `cli-table3`. Upon checking our 3rd party deps, all of them are already using `cli-table3` so the primary reason this was aliased in the first place no longer stands.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
