### PR TITLE
ci: test on macOS and Node 24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,17 +14,26 @@ concurrency:
 
 jobs:
   test:
-    name: Test (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }}, Node ${{ matrix.node-version }})
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ '20.x', '22.x' ]
+        os: [ ubuntu-latest ]
+        node-version: [ '20.x', '22.x', '24.x' ]
+        include:
+          # A darwin leg is what covers the iOS-specific suites - they are gated
+          # on the platform and never execute anywhere else. One version is
+          # enough for that; 24 is the active LTS.
+          - os: macos-latest
+            node-version: '24.x'
 
     steps:
 
       - name: Harden the runner (Audit all outbound calls)
+        # only supported on the Ubuntu runners
+        if: runner.os == 'Linux'
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [ ] There is an issue for the bug/feature this PR is for. _(no tracking issue — happy to open one)_
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing.
- [ ] Tests for the changes are included. _(this PR is CI configuration)_

## What is the current behavior?

`ubuntu-latest` with Node 20.x and 22.x — four gaps in one line.

**No macOS.** Seven test files contain darwin-gated paths that have therefore never executed in CI: `ios-project-service`, `ios-device-debug-service`, `debug-controller`, `xcode-select-service`, `ios-simulator-discovery`, `host-info`, `devices-service`. On a CLI whose primary job is building iOS apps, the iOS-specific logic is the part with no coverage. This is also the source of the count difference between local (1514) and CI (1501) — 13 tests that simply never run.

**No Node 24.** Node 24 is the active LTS. Node 20 reached end of life in April 2026 and Node 22 is in maintenance — so the matrix tests a dead runtime and the maintenance one, while the release publishes from 22 and most users are on 24.

## What is the new behavior?

| runner | Node |
| --- | --- |
| `ubuntu-latest` | 20.x, 22.x, 24.x |
| `macos-latest` | 24.x |

Four jobs rather than a 3×2 cross-product. macOS runners are free on a public repo, but queue time is not, and one darwin leg is enough to cover platform-gated code — a second Node version there would re-run the same suite for very little.

Node 24 is added rather than 20 dropped, since `engines` still declares `>=20.0.0`. Worth noting separately that permitting an end-of-life runtime is its own decision; this PR only makes the matrix match what is declared.

`harden-runner` is now conditional on `runner.os == 'Linux'` — it only supports the Ubuntu runners.

## Verification

Node 24 was validated locally before proposing it, rather than pushing and hoping:

- full suite on Node 24.18.0: **1514 passing, 38 skipped, 101 files** — identical to Node 22
- `npm run build.release` succeeds on Node 24, and the built CLI reports its version and renders help

The macOS leg is the one that cannot be pre-validated from a single machine — the point of adding it is to execute code no CI job has run before, so it is possible those 13 tests surface problems. That is the intent, and worth watching on the first run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage across Ubuntu and macOS environments.
  * Added testing for Node.js 24.x alongside existing Node.js 20.x and 22.x configurations.
  * Enabled platform-specific test coverage for iOS-related suites on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->