### PR TITLE
chore: fix tests

### DIFF
--- a/lib/services/ios/xcodebuild-args-service.ts
+++ b/lib/services/ios/xcodebuild-args-service.ts
@@ -115,6 +115,7 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 			platformData.projectRoot,
 			`${projectData.projectName}.xcworkspace`
 		);
+
 		// Introduced in Xcode 14+
 		// ref: https://forums.swift.org/t/telling-xcode-14-beta-4-to-trust-build-tool-plugins-programatically/59305/5
 		const skipPackageValidation = "-skipPackagePluginValidation";

--- a/test/services/ios/xcodebuild-args-service.ts
+++ b/test/services/ios/xcodebuild-args-service.ts
@@ -138,30 +138,19 @@ describe("xcodebuildArgsService", () => {
 					{ deviceInfo: { activeArchitecture: "arm64" } },
 					{ deviceInfo: { activeArchitecture: "armv7" } },
 				],
-				expectedArgs: [
-					"-skipPackagePluginValidation",
-					"ONLY_ACTIVE_ARCH=NO",
-					"-sdk",
-					"iphoneos",
-				].concat(getCommonArgs()),
+				expectedArgs: ["ONLY_ACTIVE_ARCH=NO", "-sdk", "iphoneos"].concat(
+					getCommonArgs()
+				),
 			},
 			{
 				name: "should return correct args when there is only one connected device",
 				connectedDevices: [{ deviceInfo: { activeArchitecture: "arm64" } }],
-				expectedArgs: [
-					"-skipPackagePluginValidation",
-					"-sdk",
-					"iphoneos",
-				].concat(getCommonArgs()),
+				expectedArgs: ["-sdk", "iphoneos"].concat(getCommonArgs()),
 			},
 			{
 				name: "should return correct args when no connected devices",
 				connectedDevices: [],
-				expectedArgs: [
-					"-skipPackagePluginValidation",
-					"-sdk",
-					"iphoneos",
-				].concat(getCommonArgs()),
+				expectedArgs: ["-sdk", "iphoneos"].concat(getCommonArgs()),
 			},
 		];
 

--- a/test/services/ios/xcodebuild-args-service.ts
+++ b/test/services/ios/xcodebuild-args-service.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as _ from "lodash";
 import { assert } from "chai";
 import { IInjector } from "../../../lib/common/definitions/yok";
