### PR TITLE
feat: custom runtime package + info in package.json

### DIFF
--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -18,7 +18,10 @@ import {
 	CONFIG_FILE_NAME_TS,
 	PACKAGE_JSON_FILE_NAME,
 	PLATFORMS_DIR_NAME,
+	PlatformTypes,
 	PREPARE_READY_EVENT_NAME,
+	SCOPED_ANDROID_RUNTIME_NAME,
+	SCOPED_IOS_RUNTIME_NAME,
 	SupportedPlatform,
 	TrackActionNames,
 } from "../constants";
@@ -36,6 +39,7 @@ import {
 	IProjectDataService,
 	IProjectService,
 } from "../definitions/project";
+import { resolvePackageJSONPath } from "@rigor789/resolve-package-path";
 
 interface IPlatformWatcherData {
 	hasWebpackCompilerProcess: boolean;
@@ -447,30 +451,72 @@ export class PrepareController extends EventEmitter {
 		this.$logger.info(
 			"Updating runtime package.json with configuration values...",
 		);
-		const nsConfig = this.$projectConfigService.readConfig(
-			projectData.projectDir,
+
+
+		const {hooks, ignoredNativeDependencies, webpackPackageName, webpackConfigPath, appResourcesPath, buildPath, appPath, ...nsConfig} = this.$projectConfigService.readConfig(
+			projectData.projectDir
 		);
+
+		const platform = platformData.platformNameLowerCase;
+		let installedRuntimePackageJSON;
+		let runtimePackageName: string;
+		if (platform === PlatformTypes.ios) {
+			runtimePackageName = projectData.nsConfig.ios?.runtimePackageName || SCOPED_IOS_RUNTIME_NAME;
+		} else if (platform === PlatformTypes.android) {
+			runtimePackageName = projectData.nsConfig.android?.runtimePackageName || SCOPED_ANDROID_RUNTIME_NAME;
+		}
+		// try reading from installed runtime first before reading from the npm registry...
+		const installedRuntimePackageJSONPath = resolvePackageJSONPath(
+			runtimePackageName,
+			{
+				paths: [projectData.projectDir],
+			}
+		);
+
+		if (installedRuntimePackageJSONPath) {
+			installedRuntimePackageJSON = this.$fs.readJson(
+				installedRuntimePackageJSONPath
+			);
+		}
 		const packageData: any = {
 			..._.pick(projectData.packageJsonData, ["name"]),
 			...nsConfig,
 			main: "bundle",
+			...(installedRuntimePackageJSON? {}:{})
 		};
-
 		if (
-			platformData.platformNameLowerCase === "ios" &&
-			packageData.ios &&
-			packageData.ios.discardUncaughtJsExceptions
+			platform === PlatformTypes.ios
 		) {
-			packageData.discardUncaughtJsExceptions =
+			if (installedRuntimePackageJSON) {
+				packageData.ios = packageData.ios || {};
+				packageData.ios.runtime = {
+					version: installedRuntimePackageJSON.version
+				};
+			}
+			if (packageData.ios &&
+				packageData.ios.discardUncaughtJsExceptions) {
+				packageData.discardUncaughtJsExceptions =
 				packageData.ios.discardUncaughtJsExceptions;
+			}
+			delete packageData.android;
 		}
 		if (
-			platformData.platformNameLowerCase === "android" &&
-			packageData.android &&
-			packageData.android.discardUncaughtJsExceptions
+			platform === PlatformTypes.android
 		) {
-			packageData.discardUncaughtJsExceptions =
-				packageData.android.discardUncaughtJsExceptions;
+			if (installedRuntimePackageJSON) {
+				packageData.android = packageData.android || {};
+				packageData.android.runtime = {
+					version: installedRuntimePackageJSON.version,
+					version_info: installedRuntimePackageJSON.version_info,
+					gradle:installedRuntimePackageJSON.gradle
+				};
+			}
+			if (packageData.android &&
+				packageData.android.discardUncaughtJsExceptions) {
+				packageData.discardUncaughtJsExceptions =
+					packageData.android.discardUncaughtJsExceptions;
+			}
+			delete packageData.ios;
 		}
 		let packagePath: string;
 		if (

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -130,6 +130,10 @@ interface INsConfigIOS extends INsConfigPlaform {
 	 * List packages to be included in the iOS build.
 	 */
 	SPMPackages?: Array<IOSSPMPackage>;
+	/**
+	 * Custom runtime package name
+	 */
+	runtimePackageName?: string
 }
 
 interface INSConfigVisionOS extends INsConfigIOS {}
@@ -168,6 +172,11 @@ interface INsConfigAndroid extends INsConfigPlaform {
 	enableLineBreakpoints?: boolean;
 
 	enableMultithreadedJavascript?: boolean;
+
+	/**
+	 * Custom runtime package name
+	 */
+	runtimePackageName?: string
 }
 
 interface INsConfigHooks {

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -490,10 +490,10 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 
 	private async getLatestRuntimeVersion(): Promise<string> {
 		let runtimeVersion: string = null;
-
+		const packageName = this.$projectData.nsConfig.android?.runtimePackageName || SCOPED_ANDROID_RUNTIME_NAME;
 		try {
 			let result = await this.$packageManager.view(
-				SCOPED_ANDROID_RUNTIME_NAME,
+				packageName,
 				{
 					"dist-tags": true,
 				}
@@ -505,7 +505,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 				`Error while getting latest android runtime version from view command: ${err}`
 			);
 			const registryData = await this.$packageManager.getRegistryPackageData(
-				SCOPED_ANDROID_RUNTIME_NAME
+				packageName
 			);
 			runtimeVersion = registryData["dist-tags"].latest;
 		}
@@ -529,9 +529,10 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			};
 		}
 
+		const packageName = this.$projectData.nsConfig.android?.runtimePackageName || SCOPED_ANDROID_RUNTIME_NAME;
 		// try reading from installed runtime first before reading from the npm registry...
 		const installedRuntimePackageJSONPath = resolvePackageJSONPath(
-			SCOPED_ANDROID_RUNTIME_NAME,
+			packageName,
 			{
 				paths: [this.$projectData.projectDir],
 			}
@@ -584,10 +585,11 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			return localVersionInfo;
 		}
 
+		const packageName = this.$projectData.nsConfig.android?.runtimePackageName || SCOPED_ANDROID_RUNTIME_NAME;
 		// fallback to reading from npm...
 		try {
 			let output = await this.$packageManager.view(
-				`${SCOPED_ANDROID_RUNTIME_NAME}@${runtimeVersion}`,
+				`${packageName}@${runtimeVersion}`,
 				{ version_info: true }
 			);
 			output = output?.["version_info"] ?? output;
@@ -602,7 +604,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 				 *
 				 */
 				output = await this.$packageManager.view(
-					`${SCOPED_ANDROID_RUNTIME_NAME}@${runtimeVersion}`,
+					`${packageName}@${runtimeVersion}`,
 					{ gradle: true }
 				);
 				output = output?.["gradle"] ?? output;
@@ -622,7 +624,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 				`Error while getting gradle data for android runtime from view command: ${err}`
 			);
 			const registryData = await this.$packageManager.getRegistryPackageData(
-				SCOPED_ANDROID_RUNTIME_NAME
+				packageName
 			);
 			runtimeGradleVersions = registryData.versions[runtimeVersion];
 		}

--- a/lib/services/project-data-service.ts
+++ b/lib/services/project-data-service.ts
@@ -50,6 +50,7 @@ export class ProjectDataService implements IProjectDataService {
 		private $fs: IFileSystem,
 		private $staticConfig: IStaticConfig,
 		private $logger: ILogger,
+		private $projectData: IProjectData,
 		private $devicePlatformsConstants: Mobile.IDevicePlatformsConstants,
 		private $androidResourcesMigrationService: IAndroidResourcesMigrationService,
 		private $injector: IInjector
@@ -628,13 +629,15 @@ export class ProjectDataService implements IProjectDataService {
 			.getDependenciesFromPackageJson(projectDir)
 			.devDependencies.find((d) => {
 				if (platform === constants.PlatformTypes.ios) {
+					const packageName = this.$projectData.nsConfig.ios?.runtimePackageName || constants.SCOPED_IOS_RUNTIME_NAME;
 					return [
-						constants.SCOPED_IOS_RUNTIME_NAME,
+						packageName,
 						constants.TNS_IOS_RUNTIME_NAME,
 					].includes(d.name);
 				} else if (platform === constants.PlatformTypes.android) {
+					const packageName = this.$projectData.nsConfig.android?.runtimePackageName || constants.SCOPED_ANDROID_RUNTIME_NAME;
 					return [
-						constants.SCOPED_ANDROID_RUNTIME_NAME,
+						packageName,
 						constants.TNS_ANDROID_RUNTIME_NAME,
 					].includes(d.name);
 				} else if (platform === constants.PlatformTypes.visionos) {
@@ -687,12 +690,12 @@ export class ProjectDataService implements IProjectDataService {
 		);
 		if (platform === constants.PlatformTypes.ios) {
 			return {
-				name: constants.SCOPED_IOS_RUNTIME_NAME,
+				name: this.$projectData.nsConfig.ios?.runtimePackageName || constants.SCOPED_IOS_RUNTIME_NAME,
 				version: null,
 			};
 		} else if (platform === constants.PlatformTypes.android) {
 			return {
-				name: constants.SCOPED_ANDROID_RUNTIME_NAME,
+				name: this.$projectData.nsConfig.android?.runtimePackageName || constants.SCOPED_ANDROID_RUNTIME_NAME,
 				version: null,
 			};
 		} else if (platform === constants.PlatformTypes.visionos) {


### PR DESCRIPTION
As we discussed this PR adds custom android/ios runtime package support.

It also adds those informations + version inside the packaged package.json. This is useful if you want to show the info in your app.

Please test it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable platform-specific runtime packages. Users can now optionally specify custom runtime package names for iOS and Android in their NativeScript configuration, with automatic fallback to default packages when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->