### PR TITLE
feat: Add support for 'projectName' setting (#2107)

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -161,6 +161,7 @@ interface INsConfig {
 	visionos?: INSConfigVisionOS;
 	ignoredNativeDependencies?: string[];
 	hooks?: INsConfigHooks[];
+	projectName?: string;
 }
 
 interface IProjectData extends ICreateProjectData {
@@ -195,6 +196,7 @@ interface IProjectData extends ICreateProjectData {
 	 * The value can be changed by setting `webpackConfigPath` in nativescript.config.
 	 */
 	webpackConfigPath: string;
+	projectName: string;
 
 	/**
 	 * Initializes project data with the given project directory. If none supplied defaults to --path option or cwd.

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -162,9 +162,10 @@ export class ProjectData implements IProjectData {
 		}
 
 		if (packageJsonData) {
-			this.projectName = this.$projectHelper.sanitizeName(
-				path.basename(projectDir)
-			);
+			this.projectName =
+				nsConfig && nsConfig.projectName
+					? nsConfig.projectName
+					: this.$projectHelper.sanitizeName(path.basename(projectDir));
 			this.platformsDir = path.join(projectDir, constants.PLATFORMS_DIR_NAME);
 			this.projectFilePath = projectFilePath;
 			this.projectIdentifiers = this.initializeProjectIdentifiers(nsConfig);

--- a/test/project-data.ts
+++ b/test/project-data.ts
@@ -53,7 +53,11 @@ describe("projectData", () => {
 			dependencies?: IStringDictionary;
 			devDependencies: IStringDictionary;
 		};
-		configData?: { shared?: boolean; webpackConfigPath?: string };
+		configData?: {
+			shared?: boolean;
+			webpackConfigPath?: string;
+			projectName?: string;
+		};
 	}): IProjectData => {
 		const testInjector = createTestInjector();
 		const fs = testInjector.resolve("fs");
@@ -169,6 +173,20 @@ describe("projectData", () => {
 		it("is true when nsconfig.json exists and shared value is true", () => {
 			const projectData = prepareTest({ configData: { shared: true } });
 			assert.isTrue(projectData.isShared);
+		});
+	});
+
+	describe("projectName", () => {
+		it("has correct name when no value is set in nativescript.conf", () => {
+			const projectData = prepareTest();
+			assert.isString("projectDir", projectData.projectName);
+		});
+
+		it("has correct name when a project name is set in nativescript.conf", () => {
+			const projectData = prepareTest({
+				configData: { projectName: "specifiedProjectName" },
+			});
+			assert.isString("specifiedProjectName", projectData.projectName);
 		});
 	});
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Currently the files generated during the build process take the project name from the basename of the directory the project is contained in.  

## What is the new behavior?
If (and only if) the new 'projectName' setting is present in the nativescript.config.ts file, the name specified there is used instead of the basename of the project directory.

Fixes/Implements/Closes #2107
(Note on iOS this requires an additional patch to @nativescript/webpack5 that will be linked below)
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
