### PR TITLE
fix: remove python six requirement

### DIFF
--- a/packages/doctor/src/doctor.ts
+++ b/packages/doctor/src/doctor.ts
@@ -220,7 +220,8 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 			);
 
 			if (sysInfoData.xcodeVer && sysInfoData.cocoaPodsVer) {
-				const isCocoaPodsWorkingCorrectly = await this.sysInfo.isCocoaPodsWorkingCorrectly();
+				const isCocoaPodsWorkingCorrectly =
+					await this.sysInfo.isCocoaPodsWorkingCorrectly();
 				result = result.concat(
 					this.processSysInfoItem({
 						item: isCocoaPodsWorkingCorrectly,
@@ -258,14 +259,6 @@ export class Doctor implements NativeScriptDoctor.IDoctor {
 						"We cannot verify your python installation is setup correctly. Please, make sure you have both 'python3' and 'pip3' installed." +
 						EOL +
 						`Error while validating Python packages. Error is: ${sysInfoData.pythonInfo.installationErrorMessage}`,
-					platforms: [Constants.IOS_PLATFORM_NAME],
-				}),
-				this.processSysInfoItem({
-					item: sysInfoData.pythonInfo.isSixPackageInstalled,
-					infoMessage: `The Python 'six' package is found.`,
-					warningMessage: `The Python 'six' package not found.`,
-					additionalInformation:
-						"This package is required by the Debugger library (LLDB) for iOS. You can install it by first making sure you have pip3 installed and then running 'pip3 install six' from the terminal.",
 					platforms: [Constants.IOS_PLATFORM_NAME],
 				})
 			);

--- a/packages/doctor/src/sys-info.ts
+++ b/packages/doctor/src/sys-info.ts
@@ -493,21 +493,15 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 			async (): Promise<NativeScriptDoctor.IPythonInfo> => {
 				if (this.hostInfo.isDarwin) {
 					try {
-						await this.childProcess.exec(`python3 -c "import six"`);
+						await this.childProcess.exec(`python3 --version`);
 					} catch (error) {
-						// error.code = 1 so the Python is present, but we don't have six.
-						if (error.code === 1) {
-							return { isInstalled: true, isSixPackageInstalled: false };
-						}
-
 						return {
 							isInstalled: false,
-							isSixPackageInstalled: false,
 							installationErrorMessage: error.message,
 						};
 					}
 
-					return { isInstalled: true, isSixPackageInstalled: true };
+					return { isInstalled: true };
 				}
 
 				return null;
@@ -678,9 +672,8 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 		return this.getValueForProperty(
 			() => this.commonSysInfoCache,
 			async (): Promise<NativeScriptDoctor.ICommonSysInfoData> => {
-				const result: NativeScriptDoctor.ICommonSysInfoData = Object.create(
-					null
-				);
+				const result: NativeScriptDoctor.ICommonSysInfoData =
+					Object.create(null);
 
 				// os stuff
 				result.platform = platform();
@@ -708,8 +701,10 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 				result.xcodeprojLocation = await this.getXcodeprojLocation();
 				result.itunesInstalled = await this.isITunesInstalled();
 				result.cocoaPodsVer = await this.getCocoaPodsVersion();
-				result.isCocoaPodsWorkingCorrectly = await this.isCocoaPodsWorkingCorrectly();
-				result.isCocoaPodsUpdateRequired = await this.isCocoaPodsUpdateRequired();
+				result.isCocoaPodsWorkingCorrectly =
+					await this.isCocoaPodsWorkingCorrectly();
+				result.isCocoaPodsUpdateRequired =
+					await this.isCocoaPodsUpdateRequired();
 				result.pythonInfo = await this.getPythonInfo();
 
 				return result;
@@ -723,9 +718,8 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 		return this.getValueForProperty(
 			() => this.androidSysInfoCache,
 			async (): Promise<NativeScriptDoctor.IAndroidSysInfoData> => {
-				const result: NativeScriptDoctor.IAndroidSysInfoData = Object.create(
-					null
-				);
+				const result: NativeScriptDoctor.IAndroidSysInfoData =
+					Object.create(null);
 
 				result.dotNetVer = await this.hostInfo.dotNetVersion();
 				result.javacVersion = await this.getJavaCompilerVersion();
@@ -737,7 +731,8 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 				result.androidInstalled = await this.isAndroidInstalled();
 				result.monoVer = await this.getMonoVersion();
 				result.gradleVer = await this.getGradleVersion();
-				result.isAndroidSdkConfiguredCorrectly = await this.isAndroidSdkConfiguredCorrectly();
+				result.isAndroidSdkConfiguredCorrectly =
+					await this.isAndroidSdkConfiguredCorrectly();
 
 				return result;
 			}
@@ -749,9 +744,8 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 		regExp: RegExp
 	): Promise<string> {
 		let javaExecutableVersion: string = null;
-		const javaExecutablePath = this.getJavaExecutablePathFromJavaHome(
-			javaExecutableName
-		);
+		const javaExecutablePath =
+			this.getJavaExecutablePathFromJavaHome(javaExecutableName);
 		if (javaExecutablePath) {
 			javaExecutableVersion = await this.getVersionOfJavaExecutable(
 				javaExecutablePath,

--- a/packages/doctor/test/sys-info.ts
+++ b/packages/doctor/test/sys-info.ts
@@ -113,7 +113,7 @@ function createChildProcessResults(
 		"tns --version": childProcessResult.nativeScriptCliVersion,
 		emulator: { shouldThrowError: false },
 		"which git": childProcessResult.git,
-		'python3 -c "import six"': childProcessResult.pythonInfo,
+		"python3 --version": childProcessResult.pythonInfo,
 	};
 }
 
@@ -164,9 +164,8 @@ function mockSysInfo(
 		isLinux: !hostInfoOptions.isDarwin && !hostInfoOptions.isWindows,
 		winreg,
 	};
-	const childProcessResultDictionary = createChildProcessResults(
-		childProcessResult
-	);
+	const childProcessResultDictionary =
+		createChildProcessResults(childProcessResult);
 	const childProcess = {
 		exec: async (command: string) => {
 			return getResultFromChildProcess(
@@ -558,7 +557,8 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.202-b08, mixed mode)`),
 					null
 				);
 				const adbVersion = await sysInfo.getAdbVersion();
-				const isAndroidSdkConfiguredCorrectly = await sysInfo.isAndroidSdkConfiguredCorrectly();
+				const isAndroidSdkConfiguredCorrectly =
+					await sysInfo.isAndroidSdkConfiguredCorrectly();
 				assert.deepEqual(adbVersion, null);
 				assert.deepEqual(isAndroidSdkConfiguredCorrectly, undefined);
 			});
@@ -583,7 +583,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.202-b08, mixed mode)`),
 				const pythonInfo = await sysInfo.getPythonInfo();
 				assert.deepEqual(pythonInfo, null);
 			});
-			it("should return {isInstalled: true, isSixPackageInstalled: true} when python is correctly installed on Mac", async () => {
+			it("should return {isInstalled: true} when python is correctly installed on Mac", async () => {
 				childProcessResult.pythonInfo = { result: "" };
 				sysInfo = mockSysInfo(
 					childProcessResult,
@@ -593,10 +593,9 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.202-b08, mixed mode)`),
 				const pythonInfo = await sysInfo.getPythonInfo();
 				assert.deepEqual(pythonInfo, {
 					isInstalled: true,
-					isSixPackageInstalled: true,
 				});
 			});
-			it("should return {isInstalled: false, isSixPackageInstalled: false} when python check throws an error", async () => {
+			it("should return {isInstalled: false} when python check throws an error", async () => {
 				childProcessResult.pythonInfo = { shouldThrowError: true };
 				sysInfo = mockSysInfo(
 					childProcessResult,
@@ -606,27 +605,25 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.202-b08, mixed mode)`),
 				const pythonInfo = await sysInfo.getPythonInfo();
 				assert.deepEqual(pythonInfo, {
 					isInstalled: false,
-					isSixPackageInstalled: false,
 					installationErrorMessage:
-						'This one throws error. (python3 -c "import six")',
+						"This one throws error. (python3 --version)",
 				});
 			});
-			it("should return {isInstalled: true, isSixPackageInstalled: false} when python is installed but six package is not", async () => {
-				childProcessResult.pythonInfo = {
-					shouldThrowError: true,
-					errorCode: 1,
-				};
-				sysInfo = mockSysInfo(
-					childProcessResult,
-					{ isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" },
-					null
-				);
-				const pythonInfo = await sysInfo.getPythonInfo();
-				assert.deepEqual(pythonInfo, {
-					isInstalled: true,
-					isSixPackageInstalled: false,
-				});
-			});
+			// it("should return {isInstalled: true} when python is installed but six package is not", async () => {
+			// 	childProcessResult.pythonInfo = {
+			// 		shouldThrowError: true,
+			// 		errorCode: 1,
+			// 	};
+			// 	sysInfo = mockSysInfo(
+			// 		childProcessResult,
+			// 		{ isWindows: false, isDarwin: true, dotNetVersion: "4.5.1" },
+			// 		null
+			// 	);
+			// 	const pythonInfo = await sysInfo.getPythonInfo();
+			// 	assert.deepEqual(pythonInfo, {
+			// 		isInstalled: true,
+			// 	});
+			// });
 		});
 
 		const testData: ICLIOutputVersionTestCase[] = [
@@ -823,7 +820,6 @@ ${expectedCliVersion}`;
 				assert.deepEqual(result.isCocoaPodsUpdateRequired, false);
 				assert.deepEqual(result.pythonInfo, {
 					isInstalled: false,
-					isSixPackageInstalled: false,
 					installationErrorMessage:
 						"Cannot read properties of undefined (reading 'shouldThrowError')",
 				});

--- a/packages/doctor/typings/interfaces.ts
+++ b/packages/doctor/typings/interfaces.ts
@@ -209,7 +209,11 @@ declare module NativeScriptDoctor {
 		 * @param {string} runtimeVersion @optional The runtime version against which the validation is executed. In case this parameter is passed, it takes precedence over the projectDir argument.
 		 * @return {Promise<boolean>} true if local build can be executed for the provided platform.
 		 */
-		canExecuteLocalBuild(platform: string, projectDir?: string, runtimeVersion?: string): Promise<boolean>;
+		canExecuteLocalBuild(
+			platform: string,
+			projectDir?: string,
+			runtimeVersion?: string
+		): Promise<boolean>;
 
 		/**
 		 * Executes all checks for the current environment and returns the warnings from each check.
@@ -363,7 +367,10 @@ declare module NativeScriptDoctor {
 		dotNetVer?: string;
 	}
 
-	interface ISysInfoData extends ICommonSysInfoData, IiOSSysInfoData, IAndroidSysInfoData { }
+	interface ISysInfoData
+		extends ICommonSysInfoData,
+			IiOSSysInfoData,
+			IAndroidSysInfoData {}
 
 	/**
 	 * Describes warning returned from @nativescript/doctor check.
@@ -439,11 +446,6 @@ declare module NativeScriptDoctor {
 		isInstalled: boolean;
 
 		/**
-		 * Determines whether python six package is installed
-		 */
-		isSixPackageInstalled: boolean;
-
-		/**
 		 * Error message from installation check
 		 */
 		installationErrorMessage?: string;
@@ -487,7 +489,11 @@ declare module NativeScriptDoctor {
 		 * @param {string} runtimeVersion @optional The runtime version against which the validation is executed. In case this parameter is passed, it takes precedence over the projectDir argument.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validateJavacVersion(installedJavaVersion: string, projectDir?: string, runtimeVersion?: string): NativeScriptDoctor.IWarning[];
+		validateJavacVersion(
+			installedJavaVersion: string,
+			projectDir?: string,
+			runtimeVersion?: string
+		): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Returns the path to the adb which is located in ANDROID_HOME.
@@ -506,14 +512,18 @@ declare module NativeScriptDoctor {
 		 * @param {ITargetValidationOptions} options The targetSdk to be validated and the project directory - used to determine the Android Runtime version.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validateMinSupportedTargetSdk(options: ITargetValidationOptions): NativeScriptDoctor.IWarning[];
+		validateMinSupportedTargetSdk(
+			options: ITargetValidationOptions
+		): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Validates if the provided targetSdk is lower that the maximum supported target SDK.
 		 * @param {ITargetValidationOptions} options The targetSdk to be validated and the project directory - used to determine the Android Runtime version.
 		 * @return {NativeScriptDoctor.IWarning[]} An array of errors from the validation checks. If there are no errors will return [].
 		 */
-		validataMaxSupportedTargetSdk(options: ITargetValidationOptions): NativeScriptDoctor.IWarning[];
+		validataMaxSupportedTargetSdk(
+			options: ITargetValidationOptions
+		): NativeScriptDoctor.IWarning[];
 
 		/**
 		 * Returns the path to the emulator executable.


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
