### PR TITLE
fix(ios): let the app's xcconfig win over a plugin's, and warn on discarded settings

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -1834,6 +1834,23 @@ export class IOSProjectService
 			this.$fs.deleteFile(pluginsXcconfigFilePath);
 		}
 
+		// mergeFiles keeps whichever value is already present, so the app's
+		// xcconfig is merged before any plugin's to make it authoritative: a
+		// plugin must not be able to dictate a setting the app has chosen.
+		const appResourcesXcconfigPath = path.join(
+			projectData.appResourcesDirectoryPath,
+			this.getPlatformData(projectData).normalizedPlatformName,
+			BUILD_XCCONFIG_FILE_NAME,
+		);
+		if (this.$fs.exists(appResourcesXcconfigPath)) {
+			for (const pluginsXcconfigFilePath of pluginsXcconfigFilePaths) {
+				await this.$xcconfigService.mergeFiles(
+					appResourcesXcconfigPath,
+					pluginsXcconfigFilePath,
+				);
+			}
+		}
+
 		const allPlugins: IPluginData[] = this.getAllProductionPlugins(projectData);
 		for (const plugin of allPlugins) {
 			const pluginPlatformsFolderPath = plugin.pluginPlatformsFolderPath(
@@ -1850,20 +1867,6 @@ export class IOSProjectService
 						pluginsXcconfigFilePath,
 					);
 				}
-			}
-		}
-
-		const appResourcesXcconfigPath = path.join(
-			projectData.appResourcesDirectoryPath,
-			this.getPlatformData(projectData).normalizedPlatformName,
-			BUILD_XCCONFIG_FILE_NAME,
-		);
-		if (this.$fs.exists(appResourcesXcconfigPath)) {
-			for (const pluginsXcconfigFilePath of pluginsXcconfigFilePaths) {
-				await this.$xcconfigService.mergeFiles(
-					appResourcesXcconfigPath,
-					pluginsXcconfigFilePath,
-				);
 			}
 		}
 

--- a/lib/services/xcconfig-service.ts
+++ b/lib/services/xcconfig-service.ts
@@ -43,18 +43,20 @@ export class XcconfigService implements IXcconfigService {
 			this.$fs.writeFile(destinationFile, "");
 		}
 
-		const escapedDestinationFile = destinationFile.replace(/'/g, "\\'");
-		const escapedSourceFile = sourceFile.replace(/'/g, "\\'");
-
 		// A key already present in the destination wins, so the incoming one is
 		// dropped. Report the drops whose values actually differ: a silently
 		// discarded setting is otherwise indistinguishable from one that was
 		// never written, which makes a plugin pinning e.g.
 		// CLANG_CXX_LANGUAGE_STANDARD very hard to track down.
-		const mergeScript = `require 'xcodeproj';
-		require 'json';
-		userConfig = Xcodeproj::Config.new('${escapedDestinationFile}')
-		existingConfig = Xcodeproj::Config.new('${escapedSourceFile}')
+		//
+		// The paths are passed as argv rather than interpolated: they come from
+		// the project and node_modules layout, and a shell-interpolated command
+		// would execute anything a directory name expands to.
+		const mergeScript = `require 'xcodeproj'
+		require 'json'
+		destination, source = ARGV
+		userConfig = Xcodeproj::Config.new(destination)
+		existingConfig = Xcodeproj::Config.new(source)
 		conflicts = []
 		userConfig.attributes.each do |key, kept|
 			if existingConfig.attributes.key?(key)
@@ -63,9 +65,14 @@ export class XcconfigService implements IXcconfigService {
 				existingConfig.attributes.delete(key)
 			end
 		end
-		userConfig.merge(existingConfig).save_as(Pathname.new('${escapedDestinationFile}'))
+		userConfig.merge(existingConfig).save_as(Pathname.new(destination))
 		print '${XcconfigService.CONFLICT_MARKER}' + JSON.generate(conflicts)`;
-		const output = await this.$childProcess.exec(`ruby -e "${mergeScript}"`);
+		const output = await this.$childProcess.execFile("ruby", [
+			"-e",
+			mergeScript,
+			destinationFile,
+			sourceFile,
+		]);
 		this.warnAboutConflicts(sourceFile, output);
 	}
 
@@ -94,7 +101,8 @@ export class XcconfigService implements IXcconfigService {
 			this.$logger.warn(
 				`Ignoring ${conflict.key} = ${conflict.ignored} from ${sourceFile}: ` +
 					`already set to ${conflict.kept} by a higher precedence xcconfig. ` +
-					`The app's App_Resources xcconfig wins over any plugin's.`,
+					`The app's App_Resources xcconfig is applied first, then each ` +
+					`plugin's in dependency order.`,
 			);
 		}
 	}

