### PR TITLE
fix(android): emulator ini file parsing

### DIFF
--- a/lib/common/mobile/android/android-ini-file-parser.ts
+++ b/lib/common/mobile/android/android-ini-file-parser.ts
@@ -20,26 +20,28 @@ export class AndroidIniFileParser implements Mobile.IAndroidIniFileParser {
 			contents,
 			(result: Mobile.IAvdInfo, line: string) => {
 				const parsedLine = line.split("=");
-				const key = parsedLine[0];
+
+				const key = parsedLine[0]?.trim();
+				const value = parsedLine[1]?.trim();
 				switch (key) {
 					case "target":
-						result.target = parsedLine[1];
+						result.target = value;
 						result.targetNum = this.readTargetNum(result.target);
 						break;
 					case "path":
 					case "AvdId":
-						result[_.lowerFirst(key)] = parsedLine[1];
+						result[_.lowerFirst(key)] = value;
 						break;
 					case "hw.device.name":
-						result.device = parsedLine[1];
+						result.device = value;
 						break;
 					case "avd.ini.displayname":
-						result.displayName = parsedLine[1];
+						result.displayName = value;
 						break;
 					case "abi.type":
 					case "skin.name":
 					case "sdcard.size":
-						result[key.split(".")[0]] = parsedLine[1];
+						result[key.split(".")[0]] = value;
 						break;
 				}
 				return result;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When setting up a new Mac I found that `ns run android` would not find and launch the android emulator, this is a result of the AVD config file having a space at the end of the key, which forces the code to rely on defaults, which did not match what android studio did in creating the VM.  This may be new android studio behaviour, as the previous code worked on my previous setups ( Win & Mac).

## What is the new behavior?
<!-- Describe the changes. -->

`ns run android` should launch the android simulator if it is not running.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
