### PR TITLE
feat(ios): ensure user defined xcconfig always takes priority

### DIFF
--- a/lib/definitions/ios.d.ts
+++ b/lib/definitions/ios.d.ts
@@ -57,7 +57,7 @@ declare global {
 			buildConfig: IBuildConfig
 		): Promise<string[]>;
 		getXcodeProjectArgs(
-			projectRoot: string,
+			platformData: IPlatformData,
 			projectData: IProjectData
 		): string[];
 	}

--- a/lib/services/ios/spm-service.ts
+++ b/lib/services/ios/spm-service.ts
@@ -78,7 +78,7 @@ export class SPMService implements ISPMService {
 	) {
 		await this.$xcodebuildCommandService.executeCommand(
 			this.$xcodebuildArgsService
-				.getXcodeProjectArgs(platformData.projectRoot, projectData)
+				.getXcodeProjectArgs(platformData, projectData)
 				.concat([
 					"-destination",
 					"generic/platform=iOS",

--- a/lib/services/ios/xcodebuild-args-service.ts
+++ b/lib/services/ios/xcodebuild-args-service.ts
@@ -119,6 +119,9 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 		// ref: https://forums.swift.org/t/telling-xcode-14-beta-4-to-trust-build-tool-plugins-programatically/59305/5
 		const skipPackageValidation = "-skipPackagePluginValidation";
 
+		// TODO:
+		// 1. make sure file exists
+		// 2. use ios/visionos based on platform target
 		const BUILD_SETTINGS_FILE_PATH = path.join(
 			projectData.appResourcesDirectoryPath,
 			"iOS",

--- a/lib/services/ios/xcodebuild-args-service.ts
+++ b/lib/services/ios/xcodebuild-args-service.ts
@@ -119,6 +119,12 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 		// ref: https://forums.swift.org/t/telling-xcode-14-beta-4-to-trust-build-tool-plugins-programatically/59305/5
 		const skipPackageValidation = "-skipPackagePluginValidation";
 
+		const BUILD_SETTINGS_FILE_PATH = path.join(
+			projectData.appResourcesDirectoryPath,
+			"iOS",
+			constants.BUILD_XCCONFIG_FILE_NAME
+		);
+
 		if (this.$fs.exists(xcworkspacePath)) {
 			return [
 				"-workspace",
@@ -126,6 +132,8 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 				"-scheme",
 				projectData.projectName,
 				skipPackageValidation,
+				"-xcconfig",
+				BUILD_SETTINGS_FILE_PATH,
 			];
 		}
 
@@ -139,6 +147,8 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 			"-scheme",
 			projectData.projectName,
 			skipPackageValidation,
+			"-xcconfig",
+			BUILD_SETTINGS_FILE_PATH,
 		];
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Xcode will use min version target priorities from different levels which can ignore user defined xcconfig at times when not desirable.

## What is the new behavior?
Ensures deployment target from user defined xcconfig always takes precedence.

Merge https://github.com/NativeScript/nativescript-cli/pull/5782 first as this branches from there.