### PR TITLE
fix: remove lock from default clean

### DIFF
--- a/lib/commands/clean.ts
+++ b/lib/commands/clean.ts
@@ -110,7 +110,6 @@ export class CleanCommand implements ICommand {
 			constants.HOOKS_DIR_NAME,
 			constants.PLATFORMS_DIR_NAME,
 			constants.NODE_MODULES_FOLDER_NAME,
-			constants.PACKAGE_LOCK_JSON_FILE_NAME,
 		];
 
 		try {


### PR DESCRIPTION
This is already on the v9 prerelease but cherry-picked to potentially back port to prior versions.