### PR TITLE
feat: bundler config

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -182,6 +182,7 @@ interface INsConfig {
 	shared?: boolean;
 	overridePods?: string;
 	webpackConfigPath?: string;
+	bundlerConfigPath?: string;
 	ios?: INsConfigIOS;
 	android?: INsConfigAndroid;
 	visionos?: INSConfigVisionOS;
@@ -217,11 +218,17 @@ interface IProjectData extends ICreateProjectData {
 	isShared: boolean;
 
 	/**
+	 * @deprecated Use bundlerConfigPath
 	 * Defines the path to the configuration file passed to webpack process.
 	 * By default this is the webpack.config.js at the root of the application.
 	 * The value can be changed by setting `webpackConfigPath` in nativescript.config.
 	 */
 	webpackConfigPath: string;
+	/**
+	 * Defines the path to the bundler configuration file passed to the compiler.
+	 * The value can be changed by setting `bundlerConfigPath` in nativescript.config.
+	 */
+	bundlerConfigPath: string;
 	projectName: string;
 
 	/**

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -99,6 +99,7 @@ export class ProjectData implements IProjectData {
 	public podfilePath: string;
 	public isShared: boolean;
 	public webpackConfigPath: string;
+	public bundlerConfigPath: string;
 	public initialized: boolean;
 
 	constructor(
@@ -110,7 +111,7 @@ export class ProjectData implements IProjectData {
 		private $logger: ILogger,
 		private $injector: IInjector,
 		private $androidResourcesMigrationService: IAndroidResourcesMigrationService,
-		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants
+		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 	) {}
 
 	get projectConfig(): IProjectConfigService {
@@ -142,7 +143,7 @@ export class ProjectData implements IProjectData {
 
 	public initializeProjectDataFromContent(
 		packageJsonContent: string,
-		projectDir?: string
+		projectDir?: string,
 	): void {
 		projectDir = projectDir || this.$projectHelper.projectDir || "";
 		this.projectDir = projectDir;
@@ -157,7 +158,7 @@ export class ProjectData implements IProjectData {
 			this.$errors.fail(
 				`The project file ${this.projectFilePath} is corrupted. ${EOL}` +
 					`Consider restoring an earlier version from your source control or backup.${EOL}` +
-					`Additional technical info: ${err.toString()}`
+					`Additional technical info: ${err.toString()}`,
 			);
 		}
 
@@ -178,36 +179,40 @@ export class ProjectData implements IProjectData {
 			this.appDirectoryPath = this.getAppDirectoryPath();
 			this.appResourcesDirectoryPath = this.getAppResourcesDirectoryPath();
 			this.androidManifestPath = this.getPathToAndroidManifest(
-				this.appResourcesDirectoryPath
+				this.appResourcesDirectoryPath,
 			);
 			this.gradleFilesDirectoryPath = path.join(
 				this.appResourcesDirectoryPath,
-				this.$devicePlatformsConstants.Android
+				this.$devicePlatformsConstants.Android,
 			);
 			this.appGradlePath = path.join(
 				this.gradleFilesDirectoryPath,
-				constants.APP_GRADLE_FILE_NAME
+				constants.APP_GRADLE_FILE_NAME,
 			);
 			this.infoPlistPath = path.join(
 				this.appResourcesDirectoryPath,
 				this.$devicePlatformsConstants.iOS,
-				constants.INFO_PLIST_FILE_NAME
+				constants.INFO_PLIST_FILE_NAME,
 			);
 			this.buildXcconfigPath = path.join(
 				this.appResourcesDirectoryPath,
 				this.$devicePlatformsConstants.iOS,
-				constants.BUILD_XCCONFIG_FILE_NAME
+				constants.BUILD_XCCONFIG_FILE_NAME,
 			);
 			this.podfilePath = path.join(
 				this.appResourcesDirectoryPath,
 				this.$devicePlatformsConstants.iOS,
-				constants.PODFILE_NAME
+				constants.PODFILE_NAME,
 			);
 			this.isShared = !!(this.nsConfig && this.nsConfig.shared);
 			this.webpackConfigPath =
 				this.nsConfig && this.nsConfig.webpackConfigPath
 					? path.resolve(this.projectDir, this.nsConfig.webpackConfigPath)
 					: path.join(this.projectDir, "webpack.config.js");
+			this.bundlerConfigPath =
+				this.nsConfig && this.nsConfig.bundlerConfigPath
+					? path.resolve(this.projectDir, this.nsConfig.bundlerConfigPath)
+					: null;
 			return;
 		}
 
@@ -217,7 +222,7 @@ export class ProjectData implements IProjectData {
 	private getPathToAndroidManifest(appResourcesDir: string): string {
 		const androidDirPath = path.join(
 			appResourcesDir,
-			this.$devicePlatformsConstants.Android
+			this.$devicePlatformsConstants.Android,
 		);
 		const androidManifestDir =
 			this.$androidResourcesMigrationService.hasMigrated(appResourcesDir)
@@ -230,13 +235,13 @@ export class ProjectData implements IProjectData {
 	private errorInvalidProject(projectDir: string): void {
 		const currentDir = path.resolve(".");
 		this.$logger.trace(
-			`Unable to find project. projectDir: ${projectDir}, options.path: ${this.$options.path}, ${currentDir}`
+			`Unable to find project. projectDir: ${projectDir}, options.path: ${this.$options.path}, ${currentDir}`,
 		);
 
 		// This is the case when no project file found
 		this.$errors.fail(
 			"No project found at or above '%s' and neither was a --path specified.",
-			projectDir || this.$options.path || currentDir
+			projectDir || this.$options.path || currentDir,
 		);
 	}
 
@@ -291,7 +296,7 @@ export class ProjectData implements IProjectData {
 
 	private resolveToProjectDir(
 		pathToResolve: string,
-		projectDir?: string
+		projectDir?: string,
 	): string {
 		if (!projectDir) {
 			projectDir = this.projectDir;
@@ -306,7 +311,7 @@ export class ProjectData implements IProjectData {
 
 	@cache()
 	private initializeProjectIdentifiers(
-		config: INsConfig
+		config: INsConfig,
 	): Mobile.IProjectIdentifier {
 		this.$logger.trace(`Initializing project identifiers. Config: `, config);
 
@@ -341,18 +346,18 @@ export class ProjectData implements IProjectData {
 	private getProjectType(): string {
 		let detectedProjectType = _.find(
 			ProjectData.PROJECT_TYPES,
-			(projectType) => projectType.isDefaultProjectType
+			(projectType) => projectType.isDefaultProjectType,
 		).type;
 
 		const deps: string[] = _.keys(this.dependencies).concat(
-			_.keys(this.devDependencies)
+			_.keys(this.devDependencies),
 		);
 
 		_.each(ProjectData.PROJECT_TYPES, (projectType) => {
 			if (
 				_.some(
 					projectType.requiredDependencies,
-					(requiredDependency) => deps.indexOf(requiredDependency) !== -1
+					(requiredDependency) => deps.indexOf(requiredDependency) !== -1,
 				)
 			) {
 				detectedProjectType = projectType.type;
@@ -366,7 +371,7 @@ export class ProjectData implements IProjectData {
 	@cache()
 	private warnProjectId(): void {
 		this.$logger.warn(
-			"[WARNING]: IProjectData.projectId is deprecated. Please use IProjectData.projectIdentifiers[platform]."
+			"[WARNING]: IProjectData.projectId is deprecated. Please use IProjectData.projectIdentifiers[platform].",
 		);
 	}
 }

--- a/lib/services/webpack/webpack-compiler-service.ts
+++ b/lib/services/webpack/webpack-compiler-service.ts
@@ -310,10 +310,18 @@ export class WebpackCompilerService
 		projectData: IProjectData,
 		prepareData: IPrepareData,
 	): Promise<child_process.ChildProcess> {
-		if (!this.$fs.exists(projectData.webpackConfigPath)) {
-			this.$errors.fail(
-				`The webpack configuration file ${projectData.webpackConfigPath} does not exist. Ensure the file exists, or update the path in ${CONFIG_FILE_NAME_DISPLAY}.`,
-			);
+		if (projectData.bundlerConfigPath) {
+			if (!this.$fs.exists(projectData.bundlerConfigPath)) {
+				this.$errors.fail(
+					`The bundler configuration file ${projectData.bundlerConfigPath} does not exist. Ensure the file exists, or update the path in ${CONFIG_FILE_NAME_DISPLAY}.`,
+				);
+			}
+		} else {
+			if (!this.$fs.exists(projectData.webpackConfigPath)) {
+				this.$errors.fail(
+					`The webpack configuration file ${projectData.webpackConfigPath} does not exist. Ensure the file exists, or update the path in ${CONFIG_FILE_NAME_DISPLAY}.`,
+				);
+			}
 		}
 
 		const envData = this.buildEnvData(
@@ -342,7 +350,7 @@ export class WebpackCompilerService
 			...additionalNodeArgs,
 			this.getWebpackExecutablePath(projectData),
 			this.isModernBundler(projectData) ? `build` : null,
-			`--config=${projectData.webpackConfigPath}`,
+			`--config=${projectData.bundlerConfigPath || projectData.webpackConfigPath}`,
 			...envParams,
 		].filter(Boolean);
 

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -658,6 +658,7 @@ export class ProjectDataStub implements IProjectData {
 	projectDir: string;
 	projectName: string;
 	webpackConfigPath: string;
+	bundlerConfigPath: string;
 
 	get platformsDir(): string {
 		return (


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?

Webpack bundler was the only supported bundling option.

## What is the new behavior?

This introduces the ability to specify a `bundler` in `nativescript.config`:

```ts
bundler: 'webpack' | 'rspack' | 'vite' 
```

It deprecates `webpackConfigPath` (will always be supported though) in favor of `bundlerConfigPath` to specify location of the config associated with the defined `bundler`.

https://github.com/NativeScript/nativescript-cli/issues/5836