### PR TITLE
feat(config): allow per-platform ignoredNativeDependencies

### DIFF
--- a/lib/contracts/project-data.ts
+++ b/lib/contracts/project-data.ts
@@ -25,6 +25,8 @@ export abstract class ProjectData {
 	abstract projectIdentifiers?: Mobile.IProjectIdentifier;
 	abstract dependencies: any;
 	abstract ignoredDependencies?: string[];
+
+	abstract getIgnoredDependencies(platform?: string): string[];
 	abstract devDependencies: IStringDictionary;
 	abstract appDirectoryPath: string;
 	abstract appResourcesDirectoryPath: string;

--- a/lib/controllers/prepare-controller.ts
+++ b/lib/controllers/prepare-controller.ts
@@ -404,7 +404,7 @@ export class PrepareController extends EventEmitter {
 		const dependencies = this.$nodeModulesDependenciesBuilder
 			.getProductionDependencies(
 				projectData.projectDir,
-				projectData.ignoredDependencies,
+				projectData.getIgnoredDependencies(platformData.platformNameLowerCase),
 			)
 			.filter((dep) => dep.nativescript);
 		const pluginsNativeDirectories = dependencies.map((dep) =>

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -101,6 +101,7 @@ interface IProjectService {
 
 interface INsConfigPlaform {
 	id?: string;
+	ignoredNativeDependencies?: string[];
 }
 
 interface IOSSPMPackageBase {

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -348,6 +348,30 @@ export class ProjectData implements IProjectData {
 		return identifier;
 	}
 
+	public getIgnoredDependencies(platform?: string): string[] {
+		const ignored = this.nsConfig?.ignoredNativeDependencies ?? [];
+		if (!platform || !this.nsConfig) {
+			return ignored;
+		}
+
+		switch (platform.toLowerCase()) {
+			case constants.PlatformTypes.ios:
+				return ignored.concat(
+					this.nsConfig.ios?.ignoredNativeDependencies ?? [],
+				);
+			case constants.PlatformTypes.visionos:
+				return ignored.concat(
+					this.nsConfig.visionos?.ignoredNativeDependencies ?? [],
+				);
+			case constants.PlatformTypes.android:
+				return ignored.concat(
+					this.nsConfig.android?.ignoredNativeDependencies ?? [],
+				);
+			default:
+				return ignored;
+		}
+	}
+
 	private getProjectType(): string {
 		let detectedProjectType = _.find(
 			ProjectData.PROJECT_TYPES,

--- a/lib/services/plugins-service.ts
+++ b/lib/services/plugins-service.ts
@@ -359,7 +359,7 @@ export class PluginsService implements IPluginsService {
 			dependencies ||
 			this.$nodeModulesDependenciesBuilder.getProductionDependencies(
 				projectData.projectDir,
-				projectData.ignoredDependencies,
+				projectData.getIgnoredDependencies(platform),
 			);
 
 		if (_.isEmpty(dependencies)) {

--- a/lib/services/project-changes-service.ts
+++ b/lib/services/project-changes-service.ts
@@ -109,7 +109,9 @@ export class ProjectChangesService implements IProjectChangesService {
 			this.$nodeModulesDependenciesBuilder
 				.getProductionDependencies(
 					projectData.projectDir,
-					projectData.ignoredDependencies
+					projectData.getIgnoredDependencies(
+						platformData.platformNameLowerCase,
+					)
 				)
 				.filter(
 					(dep) =>

--- a/lib/tools/node-modules/node-modules-builder.ts
+++ b/lib/tools/node-modules/node-modules-builder.ts
@@ -20,7 +20,9 @@ export class NodeModulesBuilder implements INodeModulesBuilder {
 	}: IPrepareNodeModulesData): Promise<void> {
 		let dependencies = this.$nodeModulesDependenciesBuilder.getProductionDependencies(
 			projectData.projectDir,
-			projectData.ignoredDependencies
+			projectData.getIgnoredDependencies(
+				platformData.platformNameLowerCase,
+			)
 		);
 		dependencies = await platformData.platformProjectService.beforePrepareAllPlugins(
 			projectData,

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -720,6 +720,10 @@ export class ProjectDataStub implements IProjectData {
 		return "";
 	}
 
+	public getIgnoredDependencies(platform?: string): string[] {
+		return [];
+	}
+
 	public getAppDirectoryPath(projectDir?: string): string {
 		if (!projectDir) {
 			projectDir = this.projectDir;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/tools/notes/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-cli/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?

`ignoredNativeDependencies` can only be declared at the top level of the config, so a dependency that must be skipped on one platform is skipped on every platform.

## What is the new behavior?

- `ignoredNativeDependencies` is declared on the shared platform interface, so the `ios`, `android` and `visionos` sections can each contribute their own entries.
- A new `ProjectData.getIgnoredDependencies(platform?)` concatenates the top level list with the platform one. Callers pass the platform they are preparing for; calling it without a platform keeps the previous top level only behaviour, so existing configs are unaffected.

## Testing

`tsc --noEmit` is clean, and existing configs keep working since the platform sections are optional and additive.

This is untested at runtime beyond that: the change is config plumbing, and the existing suite has no coverage for `ignoredNativeDependencies` to extend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring ignored native dependencies by platform.
  * Platform-specific settings are supported for iOS, visionOS, and Android while preserving global settings.
* **Bug Fixes**
  * Dependency discovery, preparation, and file watching now consistently honor platform-specific ignore rules.
  * Unknown or unspecified platforms safely fall back to globally ignored dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->