### PR TITLE
feat(ios): manage generated modulemaps in CLI-controlled directory instead of node_modules

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -1736,6 +1736,18 @@ export class IOSProjectService
 		libraryName: string,
 		modulemapDir: string,
 	): boolean {
+		const modulemapPath = path.join(modulemapDir, "module.modulemap");
+
+		// A plugin may ship a `.a` without an `include/{lib}` headers folder. In
+		// that case there's nothing to expose as a module - clean up any stale
+		// modulemap and bail out instead of letting readDirectory throw.
+		if (!this.$fs.exists(headersFolderPath)) {
+			if (this.$fs.exists(modulemapPath)) {
+				this.$fs.deleteFile(modulemapPath);
+			}
+			return false;
+		}
+
 		const headersFilter = (fileName: string, containingFolderPath: string) =>
 			path.extname(fileName) === ".h" &&
 			this.$fs.getFsStats(path.join(containingFolderPath, fileName)).isFile();
@@ -1743,8 +1755,6 @@ export class IOSProjectService
 		const headerFiles = headersFolderContents.filter((item) =>
 			headersFilter(item, headersFolderPath),
 		);
-
-		const modulemapPath = path.join(modulemapDir, "module.modulemap");
 
 		if (!headerFiles.length) {
 			if (this.$fs.exists(modulemapPath)) {

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -97,6 +97,9 @@ export class IOSProjectService
 {
 	private static IOS_PROJECT_NAME_PLACEHOLDER = "__PROJECT_NAME__";
 	private static IOS_PLATFORM_NAME = "ios";
+	// CLI-managed folder under the platform root where we write generated
+	// artifacts (e.g. plugin modulemaps) so we never write into node_modules
+	private static GENERATED_PLUGINS_DIR_NAME = ".plugins";
 
 	constructor(
 		$fs: IFileSystem,
@@ -530,7 +533,10 @@ export class IOSProjectService
 						singlePlatformFramework,
 						path.extname(singlePlatformFramework),
 					);
-					let frameworkBinaryPath = path.join(singlePlatformFramework, frameworkName)
+					let frameworkBinaryPath = path.join(
+						singlePlatformFramework,
+						frameworkName,
+					);
 					if (library.BinaryPath) {
 						frameworkBinaryPath = path.join(
 							frameworkPath,
@@ -548,7 +554,9 @@ export class IOSProjectService
 				frameworkPath,
 				path.extname(frameworkPath),
 			);
-			return await isDynamicFrameworkBundle(path.join(frameworkPath, frameworkName));
+			return await isDynamicFrameworkBundle(
+				path.join(frameworkPath, frameworkName),
+			);
 		}
 	}
 
@@ -658,7 +666,29 @@ export class IOSProjectService
 		);
 		project.addToHeaderSearchPaths({ relativePath: relativeHeaderSearchPath });
 
-		this.generateModulemap(headersSubpath, libraryName);
+		// Write the generated modulemap into a CLI-managed folder under the
+		// platform root (never into node_modules). The modulemap references the
+		// plugin's headers in-place via relative paths, so nothing is copied.
+		const modulemapDir = path.join(
+			this.getPlatformData(projectData).projectRoot,
+			IOSProjectService.GENERATED_PLUGINS_DIR_NAME,
+			libraryName,
+		);
+		const hasModulemap = this.generateModulemap(
+			headersSubpath,
+			libraryName,
+			modulemapDir,
+		);
+		if (hasModulemap) {
+			// Put the modulemap dir on the header search path so clang discovers
+			// the module there instead of inside node_modules.
+			project.addToHeaderSearchPaths({
+				relativePath: this.getLibSubpathRelativeToProjectPath(
+					modulemapDir,
+					projectData,
+				),
+			});
+		}
 		this.savePbxProj(project, projectData);
 	}
 
@@ -1682,6 +1712,19 @@ export class IOSProjectService
 				project.removeFromHeaderSearchPaths({
 					relativePath: relativeHeaderSearchPath,
 				});
+
+				// Remove the generated modulemap dir search path (see addStaticLibrary)
+				const modulemapDir = path.join(
+					this.getPlatformData(projectData).projectRoot,
+					IOSProjectService.GENERATED_PLUGINS_DIR_NAME,
+					path.basename(staticLibPath, ".a"),
+				);
+				project.removeFromHeaderSearchPaths({
+					relativePath: this.getLibSubpathRelativeToProjectPath(
+						modulemapDir,
+						projectData,
+					),
+				});
 			},
 		);
 
