### PR TITLE
feat: migrate 8.8 and associated depedencies

### DIFF
--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -121,7 +121,7 @@ export class MigrateController
 		{
 			packageName: "@nativescript/core",
 			minVersion: "6.5.0",
-			desiredVersion: "~8.7.0",
+			desiredVersion: "~8.8.0",
 			shouldAddIfMissing: true,
 		},
 		{
@@ -131,7 +131,7 @@ export class MigrateController
 		{
 			packageName: "@nativescript/types",
 			minVersion: "7.0.0",
-			desiredVersion: "~8.7.0",
+			desiredVersion: "~8.8.0",
 			isDev: true,
 		},
 		{
@@ -190,7 +190,7 @@ export class MigrateController
 		{
 			packageName: "@nativescript/angular",
 			minVersion: "10.0.0",
-			desiredVersion: "^17.0.0",
+			desiredVersion: "^18.0.0",
 			async shouldMigrateAction(
 				dependency: IMigrationDependency,
 				projectData: IProjectData,
@@ -295,13 +295,13 @@ export class MigrateController
 		{
 			packageName: "@nativescript/ios",
 			minVersion: "6.5.3",
-			desiredVersion: "~8.7.0",
+			desiredVersion: "~8.8.0",
 			isDev: true,
 		},
 		{
 			packageName: "@nativescript/android",
 			minVersion: "7.0.0",
-			desiredVersion: "~8.7.0",
+			desiredVersion: "~8.8.0",
 			isDev: true,
 		},
 	];
@@ -1310,7 +1310,7 @@ export class MigrateController
 
 	private async migrateNativeScriptAngular(): Promise<IMigrationDependency[]> {
 		const minVersion = "10.0.0";
-		const desiredVersion = "~17.3.0";
+		const desiredVersion = "~18.0.0";
 
 		const dependencies: IMigrationDependency[] = [
 			{


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base

## What is the current behavior?

ns migrate would go to 8.7.

## What is the new behavior?

ns migrate will now go to 8.8 in addition to bumping all associated dependencies.

