### PR TITLE
feat(ios): multi target support for swift packages

### DIFF
--- a/lib/definitions/ios.d.ts
+++ b/lib/definitions/ios.d.ts
@@ -41,16 +41,18 @@ declare global {
 		): Promise<string>;
 	}
 
+	type IosSPMPackage = IosSPMPackageDefinition & { targets?: string[] };
+
 	interface ISPMService {
 		applySPMPackages(
 			platformData: IPlatformData,
 			projectData: IProjectData,
-			pluginSpmPackages?: IosSPMPackageDefinition[]
+			pluginSpmPackages?: IosSPMPackage[]
 		);
 		getSPMPackages(
 			projectData: IProjectData,
 			platform: string
-		): IosSPMPackageDefinition[];
+		): IosSPMPackage[];
 	}
 
 	interface IXcodebuildArgsService {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -1425,7 +1425,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 
 		if (addedExtensionsFromResources || addedExtensionsFromPlugins) {
 			this.$logger.warn(
-				"The support for iOS App Extensions is currently in Beta. For more information about the current development state and any known issues, please check the relevant GitHub issue: https://github.com/NativeScript/nativescript-cli/issues/4472"
+				"Let us know if there are other Extension features you'd like! https://github.com/NativeScript/NativeScript/issues"
 			);
 		}
 	}

--- a/lib/services/ios/spm-service.ts
+++ b/lib/services/ios/spm-service.ts
@@ -18,7 +18,7 @@ export class SPMService implements ISPMService {
 	public getSPMPackages(
 		projectData: IProjectData,
 		platform: string
-	): IosSPMPackageDefinition[] {
+	): IosSPMPackage[] {
 		const spmPackages = this.$projectConfigService.getValue(
 			`${platform}.SPMPackages`,
 			[]
@@ -35,7 +35,7 @@ export class SPMService implements ISPMService {
 	public async applySPMPackages(
 		platformData: IPlatformData,
 		projectData: IProjectData,
-		pluginSpmPackages?: IosSPMPackageDefinition[]
+		pluginSpmPackages?: IosSPMPackage[]
 	) {
 		try {
 			const spmPackages = this.getSPMPackages(

--- a/lib/services/ios/spm-service.ts
+++ b/lib/services/ios/spm-service.ts
@@ -76,6 +76,13 @@ export class SPMService implements ISPMService {
 				}
 				this.$logger.trace(`SPM: adding package ${pkg.name} to project.`, pkg);
 				await project.ios.addSPMPackage(projectData.projectName, pkg);
+
+				// Add to other Targets if specified (like widgets, etc.)
+				if (pkg.targets?.length) {
+					for (const target of pkg.targets) {
+						await project.ios.addSPMPackage(target, pkg);
+					}
+				}
 			}
 			await project.commit();
 


### PR DESCRIPTION
Allows iOS widgets/extensions to utilize swift packages defined by `nativescript.config`

https://github.com/NativeScript/NativeScript/pull/10695
https://github.com/rigor789/trapeze/pull/1/files