### PR TITLE
fix host localhost for debug ios

### DIFF
--- a/lib/device-sockets/ios/app-debug-socket-proxy-factory.ts
+++ b/lib/device-sockets/ios/app-debug-socket-proxy-factory.ts
@@ -157,7 +157,6 @@ export class AppDebugSocketProxyFactory
 		let currentWebSocket: ws = null;
 		const server = new ws.Server(<any>{
 			port: localPort,
-			host: "localhost",
 			verifyClient: async (
 				info: any,
 				callback: (res: boolean, code?: number, message?: string) => void


### PR DESCRIPTION
This solves the problem we had debugging in vscode on ios. The problem was that when an address was not set the plugin used 127.0.0.1 when forcing localhost it worked, but now I am migrating the old [`vscode-chrome-debug-core`](https://github.com/microsoft/vscode-chrome-debug-core)   to `vscode-cdp-proxy` which uses `ws` below and when using the `localhost` address it resolves it as 127.0.0.1 and the cli does not accept the connection.
I have tried chromeDevTool and it still works with this change
