### PR TITLE
fix(di): share the injection context across duplicated CLI copies

### DIFF
--- a/dependency-injection.md
+++ b/dependency-injection.md
@@ -110,6 +110,13 @@ throws. `self` and `skipSelf` cannot be combined. There is deliberately no
 `host` option: it is an Angular component-tree concept with no analog in the
 CLI's injector hierarchy.
 
+The injection context is shared process-wide. If a hook or extension module
+ends up resolving a *duplicated* copy of the CLI (a nested `nativescript`
+install, or a project-local copy under a globally-run CLI), its `inject()`
+still resolves against the running CLI's context — with a one-time warning,
+because a duplicated copy loads the CLI twice. Declaring `nativescript` as a
+`peerDependency` lets the running copy be shared instead.
+
 Registering: providers
 ----------------------
 

--- a/lib/common/di/inject.ts
+++ b/lib/common/di/inject.ts
@@ -1,11 +1,30 @@
 import type { Injector, InjectOptions } from "./injector";
 import type { ProviderToken } from "./providers";
 
-// Sync-only by design (no AsyncLocalStorage): `current` is restored in a
-// finally, so inject() is valid in field initializers, constructor bodies and
-// provider factories — and never after an await. Self-inject the Injector for
-// later lookups.
-let current: Injector | null = null;
+/**
+ * The injection context lives on globalThis under a `Symbol.for` key rather
+ * than in a module-local variable: a hook or extension module can resolve a
+ * DIFFERENT copy of this file than the one the running CLI set the context
+ * through (a nested nativescript install, or a project-local copy under a
+ * globally-run CLI), and a module-local slot would make that copy's inject()
+ * throw despite being synchronously inside a valid context.
+ */
+const CONTEXT_SLOT = Symbol.for("nativescript:di:injectionContext");
+
+interface IInjectionContextFrame {
+	injector: Injector;
+	/** Identifies which loaded copy of this module set the frame. */
+	owner: object;
+}
+
+// One per loaded copy of this module — the cross-copy detection marker.
+const COPY_ID = {};
+
+let reportedCrossCopyUse = false;
+
+function currentFrame(): IInjectionContextFrame | null {
+	return (<any>globalThis)[CONTEXT_SLOT] || null;
+}
 
 export function inject<T = any>(token: ProviderToken<T>): T;
 export function inject<T = any>(
@@ -20,7 +39,8 @@ export function inject<T = any>(
 	token: ProviderToken<T>,
 	options?: InjectOptions,
 ): T | null {
-	if (!current) {
+	const frame = currentFrame();
+	if (!frame) {
 		throw new Error(
 			"inject() can only be called from an injection context — a field " +
 				"initializer, a constructor, or a provider factory running under " +
@@ -28,15 +48,30 @@ export function inject<T = any>(
 				"the Injector itself and use injector.get() for late lookups.",
 		);
 	}
-	return current.get(token, options);
+
+	if (frame.owner !== COPY_ID && !reportedCrossCopyUse) {
+		reportedCrossCopyUse = true;
+		const logger = frame.injector.get("logger", { optional: true });
+		if (logger) {
+			logger.warn(
+				`A second copy of the NativeScript CLI (${__dirname}) is serving ` +
+					`inject() in this process. This works, but loads the CLI twice; ` +
+					`extensions and projects should declare nativescript as a ` +
+					`peerDependency so the running copy is shared.`,
+			);
+		}
+	}
+
+	return frame.injector.get(token, options);
 }
 
 export function runInInjectionContext<T>(injector: Injector, fn: () => T): T {
-	const previous = current;
-	current = injector;
+	const g = <any>globalThis;
+	const previous = g[CONTEXT_SLOT];
+	g[CONTEXT_SLOT] = <IInjectionContextFrame>{ injector, owner: COPY_ID };
 	try {
 		return fn();
 	} finally {
-		current = previous;
+		g[CONTEXT_SLOT] = previous;
 	}
 }

--- a/test/di.ts
+++ b/test/di.ts
@@ -187,6 +187,52 @@ describe("di: forwardRef", () => {
 	});
 });
 
+describe("di: cross-copy injection context", () => {
+	// inject.js has no runtime imports, so a copied file loaded from another
+	// path is a genuine second instance of the module — the same situation as
+	// a nested nativescript install serving a hook or extension module.
+	const loadSecondCopy = (): any => {
+		const fs = require("fs");
+		const os = require("os");
+		const path = require("path");
+		const source = require.resolve("../lib/common/di/inject.js");
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ns-di-copy-"));
+		const target = path.join(dir, "inject.js");
+		fs.copyFileSync(source, target);
+		return require(target);
+	};
+
+	it("a second copy's inject() resolves against the running copy's context, with a one-time warning", () => {
+		const copyB = loadSecondCopy();
+		const warnings: string[] = [];
+		const loggerValue = {
+			warn: (message: string) => warnings.push(message),
+		};
+		const injector = new Injector([
+			{ provide: "logger", useValue: loggerValue },
+		]);
+
+		runInInjectionContext(injector, () => {
+			// The running copy serving its own context never warns.
+			assert.strictEqual(inject("logger"), loggerValue);
+			assert.equal(warnings.length, 0);
+
+			// The second copy resolves through the shared slot — and warns once.
+			assert.strictEqual(copyB.inject("logger"), loggerValue);
+			assert.strictEqual(copyB.inject("logger"), loggerValue);
+		});
+
+		assert.equal(warnings.length, 1);
+		assert.include(warnings[0], "second copy of the NativeScript CLI");
+		assert.include(warnings[0], "peerDependency");
+	});
+
+	it("a second copy outside any context still throws the teaching error", () => {
+		const copyB = loadSecondCopy();
+		assert.throws(() => copyB.inject("logger"), /injection context/);
+	});
+});
+
 describe("di: inject options", () => {
 	it("optional resolves to null for an unknown token, and normally for a known one", () => {
 		const injector = new Injector([provide(Greeter, GreeterImpl)]);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?

The injection context (`inject()`'s hidden `current` slot) is a module-local variable. Node caches modules per resolved path, so when a hook or extension module resolves a *different copy* of the CLI than the one running — a nested `nativescript` install in an extension's tree, or a project-local copy under a globally-run CLI — that copy's `inject()` reads its own dead slot and throws "inject() can only be called from an injection context", even though the author is synchronously inside `run()` in a perfectly valid context. Verified in review with a realistic duplicated-copy install; it breaks the documented flagship examples of the stacked API PRs.

## What is the new behavior?

The context lives on `globalThis` under a `Symbol.for` key, so every loaded copy shares one slot — in the single-copy world the behavior is byte-identical. When a copy serves `inject()` through a frame it did not set (i.e. a duplicated copy is in play), it warns **once**, naming its own path and pointing at the fix: duplicated copies work but load the CLI twice; `peerDependency` on `nativescript` lets the running copy be shared. This keeps the ecosystem nudged toward the single-copy/local-install direction while making the documented API true in every install layout that exists today.

Tests include a genuine second-copy scenario: `inject.js` has no runtime imports, so a copied file loaded from another path is a real second module instance — it resolves through the running copy's context and produces exactly one warning.

Full suite green; no behavior change when a single copy is loaded.
