### PR TITLE
fix(security): xml2js and braces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "@types/ws": "8.5.14",
         "@types/xml2js": "0.4.14",
         "@types/yargs": "17.0.33",
+        "braces": ">=3.0.3",
         "chai": "5.2.0",
         "chai-as-promised": "8.0.1",
         "conventional-changelog-cli": "^5.0.0",
@@ -122,7 +123,8 @@
         "lint-staged": "~15.4.3",
         "mocha": "11.1.0",
         "sinon": "19.0.2",
-        "source-map-support": "0.5.21"
+        "source-map-support": "0.5.21",
+        "xml2js": ">=0.5.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "@types/ws": "8.5.14",
     "@types/xml2js": "0.4.14",
     "@types/yargs": "17.0.33",
+    "braces": ">=3.0.3",
     "chai": "5.2.0",
     "chai-as-promised": "8.0.1",
     "conventional-changelog-cli": "^5.0.0",
@@ -160,7 +161,8 @@
     "lint-staged": "~15.4.3",
     "mocha": "11.1.0",
     "sinon": "19.0.2",
-    "source-map-support": "0.5.21"
+    "source-map-support": "0.5.21",
+    "xml2js": ">=0.5.0"
   },
   "optionalDependencies": {
     "fsevents": "*"


### PR DESCRIPTION
closes https://github.com/NativeScript/nativescript-cli/security/dependabot/234
closes https://github.com/NativeScript/nativescript-cli/security/dependabot/207