### PR TITLE
feat: build flag to append generated suffix to bundles

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -194,7 +194,7 @@ export class PrepareController extends EventEmitter {
 			};
 		}
 
-		await this.writeRuntimePackageJson(projectData, platformData);
+		await this.writeRuntimePackageJson(projectData, platformData, prepareData);
 
 		await this.$projectChangesService.savePrepareInfo(
 			platformData,
@@ -433,7 +433,8 @@ export class PrepareController extends EventEmitter {
 	 */
 	public async writeRuntimePackageJson(
 		projectData: IProjectData,
-		platformData: IPlatformData
+		platformData: IPlatformData,
+		prepareData: IPrepareData = null
 	) {
 		const configInfo = this.$projectConfigService.detectProjectConfigs(
 			projectData.projectDir
@@ -507,6 +508,10 @@ export class PrepareController extends EventEmitter {
 				"Failed to read emitted package.json. Error is: ",
 				error
 			);
+		}
+
+		if (prepareData?.uniqueBundle) {
+			packageData.main = `${packageData.main}.${prepareData.uniqueBundle}`;
 		}
 
 		this.$fs.writeJson(packagePath, packageData);

--- a/lib/data/prepare-data.ts
+++ b/lib/data/prepare-data.ts
@@ -9,6 +9,7 @@ export class PrepareData extends ControllerDataBase {
 	public watch?: boolean;
 	public watchNative: boolean = true;
 	public hostProjectPath?: string;
+	public uniqueBundle: number;
 
 	constructor(
 		public projectDir: string,
@@ -43,6 +44,8 @@ export class PrepareData extends ControllerDataBase {
 			this.watchNative = data.watchNative;
 		}
 		this.hostProjectPath = data.hostProjectPath;
+
+		this.uniqueBundle = !this.watch && data.uniqueBundle ? Date.now() : 0;
 	}
 }
 

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -709,7 +709,7 @@ interface IOptions
 	dryRun: boolean;
 
 	platformOverride: string;
-
+	uniqueBundle: boolean;
 	// allow arbitrary options
 	[optionName: string]: any;
 }

--- a/lib/definitions/prepare.d.ts
+++ b/lib/definitions/prepare.d.ts
@@ -14,6 +14,8 @@ declare global {
 
 		// embedding
 		hostProjectPath?: string;
+
+		uniqueBundle: number;
 	}
 
 	interface IiOSCodeSigningData {

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -250,6 +250,7 @@ export class Options {
 				default: true,
 			},
 			dryRun: { type: OptionType.Boolean, hasSensitiveValue: false },
+			uniqueBundle: { type: OptionType.Boolean, hasSensitiveValue: false },
 		};
 	}
 

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -436,6 +436,10 @@ export class WebpackCompilerService
 			envData.sourceMap = envData.sourceMap === "true";
 		}
 
+		if (prepareData.uniqueBundle > 0) {
+			envData.uniqueBundle = prepareData.uniqueBundle;
+		}
+
 		return envData;
 	}
 

--- a/test/controllers/prepare-controller.ts
+++ b/test/controllers/prepare-controller.ts
@@ -14,6 +14,7 @@ const prepareData = {
 	env: {},
 	watch: true,
 	watchNative: true,
+	uniqueBundle: 0,
 };
 
 let isCompileWithWatchCalled = false;
@@ -72,9 +73,8 @@ function createTestInjector(data: { hasNativeChanges: boolean }): IInjector {
 		},
 	});
 
-	const prepareController: PrepareController = injector.resolve(
-		"prepareController"
-	);
+	const prepareController: PrepareController =
+		injector.resolve("prepareController");
 	prepareController.emit = (eventName: string, eventData: any) => {
 		emittedEventNames.push(eventName);
 		emittedEventData.push(eventData);
@@ -103,9 +103,8 @@ describe("prepareController", () => {
 				it(`should execute native prepare and webpack's compilation for ${platform} platform when hasNativeChanges is ${hasNativeChanges}`, async () => {
 					const injector = createTestInjector({ hasNativeChanges });
 
-					const prepareController: PrepareController = injector.resolve(
-						"prepareController"
-					);
+					const prepareController: PrepareController =
+						injector.resolve("prepareController");
 					await prepareController.prepare({ ...prepareData, platform });
 
 					assert.isTrue(isCompileWithWatchCalled);
@@ -116,9 +115,8 @@ describe("prepareController", () => {
 			it(`should respect native changes that are made before the initial preparation of the project had been done for ${platform}`, async () => {
 				const injector = createTestInjector({ hasNativeChanges: false });
 
-				const prepareController: PrepareController = injector.resolve(
-					"prepareController"
-				);
+				const prepareController: PrepareController =
+					injector.resolve("prepareController");
 
 				const prepareNativePlatformService = injector.resolve(
 					"prepareNativePlatformService"
@@ -158,9 +156,8 @@ describe("prepareController", () => {
 			it("shouldn't start the watcher when watch is false", async () => {
 				const injector = createTestInjector({ hasNativeChanges: false });
 
-				const prepareController: PrepareController = injector.resolve(
-					"prepareController"
-				);
+				const prepareController: PrepareController =
+					injector.resolve("prepareController");
 				await prepareController.prepare({
 					...prepareData,
 					watch: false,


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See discussion:  https://discord.com/channels/603595811204366337/1276116878154268763

It seems to be the case that sometimes when an iOS app is updating it does not overwrite the old js files with the new versions, resulting in app crashes etc.

## What is the new behaviour?
<!-- Describe the changes. -->

This adds a new flag `--unique-bundle` which instructs the cli to generate an id, which is then passed to webpack to be appended as a suffix to generated bundle names.

The cli then uses this id to set the main entry in the package.json in the resulting app.

Note:  In the discussion linked to above the files are generated with hashes, but then it becomes complicated to find the correct name of the main entry and I believe more brittle. An option would be to use something like the `webpack-manifest-plugin` to find the hashed value, or just assume a pattern but this seems a more straightforward solution.

 
There is a corresponding `@nativescript/webpack` PR [#10614](https://github.com/NativeScript/NativeScript/pull/10614)


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
