### PR TITLE
fix: quote windows command line arguments

### DIFF
--- a/lib/base-package-manager.ts
+++ b/lib/base-package-manager.ts
@@ -1,4 +1,4 @@
-import { isInteractive } from "./common/helpers";
+import { isInteractive, quoteString } from "./common/helpers";
 import {
 	INodePackageManager,
 	INodePackageManagerInstallOptions,
@@ -108,11 +108,19 @@ export abstract class BasePackageManager implements INodePackageManager {
 	): Promise<INpmInstallResultInfo> {
 		const npmExecutable = this.getPackageManagerExecutableName();
 		const stdioValue = isInteractive() ? "inherit" : "pipe";
-		await this.$childProcess.spawnFromEvent(npmExecutable, params, "close", {
-			cwd: opts.cwd,
-			stdio: stdioValue,
-			shell: this.$hostInfo.isWindows,
-		});
+		const sanitizedNpmExecutable = this.$hostInfo.isWindows
+			? quoteString(npmExecutable)
+			: npmExecutable;
+		await this.$childProcess.spawnFromEvent(
+			sanitizedNpmExecutable,
+			params,
+			"close",
+			{
+				cwd: opts.cwd,
+				stdio: stdioValue,
+				shell: this.$hostInfo.isWindows,
+			}
+		);
 
 		// Whenever calling "npm install" or "yarn add" without any arguments (hence installing all dependencies) no output is emitted on stdout
 		// Luckily, whenever you call "npm install" or "yarn add" to install all dependencies chances are you won't need the name/version of the package you're installing because there is none.

--- a/lib/common/mobile/android/android-virtual-device-service.ts
+++ b/lib/common/mobile/android/android-virtual-device-service.ts
@@ -9,7 +9,7 @@ import {
 	NOT_RUNNING_EMULATOR_STATUS,
 } from "../../constants";
 import { cache } from "../../decorators";
-import { settlePromises } from "../../helpers";
+import { quoteString, settlePromises } from "../../helpers";
 import { DeviceConnectionType } from "../../../constants";
 import {
 	IStringDictionary,
@@ -221,8 +221,11 @@ export class AndroidVirtualDeviceService
 		}
 
 		if (canExecuteAvdManagerCommand) {
+			const sanitizedPathToAvdManagerExecutable = this.$hostInfo.isWindows
+				? quoteString(this.pathToAvdManagerExecutable)
+				: this.pathToAvdManagerExecutable;
 			result = await this.$childProcess.trySpawnFromCloseEvent(
-				this.pathToAvdManagerExecutable,
+				sanitizedPathToAvdManagerExecutable,
 				["list", "avds"],
 				{ shell: this.$hostInfo.isWindows }
 			);

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -8,7 +8,7 @@ import {
 	PLUGIN_BUILD_DATA_FILENAME,
 	SCOPED_ANDROID_RUNTIME_NAME,
 } from "../constants";
-import { getShortPluginName, hook } from "../common/helpers";
+import { getShortPluginName, hook, quoteString } from "../common/helpers";
 import { Builder, parseString } from "xml2js";
 import {
 	IRuntimeGradleVersions,
@@ -841,9 +841,12 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		}
 
 		try {
+			const sanitizedArgs = this.$hostInfo.isWindows
+				? localArgs.map((arg) => quoteString(arg))
+				: localArgs;
 			await this.$childProcess.spawnFromEvent(
 				gradlew,
-				localArgs,
+				sanitizedArgs,
 				"close",
 				opts
 			);

--- a/lib/services/android/gradle-command-service.ts
+++ b/lib/services/android/gradle-command-service.ts
@@ -10,6 +10,7 @@ import {
 	IGradleCommandOptions,
 } from "../../definitions/gradle";
 import { injector } from "../../common/yok";
+import { quoteString } from "../../common/helpers";
 
 export class GradleCommandService implements IGradleCommandService {
 	constructor(
@@ -35,9 +36,12 @@ export class GradleCommandService implements IGradleCommandService {
 			options.gradlePath ??
 			(this.$hostInfo.isWindows ? "gradlew.bat" : "./gradlew");
 
+		const sanitizedGradleArgs = this.$hostInfo.isWindows
+			? gradleArgs.map((arg) => quoteString(arg))
+			: gradleArgs;
 		const result = await this.executeCommandSafe(
 			gradleExecutable,
-			gradleArgs,
+			sanitizedGradleArgs,
 			childProcessOptions,
 			spawnOptions
 		);


### PR DESCRIPTION
This is a follow up of https://github.com/NativeScript/nativescript-cli/pull/5802

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When building on windows, the new `shell: true` option doesn't escape arguments anymore, meaning that any commands that had spaces in their path would not work. This includes npm/adb/avd paths and app paths (that get passed to gradle via arguments)

## What is the new behavior?
We now quote every command to preserve the previous behavior.

