### PR TITLE
fix(config): using set with undefined

### DIFF
--- a/lib/commands/config.ts
+++ b/lib/commands/config.ts
@@ -91,7 +91,8 @@ export class ConfigSetCommand implements ICommand {
 		const convertedValue = this.getConvertedValue(value);
 		const existingKey = current !== undefined;
 		const keyDisplay = color.green(key);
-		const currentDisplay = color.yellow(current);
+		// when current is undefined, return empty string to avoid throw
+		const currentDisplay = current ? color.yellow(current) : "";
 		const updatedDisplay = color.cyan(convertedValue);
 
 		this.$logger.info(


### PR DESCRIPTION
When using `ns config set <any-key> <value>`, if <any-key> had no current value, prevent the throw by just ignoring to allow the value to still be set. 