### PR TITLE
feat(android): allow to force gradle version throught nativescript-co…

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -139,6 +139,8 @@ interface INsConfigAndroid extends INsConfigPlaform {
 	enableLineBreakpoints?: boolean;
 
 	enableMultithreadedJavascript?: boolean;
+
+	gradleVersion?: string;
 }
 
 interface INsConfigHooks {

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -394,7 +394,18 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			this.$fs.copyFile(path.join(dir, "*"), destination);
 		}
 	}
-
+	private extractNamespaceFromManifest(manifestPath:string): string {
+		const fileContent = this.$fs.readText(manifestPath);
+		const contentRegex = new RegExp('package="(.*)"');
+		const match = fileContent.match(contentRegex);
+		let namespace: string;
+		if (match) {
+			namespace = match[1];
+			const replacedFileContent = fileContent.replace(contentRegex, "");
+			this.$fs.writeFile(manifestPath, replacedFileContent);
+		}
+		return namespace;
+	}
 	private async setupGradle(
 		pluginTempDir: string,
 		platformsAndroidDirPath: string,
@@ -413,14 +424,29 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		const runtimeGradleVersions = await this.getRuntimeGradleVersions(
 			projectDir
 		);
+		let gradleVersion = runtimeGradleVersions.gradleVersion;
+		if (this.$projectData.nsConfig.android.gradleVersion) {
+			gradleVersion = this.$projectData.nsConfig.android.gradleVersion;
+		}
 		this.replaceGradleVersion(
 			pluginTempDir,
-			runtimeGradleVersions.gradleVersion
+			gradleVersion
 		);
 		this.replaceGradleAndroidPluginVersion(
 			buildGradlePath,
 			runtimeGradleVersions.gradleAndroidPluginVersion
 		);
+
+		// In gradle 8 every android project must have a namespace in "android"
+		// and the package property in manifest is now forbidden
+		// let s replace it
+		const manifestFilePath = this.getManifest(path.join(pluginTempDir, 'src', 'main'));
+		let pluginNamespace = this.extractNamespaceFromManifest(manifestFilePath);
+		if (!pluginNamespace) {
+			pluginNamespace = pluginName.replace(/@/g, '').replace(/[/-]/g, '.')
+		}
+
+		this.replaceFileContent(buildGradlePath, "{{pluginNamespace}}", pluginNamespace);
 		this.replaceFileContent(buildGradlePath, "{{pluginName}}", pluginName);
 		this.replaceFileContent(settingsGradlePath, "{{pluginName}}", pluginName);
 	}

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -459,6 +459,24 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			gradleSettingsFilePath
 		);
 
