### PR TITLE
fix: ios-device-lib compiled with arm and x64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "esprima": "4.0.1",
         "font-finder": "1.1.0",
         "glob": "9.3.4",
-        "ios-device-lib": "0.9.3",
+        "ios-device-lib": "0.9.4",
         "ios-mobileprovision-finder": "1.2.1",
         "ios-sim-portable": "4.5.0",
         "jimp": "0.22.10",
@@ -7591,9 +7591,9 @@
       "license": "MIT"
     },
     "node_modules/ios-device-lib": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.9.3.tgz",
-      "integrity": "sha512-LwkC7O6S0XwslkHLtEcNLwNdBuDq2Aeit60ZO+mrOyMUKPpCJHZs2decTJdsx5uIKwLZkxd5mmcUdxlMAwsiLQ==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.9.4.tgz",
+      "integrity": "sha512-UoR3+JZ4Ox9xSbp4sM6kMQu7JL5RLqgSS4gLy39hAYYtZqMpNB/u47uN63ZEq/RhqtrNFub/w7t3QicLLQ9bvg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bufferpack": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "esprima": "4.0.1",
     "font-finder": "1.1.0",
     "glob": "9.3.4",
-    "ios-device-lib": "0.9.3",
+    "ios-device-lib": "0.9.4",
     "ios-mobileprovision-finder": "1.2.1",
     "ios-sim-portable": "4.5.0",
     "jimp": "0.22.10",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The previous  ios-device-lib was compiled with x64 only, so `ns device` failed silently on a new apple silicon Mac without Rosetta installed.

## What is the new behavior?
<!-- Describe the changes. -->

New ios-device-lib was compiled with x64 & arm so works without Rosetta.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
