### PR TITLE
feat(apple): support team signing on Swift macro SPM targets

### DIFF
--- a/lib/services/ios/xcodebuild-args-service.ts
+++ b/lib/services/ios/xcodebuild-args-service.ts
@@ -227,6 +227,18 @@ export class XcodebuildArgsService implements IXcodebuildArgsService {
 			extraArgs.push(`${swiftUIBootProperty}=${swiftUIBootValue}`);
 		}
 
+		// Swift macro/compiler-plugin SPM targets must be code-signed with a
+		// development team when building for a device. Pass DEVELOPMENT_TEAM as a
+		// command-line build setting so it applies to SPM package targets too.
+		const developmentTeamProperty = "DEVELOPMENT_TEAM";
+		const developmentTeamValue = this.$xcconfigService.readPropertyValue(
+			BUILD_SETTINGS_FILE_PATH,
+			developmentTeamProperty,
+		);
+		if (developmentTeamValue) {
+			extraArgs.push(`${developmentTeamProperty}=${developmentTeamValue}`);
+		}
+
 		if (this.$fs.exists(xcworkspacePath)) {
 			return ["-workspace", xcworkspacePath, ...extraArgs];
 		}

--- a/test/services/ios/xcodebuild-args-service.ts
+++ b/test/services/ios/xcodebuild-args-service.ts
@@ -101,6 +101,24 @@ describe("xcodebuildArgsService", () => {
 			assert.include(actualArgs, "SWIFT_ENABLE_EXPLICIT_MODULES=YES");
 			assert.notInclude(actualArgs, "SWIFT_ENABLE_EXPLICIT_MODULES=NO");
 		});
+
+		it("should include DEVELOPMENT_TEAM from build.xcconfig", () => {
+			const injector = createTestInjector({
+				logLevel: "INFO",
+				hasProjectWorkspace: false,
+				buildXcconfigContent: "DEVELOPMENT_TEAM = TEAM123",
+			});
+			const xcodebuildArgsService: IXcodebuildArgsService = injector.resolve(
+				"xcodebuildArgsService",
+			);
+
+			const actualArgs = xcodebuildArgsService.getXcodeProjectArgs(
+				<any>{ projectRoot, normalizedPlatformName },
+				<any>{ projectName, appResourcesDirectoryPath },
+			);
+
+			assert.include(actualArgs, "DEVELOPMENT_TEAM=TEAM123");
+		});
 	});
 
 	describe("getBuildForSimulatorArgs", () => {


### PR DESCRIPTION
- support code signing for Swift macro/compiler-plugin SPM targets by ensuring that the `DEVELOPMENT_TEAM` build setting is always passed to the Xcode build command if specified in the `build.xcconfig` file. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## iOS Build Improvements

* **New Features**
  * Added development team configuration support for iOS builds, enabling proper code-signing of Swift macros and compiler plugin targets during device builds.

* **Tests**
  * Added test coverage for development team configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->