### PR TITLE
feat(project): let the project config move the build directory

### DIFF
--- a/lib/commands/clean.ts
+++ b/lib/commands/clean.ts
@@ -6,6 +6,7 @@ import {
 	IProjectCleanupResult,
 	IProjectCleanupService,
 	IProjectConfigService,
+	IProjectData,
 	IProjectService,
 } from "../definitions/project";
 
@@ -83,6 +84,7 @@ export class CleanCommand implements ICommand {
 	constructor(
 		private $projectCleanupService: IProjectCleanupService,
 		private $projectConfigService: IProjectConfigService,
+		private $projectData: IProjectData,
 		private $terminalSpinnerService: ITerminalSpinnerService,
 		private $projectService: IProjectService,
 		private $prompter: IPrompter,
@@ -108,7 +110,7 @@ export class CleanCommand implements ICommand {
 
 		let pathsToClean = [
 			constants.HOOKS_DIR_NAME,
-			constants.PLATFORMS_DIR_NAME,
+			this.$projectData.getBuildRelativeDirectoryPath(),
 			constants.NODE_MODULES_FOLDER_NAME,
 		];
 

--- a/lib/commands/typings.ts
+++ b/lib/commands/typings.ts
@@ -161,8 +161,7 @@ export class TypingsCommand implements ICommand {
 		);
 
 		const dtsGeneratorPath = path.resolve(
-			this.$projectData.projectDir,
-			"platforms",
+			this.$projectData.platformsDir,
 			"android",
 			"build-tools",
 			"dts-generator.jar",

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -67,6 +67,7 @@ export const BUNDLE_DIR = "bundle";
 export const RESOURCES_DIR = "res";
 export const CONFIG_NS_FILE_NAME = "nsconfig.json";
 export const CONFIG_NS_APP_RESOURCES_ENTRY = "appResourcesPath";
+export const CONFIG_NS_BUILD_ENTRY = "buildPath";
 export const CONFIG_NS_APP_ENTRY = "appPath";
 export const CONFIG_FILE_NAME_DISPLAY = "nativescript.config.(js|ts)";
 export const CONFIG_FILE_NAME_JS = "nativescript.config.js";

--- a/lib/contracts/project-data.ts
+++ b/lib/contracts/project-data.ts
@@ -89,4 +89,6 @@ export abstract class ProjectData {
 	abstract getAppResourcesDirectoryPath(projectDir?: string): string;
 
 	abstract getAppResourcesRelativeDirectoryPath(): string;
+
+	abstract getBuildRelativeDirectoryPath(): string;
 }

--- a/lib/controllers/migrate-controller.ts
+++ b/lib/controllers/migrate-controller.ts
@@ -722,7 +722,7 @@ export class MigrateController
 	private async cleanUpProject(projectData: IProjectData): Promise<void> {
 		await this.$projectCleanupService.clean([
 			constants.HOOKS_DIR_NAME,
-			constants.PLATFORMS_DIR_NAME,
+			projectData.getBuildRelativeDirectoryPath(),
 			constants.NODE_MODULES_FOLDER_NAME,
 			constants.PACKAGE_LOCK_JSON_FILE_NAME,
 		]);

--- a/lib/controllers/update-controller.ts
+++ b/lib/controllers/update-controller.ts
@@ -109,7 +109,7 @@ export class UpdateController
 		// clean up project files
 		this.spinner.info("Cleaning up project files before update");
 
-		await this.cleanUpProject();
+		await this.cleanUpProject(projectData);
 
 		this.spinner.succeed("Project files have been cleaned up");
 
@@ -293,10 +293,10 @@ export class UpdateController
 		}
 	}
 
-	private async cleanUpProject(): Promise<void> {
+	private async cleanUpProject(projectData: IProjectData): Promise<void> {
 		await this.$projectCleanupService.clean([
 			constants.HOOKS_DIR_NAME,
-			constants.PLATFORMS_DIR_NAME,
+			projectData.getBuildRelativeDirectoryPath(),
 			constants.NODE_MODULES_FOLDER_NAME,
 			constants.PACKAGE_LOCK_JSON_FILE_NAME,
 		]);

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -191,6 +191,11 @@ interface INsConfig {
 	main?: string;
 	appPath?: string;
 	appResourcesPath?: string;
+	/**
+	 * Where the native projects are generated, relative to the project root.
+	 * Defaults to `platforms`.
+	 */
+	buildPath?: string;
 	shared?: boolean;
 	overridePods?: string;
 	webpackConfigPath?: string;

--- a/lib/project-data.ts
+++ b/lib/project-data.ts
@@ -169,14 +169,18 @@ export class ProjectData implements IProjectData {
 				nsConfig && nsConfig.projectName
 					? nsConfig.projectName
 					: this.$projectHelper.sanitizeName(path.basename(projectDir));
-			this.platformsDir = path.join(projectDir, constants.PLATFORMS_DIR_NAME);
+			// read before `platformsDir`, which is derived from it
+			this.nsConfig = nsConfig;
+			this.platformsDir = path.join(
+				projectDir,
+				this.getBuildRelativeDirectoryPath(),
+			);
 			this.projectFilePath = projectFilePath;
 			this.projectIdentifiers = this.initializeProjectIdentifiers(nsConfig);
 			this.packageJsonData = packageJsonData;
 			this.dependencies = packageJsonData.dependencies;
 			this.devDependencies = packageJsonData.devDependencies;
 			this.projectType = this.getProjectType();
-			this.nsConfig = nsConfig;
 			this.ignoredDependencies = nsConfig?.ignoredNativeDependencies;
 			this.appDirectoryPath = this.getAppDirectoryPath();
 			this.appResourcesDirectoryPath = this.getAppResourcesDirectoryPath();
@@ -274,6 +278,18 @@ export class ProjectData implements IProjectData {
 		// 	this.getAppDirectoryRelativePath(),
 		// 	constants.APP_RESOURCES_FOLDER_NAME
 		// );
+	}
+
+	/**
+	 * Where the native projects are generated, relative to the project root.
+	 * `buildPath` in the project config overrides the default `platforms`.
+	 */
+	public getBuildRelativeDirectoryPath(): string {
+		if (this.nsConfig && this.nsConfig[constants.CONFIG_NS_BUILD_ENTRY]) {
+			return this.nsConfig[constants.CONFIG_NS_BUILD_ENTRY];
+		}
+
+		return constants.PLATFORMS_DIR_NAME;
 	}
 
 	public getAppDirectoryPath(projectDir?: string): string {

--- a/test/controllers/update-controller.ts
+++ b/test/controllers/update-controller.ts
@@ -20,6 +20,7 @@ function createTestInjector(projectDir: string = projectFolder): IInjector {
 		initializeProjectData: () => {
 			/* empty */
 		},
+		getBuildRelativeDirectoryPath: () => "platforms",
 		dependencies: {
 			"@nativescript/core": "next",
 		},

--- a/test/project-data.ts
+++ b/test/project-data.ts
@@ -59,6 +59,7 @@ describe("projectData", () => {
 			bundlerConfigPath?: string;
 			projectName?: string;
 			bundler?: string;
+			buildPath?: string;
 		};
 	}): IProjectData => {
 		const testInjector = createTestInjector();
@@ -95,6 +96,36 @@ describe("projectData", () => {
 
 		return projectData;
 	};
+
+	describe("buildPath", () => {
+		it("defaults to the platforms directory", () => {
+			const projectData = prepareTest();
+
+			assert.deepStrictEqual(
+				projectData.getBuildRelativeDirectoryPath(),
+				"platforms",
+			);
+			assert.deepStrictEqual(
+				projectData.platformsDir,
+				path.join(projectDir, "platforms"),
+			);
+		});
+
+		it("is read from the project config", () => {
+			const projectData = prepareTest({
+				configData: { buildPath: "build/native" },
+			});
+
+			assert.deepStrictEqual(
+				projectData.getBuildRelativeDirectoryPath(),
+				"build/native",
+			);
+			assert.deepStrictEqual(
+				projectData.platformsDir,
+				path.join(projectDir, "build/native"),
+			);
+		});
+	});
 
 	describe("projectType", () => {
 		const assertProjectType = (

--- a/test/stubs.ts
+++ b/test/stubs.ts
@@ -731,6 +731,10 @@ export class ProjectDataStub implements IProjectData {
 	public getAppDirectoryRelativePath(): string {
 		return "app";
 	}
+
+	public getBuildRelativeDirectoryPath(): string {
+		return constants.PLATFORMS_DIR_NAME;
+	}
 }
 
 export class AndroidPluginBuildServiceStub implements IAndroidPluginBuildService {


### PR DESCRIPTION
### What

`platforms` is hardcoded as the directory the native projects are generated into. This makes it configurable:

```js
// nativescript.config.ts
export default {
  buildPath: "build/native",
} satisfies NativeScriptConfig;
```

Defaults to `platforms`, so a project that does not set it behaves exactly as before.

### How

`ProjectData.platformsDir` is derived from a new `getBuildRelativeDirectoryPath()`, which reads `buildPath` from the project config. `nsConfig` is now assigned before `platformsDir` in `initializeProjectData` so the value is available when the directory is computed.

Everything that already goes through `projectData.platformsDir` follows along for free. The four places that reached for the `PLATFORMS_DIR_NAME` constant to name the project's *own* build directory were switched to the new method:

- `ns clean`
- `ns migrate` (the pre-migration cleanup)
- `ns update` (the pre-update cleanup)
- `ns typings android` (locating `dts-generator.jar`)

The `platforms` folder inside a plugin's own npm package is a different thing entirely — `plugins-service` and `ns plugin build` keep using the constant for it.

### Tests

`npm test` — 1858 passing. Added coverage in `test/project-data.ts` for the default and for a configured `buildPath`, asserting both the relative path and the resolved `platformsDir`.

### Notes

From https://github.com/Akylas/nativescript-cli. Independent of #6129 and #6130; #6129 adds a `getBuildRelativeDirectoryPath()` computed from `platformsDir`, which this PR replaces with the config-backed version — whichever lands first, the other needs a one-method merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a custom native-project build directory.
  - The build directory defaults to `platforms` when no custom path is provided.
- **Bug Fixes**
  - Cleanup during project updates and migrations now targets the configured build directory.
  - Android type generation uses the configured native-project location.
- **Tests**
  - Added coverage for default and custom build-directory configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->