### PR TITLE
feat: macOS support

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -182,6 +182,7 @@ injector.requireCommand("run|ios", "./commands/run");
 injector.requireCommand("run|android", "./commands/run");
 injector.requireCommand("run|vision", "./commands/run");
 injector.requireCommand("run|visionos", "./commands/run");
+injector.requireCommand("run|macos", "./commands/run");
 injector.requireCommand("typings", "./commands/typings");
 
 injector.requireCommand("preview", "./commands/preview");
@@ -197,6 +198,7 @@ injector.requireCommand("build|ios", "./commands/build");
 injector.requireCommand("build|android", "./commands/build");
 injector.requireCommand("build|vision", "./commands/build");
 injector.requireCommand("build|visionos", "./commands/build");
+injector.requireCommand("build|macos", "./commands/build");
 injector.requireCommand("deploy", "./commands/deploy");
 
 injector.requireCommand("embed", "./commands/embedding/embed");

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -277,3 +277,58 @@ export class BuildVisionOsCommand extends BuildIosCommand implements ICommand {
 
 injector.registerCommand("build|vision", BuildVisionOsCommand);
 injector.registerCommand("build|visionos", BuildVisionOsCommand);
+
+export class BuildMacOSCommand extends BuildIosCommand implements ICommand {
+	constructor(
+		protected $options: IOptions,
+		$errors: IErrors,
+		$projectData: IProjectData,
+		$platformsDataService: IPlatformsDataService,
+		$devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
+		$buildController: IBuildController,
+		$platformValidationService: IPlatformValidationService,
+		$logger: ILogger,
+		$buildDataService: IBuildDataService,
+		protected $migrateController: IMigrateController,
+	) {
+		super(
+			$options,
+			$errors,
+			$projectData,
+			$platformsDataService,
+			$devicePlatformsConstants,
+			$buildController,
+			$platformValidationService,
+			$logger,
+			$buildDataService,
+			$migrateController,
+		);
+	}
+
+	public async execute(args: string[]): Promise<void> {
+		await this.executeCore([
+			this.$devicePlatformsConstants.macOS.toLowerCase(),
+		]);
+	}
+
+	public async canExecute(args: string[]): Promise<boolean> {
+		const platform = this.$devicePlatformsConstants.macOS;
+		if (!this.$options.force) {
+			await this.$migrateController.validate({
+				projectDir: this.$projectData.projectDir,
+				platforms: [platform],
+			});
+		}
+
+		super.validatePlatform(platform);
+
+		let canExecute = await super.canExecuteCommandBase(platform);
+		if (canExecute) {
+			canExecute = await super.validateArgs(args, platform);
+		}
+
+		return canExecute;
+	}
+}
+
+injector.registerCommand("build|macos", BuildMacOSCommand);

--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -1197,6 +1197,7 @@ declare global {
 			isAndroidPlatform(platform: string): boolean;
 			isiOSPlatform(platform: string): boolean;
 			isvisionOSPlatform(platform: string): boolean;
+			ismacOSPlatform?(platform: string): boolean;
 			isApplePlatform(platform: string): boolean;
 			normalizePlatformName(platform: string): string;
 			validatePlatformName(platform: string): string;
@@ -1241,10 +1242,12 @@ declare global {
 			iOS: string;
 			Android: string;
 			visionOS: string;
+			macOS?: string;
 
 			isiOS(value: string): boolean;
 			isAndroid(value: string): boolean;
 			isvisionOS(value: string): boolean;
+			ismacOS?(value: string): boolean;
 		}
 
 		interface IDeviceApplication {

--- a/lib/common/mobile/device-platforms-constants.ts
+++ b/lib/common/mobile/device-platforms-constants.ts
@@ -6,6 +6,7 @@ export class DevicePlatformsConstants
 	public iOS = "iOS";
 	public Android = "Android";
 	public visionOS = "visionOS";
+	public macOS = "macOS";
 
 	public isiOS(value: string) {
 		return value.toLowerCase() === this.iOS.toLowerCase();
@@ -17,6 +18,10 @@ export class DevicePlatformsConstants
 
 	public isvisionOS(value: string) {
 		return value.toLowerCase() === this.visionOS.toLowerCase();
+	}
+
+	public ismacOS(value: string) {
+		return value.toLowerCase() === this.macOS.toLowerCase();
 	}
 }
 injector.register("devicePlatformsConstants", DevicePlatformsConstants);

--- a/lib/common/mobile/mobile-helper.ts
+++ b/lib/common/mobile/mobile-helper.ts
@@ -21,6 +21,7 @@ export class MobileHelper implements Mobile.IMobileHelper {
 			this.$devicePlatformsConstants.iOS,
 			this.$devicePlatformsConstants.Android,
 			this.$devicePlatformsConstants.visionOS,
+			this.$devicePlatformsConstants.macOS || "macOS",
 		];
 	}
 
@@ -48,8 +49,20 @@ export class MobileHelper implements Mobile.IMobileHelper {
 		);
 	}
 
+	public ismacOSPlatform(platform: string): boolean {
+		const macOSPlatformName = this.$devicePlatformsConstants.macOS || "macOS";
+		return !!(
+			platform &&
+			macOSPlatformName.toLowerCase() === platform.toLowerCase()
+		);
+	}
+
 	public isApplePlatform(platform: string): boolean {
-		return this.isiOSPlatform(platform) || this.isvisionOSPlatform(platform);
+		return (
+			this.isiOSPlatform(platform) ||
+			this.isvisionOSPlatform(platform) ||
+			this.ismacOSPlatform(platform)
+		);
 	}
 
 	public normalizePlatformName(platform: string): string {
@@ -59,6 +72,8 @@ export class MobileHelper implements Mobile.IMobileHelper {
 			return "iOS";
 		} else if (this.isvisionOSPlatform(platform)) {
 			return "visionOS";
+		} else if (this.ismacOSPlatform(platform)) {
+			return "macOS";
 		}
 
 		return undefined;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -24,6 +24,7 @@ export const TNS_IOS_RUNTIME_NAME = "tns-ios";
 export const SCOPED_ANDROID_RUNTIME_NAME = "@nativescript/android";
 export const SCOPED_IOS_RUNTIME_NAME = "@nativescript/ios";
 export const SCOPED_VISIONOS_RUNTIME_NAME = "@nativescript/visionos";
+export const SCOPED_MACOS_RUNTIME_NAME = "@nativescript/macos";
 export const PACKAGE_JSON_FILE_NAME = "package.json";
 export const PACKAGE_LOCK_JSON_FILE_NAME = "package-lock.json";
 export const ANDROID_DEVICE_APP_ROOT_TEMPLATE = `/data/data/%s/files`;
@@ -348,12 +349,14 @@ export const enum PlatformTypes {
 	ios = "ios",
 	android = "android",
 	visionos = "visionos",
+	macos = "macos",
 }
 
 export type SupportedPlatform =
 	| PlatformTypes.ios
 	| PlatformTypes.android
-	| PlatformTypes.visionos;
+	| PlatformTypes.visionos
+	| PlatformTypes.macos;
 
 export const PODFILE_NAME = "Podfile";
 

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -133,6 +133,7 @@ interface INsConfigIOS extends INsConfigPlaform {
 }
 
 interface INSConfigVisionOS extends INsConfigIOS {}
+interface INSConfigMacOS extends INsConfigIOS {}
 
 interface INsConfigAndroid extends INsConfigPlaform {
 	v8Flags?: string;
@@ -188,6 +189,7 @@ interface INsConfig {
 	ios?: INsConfigIOS;
 	android?: INsConfigAndroid;
 	visionos?: INSConfigVisionOS;
+	macos?: INSConfigMacOS;
 	ignoredNativeDependencies?: string[];
 	hooks?: INsConfigHooks[];
 	projectName?: string;

--- a/lib/key-commands/bootstrap.ts
+++ b/lib/key-commands/bootstrap.ts
@@ -21,3 +21,4 @@ injector.requireCommand("open|ios", path);
 injector.requireCommand("open|android", path);
 injector.requireCommand("open|visionos", path);
 injector.requireCommand("open|vision", path);
+injector.requireCommand("open|macos", path);

--- a/lib/key-commands/index.ts
+++ b/lib/key-commands/index.ts
@@ -347,6 +347,7 @@ export class OpenVisionOSCommand extends ShiftV {
 }
 
 export class OpenMacOSCommand implements IKeyCommand {
+	key: IValidKeyName = "M";
 	platform: IKeyCommandPlatform = "all";
 	description: string = "Open project in Xcode";
 	group = "macOS";

--- a/lib/key-commands/index.ts
+++ b/lib/key-commands/index.ts
@@ -346,6 +346,66 @@ export class OpenVisionOSCommand extends ShiftV {
 	}
 }
 
+export class OpenMacOSCommand implements IKeyCommand {
+	platform: IKeyCommandPlatform = "all";
+	description: string = "Open project in Xcode";
+	group = "macOS";
+	willBlockKeyCommandExecution: boolean = true;
+	protected isInteractive: boolean = false;
+
+	constructor(
+		private $iOSProjectService: IOSProjectService,
+		private $logger: ILogger,
+		private $childProcess: IChildProcess,
+		private $projectData: IProjectData,
+		private $xcodeSelectService: IXcodeSelectService,
+		private $xcodebuildArgsService: IXcodebuildArgsService,
+		private $options: IOptions
+	) {}
+
+	async execute(): Promise<void> {
+		this.$options.watch = false;
+		this.$options.platformOverride = "macOS";
+		const os = currentPlatform();
+		if (os === "darwin") {
+			this.$projectData.initializeProjectData();
+			const macOSDir = path.resolve(this.$projectData.platformsDir, "macos");
+
+			if (!fs.existsSync(macOSDir)) {
+				const prepareCommand = injector.resolveCommand(
+					"prepare"
+				) as PrepareCommand;
+
+				await prepareCommand.execute(["macos"]);
+				if (this.isInteractive) {
+					process.stdin.resume();
+				}
+			}
+			const platformData = this.$iOSProjectService.getPlatformData(
+				this.$projectData
+			);
+			const xcprojectFile = this.$xcodebuildArgsService.getXcodeProjectArgs(
+				platformData,
+				this.$projectData
+			)[1];
+
+			if (fs.existsSync(xcprojectFile)) {
+				this.$xcodeSelectService
+					.getDeveloperDirectoryPath()
+					.then(() => this.$childProcess.exec(`open ${xcprojectFile}`, {}))
+					.catch((e) => {
+						this.$logger.error(e.message);
+					});
+			} else {
+				this.$logger.error(`Unable to open project file: ${xcprojectFile}`);
+			}
+		} else {
+			this.$logger.error("Opening a project in XCode requires macOS.");
+		}
+		this.$options.platformOverride = null;
+	}
+}
+
 export class R implements IKeyCommand {
 	key: IValidKeyName = "r";
 	platform: IKeyCommandPlatform = "all";
@@ -520,3 +580,4 @@ injector.registerCommand("open|ios", OpenIOSCommand);
 injector.registerCommand("open|visionos", OpenVisionOSCommand);
 injector.registerCommand("open|vision", OpenVisionOSCommand);
 injector.registerCommand("open|android", OpenAndroidCommand);
+injector.registerCommand("open|macos", OpenMacOSCommand);

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -81,6 +81,7 @@ export class ProjectData implements IProjectData {
 		this.projectIdentifiers.ios = identifier;
 		this.projectIdentifiers.android = identifier;
 		this.projectIdentifiers.visionos = identifier;
+		this.projectIdentifiers.macos = identifier;
 	}
 
 	public projectName: string;
@@ -326,6 +327,7 @@ export class ProjectData implements IProjectData {
 				ios: "",
 				android: "",
 				visionos: "",
+				macos: "",
 			};
 		}
 
@@ -333,6 +335,7 @@ export class ProjectData implements IProjectData {
 			ios: config.id,
 			android: config.id,
 			visionos: config.id,
+			macos: config.id,
 		};
 
 		if (config.ios && config.ios.id) {
@@ -343,6 +346,9 @@ export class ProjectData implements IProjectData {
 		}
 		if (config.visionos && config.visionos.id) {
 			identifier.visionos = config.visionos.id;
+		}
+		if (config.macos && config.macos.id) {
+			identifier.macos = config.macos.id;
 		}
 
 		return identifier;

--- a/lib/services/bundler/bundler-compiler-service.ts
+++ b/lib/services/bundler/bundler-compiler-service.ts
@@ -502,6 +502,7 @@ export class BundlerCompilerService
 				USER_PROJECT_PLATFORMS_ANDROID_MODULE:
 					this.$options.hostProjectModuleName,
 				USER_PROJECT_PLATFORMS_IOS: this.$options.hostProjectPath,
+				USER_PROJECT_PLATFORMS_MACOS: this.$options.hostProjectPath,
 			});
 		}
 
@@ -528,6 +529,9 @@ export class BundlerCompilerService
 	) {
 		const { env } = prepareData;
 		const envData = Object.assign({}, env, { [platform.toLowerCase()]: true });
+		if (platform.toLowerCase() === "macos") {
+			envData.platform = "macos";
+		}
 
 		const appId = projectData.projectIdentifiers[platform];
 		const appPath = projectData.getAppDirectoryRelativePath();

--- a/lib/services/bundler/bundler-compiler-service.ts
+++ b/lib/services/bundler/bundler-compiler-service.ts
@@ -407,7 +407,16 @@ export class BundlerCompilerService
 		}
 	}
 
