### PR TITLE
fix: deprecated uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6185,15 +6185,6 @@
         "uuid": "8.3.2"
       }
     },
-    "node_modules/ios-device-lib/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/ios-mobileprovision-finder": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ios-mobileprovision-finder/-/ios-mobileprovision-finder-1.2.1.tgz",
@@ -8374,19 +8365,6 @@
         "bplist-creator": "0.1.0",
         "bplist-parser": "0.3.1",
         "plist": "^3.0.5"
-      }
-    },
-    "node_modules/nativescript-dev-xcode/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/ncp": {
@@ -12076,15 +12054,6 @@
         "node": ">=12.18.2"
       }
     },
-    "node_modules/universal-analytics/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -12454,15 +12423,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/xcode/node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/xml-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nativescript/doctor": "2.0.17",
         "@nativescript/hook": "3.0.5",
         "@npmcli/arborist": "9.1.8",
-        "@nstudio/trapezedev-project": "7.2.3",
+        "@nstudio/trapezedev-project": "7.2.4",
         "@rigor789/resolve-package-path": "1.0.7",
         "axios": "1.13.5",
         "byline": "5.0.0",
@@ -26,7 +26,7 @@
         "email-validator": "2.0.4",
         "esprima": "4.0.1",
         "font-finder": "1.1.0",
-        "ios-device-lib": "0.9.4",
+        "ios-device-lib": "0.9.5",
         "ios-mobileprovision-finder": "1.2.1",
         "ios-sim-portable": "4.5.1",
         "jimp": "1.6.0",
@@ -37,7 +37,7 @@
         "minimatch": "10.2.4",
         "mkdirp": "3.0.1",
         "mute-stream": "2.0.0",
-        "nativescript-dev-xcode": "0.8.1",
+        "nativescript-dev-xcode": "0.8.2",
         "open": "8.4.2",
         "ora": "5.4.1",
         "pacote": "21.0.4",
@@ -1160,9 +1160,9 @@
       }
     },
     "node_modules/@nstudio/trapezedev-project": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@nstudio/trapezedev-project/-/trapezedev-project-7.2.3.tgz",
-      "integrity": "sha512-EIxEGjwPeMfBVkxvRvf8GY+pD3lfu8CP2sh/AD5eV4fgW/gpgRYE9WKbW4QJLj7WIRgQbn6Oos9NXq1OfTmzhA==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@nstudio/trapezedev-project/-/trapezedev-project-7.2.4.tgz",
+      "integrity": "sha512-47/E/HMoWnfYpm6EW5wCy7zM168kNkomEiQJyH3r6TYd3HVsUIdH586v8NEOGqIMAxxi+71w+Qu08ztyKgubLQ==",
       "license": "SEE LICENSE",
       "dependencies": {
         "@ionic/utils-fs": "^3.1.5",
@@ -1181,9 +1181,10 @@
         "prettier": "^2.7.1",
         "prompts": "^2.4.2",
         "replace": "^1.1.0",
+        "simple-plist": "^1.4.0",
         "tmp": "^0.2.1",
         "ts-node": "^10.2.1",
-        "xcode": "^3.0.1",
+        "uuid": "^11.1.0",
         "xml-js": "^1.6.11",
         "xpath": "^0.0.32",
         "yargs": "^17.2.1"
@@ -3581,6 +3582,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6176,13 +6178,13 @@
       "license": "MIT"
     },
     "node_modules/ios-device-lib": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.9.4.tgz",
-      "integrity": "sha512-UoR3+JZ4Ox9xSbp4sM6kMQu7JL5RLqgSS4gLy39hAYYtZqMpNB/u47uN63ZEq/RhqtrNFub/w7t3QicLLQ9bvg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/ios-device-lib/-/ios-device-lib-0.9.5.tgz",
+      "integrity": "sha512-abZn5jjIDKG+P7K9fukdWTwDdSp8U9FhjIl2/qVa7VtKA0d8hm075tdi3IEzxClKAdpqv/0zO0b+wXBF3WVzkQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bufferpack": "0.0.6",
-        "uuid": "8.3.2"
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/ios-mobileprovision-finder": {
@@ -8214,6 +8216,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -8323,13 +8326,13 @@
       }
     },
     "node_modules/nativescript-dev-xcode": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/nativescript-dev-xcode/-/nativescript-dev-xcode-0.8.1.tgz",
-      "integrity": "sha512-AIHoah4ZEo8CUC6xb7CX0dWTKHcsoO4DL+nYVwIESVd2XQspE1pzSRMmar9/maz4rxbPeFFTEN7eknqn69+aVg==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/nativescript-dev-xcode/-/nativescript-dev-xcode-0.8.2.tgz",
+      "integrity": "sha512-Df18n2/t6eS08ilPF8OfcF0d+l/cMyhnmT/ZYiWn0XWn2BaGPg1DgXY5vC7B0fFmfncngJmyrInJwoGF0whmVA==",
       "license": "Apache-2.0",
       "dependencies": {
         "simple-plist": "1.3.1",
-        "uuid": "9.0.1"
+        "uuid": "^11.1.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -12045,6 +12048,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.5.3.tgz",
       "integrity": "sha512-HXSMyIcf2XTvwZ6ZZQLfxfViRm/yTGoRgDeTbojtq6rezeyKB0sTBcKH2fhddnteAHRcHiKgr/ACpbgjGOC6RQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.1",
@@ -12176,6 +12180,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "inBundle": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
@@ -12410,19 +12415,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xcode": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
-      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "simple-plist": "^1.1.0",
-        "uuid": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/xml-js": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@nativescript/doctor": "2.0.17",
     "@nativescript/hook": "3.0.5",
     "@npmcli/arborist": "9.1.8",
-    "@nstudio/trapezedev-project": "7.2.3",
+    "@nstudio/trapezedev-project": "7.2.4",
     "@rigor789/resolve-package-path": "1.0.7",
     "axios": "1.13.5",
     "byline": "5.0.0",
@@ -70,7 +70,7 @@
     "email-validator": "2.0.4",
     "esprima": "4.0.1",
     "font-finder": "1.1.0",
-    "ios-device-lib": "0.9.4",
+    "ios-device-lib": "0.9.5",
     "ios-mobileprovision-finder": "1.2.1",
     "ios-sim-portable": "4.5.1",
     "jimp": "1.6.0",
@@ -81,7 +81,7 @@
     "minimatch": "10.2.4",
     "mkdirp": "3.0.1",
     "mute-stream": "2.0.0",
-    "nativescript-dev-xcode": "0.8.1",
+    "nativescript-dev-xcode": "0.8.2",
     "open": "8.4.2",
     "ora": "5.4.1",
     "pacote": "21.0.4",
@@ -162,6 +162,9 @@
   "optionalDependencies": {
     "fsevents": "*"
   },
+  "bundleDependencies": [
+    "universal-analytics"
+  ],
   "overrides": {
     "@conventional-changelog/git-client": "2.5.1",
     "uuid": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
   },
   "overrides": {
     "@conventional-changelog/git-client": "2.5.1",
+    "uuid": "11.1.0",
     "jimp": {
       "xml2js": "0.6.2"
     },


### PR DESCRIPTION
- fix deprecated uuid warnings on install:
```
npm warn deprecated uuid@7.0.3: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
npm warn deprecated uuid@8.3.2: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
npm warn deprecated uuid@8.3.2: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
npm warn deprecated uuid@9.0.1: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated several project dependencies to newer versions for stability and compatibility.
  * Added an analytics library to the bundled dependencies to ensure it's packaged consistently.
  * Pinned a UUID-related dependency to a specific version and extended overrides to reduce version conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->