### PR TITLE
fix(bundler): copy the vite bundle to native in non-watch builds

### DIFF
--- a/lib/services/bundler/bundler-compiler-service.ts
+++ b/lib/services/bundler/bundler-compiler-service.ts
@@ -126,13 +126,9 @@ export class BundlerCompilerService
 						}
 
 						// Copy Vite output files directly to platform destination
-						const distOutput = path.join(
-							projectData.projectDir,
-							".ns-vite-build",
-						);
-						const destDir = path.join(
-							platformData.appDestinationDirectoryPath,
-							this.$options.hostProjectModuleName,
+						const { distOutput, destDir } = this.getVitePaths(
+							platformData,
+							projectData,
 						);
 
 						if (debugLog) {
@@ -389,13 +385,9 @@ export class BundlerCompilerService
 						// the Static Binding Generator with no input. Copy the full
 						// Vite bundle here instead.
 						if (this.getBundler() === "vite") {
-							const distOutput = path.join(
-								projectData.projectDir,
-								".ns-vite-build",
-							);
-							const destDir = path.join(
-								platformData.appDestinationDirectoryPath,
-								this.$options.hostProjectModuleName,
+							const { distOutput, destDir } = this.getVitePaths(
+								platformData,
+								projectData,
 							);
 							this.copyViteBundleToNative(distOutput, destDir);
 						}
@@ -862,6 +854,21 @@ export class BundlerCompilerService
 
 	public getBundler(): BundlerType {
 		return this.$projectConfigService.getValue(`bundler`, "webpack");
+	}
+
+	// The Vite output directory and its destination in the native project —
+	// shared by the watch-mode `emittedFiles` copy and the non-watch copy.
+	private getVitePaths(
+		platformData: IPlatformData,
+		projectData: IProjectData,
+	): { distOutput: string; destDir: string } {
+		return {
+			distOutput: path.join(projectData.projectDir, ".ns-vite-build"),
+			destDir: path.join(
+				platformData.appDestinationDirectoryPath,
+				this.$options.hostProjectModuleName,
+			),
+		};
 	}
 
 	private copyViteBundleToNative(

--- a/lib/services/bundler/bundler-compiler-service.ts
+++ b/lib/services/bundler/bundler-compiler-service.ts
@@ -380,6 +380,25 @@ export class BundlerCompilerService
 					delete this.bundlerProcesses[platformData.platformNameLowerCase];
 					const exitCode = typeof arg === "number" ? arg : arg && arg.code;
 					if (exitCode === 0) {
+						// In watch mode the Vite output is copied into the native
+						// project from the `emittedFiles` IPC message. A non-watch
+						// build (`ns build`, `ns run --justlaunch`) has no IPC
+						// channel — `startBundleProcess` sets `stdio: "inherit"`
+						// when `prepareData.watch` is false — so that copy never
+						// runs and `<platform>/.../assets/app` stays empty, leaving
+						// the Static Binding Generator with no input. Copy the full
+						// Vite bundle here instead.
+						if (this.getBundler() === "vite") {
+							const distOutput = path.join(
+								projectData.projectDir,
+								".ns-vite-build",
+							);
+							const destDir = path.join(
+								platformData.appDestinationDirectoryPath,
+								this.$options.hostProjectModuleName,
+							);
+							this.copyViteBundleToNative(distOutput, destDir);
+						}
 						resolve();
 					} else {
 						const error: any = new Error(


### PR DESCRIPTION
### Problem

With `bundler: 'vite'`, a **non-watch** build leaves the app's JS out of the APK/IPA, so the build fails.

The Vite output (`.ns-vite-build/`) is copied into the native project's `assets/app` only from the **watch-mode** IPC handler in `compileWithWatch` — the `childProcess.on("message", …)` branch that reads `message.emittedFiles` and calls `copyViteBundleToNative`. A non-watch build (`ns build`, or `ns run --justlaunch`) runs `compileWithoutWatch`, which:

- has **no IPC channel** — `startBundleProcess` sets `stdio: "inherit"` when `prepareData.watch` is `false`, so `process.send(...)` in the Vite child is a no-op and the `"message"` handler never fires; and
- never calls `copyViteBundleToNative` itself.

So the Vite output stays in `.ns-vite-build/`, `<platform>/.../assets/app` stays empty, and the Static Binding Generator fails:

```
Error executing Static Binding Generator: Couldn't find '…/platforms/android/build-tools/sbg-bindings.txt' bindings input file.
…
Error processing 'sbg-js-parsed-files.txt': no file was found in …/platforms/android/app/
```

Webpack/rspack are unaffected — they write directly into the platform folder rather than into `.ns-vite-build/`.

### Repro

Any `bundler: 'vite'` app:

```sh
ns build android        # or: ns run android --justlaunch
```

→ gradle fails at the SBG step because `assets/app` has only the runtime `package.json` and no bundle. `ns run android` (watch mode) works, which is what masks the bug.

### Fix

Copy the full Vite bundle in `compileWithoutWatch`'s `close` handler on a successful (exit code 0) build, mirroring the full-build branch of the watch-mode copy (`copyViteBundleToNative(distOutput, destDir)`), guarded on `this.getBundler() === "vite"`.

### Notes

- Minimal change; mirrors the existing watch-mode copy. `tsc` is clean.
- The `compileWithoutWatch`/`compileWithWatch` unit tests currently cover only the config-path error path (not the build/copy flow), so this matches the existing coverage. Happy to add a test that stubs the child-process `close` + asserts `copyViteBundleToNative` is called if you'd like.
- Found while building NativeScript apps with a Vite-8 config via [`@gjsify/nativescript-vite`](https://github.com/gjsify/gjsify); reproduced with stock `@nativescript/vite` + `ns build android`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset handling for Vite-based builds: non-watch builds now reliably copy Vite output into platform assets so native apps get the bundled files.
  * Watch-mode behavior improved: incremental and full updates from Vite are now propagated consistently to native assets during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->