### PR TITLE
fix(windows): make compatible with latest node patch levels

### DIFF
--- a/lib/base-package-manager.ts
+++ b/lib/base-package-manager.ts
@@ -111,6 +111,7 @@ export abstract class BasePackageManager implements INodePackageManager {
 		await this.$childProcess.spawnFromEvent(npmExecutable, params, "close", {
 			cwd: opts.cwd,
 			stdio: stdioValue,
+			shell: this.$hostInfo.isWindows,
 		});
 
 		// Whenever calling "npm install" or "yarn add" without any arguments (hence installing all dependencies) no output is emitted on stdout

--- a/lib/commands/typings.ts
+++ b/lib/commands/typings.ts
@@ -173,7 +173,7 @@ export class TypingsCommand implements ICommand {
 				this.$hostInfo.isWindows ? "ns.cmd" : "ns",
 				["prepare", "android"],
 				"exit",
-				{ stdio: "inherit" }
+				{ stdio: "inherit", shell: this.$hostInfo.isWindows }
 			);
 		}
 

--- a/lib/common/mobile/android/android-virtual-device-service.ts
+++ b/lib/common/mobile/android/android-virtual-device-service.ts
@@ -22,7 +22,8 @@ import {
 import { injector } from "../../yok";
 
 export class AndroidVirtualDeviceService
-	implements Mobile.IAndroidVirtualDeviceService {
+	implements Mobile.IAndroidVirtualDeviceService
+{
 	private androidHome: string;
 	private mapEmulatorIdToImageIdentifier: IStringDictionary = {};
 
@@ -211,7 +212,8 @@ export class AndroidVirtualDeviceService
 		let result: ISpawnResult = null;
 		let devices: Mobile.IDeviceInfo[] = [];
 		let errors: string[] = [];
-		const canExecuteAvdManagerCommand = await this.canExecuteAvdManagerCommand();
+		const canExecuteAvdManagerCommand =
+			await this.canExecuteAvdManagerCommand();
 		if (!canExecuteAvdManagerCommand) {
 			errors = [
 				"Unable to execute avdmanager, ensure JAVA_HOME is set and points to correct directory",
@@ -221,7 +223,8 @@ export class AndroidVirtualDeviceService
 		if (canExecuteAvdManagerCommand) {
 			result = await this.$childProcess.trySpawnFromCloseEvent(
 				this.pathToAvdManagerExecutable,
-				["list", "avds"]
+				["list", "avds"],
+				{ shell: this.$hostInfo.isWindows }
 			);
 		} else if (
 			this.pathToAndroidExecutable &&
@@ -403,9 +406,8 @@ export class AndroidVirtualDeviceService
 	private getAvdManagerDeviceInfo(
 		output: string
 	): Mobile.IAvdManagerDeviceInfo {
-		const avdManagerDeviceInfo: Mobile.IAvdManagerDeviceInfo = Object.create(
-			null
-		);
+		const avdManagerDeviceInfo: Mobile.IAvdManagerDeviceInfo =
+			Object.create(null);
 
 		// Split by `\n`, not EOL as the avdmanager and android executables print results with `\n` only even on Windows
 		_.reduce(
@@ -437,9 +439,8 @@ export class AndroidVirtualDeviceService
 			avdFilePath,
 			AndroidVirtualDevice.CONFIG_INI_FILE_NAME
 		);
-		const configIniFileInfo = this.$androidIniFileParser.parseIniFile(
-			configIniFilePath
-		);
+		const configIniFileInfo =
+			this.$androidIniFileParser.parseIniFile(configIniFilePath);
 
 		const iniFilePath = this.getIniFilePath(configIniFileInfo, avdFilePath);
 		const iniFileInfo = this.$androidIniFileParser.parseIniFile(iniFilePath);

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -815,6 +815,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			await this.$childProcess.spawnFromEvent(gradlew, localArgs, "close", {
 				cwd: pluginBuildSettings.pluginDir,
 				stdio: "inherit",
+				shell: this.$hostInfo.isWindows,
 			});
 		} catch (err) {
 			this.$errors.fail(

--- a/lib/services/android/gradle-command-service.ts
+++ b/lib/services/android/gradle-command-service.ts
@@ -26,7 +26,11 @@ export class GradleCommandService implements IGradleCommandService {
 		const { message, cwd, stdio, spawnOptions } = options;
 		this.$logger.info(message);
 
-		const childProcessOptions = { cwd, stdio: stdio || "inherit" };
+		const childProcessOptions = {
+			cwd,
+			stdio: stdio || "inherit",
+			shell: this.$hostInfo.isWindows,
+		};
 		const gradleExecutable =
 			options.gradlePath ??
 			(this.$hostInfo.isWindows ? "gradlew.bat" : "./gradlew");
@@ -44,7 +48,7 @@ export class GradleCommandService implements IGradleCommandService {
 	private async executeCommandSafe(
 		gradleExecutable: string,
 		gradleArgs: string[],
-		childProcessOptions: { cwd: string; stdio: string },
+		childProcessOptions: { cwd: string; stdio: string; shell: boolean },
 		spawnOptions: ISpawnFromEventOptions
 	): Promise<ISpawnResult> {
 		try {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Various commands will fail on windows with EINVAL on the latest patch level of node due to node patch for CVE-2024-27980

## What is the new behavior?
<!-- Describe the changes. -->

Commands should execute correctly.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
