### PR TITLE
feat: add skipNative option to PrepareData and Options classes

### DIFF
--- a/lib/commands/prepare.ts
+++ b/lib/commands/prepare.ts
@@ -22,7 +22,11 @@ export class PrepareCommand
 			hasSensitiveValue: false,
 		},
 		hmr: { type: OptionType.Boolean, default: false, hasSensitiveValue: false },
-
+		skipNative: {
+			type: OptionType.Boolean,
+			default: false,
+			hasSensitiveValue: false,
+		},
 		whatever: {
 			type: OptionType.Boolean,
 			default: false,
@@ -38,13 +42,13 @@ export class PrepareCommand
 		public $platformCommandParameter: ICommandParameter,
 		public $platformsDataService: IPlatformsDataService,
 		public $prepareDataService: PrepareDataService,
-		public $migrateController: IMigrateController
+		public $migrateController: IMigrateController,
 	) {
 		super(
 			$options,
 			$platformsDataService,
 			$platformValidationService,
-			$projectData
+			$projectData,
 		);
 		this.$projectData.initializeProjectData();
 	}
@@ -55,7 +59,7 @@ export class PrepareCommand
 		const prepareData = this.$prepareDataService.getPrepareData(
 			this.$projectData.projectDir,
 			platform,
-			this.$options
+			this.$options,
 		);
 		await this.$prepareController.prepare(prepareData);
 	}
@@ -68,7 +72,7 @@ export class PrepareCommand
 				this.$options.provision,
 				this.$options.teamId,
 				this.$projectData,
