### PR TITLE
feat: add android 35 support

### DIFF
--- a/lib/common/mobile/emulator-helper.ts
+++ b/lib/common/mobile/emulator-helper.ts
@@ -5,6 +5,7 @@ import { injector } from "../yok";
 export class EmulatorHelper implements Mobile.IEmulatorHelper {
 	// https://developer.android.com/guide/topics/manifest/uses-sdk-element
 	public mapAndroidApiLevelToVersion = {
+		"android-35": "15.0.0",
 		"android-34": "14.0.0",
 		"android-33": "13.0.0",
 		"android-32": "12.0.0",

--- a/packages/doctor/src/android-tools-info.ts
+++ b/packages/doctor/src/android-tools-info.ts
@@ -31,6 +31,7 @@ export class AndroidToolsInfo implements NativeScriptDoctor.IAndroidToolsInfo {
 			"android-32",
 			"android-33",
 			"android-34",
+			"android-35",
 		];
 
 		const isRuntimeVersionLessThan = (targetVersion: string) => {

--- a/packages/doctor/test/android-tools-info.ts
+++ b/packages/doctor/test/android-tools-info.ts
@@ -69,6 +69,7 @@ describe("androidToolsInfo", () => {
 						"android-32",
 						"android-33",
 						"android-34",
+						"android-35",
 					];
 				}
 			},
@@ -138,7 +139,7 @@ describe("androidToolsInfo", () => {
 
 		it("runtime 8.2.0 should support android-17 - android-34", () => {
 			const min = 17;
-			const max = 34;
+			const max = 35;
 			assertSupportedRange("8.2.0", min, max);
 			assertSupportedRange("8.3.0", min, max);
 		});


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
A fresh android studio install does not work as it installs build tools 35 by default. Android sdk 35 is currently unsupported by the CLI

## What is the new behavior?
Adds support for android 35
