### PR TITLE
fix(ios): skip package validation on xcodebuild

### DIFF
--- a/lib/services/ios/xcodebuild-args-service.ts
+++ b/lib/services/ios/xcodebuild-args-service.ts
@@ -115,12 +115,17 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 			projectRoot,
 			`${projectData.projectName}.xcworkspace`
 		);
+		// Introduced in Xcode 14+
+		// ref: https://forums.swift.org/t/telling-xcode-14-beta-4-to-trust-build-tool-plugins-programatically/59305/5
+		const skipPackageValidation = "-skipPackagePluginValidation";
+
 		if (this.$fs.exists(xcworkspacePath)) {
 			return [
 				"-workspace",
 				xcworkspacePath,
 				"-scheme",
 				projectData.projectName,
+				skipPackageValidation,
 			];
 		}
 
@@ -128,7 +133,13 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 			projectRoot,
 			`${projectData.projectName}.xcodeproj`
 		);
-		return ["-project", xcodeprojPath, "-scheme", projectData.projectName];
+		return [
+			"-project",
+			xcodeprojPath,
+			"-scheme",
+			projectData.projectName,
+			skipPackageValidation,
+		];
 	}
 
 	private getBuildLoggingArgs(): string[] {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?

When Swift Packages are included, validations may run which break the build.

## What is the new behavior?

xcodebuild flag is now included during iOS development to avoid build interruptions as discussed here:
https://forums.swift.org/t/telling-xcode-14-beta-4-to-trust-build-tool-plugins-programatically/59305

