### PR TITLE
fix: remove --legacy-peer-deps flag on install

### DIFF
--- a/lib/bun-package-manager.ts
+++ b/lib/bun-package-manager.ts
@@ -47,10 +47,7 @@ export class BunPackageManager extends BasePackageManager {
 		const jsonContentBefore = this.$fs.readJson(packageJsonPath);
 
 		const flags = this.getFlagsString(config, true);
-		// TODO: Confirm desired behavior. The npm version uses --legacy-peer-deps
-		// by default, we could use `--no-peer` for Bun if similar is needed; the
-		// pnpm version uses `--shamefully-hoist`, but Bun has no similar flag.
-		let params = ["install", "--legacy-peer-deps"];
+		let params = ["install"];
 		const isInstallingAllDependencies = packageName === pathToSave;
 		if (!isInstallingAllDependencies) {
 			params.push(packageName);

--- a/lib/node-package-manager.ts
+++ b/lib/node-package-manager.ts
@@ -47,7 +47,7 @@ export class NodePackageManager extends BasePackageManager {
 		const jsonContentBefore = this.$fs.readJson(packageJsonPath);
 
 		const flags = this.getFlagsString(config, true);
-		let params = ["install", "--legacy-peer-deps"];
+		let params = ["install"];
 		const isInstallingAllDependencies = packageName === pathToSave;
 		if (!isInstallingAllDependencies) {
 			params.push(packageName);


### PR DESCRIPTION
When run application (without `node_modules`) is launched directly with the `ns run|debug xx` cli, we may encounter dependency issues because this flag causes npm to ignore `peerDependencies`, resulting in an incomplete `node_modules` path.

Documentation: https://docs.npmjs.com/cli/v11/using-npm/config#legacy-peer-deps