### PR TITLE
fix: icon generator color type error

### DIFF
--- a/lib/services/assets-generation/assets-generation-service.ts
+++ b/lib/services/assets-generation/assets-generation-service.ts
@@ -226,7 +226,7 @@ export class AssetsGenerationService implements IAssetsGenerationService {
 		return image.scaleToFit({
 			w: width,
 			h: height,
-		}) as any;
+		}) as JimpModule.JimpInstance;
 	}
 
 	private generateImage(


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Right now, cli cannot generate assets the alpha of which is disabled.
Output:
```sh
ns resources generate icons ./icon.png

Generating icons ...
image.colorType is not a function
```
This behaviour broke during 8.9 update and update of `Jimp` dependency.

## What is the new behavior?
Cli will be able to generate assets the alpha of which is disabled (rgba: true).