### PR TITLE
fix: misleading dual nativescript.config warning when reading plugin configs

### DIFF
--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -448,9 +448,15 @@ interface IProjectConfigInformation {
 interface IProjectConfigService {
 	/**
 	 * read the nativescript.config.(js|ts) file
+	 * @param options.suppressWarnings pass when reading a config that is not
+	 * the user's project (e.g. a plugin package, which may legitimately ship
+	 * compiled .js artifacts next to its .ts config)
 	 * @returns {INsConfig} the parsed config data
 	 */
-	readConfig(projectDir?: string): INsConfig;
+	readConfig(
+		projectDir?: string,
+		options?: { suppressWarnings?: boolean },
+	): INsConfig;
 	/**
 	 * Get value for a given config key path
 	 * @param key the property key path
@@ -479,7 +485,10 @@ interface IProjectConfigService {
 	 */
 	setForceUsingLegacyConfig(force: boolean): boolean;
 
-	detectProjectConfigs(projectDir?: string): IProjectConfigInformation;
+	detectProjectConfigs(
+		projectDir?: string,
+		options?: { suppressWarnings?: boolean },
+	): IProjectConfigInformation;
 
 	getDefaultTSConfig(appId: string, appPath: string): string;
 

--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -1329,7 +1329,13 @@ export class IOSProjectService
 					constants.CONFIG_FILE_NAME_TS,
 				);
 				if (this.$fs.exists(pluginConfigPath)) {
-					const config = this.$projectConfigService.readConfig(plugin.fullPath);
+					// Plugin packages may ship compiled .js artifacts next to their
+					// .ts config; the dual-config warning is guidance for the user's
+					// own project and would be misleading here.
+					const config = this.$projectConfigService.readConfig(
+						plugin.fullPath,
+						{ suppressWarnings: true },
+					);
 					const packages = _.get(
 						config,
 						`${platformData.platformNameLowerCase}.SPMPackages`,

--- a/lib/services/project-config-service.ts
+++ b/lib/services/project-config-service.ts
@@ -91,7 +91,10 @@ export default {
 		);
 	}
 
-	public detectProjectConfigs(projectDir?: string): IProjectConfigInformation {
+	public detectProjectConfigs(
+		projectDir?: string,
+		options?: { suppressWarnings?: boolean },
+	): IProjectConfigInformation {
 		// allow overriding config name with env variable or --config (or -c)
 		let configName: string | boolean =
 			process.env.NATIVESCRIPT_CONFIG_NAME ?? this.$options.config;
@@ -154,9 +157,11 @@ export default {
 		const hasNSConfig = !!NSConfigPath && hasExistingConfig;
 		const usingNSConfig = !(hasTSConfig || hasJSConfig);
 
-		if (hasTSConfig && hasJSConfig) {
+		if (hasTSConfig && hasJSConfig && !options?.suppressWarnings) {
 			this.$logger.warn(
-				`You have both a ${CONFIG_FILE_NAME_JS} and ${CONFIG_FILE_NAME_TS} file. Defaulting to ${CONFIG_FILE_NAME_TS}.`,
+				`You have both a ${CONFIG_FILE_NAME_JS} and ${CONFIG_FILE_NAME_TS} file in ${path.dirname(
+					TSConfigPath,
+				)}. Defaulting to ${CONFIG_FILE_NAME_TS}.`,
 			);
 		}
 
@@ -172,8 +177,11 @@ export default {
 	}
 
 	@exported("projectConfigService")
-	public readConfig(projectDir?: string): INsConfig {
-		const info = this.detectProjectConfigs(projectDir);
+	public readConfig(
+		projectDir?: string,
+		options?: { suppressWarnings?: boolean },
+	): INsConfig {
+		const info = this.detectProjectConfigs(projectDir, options);
 
 		if (
 			this.forceUsingLegacyConfig ||


### PR DESCRIPTION
During iOS prepare, plugin-declared SPM packages are collected by reading each plugin's nativescript.config.ts via projectConfigService.readConfig.

A plugin that publishes compiled artifacts next to its config source triggered the project-level:
> You have both a nativescript.config.js and nativescript.config.ts file

warning, with no indication it referred to a directory inside node_modules rather than the user's project.

Plugin config reads now suppress the warning, and the warning message names the directory it refers to for genuine dual-config projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary configuration warnings when inspecting compiled plugin artifacts.
  * Configuration warnings now identify the relevant directory for easier troubleshooting.

* **Improvements**
  * Added an option to suppress configuration warnings when reading or detecting project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->