### PR TITLE
feat(apple): Fix doctor issue with asdf

### DIFF
--- a/packages/doctor/src/sys-info.ts
+++ b/packages/doctor/src/sys-info.ts
@@ -425,25 +425,34 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 					);
 					const xcodeProjectDir = path.join(tempDirectory, "cocoapods");
 
-					// If ADSF version manager is installed, get the config for the project directory and write it to the temporary project directory
+					// If asdf version manager is installed, get the current Ruby version for the project directory and write it to the temporary project directory
 					const asdfResult = await this.childProcess.spawnFromEvent(
 						"asdf",
-						["list", "ruby"],
+						["current", "ruby"],
 						"exit",
-					);
-					const asdfVersionMatch = (asdfResult.stdout as string).match(
-						SysInfo.VERSION_REGEXP,
+						{ ignoreError: true },
 					);
 
-					if (asdfVersionMatch?.[0]) {
-						const asdfVersion = asdfVersionMatch[0];
-						const asdfConfigPath = path.join(xcodeProjectDir, ".tool-versions");
-						const wroteASDFConfig = this.fileSystem.appendFile(
-							asdfConfigPath,
-							`ruby ${asdfVersion}`,
+					if (asdfResult.exitCode === 0) {
+						const asdfVersionMatch = (asdfResult.stdout as string).match(
+							SysInfo.VERSION_REGEXP,
 						);
-						if (!wroteASDFConfig) {
-							console.warn(`Cocoapods invocation may fail, check asdf config`);
+
+						if (asdfVersionMatch?.[0]) {
+							const asdfVersion = asdfVersionMatch[0];
+							const asdfConfigPath = path.join(
+								xcodeProjectDir,
+								".tool-versions",
+							);
+							const wroteASDFConfig = this.fileSystem.appendFile(
+								asdfConfigPath,
+								`ruby ${asdfVersion}`,
+							);
+							if (!wroteASDFConfig) {
+								console.warn(
+									`CocoaPods invocation may fail, check asdf config`,
+								);
+							}
 						}
 					}
 

--- a/packages/doctor/src/sys-info.ts
+++ b/packages/doctor/src/sys-info.ts
@@ -424,6 +424,29 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 						tempDirectory,
 					);
 					const xcodeProjectDir = path.join(tempDirectory, "cocoapods");
+
+					// If ADSF version manager is installed, get the config for the project directory and write it to the temporary project directory
+					const asdfResult = await this.childProcess.spawnFromEvent(
+						"asdf",
+						["list", "ruby"],
+						"exit",
+					);
+					const asdfVersionMatch = (asdfResult.stdout as string).match(
+						SysInfo.VERSION_REGEXP,
+					);
+
+					if (asdfVersionMatch?.[0]) {
+						const asdfVersion = asdfVersionMatch[0];
+						const asdfConfigPath = path.join(xcodeProjectDir, ".tool-versions");
+						const wroteASDFConfig = this.fileSystem.appendFile(
+							asdfConfigPath,
+							`ruby ${asdfVersion}`,
+						);
+						if (!wroteASDFConfig) {
+							console.warn(`Cocoapods invocation may fail, check asdf config`);
+						}
+					}
+
 					const spawnResult = await this.childProcess.spawnFromEvent(
 						"pod",
 						["install"],
@@ -432,6 +455,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 					);
 					return !spawnResult.exitCode;
 				} catch (err) {
+					console.log(`Pod command failed - ${err}`);
 					return false;
 				} finally {
 					this.fileSystem.deleteEntry(tempDirectory);

--- a/packages/doctor/src/sys-info.ts
+++ b/packages/doctor/src/sys-info.ts
@@ -425,12 +425,13 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 					);
 					const xcodeProjectDir = path.join(tempDirectory, "cocoapods");
 
-					// If asdf version manager is installed, get the current Ruby version for the project directory and write it to the temporary project directory
+					// If asdf version manager is installed, get the current Ruby version for the project directory and write it to the temporary project directory.
+					// Resolve relative to the directory `ns doctor` was invoked from, since it can be run outside of a project directory.
 					const asdfResult = await this.childProcess.spawnFromEvent(
 						"asdf",
 						["current", "ruby"],
 						"exit",
-						{ ignoreError: true },
+						{ ignoreError: true, spawnOptions: { cwd: process.cwd() } },
 					);
 
 					if (asdfResult.exitCode === 0) {
@@ -446,7 +447,7 @@ export class SysInfo implements NativeScriptDoctor.ISysInfo {
 							);
 							const wroteASDFConfig = this.fileSystem.appendFile(
 								asdfConfigPath,
-								`ruby ${asdfVersion}`,
+								`ruby ${asdfVersion}\n`,
 							);
 							if (!wroteASDFConfig) {
 								console.warn(

--- a/packages/doctor/src/wrappers/file-system.ts
+++ b/packages/doctor/src/wrappers/file-system.ts
@@ -8,6 +8,17 @@ export class FileSystem {
 		return fs.existsSync(path.resolve(filePath));
 	}
 
+	public appendFile(filePath: string, text: string): boolean {
+		let success = false;
+		try {
+			fs.appendFileSync(path.resolve(filePath), text);
+			success = true;
+		} catch (err) {
+			console.error(`appendFile failed with ${err}`);
+		}
+		return success;
+	}
+
 	public extractZip(pathToZip: string, outputDir: string): Promise<void> {
 		return new Promise((resolve, reject) => {
 			yauzl.open(
@@ -46,7 +57,7 @@ export class FileSystem {
 					zipFile.once("end", () => resolve());
 
 					zipFile.readEntry();
-				}
+				},
 			);
 		});
 	}
@@ -57,7 +68,7 @@ export class FileSystem {
 
 	public readJson<T>(
 		filePath: string,
-		options?: { encoding?: null; flag?: string }
+		options?: { encoding?: null; flag?: string },
 	): T {
 		const content = fs.readFileSync(filePath, options);
 		return JSON.parse(content.toString());

--- a/packages/doctor/test/sys-info.ts
+++ b/packages/doctor/test/sys-info.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import * as fs from "fs";
 import * as path from "path";
 import { EOL } from "os";
 import { SysInfo } from "../src/sys-info";
@@ -908,6 +909,136 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.202-b08, mixed mode)`),
 				const result = await sysInfo.getJavaVersion();
 				assert.equal(result, "1.8.0_25");
 			});
+		});
+	});
+
+	describe("isCocoaPodsWorkingCorrectly", () => {
+		interface ICocoaPodsMockOptions {
+			// Mimics the ChildProcess result for `asdf current ruby`.
+			// When omitted, asdf is treated as not installed.
+			asdfResult?: {
+				stdout?: string;
+				stderr?: string;
+				exitCode?: number | string;
+			};
+			podExitCode?: number;
+		}
+
+		const createCocoaPodsSysInfo = (options: ICocoaPodsMockOptions) => {
+			const appendedFiles: { filePath: string; text: string }[] = [];
+			const spawnCalls: {
+				command: string;
+				options?: ISpawnFromEventOptions;
+			}[] = [];
+
+			const childProcess: any = {
+				spawnFromEvent: async (
+					command: string,
+					args: string[],
+					event: string,
+					spawnFromEventOptions?: ISpawnFromEventOptions,
+				) => {
+					const fullCommand = `${command} ${args.join(" ")}`;
+					spawnCalls.push({
+						command: fullCommand,
+						options: spawnFromEventOptions,
+					});
+
+					if (fullCommand === "asdf current ruby") {
+						// Mirror the ChildProcess wrapper: with `ignoreError` it always
+						// resolves, surfacing a non-zero exitCode instead of throwing when
+						// asdf is missing/misconfigured.
+						return (
+							options.asdfResult || {
+								stdout: "",
+								stderr: "spawn asdf ENOENT",
+								exitCode: "ENOENT",
+							}
+						);
+					}
+
+					return {
+						stdout: "",
+						stderr: "",
+						exitCode: options.podExitCode ?? 0,
+					};
+				},
+				exec: async () => ({ stdout: "", stderr: "" }),
+				execFile: async (): Promise<any> => undefined,
+				execSync: (): string => null,
+			};
+
+			const fileSystem: any = {
+				exists: () => true,
+				extractZip: () => Promise.resolve(),
+				readDirectory: () => [],
+				appendFile: (filePath: string, text: string) => {
+					appendedFiles.push({ filePath, text });
+					return true;
+				},
+				deleteEntry: (filePath: string) =>
+					fs.rmSync(filePath, { recursive: true, force: true }),
+			};
+
+			const hostInfo: any = {
+				isDarwin: true,
+				isWindows: false,
+				isLinux: false,
+			};
+
+			const helpers = new Helpers(hostInfo);
+			const sysInfo = new SysInfo(
+				childProcess,
+				fileSystem,
+				helpers,
+				hostInfo,
+				null,
+				androidToolsInfo,
+			);
+
+			return { sysInfo, appendedFiles, spawnCalls };
+		};
+
+		it("writes the active Ruby version to .tool-versions when asdf is available", async () => {
+			const { sysInfo, appendedFiles, spawnCalls } = createCocoaPodsSysInfo({
+				asdfResult: {
+					stdout:
+						"ruby            3.2.1           /Users/user/app/.tool-versions",
+					exitCode: 0,
+				},
+			});
+
+			const result = await sysInfo.isCocoaPodsWorkingCorrectly();
+
+			assert.deepEqual(result, true);
+			assert.deepEqual(appendedFiles.length, 1);
+			assert.ok(
+				appendedFiles[0].filePath.endsWith(
+					path.join("cocoapods", ".tool-versions"),
+				),
+			);
+			// The entry must be newline-terminated so it does not merge with existing content.
+			assert.deepEqual(appendedFiles[0].text, "ruby 3.2.1\n");
+
+			const asdfCall = spawnCalls.find(
+				(c) => c.command === "asdf current ruby",
+			);
+			assert.ok(asdfCall, "expected asdf to be probed");
+			// The probe must not throw when asdf is missing/misconfigured...
+			assert.deepEqual(asdfCall.options.ignoreError, true);
+			// ...and it must resolve the version relative to the invocation directory.
+			assert.deepEqual(asdfCall.options.spawnOptions.cwd, process.cwd());
+		});
+
+		it("does not write .tool-versions and stays healthy when asdf is not installed", async () => {
+			const { sysInfo, appendedFiles } = createCocoaPodsSysInfo({
+				// asdf missing -> wrapper resolves with a non-zero (ENOENT) exit code.
+			});
+
+			const result = await sysInfo.isCocoaPodsWorkingCorrectly();
+
+			assert.deepEqual(result, true);
+			assert.deepEqual(appendedFiles.length, 0);
 		});
 	});
 });


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Currently iOS builds can fail in the `ns doctor` stage when using `asdf` to specify the Ruby version; this happens because the CocoaPods checks performed by `ns doctor` are done in a new directory in /tmp which is missing the `asdf` configuration.

## What is the new behavior?
If `asdf` is installed, the Ruby version specified for the project is added to a `.tool-versions` file in the CocoaPods test project folder; this stops the `ns doctor` command from failing and lets the build continue.

Implements #6061.

Note: I *have* run the existing tests; the only test that fails is 'skip when missing hook args' - but this also fails on a clean clone from the repo.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CocoaPods verification now detects ASDF-managed Ruby setups and records the active Ruby version in the Ruby version configuration when found.
* **Bug Fixes**
  * Improved diagnostic logging when CocoaPods commands fail for clearer troubleshooting.
  * Enhanced file append behavior used during ASDF detection: returns reliable success/failure and reports append errors.
* **Tests**
  * Added coverage for ASDF-based CocoaPods health checks, including verification of command options and `.tool-versions` updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->