@@ -1691,29 +1734,42 @@ export class IOSProjectService
 	private generateModulemap(
 		headersFolderPath: string,
 		libraryName: string,
-	): void {
+		modulemapDir: string,
+	): boolean {
 		const headersFilter = (fileName: string, containingFolderPath: string) =>
 			path.extname(fileName) === ".h" &&
 			this.$fs.getFsStats(path.join(containingFolderPath, fileName)).isFile();
 		const headersFolderContents = this.$fs.readDirectory(headersFolderPath);
-		let headers = _(headersFolderContents)
-			.filter((item) => headersFilter(item, headersFolderPath))
-			.value();
+		const headerFiles = headersFolderContents.filter((item) =>
+			headersFilter(item, headersFolderPath),
+		);
 
-		if (!headers.length) {
-			this.$fs.deleteFile(path.join(headersFolderPath, "module.modulemap"));
-			return;
+		const modulemapPath = path.join(modulemapDir, "module.modulemap");
+
+		if (!headerFiles.length) {
+			if (this.$fs.exists(modulemapPath)) {
+				this.$fs.deleteFile(modulemapPath);
+			}
+			return false;
 		}
 
-		headers = _.map(headers, (value) => `header "${value}"`);
+		// Reference the plugin's headers (still in node_modules) relative to the
+		// generated modulemap's location, so we don't copy headers or write into
+		// node_modules.
+		const headers = _.map(headerFiles, (value) => {
+			const relativeHeaderPath = path.relative(
+				modulemapDir,
+				path.join(headersFolderPath, value),
+			);
+			return `header "${relativeHeaderPath}"`;
+		});
 
 		const modulemap = `module ${libraryName} { explicit module ${libraryName} { ${headers.join(
 			" ",
 		)} } }`;
-		this.$fs.writeFile(
-			path.join(headersFolderPath, "module.modulemap"),
-			modulemap,
-		);
+		this.$fs.ensureDirectoryExists(modulemapDir);
+		this.$fs.writeFile(modulemapPath, modulemap);
+		return true;
 	}
 
 	private async mergeProjectXcconfigFiles(

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -1035,12 +1035,26 @@ describe("Static libraries support", () => {
 			fs.writeFile(join(staticLibraryHeadersPath, header), "");
 		});
 
-		iOSProjectService.generateModulemap(staticLibraryHeadersPath, libraryName);
-		// Read the generated modulemap and verify it.
-		let modulemap = fs.readFile(
-			join(staticLibraryHeadersPath, "module.modulemap"),
+		// The modulemap is written into a CLI-managed dir (not next to the
+		// headers / not in node_modules) and references the headers in place.
+		const modulemapDir = join(projectPath, ".plugins", libraryName);
+		const generated = iOSProjectService.generateModulemap(
+			staticLibraryHeadersPath,
+			libraryName,
+			modulemapDir,
 		);
-		const headerCommands = _.map(headers, (value) => `header "${value}"`);
+		assert.isTrue(generated);
+
+		// Read the generated modulemap and verify it.
+		let modulemap = fs.readFile(join(modulemapDir, "module.modulemap"));
+		const headerCommands = _.map(
+			headers,
+			(value) =>
+				`header "${path.relative(
+					modulemapDir,
+					join(staticLibraryHeadersPath, value),
+				)}"`,
+		);
 		const modulemapExpectation = `module ${libraryName} { explicit module ${libraryName} { ${headerCommands.join(
 			" ",
 		)} } }`;
@@ -1051,13 +1065,16 @@ describe("Static libraries support", () => {
 		_.each(headers, (header) => {
 			fs.deleteFile(join(staticLibraryHeadersPath, header));
 		});
-		iOSProjectService.generateModulemap(staticLibraryHeadersPath, libraryName);
+		const regenerated = iOSProjectService.generateModulemap(
+			staticLibraryHeadersPath,
+			libraryName,
+			modulemapDir,
+		);
+		assert.isFalse(regenerated);
 
 		let error: any;
 		try {
-			modulemap = fs.readFile(
-				join(staticLibraryHeadersPath, "module.modulemap"),
-			);
+			modulemap = fs.readFile(join(modulemapDir, "module.modulemap"));
 		} catch (err) {
 			error = err;
 		}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When preparing an iOS plugin that ships a static library (`.a`) with headers, the CLI generates a `module.modulemap` and writes it **into `node_modules`** — next to the plugin's headers at `node_modules/{plugin}/platforms/ios/.../include/{lib}/module.modulemap`. This mutates `node_modules`, which should be treated as immutable (it breaks clean/reproducible installs, dirties caches, and is the iOS counterpart to the Android side writing generated `.aar`s back into `node_modules`).

## What is the new behavior?
<!-- Describe the changes. -->

The generated modulemap is now written into a CLI-managed directory under the platform root — `platforms/ios/.plugins/{lib}/module.modulemap` — and **never** into `node_modules`.

- `generateModulemap()` writes to the new `.plugins` location and references the plugin's headers **in place** via relative paths (`header "<relative path back to node_modules>"`), so no headers are copied or linked and `node_modules` is left untouched. It now returns a boolean indicating whether a modulemap was produced.
- `addStaticLibrary()` adds the `.plugins/{lib}` directory to `HEADER_SEARCH_PATHS` so clang discovers the module from the new location; `removeStaticLibs()` removes it symmetrically on plugin removal.
- No iOS runtime change is required: the runtime/metadata generator discovers modulemaps purely through `HEADER_SEARCH_PATHS`, which the CLI controls — so this works on any iOS runtime version.

Tests for `generateModulemap` were updated to cover the new output location, the relative header paths, and the boolean return value.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized iOS static-library `module.modulemap` generation into a dedicated CLI-managed directory under the iOS project root.
  * Updated modulemap handling so stale files are removed when headers are missing, and Xcode header search paths are adjusted only when a modulemap is actually produced.
  * Improved dynamic framework binary path detection to align with updated path construction behavior.
* **Tests**
  * Updated modulemap-related static library tests to match the new output location and updated generation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->