### PR TITLE
feat(android): build only the ABIs of the devices being deployed to

### DIFF
--- a/docs/man_pages/project/testing/debug-android.md
+++ b/docs/man_pages/project/testing/debug-android.md
@@ -38,6 +38,7 @@ Attach the debug tools to a running app in the native emulator | `$ ns debug and
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
+* `--no-filter-devices-arch` - If set, builds every ABI instead of only the ones the connected devices report. The narrowing only applies when the app's gradle configuration acts on the `abiFilters` property, and `ns build` never narrows.
 * `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -43,6 +43,7 @@ Start a default emulator if none are running, or run application on all connecte
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
+* `--no-filter-devices-arch` - If set, builds every ABI instead of only the ones the connected devices report. The narrowing only applies when the app's gradle configuration acts on the `abiFilters` property, and `ns build` never narrows.
 * `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -53,7 +53,12 @@ export abstract class BuildCommandBase extends ValidatePlatformCommandBase {
 		const buildData = this.$buildDataService.getBuildData(
 			this.$projectData.projectDir,
 			platform,
-			this.$options,
+			{
+				...this.$options.argv,
+				// `ns build` produces an artifact meant to be shipped, so it must
+				// not be narrowed down to the ABIs of whatever is plugged in
+				filterDevicesArch: false,
+			},
 		);
 		const outputPath = await this.$buildController.prepareAndBuild(buildData);
 

--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -100,6 +100,11 @@ declare global {
 			 * For iOS simulators - same as the identifier.
 			 */
 			imageIdentifier?: string;
+			/**
+			 * Optional property listing the ABIs the device supports, most
+			 * preferred first. Available for Android only.
+			 */
+			abis?: string[];
 		}
 
 		interface IDeviceError extends Error, IDeviceIdentifier {}

--- a/lib/common/mobile/android/android-device.ts
+++ b/lib/common/mobile/android/android-device.ts
@@ -13,6 +13,9 @@ interface IAndroidDeviceDetails {
 	name: string;
 	release: string;
 	brand: string;
+	"cpu.abi"?: string;
+	"cpu.abilist32"?: string;
+	"cpu.abilist64"?: string;
 }
 
 interface IAdbDeviceStatusInfo {
@@ -96,6 +99,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 			identifier: this.identifier,
 			displayName: details.name,
 			model: details.model,
+			abis: this.getAbis(details),
 			version,
 			vendor: details.brand,
 			platform: this.$devicePlatformsConstants.Android,
@@ -177,6 +181,25 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		this.$logger.trace(parsedDetails);
 
 		return parsedDetails;
+	}
+
+	// `ro.product.cpu.abilist64`/`abilist32` list every ABI the device supports,
+	// most preferred first. Old devices report neither and only have the single
+	// `ro.product.cpu.abi`.
+	private getAbis(details: IAndroidDeviceDetails): string[] {
+		const abis = [
+			...(details["cpu.abilist64"] || "").split(","),
+			...(details["cpu.abilist32"] || "").split(",")
+		]
+			.map((abi) => abi.trim())
+			.filter((abi) => !!abi);
+
+		if (abis.length) {
+			return abis;
+		}
+
+		const abi = (details["cpu.abi"] || "").trim();
+		return abi ? [abi] : [];
 	}
 
 	private getIsTablet(details: any): boolean {

--- a/lib/controllers/build-controller.ts
+++ b/lib/controllers/build-controller.ts
@@ -116,7 +116,7 @@ export class BuildController extends EventEmitter implements IBuildController {
 		);
 
 		if (buildData.copyTo) {
-			this.$buildArtifactsService.copyLatestAppPackage(
+			this.$buildArtifactsService.copyAppPackages(
 				buildData.copyTo,
 				platformData,
 				buildData

--- a/lib/data/build-data.ts
+++ b/lib/data/build-data.ts
@@ -51,6 +51,7 @@ export class AndroidBuildData extends BuildData {
 	public keyStoreAliasPassword: string;
 	public keyStorePassword: string;
 	public androidBundle: boolean;
+	public buildFilterDevicesArch: boolean;
 	public gradlePath: string;
 	public gradleArgs: string;
 	public hostProjectPath: string;
@@ -63,6 +64,9 @@ export class AndroidBuildData extends BuildData {
 		this.keyStoreAliasPassword = data.keyStoreAliasPassword;
 		this.keyStorePassword = data.keyStorePassword;
 		this.androidBundle = data.androidBundle || data.aab;
+		// an app bundle already carries every ABI, so there is nothing to filter
+		this.buildFilterDevicesArch =
+			!this.androidBundle && data.filterDevicesArch !== false;
 		this.gradlePath = data.gradlePath;
 		this.gradleArgs = data.gradleArgs;
 		this.hostProjectPath = data.hostProjectPath;

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -571,6 +571,12 @@ interface IEmbedOptions {
 }
 
 interface IAndroidOptions extends IEmbedOptions {
+	/**
+	 * When true (the default) `ns run`/`ns debug` restrict the native build to
+	 * the ABIs of the devices it is about to deploy to. Pass
+	 * `--no-filter-devices-arch` to always build every ABI.
+	 */
+	filterDevicesArch: boolean;
 	gradlePath: string;
 	gradleArgs: string;
 }

--- a/lib/definitions/build.d.ts
+++ b/lib/definitions/build.d.ts
@@ -31,6 +31,7 @@ interface IAndroidBuildData
 	extends IBuildData,
 		IAndroidSigningData,
 		IHasAndroidBundle {
+	buildFilterDevicesArch?: boolean;
 	gradlePath?: string;
 	gradleArgs?: string;
 }
@@ -62,7 +63,7 @@ interface IBuildArtifactsService {
 		platformData: IPlatformData,
 		buildOutputOptions: IBuildOutputOptions
 	): Promise<string>;
-	copyLatestAppPackage(
+	copyAppPackages(
 		targetPath: string,
 		platformData: IPlatformData,
 		buildOutputOptions: IBuildOutputOptions

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -219,6 +219,11 @@ export class Options {
 				default: false,
 				hasSensitiveValue: false,
 			},
+			filterDevicesArch: {
+				type: OptionType.Boolean,
+				default: true,
+				hasSensitiveValue: false,
+			},
 			gradlePath: { type: OptionType.String, hasSensitiveValue: false },
 			gradleArgs: { type: OptionType.String, hasSensitiveValue: false },
 			hostProjectPath: { type: OptionType.String, hasSensitiveValue: false },

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -47,6 +47,8 @@ import {
 import { IInjector } from "../common/definitions/yok";
 import { injector } from "../common/yok";
 import { INotConfiguredEnvOptions } from "../common/definitions/commands";
+import { AndroidPrepareData } from "../data/prepare-data";
+import { IProjectChangesInfo } from "../definitions/project-changes";
 
 interface NativeDependency {
 	name: string;
@@ -148,7 +150,9 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		private $androidPluginBuildService: IAndroidPluginBuildService,
 		private $platformEnvironmentRequirements: IPlatformEnvironmentRequirements,
 		private $androidResourcesMigrationService: IAndroidResourcesMigrationService,
+		private $devicesService: Mobile.IDevicesService,
 		private $filesHashService: IFilesHashService,
+		private $liveSyncProcessDataService: ILiveSyncProcessDataService,
 		private $gradleCommandService: IGradleCommandService,
 		private $gradleBuildService: IGradleBuildService,
 		private $analyticsService: IAnalyticsService
@@ -835,8 +839,61 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		await adb.executeShellCommand(["rm", "-rf", deviceRootPath]);
 	}
 
-	public async checkForChanges(): Promise<void> {
-		// Nothing android specific to check yet.
+	/**
+	 * When the native build is narrowed down to the ABIs of the connected
+	 * devices, a device that joins later has no package of its own in the build
+	 * output. Nothing else would trigger a native rebuild for it - the sources
+	 * did not change - so flag it here.
+	 */
+	public async checkForChanges(
+		changesInfo: IProjectChangesInfo,
+		prepareData: AndroidPrepareData,
+		projectData: IProjectData
+	): Promise<void> {
+		if (changesInfo.nativeChanged) {
+			return;
+		}
+
+		const platformData = this.getPlatformData(projectData);
+		const deviceDescriptors = this.$liveSyncProcessDataService.getDeviceDescriptors(
+			projectData.projectDir
+		);
+
+		for (const deviceDescriptor of deviceDescriptors) {
+			const buildData = <IAndroidBuildData>deviceDescriptor.buildData;
+			if (!buildData || !buildData.buildFilterDevicesArch) {
+				continue;
+			}
+
+			const packagesOutputPath = platformData.getBuildOutputPath(buildData);
+			if (!this.$fs.exists(packagesOutputPath)) {
+				continue;
+			}
+
+			const builtPackages = this.$fs.readDirectory(packagesOutputPath);
+			// a universal package runs on every device, nothing to rebuild
+			if (_.some(builtPackages, (f) => f.indexOf("universal") !== -1)) {
+				continue;
+			}
+
+			const device = _.find(
+				this.$devicesService.getDevicesForPlatform(buildData.platform),
+				(d) => d.deviceInfo.identifier === deviceDescriptor.identifier
+			);
+			const abi = device && (device.deviceInfo.abis || [])[0];
+			if (!abi) {
+				continue;
+			}
+
+			const abiRegex = new RegExp(`${abi}.*\\.apk$`);
+			if (!_.some(builtPackages, (entry) => abiRegex.test(entry))) {
+				this.$logger.trace(
+					`No package was built for '${abi}', marking the native project as changed.`
+				);
+				changesInfo.nativeChanged = true;
+				return;
+			}
+		}
 	}
 
 	public getDeploymentTarget(projectData: IProjectData): semver.SemVer {

--- a/lib/services/android/gradle-build-service.ts
+++ b/lib/services/android/gradle-build-service.ts
@@ -9,12 +9,14 @@ import {
 import { IAndroidBuildData } from "../../definitions/build";
 import { IChildProcess } from "../../common/declarations";
 import { injector } from "../../common/yok";
+import * as _ from "lodash";
 
 export class GradleBuildService
 	extends EventEmitter
 	implements IGradleBuildService {
 	constructor(
 		private $childProcess: IChildProcess,
+		private $devicesService: Mobile.IDevicesService,
 		private $gradleBuildArgsService: IGradleBuildArgsService,
 		private $gradleCommandService: IGradleCommandService
 	) {
@@ -28,6 +30,9 @@ export class GradleBuildService
 		const buildTaskArgs = await this.$gradleBuildArgsService.getBuildTaskArgs(
 			buildData
 		);
+
+		this.applyDevicesAbiFilter(buildTaskArgs, buildData);
+
 		const spawnOptions = {
 			emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME },
 			throwError: true,
@@ -49,6 +54,47 @@ export class GradleBuildService
 				gradleCommandOptions
 			)
 		);
+	}
+
+	/**
+	 * Narrows the native build down to the ABIs of the devices this build is
+	 * about to be deployed to. The app's gradle configuration decides what to do
+	 * with `abiFilters` - typically an `ndk.abiFilters`/`splits` block in
+	 * `App_Resources/Android/app.gradle`. An explicitly passed `-PabiFilters`
+	 * always wins.
+	 */
+	private applyDevicesAbiFilter(
+		buildTaskArgs: string[],
+		buildData: IAndroidBuildData
+	): void {
+		if (!buildData.buildFilterDevicesArch) {
+			return;
+		}
+
+		if (_.some(buildTaskArgs, (arg) => arg.startsWith("-PabiFilters"))) {
+			return;
+		}
+
+		let devices = this.$devicesService.getDevicesForPlatform(
+			buildData.platform
+		);
+		if (buildData.device) {
+			devices = devices.filter(
+				(d) => d.deviceInfo.identifier === buildData.device
+			);
+		} else if (buildData.emulator) {
+			devices = devices.filter((d) => d.isEmulator);
+		}
+
+		const abis = _.uniq(
+			devices
+				.map((d) => (d.deviceInfo.abis || [])[0])
+				.filter((abi) => !!abi)
+		);
+
+		if (abis.length) {
+			buildTaskArgs.push(`-PabiFilters=${abis.join(",")}`);
+		}
 	}
 
 	public async cleanProject(

--- a/lib/services/build-artifacts-service.ts
+++ b/lib/services/build-artifacts-service.ts
@@ -75,7 +75,12 @@ export class BuildArtifactsService implements IBuildArtifactsService {
 		return [];
 	}
 
-	public copyLatestAppPackage(
+	/**
+	 * Copies what the build produced to `targetPath`. A build can produce more
+	 * than one package - an app split per ABI - so a directory target receives
+	 * all of them, while a single file target receives the universal one.
+	 */
+	public copyAppPackages(
 		targetPath: string,
 		platformData: IPlatformData,
 		buildOutputOptions: IBuildOutputOptions
@@ -85,26 +90,36 @@ export class BuildArtifactsService implements IBuildArtifactsService {
 		const outputPath =
 			buildOutputOptions.outputPath ||
 			platformData.getBuildOutputPath(buildOutputOptions);
-		const applicationPackage = this.getLatestApplicationPackage(
+		const applicationPackages = this.getAllAppPackages(
 			outputPath,
 			platformData.getValidBuildOutputData(buildOutputOptions)
 		);
-		const packageFile = applicationPackage.packageName;
 
 		this.$fs.ensureDirectoryExists(path.dirname(targetPath));
 
-		if (
-			this.$fs.exists(targetPath) &&
-			this.$fs.getFsStats(targetPath).isDirectory()
-		) {
-			const sourceFileName = path.basename(packageFile);
+		const targetIsDirectory =
+			(this.$fs.exists(targetPath) &&
+				this.$fs.getFsStats(targetPath).isDirectory()) ||
+			!path.extname(targetPath);
+
+		let packagesToCopy = applicationPackages;
+		if (!targetIsDirectory && applicationPackages.length > 1) {
 			this.$logger.trace(
-				`Specified target path: '${targetPath}' is directory. Same filename will be used: '${sourceFileName}'.`
+				`Specified target path: '${targetPath}' is a single file, but the build produced ${applicationPackages.length} packages. Only the universal one will be copied.`
 			);
-			targetPath = path.join(targetPath, sourceFileName);
+			packagesToCopy = applicationPackages.filter((pack) =>
+				path.basename(pack.packageName).includes("universal")
+			);
 		}
-		this.$fs.copyFile(packageFile, targetPath);
-		this.$logger.info(`Copied file '${packageFile}' to '${targetPath}'.`);
+
+		_.each(packagesToCopy, (pack) => {
+			const packageFile = pack.packageName;
+			const targetFilePath = targetIsDirectory
+				? path.join(targetPath, path.basename(packageFile))
+				: targetPath;
+			this.$fs.copyFile(packageFile, targetFilePath);
+			this.$logger.info(`Copied file '${packageFile}' to '${targetFilePath}'.`);
+		});
 	}
 
 	private getLatestApplicationPackage(

--- a/lib/services/device/device-install-app-service.ts
+++ b/lib/services/device/device-install-app-service.ts
@@ -51,7 +51,8 @@ export class DeviceInstallAppService {
 		});
 
 		if (!packageFile) {
-			packageFile = await this.$buildArtifactsService.getLatestAppPackagePath(
+			packageFile = await this.getPackageForDevice(
+				device,
 				platformData,
 				buildData
 			);
@@ -89,6 +90,49 @@ export class DeviceInstallAppService {
 
 		this.$logger.info(
 			`Successfully installed on device with identifier '${device.deviceInfo.identifier}'.`
+		);
+	}
+
+	/**
+	 * A build narrowed down to the connected devices' ABIs produces one package
+	 * per ABI, so the one this device can run has to be picked. Falls back to
+	 * the universal package and then to the newest one, which is what a build
+	 * that was not split produces anyway.
+	 */
+	private async getPackageForDevice(
+		device: Mobile.IDevice,
+		platformData: IPlatformData,
+		buildData: IBuildData
+	): Promise<string> {
+		const outputPath =
+			buildData.outputPath || platformData.getBuildOutputPath(buildData);
+		const packages = this.$buildArtifactsService.getAllAppPackages(
+			outputPath,
+			platformData.getValidBuildOutputData(buildData)
+		);
+
+		if (packages.length > 1) {
+			const abis = device.deviceInfo.abis || [];
+			for (const abi of abis) {
+				const match = packages.find((p) =>
+					path.basename(p.packageName).includes(abi)
+				);
+				if (match) {
+					return match.packageName;
+				}
+			}
+
+			const universalPackage = packages.find((p) =>
+				path.basename(p.packageName).includes("universal")
+			);
+			if (universalPackage) {
+				return universalPackage.packageName;
+			}
+		}
+
+		return this.$buildArtifactsService.getLatestAppPackagePath(
+			platformData,
+			buildData
 		);
 	}
 

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -185,6 +185,12 @@ function createTestInjector() {
 	);
 
 	testInjector.register("platformEnvironmentRequirements", {});
+	testInjector.register("devicesService", {
+		getDevicesForPlatform: (): Mobile.IDevice[] => [],
+	});
+	testInjector.register("liveSyncProcessDataService", {
+		getDeviceDescriptors: (): ILiveSyncDeviceDescriptor[] => [],
+	});
 	testInjector.register("filesHashService", {
 		hasChangesInShasums: (
 			oldPluginNativeHashes: IStringDictionary,

--- a/test/services/android-project-service.ts
+++ b/test/services/android-project-service.ts
@@ -38,6 +38,12 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("filesHashService", {
 		saveHashesForProject: () => ({}),
 	});
+	testInjector.register("devicesService", {
+		getDevicesForPlatform: (): Mobile.IDevice[] => [],
+	});
+	testInjector.register("liveSyncProcessDataService", {
+		getDeviceDescriptors: (): ILiveSyncDeviceDescriptor[] => [],
+	});
 	testInjector.register("androidPluginBuildService", {});
 	testInjector.register("errors", stubs.ErrorsStub);
 	testInjector.register("logger", stubs.LoggerStub);

--- a/test/services/android/gradle-build-service.ts
+++ b/test/services/android/gradle-build-service.ts
@@ -1,0 +1,125 @@
+import { Yok } from "../../../lib/common/yok";
+import { GradleBuildService } from "../../../lib/services/android/gradle-build-service";
+import { assert } from "chai";
+import { IInjector } from "../../../lib/common/definitions/yok";
+import { IAndroidBuildData } from "../../../lib/definitions/build";
+
+const createDevice = (
+	identifier: string,
+	abis: string[],
+	isEmulator = false,
+): any => ({
+	deviceInfo: { identifier, abis, platform: "android" },
+	isEmulator,
+});
+
+function createTestInjector(devices: any[]): IInjector {
+	const injector = new Yok();
+	injector.register("childProcess", {
+		on: (): void => undefined,
+		removeListener: (): void => undefined,
+	});
+	injector.register("devicesService", {
+		getDevicesForPlatform: () => devices,
+	});
+	injector.register("gradleBuildArgsService", {
+		getBuildTaskArgs: async () => ["assembleDebug"],
+		getCleanTaskArgs: () => ["clean"],
+		getBuildLoggingArgs: (): string[] => [],
+	});
+	injector.register("gradleCommandService", {
+		executeCommand: async (args: string[]): Promise<any> => {
+			executedArgs = args;
+			return null;
+		},
+	});
+	injector.register("gradleBuildService", GradleBuildService);
+
+	return injector;
+}
+
+let executedArgs: string[] = null;
+
+const buildProject = async (
+	devices: any[],
+	buildData: Partial<IAndroidBuildData>,
+): Promise<string[]> => {
+	executedArgs = null;
+	const injector = createTestInjector(devices);
+	const gradleBuildService = injector.resolve("gradleBuildService");
+	await gradleBuildService.buildProject("projectRoot", <IAndroidBuildData>{
+		platform: "android",
+		...buildData,
+	});
+
+	return executedArgs;
+};
+
+describe("GradleBuildService", () => {
+	describe("abi filtering", () => {
+		it("passes the abis of the connected devices", async () => {
+			const args = await buildProject(
+				[
+					createDevice("device1", ["arm64-v8a", "armeabi-v7a"]),
+					createDevice("emulator1", ["x86_64", "x86"], true),
+				],
+				{ buildFilterDevicesArch: true },
+			);
+
+			assert.include(args, "-PabiFilters=arm64-v8a,x86_64");
+		});
+
+		it("passes the abi of the selected device only", async () => {
+			const args = await buildProject(
+				[
+					createDevice("device1", ["arm64-v8a"]),
+					createDevice("emulator1", ["x86_64"], true),
+				],
+				{ buildFilterDevicesArch: true, device: "device1" },
+			);
+
+			assert.include(args, "-PabiFilters=arm64-v8a");
+		});
+
+		it("passes the abis of the emulators only when --emulator is used", async () => {
+			const args = await buildProject(
+				[
+					createDevice("device1", ["arm64-v8a"]),
+					createDevice("emulator1", ["x86_64"], true),
+				],
+				{ buildFilterDevicesArch: true, emulator: true },
+			);
+
+			assert.include(args, "-PabiFilters=x86_64");
+		});
+
+		it("deduplicates the abis", async () => {
+			const args = await buildProject(
+				[
+					createDevice("device1", ["arm64-v8a"]),
+					createDevice("device2", ["arm64-v8a"]),
+				],
+				{ buildFilterDevicesArch: true },
+			);
+
+			assert.include(args, "-PabiFilters=arm64-v8a");
+		});
+
+		it("passes nothing when the filtering is off", async () => {
+			const args = await buildProject(
+				[createDevice("device1", ["arm64-v8a"])],
+				{ buildFilterDevicesArch: false },
+			);
+
+			assert.isUndefined(args.find((a) => a.startsWith("-PabiFilters")));
+		});
+
+		it("passes nothing when no device reports its abis", async () => {
+			const args = await buildProject([createDevice("device1", [])], {
+				buildFilterDevicesArch: true,
+			});
+
+			assert.isUndefined(args.find((a) => a.startsWith("-PabiFilters")));
+		});
+	});
+});


### PR DESCRIPTION
### What

`ns run android` with a single arm64 device plugged in still builds x86, x86_64 and armeabi-v7a. This narrows the native build down to the ABIs of the devices it is about to deploy to, and installs the package that matches each device.

### How

`GradleBuildService` passes `-PabiFilters=<abis>` built from the devices the build targets, honouring `--device` and `--emulator`. Only the first (most preferred) ABI of each device is used, deduplicated across devices.

The CLI does not decide what that means for the build — the app's gradle configuration does, typically an `ndk.abiFilters` or `splits { abi { ... } }` block reading the property. A build that ignores it keeps building exactly what it built before, so this PR alone is a no-op until something consumes the property. An explicit `-PabiFilters` in `--gradleArgs` always wins.

**This needs #6129 to be fully functional.** The `app/build.gradle` that ships with the runtime today ignores `-PabiFilters`, so on its own this PR only helps projects that read the property from their own `App_Resources/Android/app.gradle`. #6129 ships the app gradle files with the CLI and its `app/build.gradle` consumes the property: it narrows `ndk.abiFilters` down, and for an apk debug build it splits so each abi gets its own package — which is what the install and rebuild logic below expects. Merged the other way round, #6129 gives the gradle side with nothing passing the property.

### When it does not apply

- `--no-filter-devices-arch` turns it off.
- `ns build` never narrows — its artifact is meant to be shipped. The command forces the flag off rather than relying on the default.
- App bundle (`--aab`) builds never narrow; a bundle carries every ABI.

### Device ABIs

`Mobile.IDeviceInfo` gained an optional `abis: string[]`. On android it comes from `ro.product.cpu.abilist64` + `ro.product.cpu.abilist32`, most preferred first, falling back to the single `ro.product.cpu.abi` on old devices that report neither. Both are already part of the `getprop` output the device details parser reads, so there is no extra adb round trip.

### Consuming the split output

Two things follow from a build that can now produce several packages:

- `DeviceInstallAppService` picks the package whose name contains one of the device's ABIs, falling back to the universal package and then to the newest one — which is what an unsplit build produces anyway, so single-package projects take the same path as before.
- `AndroidProjectService.checkForChanges` marks the native project as changed when a device in the current run has no package of its own in the build output. Without it a device plugged in after the first build would never get one: the sources did not change, so nothing else would ask for a native rebuild.
- `copyLatestAppPackage` became `copyAppPackages`. A directory `--copy-to` target receives every package the build produced; a single file target receives the universal one (or the only one). This is the one signature change on `IBuildArtifactsService`.

### Tests

`npm test` — 1862 passing. Added `test/services/android/gradle-build-service.ts` covering the ABI selection: all devices, `--device`, `--emulator`, deduplication, filtering off, and devices that report no ABIs.

### Notes

From https://github.com/Akylas/nativescript-cli, in production use there. Mergeable independently of #6129, but only useful together with it — see above. #6134 builds on this one to pass the same ABIs to plugin builds. Expect a small textual conflict in `lib/options.ts` and `lib/definitions/build.d.ts` depending on merge order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android ABI filtering for source-built plugins through `--filter-plugins-devices-arch`.
  * Android builds and plugin builds now better match packages to connected devices and selected emulators.
  * Improved installation by selecting device-specific packages, with universal-package fallback.
  * Builds can copy multiple generated application packages to directory destinations.
* **Bug Fixes**
  * Native Android changes now trigger rebuilds when required device-specific packages are unavailable.
* **Documentation**
  * Documented Android architecture-filtering options and their behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