+import { BUILD_XCCONFIG_FILE_NAME } from "../../../lib/constants";
 
 function createTestInjector(data: {
 	logLevel: string;
@@ -18,7 +19,13 @@ function createTestInjector(data: {
 		getDevicesForPlatform: () => data.connectedDevices || [],
 	});
 	injector.register("fs", {
-		exists: () => data.hasProjectWorkspace,
+		exists: (filepath: string) => {
+			if (filepath.includes(BUILD_XCCONFIG_FILE_NAME)) {
+				return true;
+			} else {
+				return data.hasProjectWorkspace;
+			}
+		},
 	});
 	injector.register("logger", {
 		getLevel: () => data.logLevel,
@@ -32,6 +39,8 @@ function createTestInjector(data: {
 }
 
 const projectRoot = "path/to/my/app/folder/platforms/ios";
+const normalizedPlatformName = "iOS";
+const appResourcesDirectoryPath = "App_Resources";
 const projectName = "myApp";
 const buildOutputPath = path.join(projectRoot, projectName, "archive");
 
@@ -43,18 +52,27 @@ function getCommonArgs() {
 }
 
 function getXcodeProjectArgs(data?: { hasProjectWorkspace: boolean }) {
+	const extraArgs = [
+		"-scheme",
+		projectName,
+		"-skipPackagePluginValidation",
+		"-xcconfig",
+		path.join(
+			appResourcesDirectoryPath,
+			normalizedPlatformName,
+			BUILD_XCCONFIG_FILE_NAME
+		),
+	];
 	return data && data.hasProjectWorkspace
 		? [
 				"-workspace",
 				path.join(projectRoot, `${projectName}.xcworkspace`),
-				"-scheme",
-				projectName,
+				...extraArgs,
 		  ]
 		: [
 				"-project",
 				path.join(projectRoot, `${projectName}.xcodeproj`),
-				"-scheme",
-				projectName,
+				...extraArgs,
 		  ];
 }
 
@@ -84,11 +102,12 @@ describe("xcodebuildArgsService", () => {
 						const xcodebuildArgsService = injector.resolve(
 							"xcodebuildArgsService"
 						);
-						const actualArgs = await xcodebuildArgsService.getBuildForSimulatorArgs(
-							{ projectRoot },
-							{ projectName },
-							buildConfig
-						);
+						const actualArgs =
+							await xcodebuildArgsService.getBuildForSimulatorArgs(
+								{ projectRoot, normalizedPlatformName },
+								{ projectName, appResourcesDirectoryPath },
+								buildConfig
+							);
 
 						const expectedArgs = [
 							"ONLY_ACTIVE_ARCH=NO",
@@ -114,26 +133,35 @@ describe("xcodebuildArgsService", () => {
 	describe("getBuildForDeviceArgs", () => {
 		const testCases = [
 			{
-				name:
-					"should return correct args when there are more than one connected device",
+				name: "should return correct args when there are more than one connected device",
 				connectedDevices: [
 					{ deviceInfo: { activeArchitecture: "arm64" } },
 					{ deviceInfo: { activeArchitecture: "armv7" } },
 				],
-				expectedArgs: ["ONLY_ACTIVE_ARCH=NO", "-sdk", "iphoneos"].concat(
-					getCommonArgs()
-				),
+				expectedArgs: [
+					"-skipPackagePluginValidation",
+					"ONLY_ACTIVE_ARCH=NO",
+					"-sdk",
+					"iphoneos",
+				].concat(getCommonArgs()),
 			},
 			{
-				name:
-					"should return correct args when there is only one connected device",
+				name: "should return correct args when there is only one connected device",
 				connectedDevices: [{ deviceInfo: { activeArchitecture: "arm64" } }],
-				expectedArgs: ["-sdk", "iphoneos"].concat(getCommonArgs()),
+				expectedArgs: [
+					"-skipPackagePluginValidation",
+					"-sdk",
+					"iphoneos",
+				].concat(getCommonArgs()),
 			},
 			{
 				name: "should return correct args when no connected devices",
 				connectedDevices: [],
-				expectedArgs: ["-sdk", "iphoneos"].concat(getCommonArgs()),
+				expectedArgs: [
+					"-skipPackagePluginValidation",
+					"-sdk",
+					"iphoneos",
+				].concat(getCommonArgs()),
 			},
 		];
 
@@ -150,21 +178,25 @@ describe("xcodebuildArgsService", () => {
 
 							const platformData = {
 								projectRoot,
+								normalizedPlatformName,
 								getBuildOutputPath: () => buildOutputPath,
 							};
-							const projectData = { projectName };
+							const projectData = {
+								projectName,
+								appResourcesDirectoryPath,
+							};
 							const buildConfig = {
 								buildForDevice: true,
 								release: configuration === "Release",
 							};
-							const xcodebuildArgsService: IXcodebuildArgsService = injector.resolve(
-								"xcodebuildArgsService"
-							);
-							const actualArgs = await xcodebuildArgsService.getBuildForDeviceArgs(
-								<any>platformData,
-								<any>projectData,
-								<any>buildConfig
-							);
+							const xcodebuildArgsService: IXcodebuildArgsService =
+								injector.resolve("xcodebuildArgsService");
+							const actualArgs =
+								await xcodebuildArgsService.getBuildForDeviceArgs(
+									<any>platformData,
+									<any>projectData,
+									<any>buildConfig
+								);
 
 							const expectedArgs = [
 								"-destination",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