+
+		const gradleVersion  = projectData.nsConfig.android.gradleVersion;
+		if (gradleVersion) {
+			// user defined a custom gradle version, let's apply it
+			const gradleWrapperFilePath = path.join(
+				this.getPlatformData(projectData).projectRoot,
+				"gradle",
+				"wrapper",
+				"gradle-wrapper.properties"
+			);
+			shell.sed(
+				"-i",
+				/gradle-([0-9.]+)-bin.zip/,
+				`gradle-${gradleVersion}-bin.zip`,
+				gradleWrapperFilePath
+			);
+		}
+
 		try {
 			// will replace applicationId in app/App_Resources/Android/app.gradle if it has not been edited by the user
 			const appGradleContent = this.$fs.readText(projectData.appGradlePath);
@@ -486,6 +504,17 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			/__PACKAGE__/,
 			projectData.projectIdentifiers.android,
 			manifestPath
+		);
+		const buildGradlePath = path.join(
+			this.getPlatformData(projectData).projectRoot,
+			"app",
+			"build.gradle"
+		);
+		shell.sed(
+			"-i",
+			/__PACKAGE__/,
+			projectData.projectIdentifiers.android,
+			buildGradlePath
 		);
 	}
 

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -156,6 +156,7 @@ def computeBuildToolsVersion = { ->
 }
 
 android {
+    namespace "{{pluginNamespace}}"
     def applyPluginGradleConfigurations = { ->
         nativescriptDependencies.each { dep ->
             def includeGradlePath = "${getDepPlatformDir(dep)}/include.gradle"
@@ -209,24 +210,24 @@ task addDependenciesFromNativeScriptPlugins {
     }
 }
 
-afterEvaluate {
-    def generateBuildConfig =  project.hasProperty("generateBuildConfig") ? project.generateBuildConfig : false
-    def generateR =  project.hasProperty("generateR") ? project.generateR : false
-    generateReleaseBuildConfig.enabled = generateBuildConfig
-    generateDebugBuildConfig.enabled = generateBuildConfig
-    generateReleaseResValues.enabled = generateR
-    generateDebugResValues.enabled = generateR
-}
-
-tasks.whenTaskAdded({ DefaultTask currentTask ->
-    if (currentTask.name == 'bundleRelease' || currentTask.name == 'bundleDebug') {
+// This wont work with gradle 8 + should be the same as the code  just after
+// afterEvaluate {
+//     def generateBuildConfig =  project.hasProperty("generateBuildConfig") ? project.generateBuildConfig : false
+//     def generateR =  project.hasProperty("generateR") ? project.generateR : false
+//     generateReleaseBuildConfig.enabled = generateBuildConfig
+//     generateDebugBuildConfig.enabled = generateBuildConfig
+//     generateReleaseResValues.enabled = generateR
+//     generateDebugResValues.enabled = generateR
+// }
+project.tasks.configureEach {
+    if (name == 'bundleRelease') {
         def generateBuildConfig =  project.hasProperty("generateBuildConfig") ? project.generateBuildConfig : false
         def generateR =  project.hasProperty("generateR") ? project.generateR : false
         if (!generateBuildConfig) {
-            currentTask.exclude '**/BuildConfig.class'
+            it.exclude '**/BuildConfig.class'
         }
         if (!generateR) {
-            currentTask.exclude '**/R.class', '**/R$*.class'
+            it.exclude '**/R.class', '**/R$*.class'
         }
     }
-})
+}

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -152,7 +152,7 @@ allprojects {
 def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 31 }
 def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 31 as int }
 def computeBuildToolsVersion = { ->
-    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "33.0.1"
+    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "31.0.0"
 }
 
 android {

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -13,12 +13,16 @@ buildscript {
     }
     def computeKotlinVersion = { -> project.hasProperty("kotlinVersion") ? kotlinVersion : "1.8.20" }
     def kotlinVersion = computeKotlinVersion()
+    def computeBuildToolsVersion = { ->
+        project.hasProperty("buildToolsVersion") ? buildToolsVersion : "{{runtimeAndroidPluginVersion}}"
+    }
+    def buildToolsVersion = computeBuildToolsVersion()
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{runtimeAndroidPluginVersion}}'
+        classpath "com.android.tools.build:gradle:$buildToolsVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -148,7 +152,7 @@ allprojects {
 def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 31 }
 def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 31 as int }
 def computeBuildToolsVersion = { ->
-    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "31.0.0"
+    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "{{runtimeAndroidPluginVersion}}"
 }
 
 android {

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -14,15 +14,15 @@ buildscript {
     def computeKotlinVersion = { -> project.hasProperty("kotlinVersion") ? kotlinVersion : "1.8.20" }
     def kotlinVersion = computeKotlinVersion()
     def computeBuildToolsVersion = { ->
-        project.hasProperty("buildToolsVersion") ? buildToolsVersion : "{{runtimeAndroidPluginVersion}}"
+        project.hasProperty("androiBuildToolsVersion") ? buildToolsVersion : "{{runtimeAndroidPluginVersion}}"
     }
-    def buildToolsVersion = computeBuildToolsVersion()
+    def androiBuildToolsVersion = computeBuildToolsVersion()
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:$buildToolsVersion"
+        classpath "com.android.tools.build:gradle:$androiBuildToolsVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -152,7 +152,7 @@ allprojects {
 def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 31 }
 def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 31 as int }
 def computeBuildToolsVersion = { ->
-    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "{{runtimeAndroidPluginVersion}}"
+    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "33.0.1"
 }
 
 android {

--- a/vendor/gradle-plugin/build.gradle
+++ b/vendor/gradle-plugin/build.gradle
@@ -171,6 +171,11 @@ android {
     compileSdkVersion computeCompileSdkVersion()
     buildToolsVersion computeBuildToolsVersion()
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
     defaultConfig {
         targetSdkVersion computeTargetSdkVersion()
         versionCode 1


### PR DESCRIPTION
…nfig (`android.gradleVersion`).

We also now allows `buildToolsVersion` to be correctly overriden Also we now replace `{{pluginNamespace}}` for plugins as requirement for gradle 8 Same `__PACKAGE__` is replaced in app build.gradle (for namespace or app id)