--- a/lib/services/xcconfig-service.ts
+++ b/lib/services/xcconfig-service.ts
@@ -10,7 +10,13 @@ import * as _ from "lodash";
 import { injector } from "../common/yok";
 
 export class XcconfigService implements IXcconfigService {
-	constructor(private $childProcess: IChildProcess, private $fs: IFileSystem) {}
+	private static readonly CONFLICT_MARKER = "NS_XCCONFIG_CONFLICTS:";
+
+	constructor(
+		private $childProcess: IChildProcess,
+		private $fs: IFileSystem,
+		private $logger: ILogger
+	) {}
 
 	public getPluginsXcconfigFilePaths(projectRoot: string): IStringDictionary {
 		return {
@@ -42,14 +48,56 @@ export class XcconfigService implements IXcconfigService {
 		const escapedDestinationFile = destinationFile.replace(/'/g, "\\'");
 		const escapedSourceFile = sourceFile.replace(/'/g, "\\'");
 
+		// A key already present in the destination wins, so the incoming one is
+		// dropped. Report the drops whose values actually differ: a silently
+		// discarded setting is otherwise indistinguishable from one that was
+		// never written, which makes a plugin pinning e.g.
+		// CLANG_CXX_LANGUAGE_STANDARD very hard to track down.
 		const mergeScript = `require 'xcodeproj';
+		require 'json';
 		userConfig = Xcodeproj::Config.new('${escapedDestinationFile}')
 		existingConfig = Xcodeproj::Config.new('${escapedSourceFile}')
-		userConfig.attributes.each do |key,|
-  			existingConfig.attributes.delete(key) if (userConfig.attributes.key?(key) && existingConfig.attributes.key?(key))
+		conflicts = []
+		userConfig.attributes.each do |key, kept|
+			if existingConfig.attributes.key?(key)
+				ignored = existingConfig.attributes[key]
+				conflicts << { 'key' => key, 'kept' => kept.to_s, 'ignored' => ignored.to_s } if ignored.to_s != kept.to_s
+				existingConfig.attributes.delete(key)
+			end
 		end
-		userConfig.merge(existingConfig).save_as(Pathname.new('${escapedDestinationFile}'))`;
-		await this.$childProcess.exec(`ruby -e "${mergeScript}"`);
+		userConfig.merge(existingConfig).save_as(Pathname.new('${escapedDestinationFile}'))
+		print '${XcconfigService.CONFLICT_MARKER}' + JSON.generate(conflicts)`;
+		const output = await this.$childProcess.exec(`ruby -e "${mergeScript}"`);
+		this.warnAboutConflicts(sourceFile, output);
+	}
+
+	private warnAboutConflicts(sourceFile: string, output: any): void {
+		const text: string = output === null || output === undefined ? "" : `${output}`;
+		const markerIndex = text.lastIndexOf(XcconfigService.CONFLICT_MARKER);
+		if (markerIndex === -1) {
+			return;
+		}
+
+		let conflicts: { key: string; kept: string; ignored: string }[];
+		try {
+			conflicts = JSON.parse(
+				text.substring(markerIndex + XcconfigService.CONFLICT_MARKER.length)
+			);
+		} catch (err) {
+			// Never let a reporting problem fail the merge itself.
+			this.$logger.trace(
+				`Unable to read xcconfig conflicts for ${sourceFile}: ${err}`
+			);
+			return;
+		}
+
+		for (const conflict of conflicts || []) {
+			this.$logger.warn(
+				`Ignoring ${conflict.key} = ${conflict.ignored} from ${sourceFile}: ` +
+					`already set to ${conflict.kept} by a higher precedence xcconfig. ` +
+					`The app's App_Resources xcconfig wins over any plugin's.`
+			);
+		}
 	}
 
 	public readPropertyValue(

--- a/lib/services/xcconfig-service.ts
+++ b/lib/services/xcconfig-service.ts
@@ -15,17 +15,15 @@ export class XcconfigService implements IXcconfigService {
 	constructor(
 		private $childProcess: IChildProcess,
 		private $fs: IFileSystem,
-		private $logger: ILogger
+		private $logger: ILogger,
 	) {}
 
 	public getPluginsXcconfigFilePaths(projectRoot: string): IStringDictionary {
 		return {
-			[Configurations.Debug.toLowerCase()]: this.getPluginsDebugXcconfigFilePath(
-				projectRoot
-			),
-			[Configurations.Release.toLowerCase()]: this.getPluginsReleaseXcconfigFilePath(
-				projectRoot
-			),
+			[Configurations.Debug.toLowerCase()]:
+				this.getPluginsDebugXcconfigFilePath(projectRoot),
+			[Configurations.Release.toLowerCase()]:
+				this.getPluginsReleaseXcconfigFilePath(projectRoot),
 		};
 	}
 
@@ -39,7 +37,7 @@ export class XcconfigService implements IXcconfigService {
 
 	public async mergeFiles(
 		sourceFile: string,
-		destinationFile: string
+		destinationFile: string,
 	): Promise<void> {
 		if (!this.$fs.exists(destinationFile)) {
 			this.$fs.writeFile(destinationFile, "");
@@ -72,7 +70,8 @@ export class XcconfigService implements IXcconfigService {
 	}
 
 	private warnAboutConflicts(sourceFile: string, output: any): void {
-		const text: string = output === null || output === undefined ? "" : `${output}`;
+		const text: string =
+			output === null || output === undefined ? "" : `${output}`;
 		const markerIndex = text.lastIndexOf(XcconfigService.CONFLICT_MARKER);
 		if (markerIndex === -1) {
 			return;
@@ -81,12 +80,12 @@ export class XcconfigService implements IXcconfigService {
 		let conflicts: { key: string; kept: string; ignored: string }[];
 		try {
 			conflicts = JSON.parse(
-				text.substring(markerIndex + XcconfigService.CONFLICT_MARKER.length)
+				text.substring(markerIndex + XcconfigService.CONFLICT_MARKER.length),
 			);
 		} catch (err) {
 			// Never let a reporting problem fail the merge itself.
 			this.$logger.trace(
-				`Unable to read xcconfig conflicts for ${sourceFile}: ${err}`
+				`Unable to read xcconfig conflicts for ${sourceFile}: ${err}`,
 			);
 			return;
 		}
@@ -95,14 +94,14 @@ export class XcconfigService implements IXcconfigService {
 			this.$logger.warn(
 				`Ignoring ${conflict.key} = ${conflict.ignored} from ${sourceFile}: ` +
 					`already set to ${conflict.kept} by a higher precedence xcconfig. ` +
-					`The app's App_Resources xcconfig wins over any plugin's.`
+					`The app's App_Resources xcconfig wins over any plugin's.`,
 			);
 		}
 	}
 
 	public readPropertyValue(
 		xcconfigFilePath: string,
-		propertyName: string
+		propertyName: string,
 	): string {
 		if (this.$fs.exists(xcconfigFilePath)) {
 			const text = this.$fs.readText(xcconfigFilePath);

--- a/test/ios-project-service.ts
+++ b/test/ios-project-service.ts
@@ -1201,6 +1201,45 @@ describe("Merge Project XCConfig files", () => {
 		}
 	});
 
+	it("The app's build.xcconfig wins over a plugin's", async () => {
+		fs.writeFile(
+			appResourcesXcconfigPath,
+			`CLANG_CXX_LANGUAGE_STANDARD = c++20${EOL}`,
+		);
+
+		const pluginPlatformsFolderPath = join(projectPath, "somePlugin", "ios");
+		fs.writeFile(
+			join(pluginPlatformsFolderPath, BUILD_XCCONFIG_FILE_NAME),
+			`CLANG_CXX_LANGUAGE_STANDARD = c++17${EOL}GCC_C_LANGUAGE_STANDARD = gnu17${EOL}`,
+		);
+
+		const pluginsService = testInjector.resolve("pluginsService");
+		pluginsService.getAllProductionPlugins = () => [
+			{
+				name: "somePlugin",
+				pluginPlatformsFolderPath: () => pluginPlatformsFolderPath,
+			},
+		];
+
+		await (<any>iOSProjectService).mergeProjectXcconfigFiles(projectData);
+
+		_.each(
+			xcconfigService.getPluginsXcconfigFilePaths(projectRoot),
+			(destinationFilePath) => {
+				assertPropertyValues(
+					{
+						// The app pinned this, so the plugin's c++17 must not win.
+						CLANG_CXX_LANGUAGE_STANDARD: "c++20",
+						// Keys the app says nothing about still come from the plugin.
+						GCC_C_LANGUAGE_STANDARD: "gnu17",
+					},
+					destinationFilePath,
+					testInjector,
+				);
+			},
+		);
+	});
+
 	it("Adds the entitlements property if not set by the user", async () => {
 		for (const release in [true, false]) {
 			const realExistsFunction = testInjector.resolve("fs").exists;

--- a/test/xcconfig-service.ts
+++ b/test/xcconfig-service.ts
@@ -5,6 +5,7 @@ import * as yok from "../lib/common/yok";
 import { IXcconfigService } from "../lib/declarations";
 import { IInjector } from "../lib/common/definitions/yok";
 import { IReadFileOptions } from "../lib/common/declarations";
+import { LoggerStub } from "./stubs";
 
 // start tracking temporary folders/files
 
@@ -18,6 +19,7 @@ describe("XCConfig Service Tests", () => {
 		});
 		testInjector.register("childProcess", {});
 		testInjector.register("xcprojService", {});
+		testInjector.register("logger", LoggerStub);
 
 		testInjector.register("xcconfigService", XcconfigService);
 


### PR DESCRIPTION
An app currently has no way to override a build setting that a plugin declares, and no way to find out that it failed to.

## The app's xcconfig never wins

`XcconfigService.mergeFiles` keeps whichever value is already in the destination and deletes the incoming one:

```ruby
userConfig.attributes.each do |key,|
  existingConfig.attributes.delete(key) if (userConfig.attributes.key?(key) && existingConfig.attributes.key?(key))
end
userConfig.merge(existingConfig)
```

First writer wins — and `mergeProjectXcconfigFiles` merged every plugin's `platforms/ios/build.xcconfig` *before* the app's `App_Resources/iOS/build.xcconfig`. So for any key a plugin set, the app's value was discarded outright. Not "sometimes lost": never applied. Among plugins the winner was whichever came first in dependency-resolution order, which nobody controls.

This PR merges the app's file first. Plugins still supply every key the app says nothing about; they just stop overriding the ones it does.

**Where this bites today:** V8 14.9 (NativeScript iOS 9) made `v8config.h` reject C++17 outright —

```c
#if __cplusplus <= 201703L
#error "C++20 or later required."
#endif
```

— while several plugins pin `CLANG_CXX_LANGUAGE_STANDARD = c++17`, which sat exactly on the old floor. One stale transitive plugin holds the whole app below the floor, and the app cannot lift it. The resulting error points at the runtime's headers rather than at the plugin that pinned the standard.

## Discarded settings are now reported

The merge dropped keys in silence, so a discarded setting was indistinguishable from one that was never written. That's the reason the case above is hard to diagnose: nothing tells you which plugin pinned the value, and the failure surfaces somewhere else entirely.

`mergeFiles` now reports what it dropped:

```
Ignoring CLANG_CXX_LANGUAGE_STANDARD = c++17 from node_modules/some-plugin/platforms/ios/build.xcconfig:
already set to c++20 by a higher precedence xcconfig. The app's App_Resources xcconfig wins over any plugin's.
```

Only conflicts whose values genuinely **differ** are reported — two files agreeing on a key is not worth a warning, and that keeps this quiet on normal projects. Reporting is also fully isolated from the merge: an unparseable result is traced and ignored, never thrown.

## Compatibility

The precedence change is behavioural. An app that sets a key a plugin also sets now gets its own value where it previously got the plugin's. That is the intent, but it can surface a latent misconfiguration — a value set long ago that silently never applied and now does. The new warning makes those visible rather than mysterious.

Conflicts *between* plugins are unchanged: still resolved by dependency order, still arbitrary. xcconfig can't express "highest wins" for an ordered value like a language standard, so warning is the practical ceiling; this PR at least makes them audible.

## Tests

`npm test` — 1514 passing, 9 pending, 0 failures.

Added `The app's build.xcconfig wins over a plugin's`, which sets `CLANG_CXX_LANGUAGE_STANDARD` in both an app and a plugin xcconfig and asserts the app's value survives while a plugin-only key still lands. It runs the real `xcodeproj` merge rather than a stub, so it also covers the modified Ruby.

`test/xcconfig-service.ts` gains a `logger` registration for the new dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated iOS xcconfig merging so app `App_Resources` settings are authoritative over plugin-provided values when conflicts occur.
  * Added warnings for detected xcconfig key conflicts, while continuing to preserve the higher-priority (app) values.

* **Tests**
  * Added a merge test covering precedence for conflicting `CLANG_CXX_LANGUAGE_STANDARD`, ensuring app-pinned values win while unrelated plugin settings (e.g., `GCC_C_LANGUAGE_STANDARD`) are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->