### PR TITLE
fix(widget): handle configs with other SPMPackages

### DIFF
--- a/lib/commands/widget.ts
+++ b/lib/commands/widget.ts
@@ -8,7 +8,6 @@ import * as plist from "plist";
 import { injector } from "../common/yok";
 import { capitalizeFirstLetter } from "../common/utils";
 import { EOL } from "os";
-import { SupportedConfigValues } from "../tools/config-manipulation/config-transformer";
 
 export class WidgetCommand implements ICommand {
 	public allowedParameters: ICommandParameter[] = [];
@@ -219,10 +218,7 @@ public struct ${capitalizeFirstLetter(name)}Model: ActivityAttributes {
 			}
 
 			configData.ios.SPMPackages = spmPackages;
-			await this.$projectConfigService.setValue(
-				"", // root
-				configData as { [key: string]: SupportedConfigValues },
-			);
+			await this.$projectConfigService.setValue("ios.SPMPackages", spmPackages);
 
 			if (fs.existsSync(gitIgnorePath)) {
 				const gitIgnore = fs.readFileSync(gitIgnorePath, {

--- a/lib/tools/config-manipulation/config-transformer.ts
+++ b/lib/tools/config-manipulation/config-transformer.ts
@@ -184,24 +184,54 @@ export class ConfigTransformer implements IConfigTransformer {
 		return `{}`;
 	}
 
+	private isBooleanLiteralNode(initializer: any): boolean {
+		return (
+			initializer?.getKind() === SyntaxKind.TrueKeyword ||
+			initializer?.getKind() === SyntaxKind.FalseKeyword
+		);
+	}
+
+	private replaceInitializer(
+		initializer: any,
+		newValue: SupportedConfigValues,
+	) {
+		return initializer.replaceWithText(this.createInitializer(newValue));
+	}
+
 	private setInitializerValue(
 		initializer: any,
 		newValue: SupportedConfigValues,
 	) {
 		if (Node.isStringLiteral(initializer)) {
+			if (typeof newValue !== "string") {
+				return this.replaceInitializer(initializer, newValue);
+			}
 			return (initializer as StringLiteral).setLiteralValue(newValue as string);
 		}
 
 		if (Node.isNumericLiteral(initializer)) {
+			if (typeof newValue !== "number") {
+				return this.replaceInitializer(initializer, newValue);
+			}
 			return (initializer as NumericLiteral).setLiteralValue(
 				newValue as number,
 			);
 		}
 
-		if (Node.isBooleanKeyword(initializer)) {
+		if (this.isBooleanLiteralNode(initializer)) {
+			if (typeof newValue !== "boolean") {
+				return this.replaceInitializer(initializer, newValue);
+			}
 			return (initializer as BooleanLiteral).setLiteralValue(
 				newValue as boolean,
 			);
+		}
+
+		if (
+			Node.isArrayLiteralExpression(initializer) ||
+			Node.isObjectLiteralExpression(initializer)
+		) {
+			return this.replaceInitializer(initializer, newValue);
 		}
 
 		if (Node.isIdentifier(initializer)) {
@@ -211,7 +241,7 @@ export class ConfigTransformer implements IConfigTransformer {
 		throw new Error("Unsupported value type: " + initializer.getKindName());
 	}
 
-	private getInitializerValue(initializer: any) {
+	private getInitializerValue(initializer: any): any {
 		if (Node.isStringLiteral(initializer)) {
 			return (initializer as StringLiteral).getLiteralValue();
 		}
@@ -220,8 +250,28 @@ export class ConfigTransformer implements IConfigTransformer {
 			return (initializer as NumericLiteral).getLiteralValue();
 		}
 
-		if (Node.isBooleanKeyword(initializer)) {
+		if (this.isBooleanLiteralNode(initializer)) {
 			return (initializer as BooleanLiteral).getLiteralValue();
+		}
+
+		if (Node.isArrayLiteralExpression(initializer)) {
+			return initializer
+				.getElements()
+				.map((element: any) => this.getInitializerValue(element));
+		}
+
+		if (Node.isObjectLiteralExpression(initializer)) {
+			const result: Record<string, SupportedConfigValues> = {};
+			for (const property of initializer.getProperties()) {
+				if (!Node.isPropertyAssignment(property)) {
+					continue;
+				}
+				const name = property.getNameNode().getText().replace(/['\"]/g, "");
+				result[name] = this.getInitializerValue(
+					property.getInitializerOrThrow(),
+				);
+			}
+			return result;
 		}
 
 		if (Node.isIdentifier(initializer)) {
@@ -278,8 +328,28 @@ export class ConfigTransformer implements IConfigTransformer {
 			return (initializer as NumericLiteral).getLiteralValue();
 		}
 
-		if (Node.isBooleanKeyword(initializer)) {
+		if (this.isBooleanLiteralNode(initializer)) {
 			return (initializer as BooleanLiteral).getLiteralValue();
+		}
+
+		if (Node.isArrayLiteralExpression(initializer)) {
+			return initializer
+				.getElements()
+				.map((element: any) => this.getInitializerValue(element));
+		}
+
+		if (Node.isObjectLiteralExpression(initializer)) {
+			const result: Record<string, SupportedConfigValues> = {};
+			for (const property of initializer.getProperties()) {
+				if (!Node.isPropertyAssignment(property)) {
+					continue;
+				}
+				const name = property.getNameNode().getText().replace(/['\"]/g, "");
+				result[name] = this.getInitializerValue(
+					property.getInitializerOrThrow(),
+				);
+			}
+			return result;
 		}
 
 		if (Node.isIdentifier(initializer)) {

--- a/test/tools/config-manipulation/config-transformer.ts
+++ b/test/tools/config-manipulation/config-transformer.ts
@@ -1,0 +1,62 @@
+import { assert } from "chai";
+import { ConfigTransformer } from "../../../lib/tools/config-manipulation/config-transformer";
+
+describe("ConfigTransformer", () => {
+	it("updates existing boolean literals", () => {
+		const content = `export default {
+  id: 'org.nativescript.myapp',
+  discardUncaughtJsExceptions: true,
+} as any;`;
+
+		const transformer = new ConfigTransformer(content);
+		const updated = transformer.setValue("discardUncaughtJsExceptions", false);
+		const updatedTransformer = new ConfigTransformer(updated);
+
+		assert.strictEqual(
+			updatedTransformer.getValue("discardUncaughtJsExceptions"),
+			false,
+		);
+	});
+
+	it("updates existing ios.SPMPackages array literals", () => {
+		const content = `import { NativeScriptConfig } from '@nativescript/core'
+
+export default {
+  id: 'org.nativescript.myapp',
+  ios: {
+    SPMPackages: [
+      {
+        name: 'RiveRuntime',
+        libs: ['RiveRuntime'],
+        repositoryURL: 'https://github.com/rive-app/rive-ios.git',
+        version: '6.11.0',
+      },
+    ],
+  },
+} as NativeScriptConfig`;
+
+		const spmPackages = [
+			{
+				name: "RiveRuntime",
+				libs: ["RiveRuntime"],
+				repositoryURL: "https://github.com/rive-app/rive-ios.git",
+				version: "6.11.0",
+			},
+			{
+				name: "SharedWidget",
+				libs: ["SharedWidget"],
+				path: "./Shared_Resources/iOS/SharedWidget",
+				targets: ["widget"],
+			},
+		];
+
+		const transformer = new ConfigTransformer(content);
+		const updated = transformer.setValue("ios.SPMPackages", spmPackages);
+		const updatedTransformer = new ConfigTransformer(updated);
+
+		assert.deepStrictEqual(
+			updatedTransformer.getValue("ios.SPMPackages"),
+			spmPackages,
+		);
+	});
+});


### PR DESCRIPTION
- Improved `ConfigTransformer` to correctly handle and update boolean, array, and object literal values, including adding helper methods for type checks and initializer replacement. [[1]](diffhunk://#diff-8bf1d62751b1bb609f0e993cef8107046ac3efc7f0232c9e3431524b0e05aa5cR187-R244) [[2]](diffhunk://#diff-8bf1d62751b1bb609f0e993cef8107046ac3efc7f0232c9e3431524b0e05aa5cL223-R276) [[3]](diffhunk://#diff-8bf1d62751b1bb609f0e993cef8107046ac3efc7f0232c9e3431524b0e05aa5cL281-R354)
* Updated usage in `widget.ts` to set the `ios.SPMPackages` config value directly, instead of updating the root config object, ensuring more targeted updates.

Testing improvements:

* Added unit tests in `test/tools/config-manipulation/config-transformer.ts` to verify updating boolean literals and array literals for config values, increasing reliability and coverage.