### PR TITLE
fix(android): livesync tool connect race condition

### DIFF
--- a/lib/services/livesync/android-livesync-tool.ts
+++ b/lib/services/livesync/android-livesync-tool.ts
@@ -475,7 +475,9 @@ export class AndroidLivesyncTool implements IAndroidLivesyncTool {
 					this.pendingConnectionData.socketTimer = setTimeout(tryConnect, 1000);
 				};
 
-				this.pendingConnectionData.socket = socket;
+				if (this.pendingConnectionData) {
+					this.pendingConnectionData.socket = socket;
+				}
 
 				socket.once("data", (data) => {
 					socket.removeListener("close", tryConnectAfterTimeout);


### PR DESCRIPTION
On some systems with different node versions, a race condition can occur causing the cli to fail/exit due to race condition on the livesync socket connect handling. This case only needs to assign the socket when the pending connection was still active.