### PR TITLE
feat(open): Add open ios/android

### DIFF
--- a/docs/man_pages/project/configuration/open-android.md
+++ b/docs/man_pages/project/configuration/open-android.md
@@ -1,0 +1,27 @@
+<% if (isJekyll) { %>---
+title: ns open android
+position: 10
+---<% } %>
+
+# ns open ios
+
+### Description
+
+Opens the Android native project from the corresponding `platforms` directory. 
+
+If the native project has not already been generated, the `prepare` command will be issued to generate the project, and the project will then be opened.
+
+### Commands
+
+Usage | Synopsis
+------|-------
+Open the project in Android Studio | `$ ns open android`
+
+<% if(isHtml) { %>
+
+### Related Commands
+
+Command | Description
+----------|----------
+[prepare](prepare.html) | Copies common and relevant platform-specific content from the app directory to the subdirectory for the selected target platform in the platforms directory.
+<% } %>

--- a/docs/man_pages/project/configuration/open-android.md
+++ b/docs/man_pages/project/configuration/open-android.md
@@ -3,7 +3,7 @@ title: ns open android
 position: 10
 ---<% } %>
 
-# ns open ios
+# ns open android
 
 ### Description
 

--- a/docs/man_pages/project/configuration/open-ios.md
+++ b/docs/man_pages/project/configuration/open-ios.md
@@ -1,0 +1,31 @@
+<% if (isJekyll) { %>---
+title: ns open ios
+position: 10
+---<% } %>
+
+# ns open ios
+
+### Description
+
+Opens the iOS native project from the corresponding `platforms` directory. 
+
+If the native project has not already been generated, the `prepare` command will be issued to generate the project, and the project will then be opened.
+
+### Commands
+
+Usage | Synopsis
+------|-------
+Open the project in Xcode | `$ ns open ios`
+
+<% if(isHtml) { %>
+
+### Command Limitations
+
+* You can run `$ ns open ios` only on macOS systems.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[prepare](prepare.html) | Copies common and relevant platform-specific content from the app directory to the subdirectory for the selected target platform in the platforms directory.
+<% } %>

--- a/docs/man_pages/project/configuration/open.md
+++ b/docs/man_pages/project/configuration/open.md
@@ -1,0 +1,36 @@
+<% if (isJekyll) { %>---
+title: ns open
+position: 10
+---<% } %>
+
+# ns open
+
+### Description
+
+Opens the iOS/Android native project from the corresponding `platforms` directory. 
+
+If the native project has not already been generated, the `prepare` command will be issued to generate the project, and the project will then be opened.
+
+### Commands
+
+Usage | Synopsis
+------|-------
+<% if((isConsole && isMacOS) || isHtml) { %>General | `$ ns open <Platform>`<% } %><% if(isConsole && (isLinux || isWindows)) { %>General | `$ ns open android`<% } %>
+
+<% if(isMacOS) { %>### Arguments
+`<Platform>` is the target mobile platform for which you want to open the native project. You can set the following target platforms.
+* `android` - Opens the Android project in Android Studio.
+* `ios` - Opens native iOS project in Xcode.<% } %>
+
+<% if(isHtml) { %>
+
+### Command Limitations
+
+* You can run `$ ns open ios` only on macOS systems.
+
+### Related Commands
+
+Command | Description
+----------|----------
+[prepare](prepare.html) | Copies common and relevant platform-specific content from the app directory to the subdirectory for the selected target platform in the platforms directory.
+<% } %>

--- a/docs/man_pages/start.md
+++ b/docs/man_pages/start.md
@@ -49,6 +49,7 @@ Command | Description
 [test `<Platform>`](project/testing/test.html) | Runs the unit tests in your project on a connected physical or virtual device.
 [install](project/configuration/install.html) | Installs all platforms and dependencies described in the `package.json` file in the current directory.
 [plugin](lib-management/plugin.html) | Lets you manage the plugins for your project.
+[open](project/configuration/open.md) | Opens the native project in Xcode/Android Studio.
 
 ## Publishing Commands
 Command | Description

--- a/lib/key-commands/bootstrap.ts
+++ b/lib/key-commands/bootstrap.ts
@@ -15,3 +15,5 @@ injector.requireKeyCommand("n", path);
 
 injector.requireKeyCommand(SpecialKeys.QuestionMark, path);
 injector.requireKeyCommand(SpecialKeys.CtrlC, path);
+injector.requireCommand("open|ios", path);
+injector.requireCommand("open|android", path);


### PR DESCRIPTION
Add open iOS/android command.
Generalize iOS open command to cater for non standard installations. Fix open command on windows ( detach from launched process )

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Currently the start menu open on IOS does not deal with non standard installs of Xcode, e.g. using xcodes, this utilizes the existing services to figure out where the installation is.
On open android on windows the process is tied to the parent, so will not exit until Android Studio exits.

## What is the new behavior?
<!-- Describe the changes. -->

Leveraged the start / open functionality to add command `ns open <ios|android>`
Fixed the above issues.

Fixes/Implements/Closes #5754.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
