### PR TITLE
fix: bun does not require symlink

### DIFF
--- a/lib/services/bundler/bundler-compiler-service.ts
+++ b/lib/services/bundler/bundler-compiler-service.ts
@@ -480,12 +480,14 @@ export class BundlerCompilerService
 	}
 
 	private async shouldUsePreserveSymlinksOption(): Promise<boolean> {
-		// pnpm does not require symlink (https://github.com/nodejs/node-eps/issues/46#issuecomment-277373566)
+		// pnpm and Bun's isolated linker do not require symlink (https://github.com/nodejs/node-eps/issues/46#issuecomment-277373566)
 		// and it also does not work in some cases.
 		// Check https://github.com/NativeScript/nativescript-cli/issues/5259 for more information
 		const currentPackageManager =
 			await this.$packageManager.getPackageManagerName();
-		const res = currentPackageManager !== PackageManagers.pnpm;
+		const res =
+			currentPackageManager !== PackageManagers.pnpm &&
+			currentPackageManager !== PackageManagers.bun;
 		return res;
 	}
 

--- a/test/services/bundler/bundler-compiler-service.ts
+++ b/test/services/bundler/bundler-compiler-service.ts
@@ -8,6 +8,7 @@ import { IInjector } from "../../../lib/common/definitions/yok";
 import {
 	BUNDLER_COMPILATION_COMPLETE,
 	CONFIG_FILE_NAME_DISPLAY,
+	PackageManagers,
 } from "../../../lib/constants";
 
 const iOSPlatformName = "ios";
@@ -23,10 +24,12 @@ function getAllEmittedFiles(hash: string) {
 	];
 }
 
-function createTestInjector(): IInjector {
+function createTestInjector(
+	packageManager: PackageManagers = PackageManagers.npm,
+): IInjector {
 	const testInjector = new Yok();
 	testInjector.register("packageManager", {
-		getPackageManagerName: async () => "npm",
+		getPackageManagerName: async () => packageManager,
 	});
 	testInjector.register("bundlerCompilerService", BundlerCompilerService);
 	testInjector.register("childProcess", {});
@@ -62,6 +65,29 @@ describe("BundlerCompilerService", () => {
 	beforeEach(() => {
 		testInjector = createTestInjector();
 		bundlerCompilerService = testInjector.resolve(BundlerCompilerService);
+	});
+
+	describe("shouldUsePreserveSymlinksOption", () => {
+		it("should preserve symlinks for npm", async () => {
+			const result = await (<any>(
+				bundlerCompilerService
+			)).shouldUsePreserveSymlinksOption();
+
+			assert.isTrue(result);
+		});
+
+		for (const packageManager of [PackageManagers.pnpm, PackageManagers.bun]) {
+			it(`should not preserve symlinks for ${packageManager}`, async () => {
+				testInjector = createTestInjector(packageManager);
+				bundlerCompilerService = testInjector.resolve(BundlerCompilerService);
+
+				const result = await (<any>(
+					bundlerCompilerService
+				)).shouldUsePreserveSymlinksOption();
+
+				assert.isFalse(result);
+			});
+		}
 	});
 
 	describe("getUpdatedEmittedFiles", () => {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When the `bun` package manager is set in the config, the node `--preserve-symlinks` flag is set. This affects `link:` and `workspace:` dependency resolution in monorepos.

## What is the new behavior?
<!-- Describe the changes. -->
Bun is treated specially and no flag will be passed for it, just like pnpm.

Fixes #6118.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


<!-- 
E2E TESTS

Additional e2e tests can be executed by comment including trigger phrase.

Phrases:
`test cli-smoke`: Smoke tests for `tns run`.
`test cli-create`: Tests for `tns create` commans.
`test cli-plugin`: Tests for `tns plugin *` commands.
`test cli-preview`: Tests for `tns preview` command.
`test cli-regression`: Tests for backward compatibility with old projects.
`test cli-resources`: Test for resource generate.
`test cli-tests`: Tests for `tns test` command.
`test cli-vue`: Smoke tests for VueJS projects based on {N} cli.
`test cli-templates`: Tests for `tns run` on {N} templates.

Define other packages used in e2e tests:

- If PR targets master branch e2e tests will take runtimes and modules @next.
- If PR targets release branch e2e tests will take runtimes and modules @rc.
- You can control version of other packages used in e2e test by adding `package_version#<tag>` as param in trigger phrase  (for example `test package_version#latest`).
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Bun projects by disabling the preserve-symlinks compiler option where appropriate.
  * Ensured package-manager-specific compiler behavior works consistently for npm, pnpm, and Bun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->