### PR TITLE
feat: add support for android widgets

### DIFF
--- a/docs/man_pages/project/configuration/widget.md
+++ b/docs/man_pages/project/configuration/widget.md
@@ -1,19 +1,19 @@
 <% if (isJekyll) { %>---
-title: ns widget ios
+title: ns widget
 position: 11
 ---<% } %>
 
-# ns widget ios
+# ns widget
 
 ### Description
 
-Interactively adds a new iOS widget based on a predefined template.
+Interactively adds a new iOS/Android widget based on a predefined template.
 
 ### Commands
 
 Usage | Synopsis
 ------|-------
-General | `$ ns widget ios`
+General | `$ ns widget <Platform>`
 
 <% if(isHtml) { %>
 

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -479,5 +479,8 @@ injector.requireCommand(
 	],
 	"./commands/native-add",
 );
-injector.requireCommand(["widget", "widget|ios"], "./commands/widget");
+injector.requireCommand(
+	["widget", "widget|ios", "widget|android"],
+	"./commands/widget",
+);
 require("./key-commands/bootstrap");

--- a/lib/commands/widget.ts
+++ b/lib/commands/widget.ts
@@ -1212,13 +1212,13 @@ export class WidgetAndroidCommand extends WidgetCommand {
 		if (!fs.existsSync(widgetPath)) {
 			fs.mkdirSync(path.dirname(widgetPath), { recursive: true });
 
-			const content = `
-			package ${packageName}
-			import org.nativescript.widgets.AppWidgetProvider
+			const content = `package ${packageName}
+import org.nativescript.widgets.AppWidgetProvider
 
-			class ${widgetClassName} : AppWidgetProvider() {
-				override val interval = ${updateInterval}L
-			}${EOL}`;
+class ${widgetClassName} : AppWidgetProvider() {
+	override val interval = ${updateInterval}L
+}
+${EOL}`;
 
 			fs.writeFileSync(widgetPath, content);
 		}

--- a/lib/commands/widget.ts
+++ b/lib/commands/widget.ts
@@ -1258,9 +1258,15 @@ ${EOL}`;
     <receiver
         android:name="${packageName}.${widgetClassName}"
         android:exported="true">
+		<intent-filter>
+			 <action android:name="android.intent.action.BOOT_COMPLETED" />
+        </intent-filter>
         <intent-filter>
             <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
         </intent-filter>
+		 <intent-filter>
+        	<action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+    	</intent-filter>
         <meta-data
             android:name="android.appwidget.provider"
             android:resource="@xml/ns_${name}_widget_info" />

--- a/lib/commands/widget.ts
+++ b/lib/commands/widget.ts
@@ -1062,11 +1062,18 @@ export class WidgetAndroidCommand extends WidgetCommand {
 		result = await prompts.prompt({
 			type: "text",
 			name: "initialLayout",
-			message: `What initial layout would you like for this widget? (Default is 'ns_remote_views_linear_layout' which is an empty linear layout. You can customize this with your own custom layout)`,
+			message: `What initial layout would you like for this widget? (Default is 'ns_remote_views_root_layout' which is an empty linear layout. You can customize this with your own custom layout)`,
 		});
 
-		const initialLayout =
-			result.initialLayout || "ns_remote_views_linear_layout";
+		result = await prompts.prompt({
+			type: "text",
+			name: "widgetFeatures",
+			message: `Enable responsive layout features for this widget? (Default is 'Y')`,
+		});
+
+		const widgetFeatures = result.widgetFeatures || "Y";
+
+		const initialLayout = result.initialLayout || "ns_remote_views_root_layout";
 
 		const bundleId = this.$projectConfigService.getValue(`id`, "");
 
@@ -1096,6 +1103,7 @@ export class WidgetAndroidCommand extends WidgetCommand {
 			minWidth,
 			minHeight,
 			initialLayout,
+			widgetFeatures === "N" ? false : true,
 		);
 
 		await this.generateWidget(
@@ -1153,6 +1161,7 @@ export class WidgetAndroidCommand extends WidgetCommand {
 		minWidth: string,
 		minHeight: string,
 		initialLayout: string,
+		enableWidgetFeatures: boolean,
 	) {
 		const appResourcePath = this.$projectData.appResourcesDirectoryPath;
 		const widgetInfoPath = path.join(
@@ -1177,7 +1186,8 @@ export class WidgetAndroidCommand extends WidgetCommand {
 	android:minHeight="${minHeight}"
 	android:resizeMode="${resizeMode}"
 	android:updatePeriodMillis="0"
-	android:widgetCategory="home_screen" />${EOL}`;
+	android:widgetCategory="home_screen"
+	${enableWidgetFeatures ? ' android:widgetFeatures="reconfigurable|configuration_optional"' : ""} />${EOL}`;
 
 			fs.writeFileSync(widgetInfoPath, content);
 		}
@@ -1194,7 +1204,7 @@ export class WidgetAndroidCommand extends WidgetCommand {
 			"Android",
 			"src",
 			"main",
-			"kotlin",
+			"java",
 			packageName.replace(/\./g, "/"),
 			`${widgetClassName}.kt`,
 		);

--- a/lib/commands/widget.ts
+++ b/lib/commands/widget.ts
@@ -1187,7 +1187,11 @@ export class WidgetAndroidCommand extends WidgetCommand {
 	android:resizeMode="${resizeMode}"
 	android:updatePeriodMillis="0"
 	android:widgetCategory="home_screen"
-	${enableWidgetFeatures ? ' android:widgetFeatures="reconfigurable|configuration_optional"' : ""} />${EOL}`;
+	${enableWidgetFeatures ? 'android:widgetFeatures="reconfigurable|configuration_optional"' : ""}>
+	<meta-data
+        android:name="org.nativescript.widgets.MANAGED_WIDGET"
+        android:value="true"/>
+	</appwidget-provider>${EOL}`;
 
 			fs.writeFileSync(widgetInfoPath, content);
 		}
@@ -1264,9 +1268,6 @@ ${EOL}`;
         <intent-filter>
             <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
         </intent-filter>
-		 <intent-filter>
-        	<action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
-    	</intent-filter>
         <meta-data
             android:name="android.appwidget.provider"
             android:resource="@xml/ns_${name}_widget_info" />

--- a/lib/commands/widget.ts
+++ b/lib/commands/widget.ts
@@ -1062,7 +1062,7 @@ export class WidgetAndroidCommand extends WidgetCommand {
 		result = await prompts.prompt({
 			type: "text",
 			name: "initialLayout",
-			message: `What initial layout would you like for this widget? (Default is 'ns_remote_views_root_layout' which is an empty linear layout. You can customize this with your own custom layout)`,
+			message: `What initial layout would you like for this widget? (Default is 'ns_remote_views_linear_layout' which is an empty linear layout. You can customize this with your own custom layout)`,
 		});
 
 		result = await prompts.prompt({
@@ -1073,7 +1073,7 @@ export class WidgetAndroidCommand extends WidgetCommand {
 
 		const widgetFeatures = result.widgetFeatures || "Y";
 
-		const initialLayout = result.initialLayout || "ns_remote_views_root_layout";
+		const initialLayout = result.initialLayout || "ns_remote_views_linear_layout";
 
 		const bundleId = this.$projectConfigService.getValue(`id`, "");
 


### PR DESCRIPTION
Enables `ns widget android`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android support for widget creation, including an interactive setup flow that generates the needed app resources and app registration entries.
  * Widget commands now support both iOS and Android platforms.

* **Documentation**
  * Updated the widget guide to describe platform-based usage and added a note about platform-specific command limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->