-				platform
+				platform,
 			));
 
 		if (!this.$options.force) {

--- a/lib/data/prepare-data.ts
+++ b/lib/data/prepare-data.ts
@@ -14,7 +14,7 @@ export class PrepareData extends ControllerDataBase {
 	constructor(
 		public projectDir: string,
 		public platform: string,
-		data: IOptions
+		data: IOptions,
 	) {
 		super(projectDir, platform, data);
 
@@ -44,6 +44,11 @@ export class PrepareData extends ControllerDataBase {
 			this.watchNative = data.watchNative;
 		}
 		this.hostProjectPath = data.hostProjectPath;
+
+		if (data.skipNative) {
+			this.nativePrepare = { skipNativePrepare: true };
+			this.watchNative = false;
+		}
 
 		this.uniqueBundle = !this.watch && data.uniqueBundle ? Date.now() : 0;
 	}

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -31,7 +31,7 @@ interface INodePackageManager {
 	install(
 		packageName: string,
 		pathToSave: string,
-		config: INodePackageManagerInstallOptions
+		config: INodePackageManagerInstallOptions,
 	): Promise<INpmInstallResultInfo>;
 
 	/**
@@ -44,7 +44,7 @@ interface INodePackageManager {
 	uninstall(
 		packageName: string,
 		config?: IDictionary<string | boolean>,
-		path?: string
+		path?: string,
 	): Promise<string>;
 
 	/**
@@ -84,7 +84,7 @@ interface INodePackageManager {
 	 */
 	search(
 		filter: string[],
-		config: IDictionary<string | boolean>
+		config: IDictionary<string | boolean>,
 	): Promise<string>;
 
 	/**
@@ -130,7 +130,7 @@ interface IPerformanceService {
 		methodInfo: string,
 		startTime: number,
 		endTime: number,
-		args: any[]
+		args: any[],
 	): void;
 
 	// Will return a reference time in milliseconds
@@ -141,39 +141,39 @@ interface IPackageInstallationManager {
 	install(
 		packageName: string,
 		packageDir: string,
-		options?: INpmInstallOptions
+		options?: INpmInstallOptions,
 	): Promise<any>;
 	uninstall(
 		packageName: string,
 		packageDir: string,
-		options?: IDictionary<string | boolean>
+		options?: IDictionary<string | boolean>,
 	): Promise<any>;
 	getLatestVersion(packageName: string): Promise<string>;
 	getNextVersion(packageName: string): Promise<string>;
 	getLatestCompatibleVersion(
 		packageName: string,
-		referenceVersion?: string
+		referenceVersion?: string,
 	): Promise<string>;
 	getMaxSatisfyingVersion(
 		packageName: string,
-		versionRange: string
+		versionRange: string,
 	): Promise<string>;
 	getLatestCompatibleVersionSafe(
 		packageName: string,
-		referenceVersion?: string
+		referenceVersion?: string,
 	): Promise<string>;
 	getInspectorFromCache(
 		inspectorNpmPackageName: string,
-		projectDir: string
+		projectDir: string,
 	): Promise<string>;
 	clearInspectorCache(): void;
 	getInstalledDependencyVersion(
 		packageName: string,
-		projectDir?: string
+		projectDir?: string,
 	): Promise<string>;
 	getMaxSatisfyingVersionSafe(
 		packageName: string,
-		versionIdentifier: string
+		versionIdentifier: string,
 	): Promise<string>;
 }
 
@@ -181,8 +181,7 @@ interface IPackageInstallationManager {
  * Describes options that can be passed to manipulate package installation.
  */
 interface INodePackageManagerInstallOptions
-	extends INpmInstallConfigurationOptions,
-		IDictionary<string | boolean> {
+	extends INpmInstallConfigurationOptions, IDictionary<string | boolean> {
 	/**
 	 * Destination of the installation.
 	 * @type {string}
@@ -266,7 +265,7 @@ interface INpmPeerDependencyInfo {
 				 * @type {string}
 				 */
 				requires: string;
-			}
+			},
 		];
 		/**
 		 * Dependencies of the dependency.
@@ -550,8 +549,7 @@ interface INpmInstallConfigurationOptionsBase {
 	ignoreScripts: boolean; //npm flag
 }
 
-interface INpmInstallConfigurationOptions
-	extends INpmInstallConfigurationOptionsBase {
+interface INpmInstallConfigurationOptions extends INpmInstallConfigurationOptionsBase {
 	disableNpmInstall: boolean;
 }
 
@@ -597,7 +595,8 @@ interface ITypingsOptions {
 }
 
 interface IOptions
-	extends IRelease,
+	extends
+		IRelease,
 		IDeviceIdentifier,
 		IJustLaunch,
 		IAvd,
@@ -622,7 +621,7 @@ interface IOptions
 	argv: IYargArgv;
 	validateOptions(
 		commandSpecificDashedOptions?: IDictionary<IDashedOption>,
-		projectData?: IProjectData
+		projectData?: IProjectData,
 	): void;
 	options: IDictionary<IDashedOption>;
 	shorthands: string[];
@@ -709,6 +708,7 @@ interface IOptions
 	dryRun: boolean;
 
 	platformOverride: string;
+	skipNative: boolean;
 	uniqueBundle: boolean;
 	// allow arbitrary options
 	[optionName: string]: any;
@@ -719,26 +719,22 @@ interface IEnvOptions {
 }
 
 interface IAndroidBuildOptionsSettings
-	extends IAndroidReleaseOptions,
-		IRelease,
-		Partial<IHasAndroidBundle> {}
+	extends IAndroidReleaseOptions, IRelease, Partial<IHasAndroidBundle> {}
 
 interface IHasAndroidBundle {
 	androidBundle: boolean;
 }
 
 interface IPlatformBuildData
-	extends IRelease,
-		IHasUseHotModuleReloadOption,
-		IBuildConfig,
-		IEnvOptions {}
+	extends IRelease, IHasUseHotModuleReloadOption, IBuildConfig, IEnvOptions {}
 
 interface IDeviceEmulator extends IHasEmulatorOption, IDeviceIdentifier {}
 
 interface IRunPlatformOptions extends IJustLaunch, IDeviceEmulator {}
 
 interface IDeployPlatformOptions
-	extends IAndroidReleaseOptions,
+	extends
+		IAndroidReleaseOptions,
 		IRelease,
 		IClean,
 		IDeviceEmulator,
@@ -834,7 +830,7 @@ interface IAndroidToolsInfo {
 	 */
 	validateJavacVersion(
 		installedJavaVersion: string,
-		options?: IAndroidToolsInfoOptions
+		options?: IAndroidToolsInfoOptions,
 	): boolean;
 
 	/**
@@ -913,14 +909,14 @@ interface IAppDebugSocketProxyFactory extends NodeJS.EventEmitter {
 		device: Mobile.IiOSDevice,
 		appId: string,
 		projectName: string,
-		projectDir: string
+		projectDir: string,
 	): Promise<any>;
 
 	ensureWebSocketProxy(
 		device: Mobile.IiOSDevice,
 		appId: string,
 		projectName: string,
-		projectDir: string
+		projectDir: string,
 	): Promise<any>;
 
 	removeAllProxies(): void;
@@ -939,12 +935,12 @@ interface IiOSSocketRequestExecutor {
 	executeAttachRequest(
 		device: Mobile.IiOSDevice,
 		timeout: number,
-		projectId: string
+		projectId: string,
 	): Promise<void>;
 	executeRefreshRequest(
 		device: Mobile.IiOSDevice,
 		timeout: number,
-		appId: string
+		appId: string,
 	): Promise<boolean>;
 }
 
@@ -995,7 +991,7 @@ interface IProjectNameService {
 	 */
 	ensureValidName(
 		projectName: string,
-		validateOptions?: { force: boolean }
+		validateOptions?: { force: boolean },
 	): Promise<string>;
 }
 
@@ -1089,7 +1085,7 @@ interface IBundleValidatorHelper {
 	 */
 	getBundlerDependencyVersion(
 		projectData: IProjectData,
-		bundlerName?: string
+		bundlerName?: string,
 	): string;
 }
 
@@ -1171,7 +1167,7 @@ interface IAssetsGenerationService {
 	 * @returns {Promise<void>}
 	 */
 	generateSplashScreens(
-		splashesGenerationData: IResourceGenerationData
+		splashesGenerationData: IResourceGenerationData,
 	): Promise<void>;
 }
 
@@ -1207,7 +1203,7 @@ interface IPlatformValidationService {
 		provision: true | string,
 		teamId: true | string,
 		projectData: IProjectData,
-		platform?: string
+		platform?: string,
 	): Promise<boolean>;
 
 	validatePlatformInstalled(platform: string, projectData: IProjectData): void;
@@ -1220,7 +1216,7 @@ interface IPlatformValidationService {
 	 */
 	isPlatformSupportedForOS(
 		platform: string,
-		projectData: IProjectData
+		projectData: IProjectData,
 	): boolean;
 }
 
@@ -1228,27 +1224,27 @@ interface IPlatformCommandHelper {
 	addPlatforms(
 		platforms: string[],
 		projectData: IProjectData,
-		frameworkPath?: string
+		frameworkPath?: string,
 	): Promise<void>;
 	cleanPlatforms(
 		platforms: string[],
 		projectData: IProjectData,
-		frameworkPath: string
+		frameworkPath: string,
 	): Promise<void>;
 	removePlatforms(
 		platforms: string[],
-		projectData: IProjectData
+		projectData: IProjectData,
 	): Promise<void>;
 	updatePlatforms(
 		platforms: string[],
-		projectData: IProjectData
+		projectData: IProjectData,
 	): Promise<void>;
 	getInstalledPlatforms(projectData: IProjectData): string[];
 	getAvailablePlatforms(projectData: IProjectData): string[];
 	getPreparedPlatforms(projectData: IProjectData): string[];
 	getCurrentPlatformVersion(
 		platform: string,
-		projectData: IProjectData
+		projectData: IProjectData,
 	): string;
 }
 

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -42,7 +42,7 @@ export class Options {
 	public options: IDictionary<IDashedOption>;
 
 	public setupOptions(
-		commandSpecificDashedOptions?: IDictionary<IDashedOption>
+		commandSpecificDashedOptions?: IDictionary<IDashedOption>,
 	): void {
 		if (commandSpecificDashedOptions) {
 			_.extend(this.options, commandSpecificDashedOptions);
@@ -54,7 +54,7 @@ export class Options {
 		// Check if the user has explicitly provide --hmr and --release options from command line
 		if (this.initialArgv.release && this.initialArgv.hmr) {
 			this.$errors.fail(
-				"The options --release and --hmr cannot be used simultaneously."
+				"The options --release and --hmr cannot be used simultaneously.",
 			);
 		}
 
@@ -75,7 +75,7 @@ export class Options {
 
 	constructor(
 		private $errors: IErrors,
-		private $settingsService: ISettingsService
+		private $settingsService: ISettingsService,
 	) {
 		this.options = _.extend({}, this.commonOptions, this.globalOptions);
 		this.setArgv();
@@ -250,6 +250,7 @@ export class Options {
 				default: true,
 			},
 			dryRun: { type: OptionType.Boolean, hasSensitiveValue: false },
+			skipNative: { type: OptionType.Boolean, hasSensitiveValue: false },
 			uniqueBundle: { type: OptionType.Boolean, hasSensitiveValue: false },
 		};
 	}
@@ -264,7 +265,7 @@ export class Options {
 	}
 
 	public validateOptions(
-		commandSpecificDashedOptions?: IDictionary<IDashedOption>
+		commandSpecificDashedOptions?: IDictionary<IDashedOption>,
 	): void {
 		this.setupOptions(commandSpecificDashedOptions);
 		const parsed: any = {};
@@ -284,7 +285,7 @@ export class Options {
 			if (!_.includes(this.optionsWhiteList, optionName)) {
 				if (!this.isOptionSupported(optionName)) {
 					this.$errors.failWithHelp(
-						`The option '${originalOptionName}' is not supported.`
+						`The option '${originalOptionName}' is not supported.`,
 					);
 				}
 
@@ -294,7 +295,7 @@ export class Options {
 				if (_.isArray(optionValue) && optionType !== OptionType.Array) {
 					this.$errors.failWithHelp(
 						"The '%s' option requires a single value.",
-						originalOptionName
+						originalOptionName,
 					);
 				} else if (
 					optionType === OptionType.String &&
@@ -302,14 +303,14 @@ export class Options {
 				) {
 					this.$errors.failWithHelp(
 						"The option '%s' requires non-empty value.",
-						originalOptionName
+						originalOptionName,
 					);
 				} else if (
 					optionType === OptionType.Array &&
 					optionValue.length === 0
 				) {
 					this.$errors.failWithHelp(
-						`The option '${originalOptionName}' requires one or more values, separated by a space.`
+						`The option '${originalOptionName}' requires one or more values, separated by a space.`,
 					);
 				}
 			}
@@ -350,7 +351,7 @@ export class Options {
 	// This way your code will work in case "$ <cli name> emulate android --profile-dir" or "$ <cli name> emulate android --profileDir" is used by user.
 	private getNonDashedOptionName(optionName: string): string {
 		const matchUpperCaseLetters = optionName.match(
-			Options.NONDASHED_OPTION_REGEX
+			Options.NONDASHED_OPTION_REGEX,
 		);
 		if (matchUpperCaseLetters) {
 			// get here if option with upperCase letter is specified, for example profileDir
@@ -410,7 +411,7 @@ export class Options {
 							.map((match) => {
 								return match[currentDepth];
 							})
-							.filter(Boolean)
+							.filter(Boolean),
 					),
 				];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@foxt/js-srp": "0.0.3-patch2",
         "@nativescript/doctor": "2.0.17",
-        "@nativescript/hook": "3.0.4",
+        "@nativescript/hook": "3.0.5",
         "@npmcli/arborist": "9.1.8",
         "@nstudio/trapezedev-project": "7.2.3",
         "@rigor789/resolve-package-path": "1.0.7",
@@ -344,6 +344,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
       "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -851,14 +852,10 @@
       }
     },
     "node_modules/@nativescript/hook": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@nativescript/hook/-/hook-3.0.4.tgz",
-      "integrity": "sha512-oahiN7V0D+fgl9o8mjGRgExujTpgSBB0DAFr3eX91qdlJZV8ywJ6mnvtHZyEI2j46yPgAE8jmNIw/Z/d3aWetw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "glob": "^11.0.0",
-        "mkdirp": "^3.0.1"
-      }
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@nativescript/hook/-/hook-3.0.5.tgz",
+      "integrity": "sha512-MzL7R/nPZU2qnvDWWuJ8RB7H3luEwANgFX/d/ILdg7bSYxl6uANCfzlueHnWgrQmBxu6dTkvPsFW2WNVUxlhUg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4487,6 +4484,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -4503,6 +4501,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -4759,6 +4758,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
       "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
@@ -6891,6 +6891,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
       "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^9.0.0"
@@ -9045,6 +9046,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pacote": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
 		"skipLibCheck": true,
 		"alwaysStrict": true,
 		"noUnusedLocals": true,
-		"lib": ["ESNext"]
+		"lib": ["ESNext"],
+		"strict": false
 	},
 	"include": ["lib/", "test/"]
 }


### PR DESCRIPTION
Slight scope creep: disable strict and update wrong package-lock.json


adds --skipNative so we can build only webpack for validating the JS is fine