### PR TITLE
fix: skip log-source-maps for large files

### DIFF
--- a/lib/services/log-source-map-service.ts
+++ b/lib/services/log-source-map-service.ts
@@ -69,6 +69,15 @@ export class LogSourceMapService implements Mobile.ILogSourceMapService {
 			if (!this.$fs.getFsStats(filePath).isDirectory()) {
 				const mapFile = filePath + ".map";
 				let sourceMapRaw;
+
+				// Skip files bigger than 50MB
+				if (this.$fs.getSize(filePath) > 50 * 1000 * 1000) {
+					this.$logger.trace(
+						`Skipping source map for file ${filePath} because it is too big (> 50MB).`
+					);
+					return;
+				}
+
 				const source = this.$fs.readText(filePath);
 				if (this.$fs.exists(mapFile)) {
 					sourceMapRaw = sourceMapConverter.fromMapFileSource(

--- a/lib/services/log-source-map-service.ts
+++ b/lib/services/log-source-map-service.ts
@@ -71,7 +71,7 @@ export class LogSourceMapService implements Mobile.ILogSourceMapService {
 				let sourceMapRaw;
 
 				// Skip files bigger than 50MB
-				if (this.$fs.getSize(filePath) > 50 * 1000 * 1000) {
+				if (this.$fs.getFileSize(filePath) > 50 * 1000 * 1000) {
 					this.$logger.trace(
 						`Skipping source map for file ${filePath} because it is too big (> 50MB).`
 					);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Large files in the output directory can crash node/v8.

## What is the new behavior?
<!-- Describe the changes. -->

We skip reading files larger than 50mb as those are unlikely to be source code anyways. This doesn't affect anything but logs - where larger files would just log their actual stack traces rather than a source-mapped one. In practice source would rarely if ever be >50mb though.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