-	private async shouldUsePreserveSymlinksOption(): Promise<boolean> {
+	private async shouldUsePreserveSymlinksOption(
+		projectData: IProjectData,
+	): Promise<boolean> {
+		// Modern bundlers (webpack v5+ and rspack) are more sensitive to
+		// duplicate module identities when symlink paths are preserved.
+		// In local file-linked setups this can load webpack internals twice.
+		if (this.isModernBundler(projectData)) {
+			return false;
+		}
+
 		// pnpm does not require symlink (https://github.com/nodejs/node-eps/issues/46#issuecomment-277373566)
 		// and it also does not work in some cases.
 		// Check https://github.com/NativeScript/nativescript-cli/issues/5259 for more information
@@ -461,7 +470,7 @@ export class BundlerCompilerService
 		const additionalNodeArgs =
 			semver.major(process.version) <= 8 ? ["--harmony"] : [];
 
-		if (await this.shouldUsePreserveSymlinksOption()) {
+		if (await this.shouldUsePreserveSymlinksOption(projectData)) {
 			additionalNodeArgs.push("--preserve-symlinks");
 		}
 

--- a/lib/services/ios/spm-service.ts
+++ b/lib/services/ios/spm-service.ts
@@ -116,12 +116,19 @@ export class SPMService implements ISPMService {
 		platformData: IPlatformData,
 		projectData: IProjectData,
 	) {
+		let destination = "generic/platform=iOS";
+		if (platformData.platformNameLowerCase === "visionos") {
+			destination = "generic/platform=visionOS";
+		} else if (platformData.platformNameLowerCase === "macos") {
+			destination = "generic/platform=macOS";
+		}
+
 		await this.$xcodebuildCommandService.executeCommand(
 			this.$xcodebuildArgsService
 				.getXcodeProjectArgs(platformData, projectData)
 				.concat([
 					"-destination",
-					"generic/platform=iOS",
+					destination,
 					"-resolvePackageDependencies",
 				]),
 			{

--- a/lib/services/ios/xcodebuild-args-service.ts
+++ b/lib/services/ios/xcodebuild-args-service.ts
@@ -18,6 +18,7 @@ import {
 	SimulatorPlatformSdkName,
 	VisionDevicePlatformSdkName,
 	VisionSimulatorPlatformSdkName,
+	MacOSPlatformSdkName,
 } from "../ios-project-service";
 
 export class XcodebuildArgsService implements IXcodebuildArgsService {
@@ -37,7 +38,13 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 	): Promise<string[]> {
 		let args = await this.getArchitecturesArgs(buildConfig);
 
-		if (this.$iOSWatchAppService.hasWatchApp(platformData, projectData)) {
+		const isMacOS = this.$devicePlatformsConstants.ismacOS(
+			buildConfig.platform,
+		);
+
+		if (isMacOS) {
+			args = args.concat(["CODE_SIGNING_ALLOWED=NO"]);
+		} else if (this.$iOSWatchAppService.hasWatchApp(platformData, projectData)) {
 			args = args.concat(["CODE_SIGNING_ALLOWED=NO"]);
 		} else {
 			args = args.concat(["CODE_SIGN_IDENTITY="]);
@@ -48,6 +55,10 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 		let isvisionOS = this.$devicePlatformsConstants.isvisionOS(
 			buildConfig.platform,
 		);
+
+		if (isMacOS) {
+			destination = "generic/platform=macOS";
+		}
 
 		if (isvisionOS) {
 			destination = "generic/platform=visionOS Simulator";
@@ -68,9 +79,11 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 				this.getBuildCommonArgs(
 					platformData,
 					projectData,
-					isvisionOS
-						? VisionSimulatorPlatformSdkName
-						: SimulatorPlatformSdkName,
+					isMacOS
+						? MacOSPlatformSdkName
+						: isvisionOS
+							? VisionSimulatorPlatformSdkName
+							: SimulatorPlatformSdkName,
 				),
 			)
 			.concat(this.getBuildLoggingArgs())
@@ -93,6 +106,11 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 		let isvisionOS = this.$devicePlatformsConstants.isvisionOS(
 			buildConfig.platform,
 		);
+		const isMacOS = this.$devicePlatformsConstants.ismacOS(buildConfig.platform);
+
+		if (isMacOS) {
+			destination = "generic/platform=macOS";
+		}
 
 		if (isvisionOS) {
 			destination = "generic/platform=visionOS";
@@ -116,7 +134,11 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 				this.getBuildCommonArgs(
 					platformData,
 					projectData,
-					isvisionOS ? VisionDevicePlatformSdkName : DevicePlatformSdkName,
+					isMacOS
+						? MacOSPlatformSdkName
+						: isvisionOS
+							? VisionDevicePlatformSdkName
+							: DevicePlatformSdkName,
 				),
 			)
 			.concat(this.getBuildLoggingArgs());
@@ -133,6 +155,14 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 			// visionOS builds (device/simulator) are arm64-only; rely on destination for arch
 			// and explicitly exclude x86_64 to avoid accidental selection
 			args.push("ONLY_ACTIVE_ARCH=YES", "EXCLUDED_ARCHS=x86_64");
+			return args;
+		}
+
+		if (this.$devicePlatformsConstants.ismacOS(buildConfig.platform)) {
+			if (process.arch === "arm64") {
+				// Avoid attempting x86_64 builds against arm64-only frameworks.
+				args.push("ONLY_ACTIVE_ARCH=YES", "EXCLUDED_ARCHS=x86_64");
+			}
 			return args;
 		}
 

--- a/lib/services/platforms-data-service.ts
+++ b/lib/services/platforms-data-service.ts
@@ -16,6 +16,7 @@ export class PlatformsDataService implements IPlatformsDataService {
 			ios: $iOSProjectService,
 			android: $androidProjectService,
 			visionos: $iOSProjectService,
+			macos: $iOSProjectService,
 		};
 	}
 

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -89,22 +89,37 @@ export class ProjectChangesService implements IProjectChangesService {
 				projectData.appResourcesDirectoryPath,
 				platformData.normalizedPlatformName
 			);
+			const visionOSPlatformName =
+				this.$devicePlatformsConstants.visionOS &&
+				this.$devicePlatformsConstants.visionOS.toLowerCase();
+			const macOSPlatformName =
+				this.$devicePlatformsConstants.macOS &&
+				this.$devicePlatformsConstants.macOS.toLowerCase();
+			const iOSPlatformName =
+				this.$devicePlatformsConstants.iOS || "iOS";
 
 			if (
 				!this.$fs.exists(platformResourcesDir) &&
-				platformData.platformNameLowerCase ===
-					this.$devicePlatformsConstants.visionOS.toLowerCase()
+				(platformData.platformNameLowerCase === visionOSPlatformName ||
+					platformData.platformNameLowerCase === macOSPlatformName)
 			) {
 				platformResourcesDir = path.join(
 					projectData.appResourcesDirectoryPath,
-					this.$devicePlatformsConstants.iOS
+					iOSPlatformName
 				);
 			}
 
-			this._changesInfo.appResourcesChanged = this.containsNewerFiles(
-				platformResourcesDir,
-				projectData
-			);
+			if (this.$fs.exists(platformResourcesDir)) {
+				this._changesInfo.appResourcesChanged = this.containsNewerFiles(
+					platformResourcesDir,
+					projectData
+				);
+			} else {
+				this.$logger.trace(
+					`App resources path does not exist: ${platformResourcesDir}`
+				);
+				this._changesInfo.appResourcesChanged = false;
+			}
 
 			this.$nodeModulesDependenciesBuilder
 				.getProductionDependencies(

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -586,7 +586,9 @@ export class ProjectDataService implements IProjectDataService {
 		const runtimeName =
 			platform === PlatformTypes.android
 				? constants.TNS_ANDROID_RUNTIME_NAME
-				: constants.TNS_IOS_RUNTIME_NAME;
+				: platform === PlatformTypes.macos
+					? constants.SCOPED_MACOS_RUNTIME_NAME
+					: constants.TNS_IOS_RUNTIME_NAME;
 
 		if (
 			packageJson &&
@@ -639,6 +641,8 @@ export class ProjectDataService implements IProjectDataService {
 					].includes(d.name);
 				} else if (platform === constants.PlatformTypes.visionos) {
 					return d.name === constants.SCOPED_VISIONOS_RUNTIME_NAME;
+				} else if (platform === constants.PlatformTypes.macos) {
+					return d.name === constants.SCOPED_MACOS_RUNTIME_NAME;
 				}
 			});
 
@@ -698,6 +702,11 @@ export class ProjectDataService implements IProjectDataService {
 		} else if (platform === constants.PlatformTypes.visionos) {
 			return {
 				name: constants.SCOPED_VISIONOS_RUNTIME_NAME,
+				version: null,
+			};
+		} else if (platform === constants.PlatformTypes.macos) {
+			return {
+				name: constants.SCOPED_MACOS_RUNTIME_NAME,
 				version: null,
 			};
 		}

--- a/lib/services/versions-service.ts
+++ b/lib/services/versions-service.ts
@@ -134,6 +134,10 @@ class VersionsService implements IVersionsService {
 			this.projectData.projectDir,
 			constants.PlatformTypes.android
 		);
+		const macOSRuntime = this.$projectDataService.getRuntimePackage(
+			this.projectData.projectDir,
+			constants.PlatformTypes.macos
+		);
 		let runtimes: IBasePluginData[] = [];
 
 		if (!platform) {
@@ -142,6 +146,8 @@ class VersionsService implements IVersionsService {
 			runtimes.push(iosRuntime);
 		} else if (platform === PlatformTypes.android) {
 			runtimes.push(androidRuntime);
+		} else if (platform === PlatformTypes.macos) {
+			runtimes.push(macOSRuntime);
 		}
 
 		const runtimesVersions: IVersionInformation[] = await Promise.all(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nativescript",
   "main": "./lib/nativescript-cli-lib.js",
-  "version": "9.0.3",
+  "version": "9.1.0-alpha.0",
   "author": "NativeScript <oss@nativescript.org>",
   "description": "Command-line interface for building NativeScript projects",
   "bin": {

--- a/test/services/platform/add-platform-service.ts
+++ b/test/services/platform/add-platform-service.ts
@@ -44,7 +44,7 @@ describe("AddPlatformService", () => {
 			projectData = injector.resolve("projectData");
 		});
 
-		_.each(["ios", "android"], (platform) => {
+		_.each(["ios", "android", "macos"], (platform) => {
 			it(`should fail if unable to install runtime package for ${platform}`, async () => {
 				const errorMessage = "Pacote service unable to extract package";
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the new behavior?

Introduces support in CLI for building and running apps on macOS platform using Node-API runtime.
Depends on nativescript/macos which is not published on NPM yet - so need to package tgz from napi-ios repo.

<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
