### PR TITLE
fix(plugins): parse name issue with invalid plugins

### DIFF
--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -623,25 +623,32 @@ This framework comes from ${dependencyName} plugin, which is installed multiple 
 		cacheData: IDependencyData | INodeModuleData,
 		projectDir: string
 	): IPluginData {
-		const pluginData: any = {};
-		pluginData.name = cacheData.name;
-		pluginData.version = cacheData.version;
-		pluginData.fullPath =
-			(<IDependencyData>cacheData).directory ||
-			path.dirname(
-				this.getPackageJsonFilePathForModule(cacheData.name, projectDir)
+		try {
+			const pluginData: any = {};
+			pluginData.name = cacheData.name;
+			pluginData.version = cacheData.version;
+			pluginData.fullPath =
+				(<IDependencyData>cacheData).directory ||
+				path.dirname(
+					this.getPackageJsonFilePathForModule(cacheData.name, projectDir)
+				);
+			pluginData.isPlugin = !!cacheData.nativescript;
+			pluginData.pluginPlatformsFolderPath = (platform: string) =>
+				path.join(pluginData.fullPath, "platforms", platform.toLowerCase());
+			const data = cacheData.nativescript;
+
+			if (pluginData.isPlugin) {
+				pluginData.platformsData = data.platforms;
+				pluginData.pluginVariables = data.variables;
+			}
+		} catch (err) {
+			this.$logger.trace(
+				"NOTE: There appears to be a problem with this dependency:",
+				cacheData.name
 			);
-		pluginData.isPlugin = !!cacheData.nativescript;
-		pluginData.pluginPlatformsFolderPath = (platform: string) =>
-			path.join(pluginData.fullPath, "platforms", platform.toLowerCase());
-		const data = cacheData.nativescript;
-
-		if (pluginData.isPlugin) {
-			pluginData.platformsData = data.platforms;
-			pluginData.pluginVariables = data.variables;
+			this.$logger.trace(err);
+			return null;
 		}
-
-		return pluginData;
 	}
 
 	private removeDependencyFromPackageJsonContent(


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?

If a plugin contains invalid data like the wrong name according to package.json, a 'path' from 'undefined' ambiguous error occurs. 

## What is the new behavior?

This will now print the name of the invalid package to allow one to resolve effectively.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
