### PR TITLE
fix: windows glob paths used in copy operations not working.

### DIFF
--- a/lib/nativescript-cli.ts
+++ b/lib/nativescript-cli.ts
@@ -3,6 +3,35 @@ require("./bootstrap");
 import * as shelljs from "shelljs";
 shelljs.config.silent = true;
 shelljs.config.fatal = true;
+
+if (process.platform === "win32") {
+	// Later versions of shelljs do not process globs with \ path delimiters correctly, for windows change to /
+	const realcp = shelljs.cp;
+	(shelljs as any).cp = (...args: unknown[]) => {
+		if (args.length === 3) {
+			args[1] = replaceDashes(args[1] as string | string[]);
+		} else {
+			args[0] = replaceDashes(args[0] as string | string[]);
+		}
+
+		if (args.length == 2) {
+			realcp(args[0] as string[], args[1] as string);
+		} else {
+			realcp(args[0] as string, args[1] as string[], args[2] as string);
+		}
+	};
+	function replaceDashes(values: string | string[]): string | string[] {
+		if (Array.isArray(values)) {
+			for (let i = 0; i < values.length; ++i) {
+				values[i] = replaceDashes(values[i]) as string;
+			}
+			return values;
+		} else {
+			return values.replace(/\\/g, "/");
+		}
+	}
+}
+
 import { installUncaughtExceptionListener } from "./common/errors";
 import { settlePromises } from "./common/helpers";
 import { injector } from "./common/yok";
@@ -14,7 +43,7 @@ import {
 import { IInitializeService } from "./definitions/initialize-service";
 import { color } from "./color";
 installUncaughtExceptionListener(
-	process.exit.bind(process, ErrorCodes.UNCAUGHT)
+	process.exit.bind(process, ErrorCodes.UNCAUGHT),
 );
 
 const logger: ILogger = injector.resolve("logger");
@@ -23,7 +52,7 @@ export const originalProcessOn = process.on.bind(process);
 process.on = (event: string, listener: any): any => {
 	if (event === "SIGINT") {
 		logger.trace(
-			`Trying to handle SIGINT event. CLI overrides this behavior and does not allow handling SIGINT as this causes issues with Ctrl + C in terminal.`
+			`Trying to handle SIGINT event. CLI overrides this behavior and does not allow handling SIGINT as this causes issues with Ctrl + C in terminal.`,
 		);
 		const msg = "The stackTrace of the location trying to handle SIGINT is";
 		const stackTrace = new Error(msg).stack || "";
@@ -31,9 +60,9 @@ process.on = (event: string, listener: any): any => {
 			stackTrace.replace(
 				`Error: ${msg}`,
 				`${msg} (${color.yellow(
-					"note:"
-				)} this is not an error, just a stack-trace for debugging purposes):`
-			)
+					"note:",
+				)} this is not an error, just a stack-trace for debugging purposes):`,
+			),
 		);
 	} else {
 		return originalProcessOn(event, listener);
@@ -52,13 +81,12 @@ process.on = (event: string, listener: any): any => {
 	const err: IErrors = injector.resolve("$errors");
 	err.printCallStack = config.DEBUG;
 
-	const $initializeService = injector.resolve<IInitializeService>(
-		"initializeService"
-	);
+	const $initializeService =
+		injector.resolve<IInitializeService>("initializeService");
 	await $initializeService.initialize();
 
 	const extensibilityService: IExtensibilityService = injector.resolve(
-		"extensibilityService"
+		"extensibilityService",
 	);
 	try {
 		await settlePromises<IExtensionData>(extensibilityService.loadExtensions());
@@ -66,9 +94,8 @@ process.on = (event: string, listener: any): any => {
 		logger.trace("Unable to load extensions. Error is: ", err);
 	}
 
-	const commandDispatcher: ICommandDispatcher = injector.resolve(
-		"commandDispatcher"
-	);
+	const commandDispatcher: ICommandDispatcher =
+		injector.resolve("commandDispatcher");
 
 	// unused...
 	// const messages: IMessagesService = injector.resolve("$messagesService");


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`ns prepare android` etc. does not work on windows

## What is the new behavior?
<!-- Describe the changes. -->
The reason is that the latest versions of `shelljs` use `fast-blob` which does not support `\` as a path separator.
This wraps calls to `shelljs.cp` on windows and replaces the `\` with `/`.




<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
