### PR TITLE
fix(ios): Fix check for dynamic lib

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -500,12 +500,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 	}
 
 	private async isDynamicFramework(frameworkPath: string): Promise<boolean> {
-		const isDynamicFrameworkBundle = async (
-			bundlePath: string,
-			frameworkName: string,
-		) => {
-			const frameworkBinaryPath = path.join(bundlePath, frameworkName);
-
+		const isDynamicFrameworkBundle = async (frameworkBinaryPath: string) => {
 			const fileResult = (
 				await this.$childProcess.spawnFromEvent(
 					"file",
@@ -533,10 +528,15 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 						singlePlatformFramework,
 						path.extname(singlePlatformFramework),
 					);
-					isDynamic = await isDynamicFrameworkBundle(
-						singlePlatformFramework,
-						frameworkName,
-					);
+					let frameworkBinaryPath = path.join(singlePlatformFramework, frameworkName)
+					if (library.BinaryPath) {
+						frameworkBinaryPath = path.join(
+							frameworkPath,
+							library.LibraryIdentifier,
+							library.BinaryPath,
+						);
+					}
+					isDynamic = await isDynamicFrameworkBundle(frameworkBinaryPath);
 					break;
 				}
 			}
@@ -546,7 +546,7 @@ export class IOSProjectService extends projectServiceBaseLib.PlatformProjectServ
 				frameworkPath,
 				path.extname(frameworkPath),
 			);
-			return await isDynamicFrameworkBundle(frameworkPath, frameworkName);
+			return await isDynamicFrameworkBundle(path.join(frameworkPath, frameworkName));
 		}
 	}
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
There seems to be a problem with the check whether or not a library is dynamic so it can be set to embed. This causes problems with some 3rd party plugins (see https://github.com/triniwiz/nativescript-plugins/issues/223) and makes the apps crash on startup (both simulator and device). 

For some reason the current logic isn't looking at the `BinaryPath` that there is in the Info.plist for the framework, but is trying to "guess" the path to the binary from other parts. 

For example for the CouchBase plugin the path that the current logic generates is:
```
/path/to/project/node_modules/@triniwiz/nativescript-couchbase/platforms/ios/CouchbaseLite.xcframework/ios-arm64_x86_64-maccatalyst/CouchbaseLite.framework/CouchbaseLite
```

But the correct path is:
```
/path/to/project/node_modules/@triniwiz/nativescript-couchbase/platforms/ios/CouchbaseLite.xcframework/ios-arm64_x86_64-maccatalyst/CouchbaseLite.framework/Versions/A/CouchbaseLite
```

## What is the new behavior?
The binary path is calculated first based on the `BinaryPath` from the Info.plist and if that is not present the old logic is used. 

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved iOS framework binary detection and resolution mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NativeScript/nativescript-cli/pull/6032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->