### PR TITLE
fix(bundler): resolve the configured bundler package and pass buildPath

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -67,6 +67,7 @@ export const BUNDLE_DIR = "bundle";
 export const RESOURCES_DIR = "res";
 export const CONFIG_NS_FILE_NAME = "nsconfig.json";
 export const CONFIG_NS_APP_RESOURCES_ENTRY = "appResourcesPath";
+export const CONFIG_NS_BUILD_ENTRY = "buildPath";
 export const CONFIG_NS_APP_ENTRY = "appPath";
 export const CONFIG_FILE_NAME_DISPLAY = "nativescript.config.(js|ts)";
 export const CONFIG_FILE_NAME_JS = "nativescript.config.js";

--- a/lib/contracts/project-data.ts
+++ b/lib/contracts/project-data.ts
@@ -89,4 +89,6 @@ export abstract class ProjectData {
 	abstract getAppResourcesDirectoryPath(projectDir?: string): string;
 
 	abstract getAppResourcesRelativeDirectoryPath(): string;
+
+	abstract getBuildRelativeDirectoryPath(): string;
 }

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -282,6 +282,14 @@ export class ProjectData implements IProjectData {
 		return this.resolveToProjectDir(appRelativePath, projectDir);
 	}
 
+	public getBuildRelativeDirectoryPath(): string {
+		if (this.nsConfig && this.nsConfig[constants.CONFIG_NS_BUILD_ENTRY]) {
+			return this.nsConfig[constants.CONFIG_NS_BUILD_ENTRY];
+		}
+
+		return constants.PLATFORMS_DIR_NAME;
+	}
+
 	public getAppDirectoryRelativePath(): string {
 		if (this.nsConfig && this.nsConfig[constants.CONFIG_NS_APP_ENTRY]) {
 			return this.nsConfig[constants.CONFIG_NS_APP_ENTRY];

--- a/lib/services/bundler/bundler-compiler-service.ts
+++ b/lib/services/bundler/bundler-compiler-service.ts
@@ -822,12 +822,14 @@ export class BundlerCompilerService
 		const appId = projectData.projectIdentifiers[platform];
 		const appPath = projectData.getAppDirectoryRelativePath();
 		const appResourcesPath = projectData.getAppResourcesRelativeDirectoryPath();
+		const buildPath = projectData.getBuildRelativeDirectoryPath();
 
 		Object.assign(
 			envData,
 			appId && { appId },
 			appPath && { appPath },
 			appResourcesPath && { appResourcesPath },
+			buildPath && { buildPath },
 			{
 				nativescriptLibPath: path.resolve(
 					__dirname,
@@ -1097,7 +1099,7 @@ export class BundlerCompilerService
 				return path.resolve(packagePath, "bin", "vite.js");
 			}
 		} else if (this.isModernBundler(projectData)) {
-			const packagePath = resolvePackagePath(`@nativescript/${bundler}`, {
+			const packagePath = resolvePackagePath(this.getBundlerPackageName(), {
 				paths: [projectData.projectDir],
 			});
 
@@ -1117,15 +1119,31 @@ export class BundlerCompilerService
 		return path.resolve(packagePath, "bin", "webpack.js");
 	}
 
+	// Forks such as @akylas/nativescript-webpack replace the default package.
+	private getBundlerPackageName(): string {
+		const bundler = this.getBundler();
+		if (bundler !== "webpack") {
+			return `@nativescript/${bundler}`;
+		}
+
+		return this.$projectConfigService.getValue(
+			"webpackPackageName",
+			WEBPACK_PLUGIN_NAME,
+		);
+	}
+
 	private isModernBundler(projectData: IProjectData): boolean {
 		const bundler = this.getBundler();
 		switch (bundler) {
 			case "rspack":
 				return true;
 			default:
-				const packageJSONPath = resolvePackageJSONPath(WEBPACK_PLUGIN_NAME, {
-					paths: [projectData.projectDir],
-				});
+				const packageJSONPath = resolvePackageJSONPath(
+					this.getBundlerPackageName(),
+					{
+						paths: [projectData.projectDir],
+					},
+				);
 
 				if (packageJSONPath) {
 					const packageData = this.$fs.readJson(packageJSONPath);

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -720,6 +720,10 @@ export class ProjectDataStub implements IProjectData {
 		return "";
 	}
 
+	public getBuildRelativeDirectoryPath(): string {
+		return "platforms";
+	}
+
 	public getAppDirectoryPath(projectDir?: string): string {
 		if (!projectDir) {
 			projectDir = this.projectDir;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?

Two problems for projects that set `webpackPackageName` in their config:

- `getBundlerExecutablePath()` and `isModernBundler()` both resolve the hardcoded `@nativescript/webpack`. When a project uses a fork (for instance `@akylas/nativescript-webpack`), that lookup fails and the CLI falls back to raw `webpack/bin/webpack.js`. webpack-cli then rejects the `--env.x` flags the CLI emits and the build dies with `Unknown option '--env.<name>'`.
- `buildEnvData()` no longer passes `buildPath`, so bundlers resolving their output as `${env.buildPath}/<platform>/dist` write outside the platform folder. The CLI keeps waiting for files that never arrive and the run hangs after the bundler reports a successful compilation.

## What is the new behavior?

- Both bundler lookups go through the configured package name, falling back to `@nativescript/webpack` when none is set, so forks use the modern bin.
- `buildPath` is back in the bundler env, sourced from a new `ProjectData.getBuildRelativeDirectoryPath()` that honours the `buildPath` config entry and defaults to `platforms`.

## Testing

`tsc --noEmit` is clean. Verified end to end against a project using `@akylas/nativescript-webpack`: before this change the run failed with `Unknown option '--env.watchNodeModules'`, and once the bundler resolved it hung right after `webpack compiled`. With both fixes the run proceeds through prepare, pods and the native build.

No unit tests are added — the change is in package resolution and env plumbing, which the existing suite does not cover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build output paths can now be customized through NativeScript configuration.
  * Bundler processing now supports configured webpack package alternatives.
  * Build environment data includes the project’s relative build directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->