### PR TITLE
fix(windows): avoid EPERM rename error during platform project creation

### DIFF
--- a/lib/services/windows-project-service.ts
+++ b/lib/services/windows-project-service.ts
@@ -201,14 +201,20 @@ export class WindowsProjectService
 		_frameworkVersion: string,
 		projectData: IProjectData,
 	): Promise<void> {
-		this.$fs.ensureDirectoryExists(
-			this.getPlatformData(projectData).projectRoot,
-		);
-		shell.cp(
-			"-R",
-			path.join(frameworkDir, "*"),
-			this.getPlatformData(projectData).projectRoot,
-		);
+		const projectRoot = this.getPlatformData(projectData).projectRoot;
+		this.$fs.ensureDirectoryExists(projectRoot);
+		const name = projectData.projectName;
+		const entries = fs.readdirSync(frameworkDir, { withFileTypes: true });
+		for (const entry of entries) {
+			const srcPath = path.join(frameworkDir, entry.name);
+			if (entry.name === "__PROJECT_NAME__") {
+				const destPath = path.join(projectRoot, name);
+				shell.cp("-R", srcPath, destPath);
+			} else {
+				const destPath = path.join(projectRoot, entry.name);
+				shell.cp("-R", srcPath, destPath);
+			}
+		}
 	}
 
 	public async interpolateData(projectData: IProjectData): Promise<void> {
@@ -218,12 +224,45 @@ export class WindowsProjectService
 		const appId =
 			projectData.projectIdentifiers?.["windows"] ?? projectData.projectId;
 
-		const templateDir = path.join(projectRoot, placeholder);
 		const projectDir = path.join(projectRoot, name);
 
-		if (this.$fs.exists(templateDir)) {
-			this.$fs.rename(templateDir, projectDir);
+		const clearReadOnlyRecursive = (dir: string): void => {
+			try {
+				const entries = fs.readdirSync(dir, { withFileTypes: true });
+				for (const entry of entries) {
+					const fullPath = path.join(dir, entry.name);
+					fs.chmodSync(fullPath, 0o666);
+					if (entry.isDirectory()) {
+						clearReadOnlyRecursive(fullPath);
+					}
+				}
+				fs.chmodSync(dir, 0o666);
+			} catch (e) {
+				// ignore
+			}
+		};
+
+		if (process.platform === "win32" && this.$fs.exists(projectDir)) {
+			clearReadOnlyRecursive(projectDir);
 		}
+
+		const renameWithRetry = async (from: string, to: string): Promise<void> => {
+			let retries = 30;
+			while (retries > 0) {
+				try {
+					fs.renameSync(from, to);
+					return;
+				} catch (err: any) {
+					if ((err.code === "EPERM" || err.code === "EBUSY") && retries > 1) {
+						retries--;
+						console.warn(`Rename failed, retrying... (${retries} retries left): ${err.message}`);
+						await new Promise((resolve) => setTimeout(resolve, 300));
+					} else {
+						throw err;
+					}
+				}
+			}
+		};
 
 		if (!this.$fs.exists(projectDir)) {
 			return;
@@ -232,7 +271,7 @@ export class WindowsProjectService
 		const csprojPlaceholder = path.join(projectDir, `${placeholder}.csproj`);
 		const csprojDest = path.join(projectDir, `${name}.csproj`);
 		if (this.$fs.exists(csprojPlaceholder)) {
-			this.$fs.rename(csprojPlaceholder, csprojDest);
+			await renameWithRetry(csprojPlaceholder, csprojDest);
 		}
 
 		this._replaceInFiles(projectDir, placeholder, name);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When adding the `windows` platform to a project on Windows OS, the NativeScript CLI copies the platform template into a directory named `__PROJECT_NAME__` under `platforms/windows/`, and subsequently attempts to rename it to the actual project name using Node's `fs.rename` function. 

However, because background OS processes (such as Windows Defender real-time protection, search indexers, or antivirus scanners) instantly inspect/lock newly created folders, this immediate directory rename fails with a persistent `EPERM: operation not permitted` error, causing the platform setup command to crash.

## What is the new behavior?
<!-- Describe the changes. -->
1. **Direct Copy Bypass:** Modified the `createProject` function in `windows-project-service.ts` to copy the template directory directly using the target project name from the start. This completely eliminates the directory rename step (`__PROJECT_NAME__` -> `projectDir`), bypassing the EPERM lock on the folder.
2. **Permissions Cleanup:** Added a recursive `clearReadOnlyRecursive` helper using `fs.chmodSync` to strip any read-only properties from the platform project files on Windows before editing.
3. **Retry rename utility:** Added a `renameWithRetry` utility featuring a 30-retry loop (with 300ms delays) to gracefully handle transient locks when renaming internal project files, such as the `.csproj` file.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->
