### PR TITLE
chore: only check for min android runtime version for scoped runtime

### DIFF
--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -328,7 +328,9 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		frameworkVersion: string,
 		projectData: IProjectData
 	): Promise<void> {
+		const packageName = projectData.nsConfig.android?.runtimePackageName || constants.SCOPED_ANDROID_RUNTIME_NAME;
 		if (
+			packageName === constants.SCOPED_ANDROID_RUNTIME_NAME &&
 			semver.lt(
 				frameworkVersion,
 				AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE
@@ -518,7 +520,9 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		addPlatform?: Function,
 		removePlatforms?: (platforms: string[]) => Promise<void>
 	): Promise<boolean> {
+		const packageName = projectData.nsConfig.android?.runtimePackageName || constants.SCOPED_ANDROID_RUNTIME_NAME;
 		if (
+			packageName === constants.SCOPED_ANDROID_RUNTIME_NAME &&
 			semver.eq(
 				newVersion,
 				AndroidProjectService.MIN_RUNTIME_VERSION_WITH_GRADLE


### PR DESCRIPTION
We were checking for runtime > 1.5.0. Does not make sense with custom runtimes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android project creation and platform updates to apply runtime version checks only for the scoped Android runtime.
  * Reduced unexpected failures for projects using a custom Android runtime package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->