### PR TITLE
fix: resolve compiled output from dist in bin and postinstall

### DIFF
--- a/bin/tns
+++ b/bin/tns
@@ -2,7 +2,14 @@
 
 "use strict";
 var path = require("path"),
-	pathToLib = path.join(__dirname, "..", "lib"),
+	fs = require("fs"),
+	// In the published package dist/ is the root, so lib/ already sits next to
+	// bin/. In a source checkout lib/ holds only TypeScript and the compiled
+	// output lives under dist/.
+	distLib = path.join(__dirname, "..", "dist", "lib"),
+	pathToLib = fs.existsSync(distLib)
+		? distLib
+		: path.join(__dirname, "..", "lib"),
 	pathToCommon = path.join(pathToLib, "common");
 
 require(path.join(pathToCommon, "verify-node-version")).verifyNodeVersion();

--- a/postinstall.js
+++ b/postinstall.js
@@ -2,9 +2,14 @@
 
 var child_process = require("child_process");
 var path = require("path");
-var constants = require(path.join(__dirname, "lib", "constants"));
+var fs = require("fs");
+// In the published package dist/ is the root; in a source checkout the compiled
+// output lives under dist/ while lib/ holds only TypeScript.
+var distLib = path.join(__dirname, "dist", "lib");
+var pathToLib = fs.existsSync(distLib) ? distLib : path.join(__dirname, "lib");
+var constants = require(path.join(pathToLib, "constants"));
 var commandArgs = [path.join(__dirname, "bin", "tns"), constants.POST_INSTALL_COMMAND_NAME];
-var helpers = require(path.join(__dirname, "lib", "common", "helpers"));
+var helpers = require(path.join(pathToLib, "common", "helpers"));
 if (helpers.isInstallingNativeScriptGlobally()) {
 	child_process.spawn(process.argv[0], commandArgs, { stdio: "inherit" });
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. _(no tracking issue — happy to open one)_
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing (1514 passing, unchanged).
- [ ] Tests for the changes are included. _(the failure is not reachable from the unit suite — verification below)_

A regression from #6092. The release-script half of this went straight to `main` as `cb3fb8db5`, since it was blocking publishing; this is the remainder.

## What is the current behavior?

`bin/tns` and `postinstall.js` resolve into `lib/` relative to their own location:

```js
pathToLib = path.join(__dirname, "..", "lib");          // bin/tns
require(path.join(__dirname, "lib", "constants"));      // postinstall.js
```

Since the build moved output to `dist/`, `lib/` holds only TypeScript, so from a checkout:

```
$ ./bin/tns --version
Error: Cannot find module '.../lib/common/verify-node-version'
```

The published package is unaffected — `dist/` is its root there, so `lib/` already sits next to `bin/`. Only the source tree broke, which is exactly why the packaging verification on #6092 did not catch it.

`npm install` in a checkout runs `postinstall` and hits the same failure. That is masked today only because `npm run setup` passes `--ignore-scripts`.

## What is the new behavior?

Both prefer `dist/lib` when it exists and fall back otherwise, so neither needs to know which layout it is in. The remaining `bin/` entries (`nativescript`, `ns`, `nsc`, …) all `require("./tns")`, so they are fixed with it.

## Verification

Not reachable from the unit suite, so both layouts were exercised directly:

- **Checkout:** `./bin/tns --version` reports, `./bin/tns` renders 56 help rows, the `nativescript`/`ns`/`nsc` aliases work, `node postinstall.js` resolves
- **Installed package:** packed, installed into a clean consumer, confirmed the fallback is the branch taken (no `dist/lib` present) — `--version` reports, help renders 56 rows, `postinstall.js` resolves
- 1514 passing, unchanged

Worth noting for follow-up: nothing in the suite executes `bin/tns` in either layout, which is why this class of bug is invisible to CI. A smoke test covering both would close that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI startup across both published package installations and source checkouts.
  * Improved post-install setup by correctly locating required files in different package layouts.
  * Prevented installation and command-loading issues caused by incorrect library paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->