### PR TITLE
ci: run unit tests on pull requests and pushes to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: 'Tests'
+
+on:
+  pull_request:
+  push:
+    branches: [ 'main' ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [ '20.x', '22.x' ]
+
+    steps:
+
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # nothing here needs git auth after checkout, and npm test runs
+          # repository code
+          persist-credentials: false
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci --ignore-scripts
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. _(no tracking issue — happy to open one)_
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing.
- [ ] Tests for the changes are included. _(this PR is the test infrastructure itself)_

## What is the current behavior?

Nothing runs the unit tests in CI. The existing workflows cover releases, CodeQL, Scorecard and dependency review, but never `npm test`.

The suite runs in exactly one place: `prepack` → `grunt prepare` → `shell:npm_test`, which only fires during `npm pack`. So a broken test first surfaces while cutting a release rather than on the PR that broke it.

## What is the new behavior?

Adds `.github/workflows/tests.yml`, running `npm ci --ignore-scripts && npm test` on pull requests and pushes to `main`.

- Matrixed over Node 20.x and 22.x, matching `engines` and the version the release workflow publishes with
- `concurrency` group so superseded runs are cancelled
- Action SHAs pinned to the ones already in use in this repo, plus the `harden-runner` step, to stay consistent with the existing workflows
- `npm ci` resolves cleanly without `--legacy-peer-deps` (verified), so unlike the release workflow this one gets a reproducible install from the lockfile

Worth noting separately: `engines` currently allows `>=20.0.0`, but Node 20 reached end of life in April 2026. Adding 24.x to the matrix and raising the floor is probably worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated “Tests” workflow for pull requests and for pushes to the main branch.
  * Tests now run across supported Node.js versions for broader compatibility coverage.
  * Enabled dependency caching and improved test execution security and concurrency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->