### PR TITLE
feat(android): per-plugin build options, with aarSuffix to break name clashes

### DIFF
--- a/lib/definitions/android-plugin-migrator.d.ts
+++ b/lib/definitions/android-plugin-migrator.d.ts
@@ -12,6 +12,13 @@ interface IAndroidBuildOptions {
 	tempPluginDirPath: string;
 	gradlePath?: string;
 	gradleArgs?: string;
+	/**
+	 * Appended to the plugin name before it is shortened into the name of the
+	 * produced `.aar`. The npm scope is dropped when shortening, so two plugins
+	 * from different scopes can end up with the same `.aar` - a suffix tells
+	 * them apart.
+	 */
+	aarSuffix?: string;
 }
 
 interface IAndroidPluginBuildService {

--- a/lib/definitions/project.d.ts
+++ b/lib/definitions/project.d.ts
@@ -8,6 +8,7 @@ import {
 import { ICheckEnvironmentRequirementsOutput, IPlatformData } from "./platform";
 import { IPluginData, IBasePluginData } from "./plugins";
 import {
+	IDictionary,
 	IStringDictionary,
 	IProjectDir,
 	IDeviceIdentifier,
@@ -179,6 +180,21 @@ interface INsConfigAndroid extends INsConfigPlaform {
 	 * Custom runtime package name
 	 */
 	runtimePackageName?: string;
+
+	/**
+	 * Per plugin build options, keyed by the plugin's npm package name.
+	 */
+	plugins?: IDictionary<INsConfigAndroidPlugin>;
+}
+
+interface INsConfigAndroidPlugin {
+	/**
+	 * Appended to the plugin name before it is shortened into the name of the
+	 * produced `.aar`. The npm scope is dropped when shortening, so
+	 * `@foo/plugin` and `@bar/plugin` both build a `plugin.aar` and overwrite
+	 * each other - a suffix tells them apart.
+	 */
+	aarSuffix?: string;
 }
 
 interface INsConfigHooks {

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -226,7 +226,11 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		const androidSourceDirectories = this.getAndroidSourceDirectories(
 			options.platformsAndroidDirPath,
 		);
-		const shortPluginName = getShortPluginName(options.pluginName);
+		// the npm scope is dropped when shortening, so an optional suffix is what
+		// keeps two same-named plugins from overwriting each other's `.aar`
+		const shortPluginName = getShortPluginName(
+			`${options.pluginName}${options.aarSuffix || ""}`,
+		);
 		const pluginTempDir = path.join(options.tempPluginDirPath, shortPluginName);
 		const pluginSourceFileHashesInfo = await this.getSourceFilesHashes(
 			options.platformsAndroidDirPath,
@@ -260,6 +264,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 				options.platformsAndroidDirPath,
 				options.projectDir,
 				options.pluginName,
+				shortPluginName,
 			);
 			await this.buildPlugin({
 				gradlePath: options.gradlePath,
@@ -401,6 +406,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		platformsAndroidDirPath: string,
 		projectDir: string,
 		pluginName: string,
+		shortPluginName: string,
 	): Promise<void> {
 		const gradleTemplatePath = path.resolve(
 			path.join(__dirname, "../../vendor/gradle-plugin"),
@@ -425,8 +431,6 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		this.replaceFileContent(settingsGradlePath, "{{pluginName}}", pluginName);
 
 		// gets the package from the AndroidManifest to use as the namespace or fallback to the `org.nativescript.${shortPluginName}`
-		const shortPluginName = getShortPluginName(pluginName);
-
 		const manifestPath = path.join(
 			pluginTempDir,
 			"src",

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -688,6 +688,8 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			AndroidProjectService.ANDROID_PLATFORM_NAME
 		);
 		if (this.$fs.exists(pluginPlatformsFolderPath)) {
+			const pluginConfig =
+				(projectData.nsConfig?.android?.plugins || {})[pluginData.name] || {};
 			const options: IPluginBuildOptions = {
 				gradlePath: this.$options.gradlePath,
 				gradleArgs: this.$options.gradleArgs,
@@ -696,6 +698,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 				platformsAndroidDirPath: pluginPlatformsFolderPath,
 				aarOutputDir: pluginPlatformsFolderPath,
 				tempPluginDirPath: path.join(projectData.platformsDir, "tempPlugin"),
+				...pluginConfig,
 			};
 
 			if (await this.$androidPluginBuildService.buildAar(options)) {

--- a/test/services/android-plugin-build-service.ts
+++ b/test/services/android-plugin-build-service.ts
@@ -24,6 +24,7 @@ describe("androidPluginBuildService", () => {
 	const pluginName = "my-plugin";
 	const shortPluginName = getShortPluginName(pluginName);
 	let spawnFromEventCalled = false;
+	let builtPluginDirName: string = null;
 	let fs: IFileSystem;
 	let androidBuildPluginService: AndroidPluginBuildService;
 	let tempFolder: string;
@@ -46,6 +47,7 @@ describe("androidPluginBuildService", () => {
 	}): IPluginBuildOptions {
 		options = options || {};
 		spawnFromEventCalled = false;
+		builtPluginDirName = null;
 		tempFolder = mkdtempSync(
 			path.join(tmpdir(), "androidPluginBuildService-temp-"),
 		);
@@ -75,11 +77,16 @@ describe("androidPluginBuildService", () => {
 		const testInjector: IInjector = new stubs.InjectorStub();
 		testInjector.register("fs", FsLib.FileSystem);
 		testInjector.register("childProcess", {
-			spawnFromEvent: async (command: string): Promise<ISpawnResult> => {
-				const finalAarName = `${shortPluginName}-release.aar`;
+			spawnFromEvent: async (
+				command: string,
+				args: string[],
+			): Promise<ISpawnResult> => {
+				// the plugin dir gradle was pointed at is what names the built aar
+				const pluginDir = args[args.indexOf("-p") + 1];
+				builtPluginDirName = path.basename(pluginDir);
+				const finalAarName = `${builtPluginDirName}-release.aar`;
 				const aar = path.join(
-					tempFolder,
-					shortPluginName,
+					pluginDir,
 					"build",
 					"outputs",
 					"aar",
@@ -267,6 +274,28 @@ dependencies {
 			await androidBuildPluginService.buildAar(config);
 
 			assert.isTrue(spawnFromEventCalled);
+		});
+
+		it("builds an aar named after the plugin", async () => {
+			const config: IPluginBuildOptions = setup({ addManifest: true });
+
+			await androidBuildPluginService.buildAar(config);
+
+			assert.deepStrictEqual(builtPluginDirName, shortPluginName);
+			assert.isTrue(
+				fs.exists(path.join(pluginFolder, `${shortPluginName}.aar`)),
+			);
+		});
+
+		it("appends aarSuffix to the name of the built aar", async () => {
+			const config: IPluginBuildOptions = setup({ addManifest: true });
+			config.aarSuffix = "-v2";
+
+			await androidBuildPluginService.buildAar(config);
+
+			const expectedName = getShortPluginName(`${pluginName}-v2`);
+			assert.deepStrictEqual(builtPluginDirName, expectedName);
+			assert.isTrue(fs.exists(path.join(pluginFolder, `${expectedName}.aar`)));
 		});
 
 		it("does not build aar when there are no supported files in the plugin", async () => {


### PR DESCRIPTION
### The problem

`getShortPluginName` drops the npm scope:

```ts
sanitizePluginName(pluginName).replace(/[\-]/g, "_")  // "@foo/plugin-x" -> "plugin_x"
```

That name becomes the temp build directory, the produced `.aar` and the android namespace fallback. Two plugins from different scopes with the same package name — `@foo/plugin-x` and `@bar/plugin-x` — both build a `plugin_x.aar`, and which one gradle ends up linking depends on build order.

### What

A project can give one of them a suffix:

```js
// nativescript.config.ts
export default {
  android: {
    plugins: {
      "@bar/plugin-x": { aarSuffix: "-bar" },
    },
  },
} satisfies NativeScriptConfig;
```

`@bar/plugin-x` now builds `plugin_x_bar.aar` and stops colliding.

`android.plugins` is a map keyed by npm package name whose entries are spread into the options `buildAar` receives, so it is also where future per-plugin build settings can go. `aarSuffix` is the only key it carries today.

### Details

The suffix is appended to the plugin name *before* it is shortened, so it goes through the same sanitizing as the rest of the name.

`setupGradle` used to recompute `getShortPluginName(pluginName)` for the namespace fallback (`org.nativescript.<short name>`), which would have kept colliding. It now takes the already-computed name as a parameter, so the temp directory, the `.aar` and the namespace all agree.

Nothing changes for a project that does not set `plugins` — the suffix defaults to empty and the name is exactly what it was.

### Not covered

`ns plugin build` does not read the config: it runs inside a plugin's own directory, where there is no consuming app to declare a suffix. The option is on `IPluginBuildOptions`, so a hook can still set it there.

### Tests

`npm test` — 1858 passing. The `childProcess` stub in `test/services/android-plugin-build-service.ts` now derives the built `.aar` name from the plugin directory gradle was pointed at instead of assuming it, which let me add two cases: the default name, and the name with `aarSuffix` applied.

### Notes

From https://github.com/Akylas/nativescript-cli. Independent of #6129, #6130 and #6131, though #6129 also touches `IAndroidBuildOptions.gradleArgs` and the options object in `android-project-service` — expect a small textual conflict depending on merge order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Android plugin configuration for customizing generated `.aar` filenames with a suffix.
  * Supports per-plugin suffixes to prevent naming conflicts between similarly named plugins.

* **Bug Fixes**
  * Improved Android plugin build output naming to consistently honor configured suffixes and plugin paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->