### PR TITLE
feat(android): optionally pass the device ABIs to plugin builds

### DIFF
--- a/docs/man_pages/project/testing/debug-android.md
+++ b/docs/man_pages/project/testing/debug-android.md
@@ -39,6 +39,7 @@ Attach the debug tools to a running app in the native emulator | `$ ns debug and
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
 * `--no-filter-devices-arch` - If set, builds every ABI instead of only the ones the connected devices report. The narrowing only applies when the app's gradle configuration acts on the `abiFilters` property, and `ns build` never narrows.
+* `--filter-plugins-devices-arch` - If set, the ABIs of the connected devices are also passed to the gradle build of every plugin built from source. Nothing in the gradle files the CLI generates for a plugin acts on them - this is for a plugin whose own `include.gradle` reads the `abiFilters` property to shorten a long native build.
 * `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/debug-android.md
+++ b/docs/man_pages/project/testing/debug-android.md
@@ -38,6 +38,7 @@ Attach the debug tools to a running app in the native emulator | `$ ns debug and
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
+* `--no-filter-devices-arch` - If set, builds every ABI instead of only the ones the connected devices report. The narrowing only applies when the app's gradle configuration acts on the `abiFilters` property, and `ns build` never narrows.
 * `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -44,6 +44,7 @@ Start a default emulator if none are running, or run application on all connecte
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
 * `--no-filter-devices-arch` - If set, builds every ABI instead of only the ones the connected devices report. The narrowing only applies when the app's gradle configuration acts on the `abiFilters` property, and `ns build` never narrows.
+* `--filter-plugins-devices-arch` - If set, the ABIs of the connected devices are also passed to the gradle build of every plugin built from source. Nothing in the gradle files the CLI generates for a plugin acts on them - this is for a plugin whose own `include.gradle` reads the `abiFilters` property to shorten a long native build.
 * `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>

--- a/docs/man_pages/project/testing/run-android.md
+++ b/docs/man_pages/project/testing/run-android.md
@@ -43,6 +43,7 @@ Start a default emulator if none are running, or run application on all connecte
     *   `--env.sourceMap` - creates inline source maps.
     *   `--env.hiddenSourceMap` - creates sources maps in the root folder (useful for Crashlytics usage with bundled app in release).
 * `--aab` - Specifies that the command will produce and deploy an Android App Bundle.
+* `--no-filter-devices-arch` - If set, builds every ABI instead of only the ones the connected devices report. The narrowing only applies when the app's gradle configuration acts on the `abiFilters` property, and `ns build` never narrows.
 * `--force` - If set, skips the application compatibility checks and forces `npm i` to ensure all dependencies are installed. Otherwise, the command will check the application compatibility with the current CLI version and could fail requiring `ns migrate`.
 
 <% if(isHtml) { %>

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -53,7 +53,12 @@ export abstract class BuildCommandBase extends ValidatePlatformCommandBase {
 		const buildData = this.$buildDataService.getBuildData(
 			this.$projectData.projectDir,
 			platform,
-			this.$options,
+			{
+				...this.$options.argv,
+				// `ns build` produces an artifact meant to be shipped, so it must
+				// not be narrowed down to the ABIs of whatever is plugged in
+				filterDevicesArch: false,
+			},
 		);
 		const outputPath = await this.$buildController.prepareAndBuild(buildData);
 

--- a/lib/common/definitions/mobile.d.ts
+++ b/lib/common/definitions/mobile.d.ts
@@ -100,6 +100,11 @@ declare global {
 			 * For iOS simulators - same as the identifier.
 			 */
 			imageIdentifier?: string;
+			/**
+			 * Optional property listing the ABIs the device supports, most
+			 * preferred first. Available for Android only.
+			 */
+			abis?: string[];
 		}
 
 		interface IDeviceError extends Error, IDeviceIdentifier {}

--- a/lib/common/mobile/android/android-device.ts
+++ b/lib/common/mobile/android/android-device.ts
@@ -13,6 +13,9 @@ interface IAndroidDeviceDetails {
 	name: string;
 	release: string;
 	brand: string;
+	"cpu.abi"?: string;
+	"cpu.abilist32"?: string;
+	"cpu.abilist64"?: string;
 }
 
 interface IAdbDeviceStatusInfo {
@@ -96,6 +99,7 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 			identifier: this.identifier,
 			displayName: details.name,
 			model: details.model,
+			abis: this.getAbis(details),
 			version,
 			vendor: details.brand,
 			platform: this.$devicePlatformsConstants.Android,
@@ -177,6 +181,25 @@ export class AndroidDevice implements Mobile.IAndroidDevice {
 		this.$logger.trace(parsedDetails);
 
 		return parsedDetails;
+	}
+
+	// `ro.product.cpu.abilist64`/`abilist32` list every ABI the device supports,
+	// most preferred first. Old devices report neither and only have the single
+	// `ro.product.cpu.abi`.
+	private getAbis(details: IAndroidDeviceDetails): string[] {
+		const abis = [
+			...(details["cpu.abilist64"] || "").split(","),
+			...(details["cpu.abilist32"] || "").split(",")
+		]
+			.map((abi) => abi.trim())
+			.filter((abi) => !!abi);
+
+		if (abis.length) {
+			return abis;
+		}
+
+		const abi = (details["cpu.abi"] || "").trim();
+		return abi ? [abi] : [];
 	}
 
 	private getIsTablet(details: any): boolean {

--- a/lib/controllers/build-controller.ts
+++ b/lib/controllers/build-controller.ts
@@ -116,7 +116,7 @@ export class BuildController extends EventEmitter implements IBuildController {
 		);
 
 		if (buildData.copyTo) {
-			this.$buildArtifactsService.copyLatestAppPackage(
+			this.$buildArtifactsService.copyAppPackages(
 				buildData.copyTo,
 				platformData,
 				buildData

--- a/lib/data/build-data.ts
+++ b/lib/data/build-data.ts
@@ -51,6 +51,7 @@ export class AndroidBuildData extends BuildData {
 	public keyStoreAliasPassword: string;
 	public keyStorePassword: string;
 	public androidBundle: boolean;
+	public buildFilterDevicesArch: boolean;
 	public gradlePath: string;
 	public gradleArgs: string;
 	public hostProjectPath: string;
@@ -63,6 +64,9 @@ export class AndroidBuildData extends BuildData {
 		this.keyStoreAliasPassword = data.keyStoreAliasPassword;
 		this.keyStorePassword = data.keyStorePassword;
 		this.androidBundle = data.androidBundle || data.aab;
+		// an app bundle already carries every ABI, so there is nothing to filter
+		this.buildFilterDevicesArch =
+			!this.androidBundle && data.filterDevicesArch !== false;
 		this.gradlePath = data.gradlePath;
 		this.gradleArgs = data.gradleArgs;
 		this.hostProjectPath = data.hostProjectPath;

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -577,6 +577,14 @@ interface IAndroidOptions extends IEmbedOptions {
 	 * `--no-filter-devices-arch` to always build every ABI.
 	 */
 	filterDevicesArch: boolean;
+
+	/**
+	 * When true, the same ABIs are passed to the gradle build of every plugin
+	 * that is built from source. Off by default - the CLI's own plugin gradle
+	 * files ignore the property, only a plugin acting on it in its
+	 * `include.gradle` gains anything from it.
+	 */
+	filterPluginsDevicesArch: boolean;
 	gradlePath: string;
 	gradleArgs: string;
 }

--- a/lib/declarations.d.ts
+++ b/lib/declarations.d.ts
@@ -571,6 +571,12 @@ interface IEmbedOptions {
 }
 
 interface IAndroidOptions extends IEmbedOptions {
+	/**
+	 * When true (the default) `ns run`/`ns debug` restrict the native build to
+	 * the ABIs of the devices it is about to deploy to. Pass
+	 * `--no-filter-devices-arch` to always build every ABI.
+	 */
+	filterDevicesArch: boolean;
 	gradlePath: string;
 	gradleArgs: string;
 }

--- a/lib/definitions/android-plugin-migrator.d.ts
+++ b/lib/definitions/android-plugin-migrator.d.ts
@@ -12,6 +12,7 @@ interface IAndroidBuildOptions {
 	tempPluginDirPath: string;
 	gradlePath?: string;
 	gradleArgs?: string;
+	abiFilters?: string[];
 }
 
 interface IAndroidPluginBuildService {
@@ -49,4 +50,13 @@ interface IBuildAndroidPluginData extends Partial<IProjectDir> {
 	 * Optional custom Gradle arguments.
 	 */
 	gradleArgs?: string;
+
+	/**
+	 * The ABIs the build this plugin is prepared for is about to deploy to,
+	 * passed to the plugin build as `-PabiFilters`. Nothing in the gradle files
+	 * the CLI generates for a plugin acts on it - it is there for a plugin whose
+	 * own `include.gradle` reads the property to skip the ABIs the build does
+	 * not need.
+	 */
+	abiFilters?: string[];
 }

--- a/lib/definitions/build.d.ts
+++ b/lib/definitions/build.d.ts
@@ -31,6 +31,7 @@ interface IAndroidBuildData
 	extends IBuildData,
 		IAndroidSigningData,
 		IHasAndroidBundle {
+	buildFilterDevicesArch?: boolean;
 	gradlePath?: string;
 	gradleArgs?: string;
 }
@@ -62,7 +63,7 @@ interface IBuildArtifactsService {
 		platformData: IPlatformData,
 		buildOutputOptions: IBuildOutputOptions
 	): Promise<string>;
-	copyLatestAppPackage(
+	copyAppPackages(
 		targetPath: string,
 		platformData: IPlatformData,
 		buildOutputOptions: IBuildOutputOptions

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -219,6 +219,11 @@ export class Options {
 				default: false,
 				hasSensitiveValue: false,
 			},
+			filterDevicesArch: {
+				type: OptionType.Boolean,
+				default: true,
+				hasSensitiveValue: false,
+			},
 			gradlePath: { type: OptionType.String, hasSensitiveValue: false },
 			gradleArgs: { type: OptionType.String, hasSensitiveValue: false },
 			hostProjectPath: { type: OptionType.String, hasSensitiveValue: false },

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -224,6 +224,11 @@ export class Options {
 				default: true,
 				hasSensitiveValue: false,
 			},
+			filterPluginsDevicesArch: {
+				type: OptionType.Boolean,
+				default: false,
+				hasSensitiveValue: false,
+			},
 			gradlePath: { type: OptionType.String, hasSensitiveValue: false },
 			gradleArgs: { type: OptionType.String, hasSensitiveValue: false },
 			hostProjectPath: { type: OptionType.String, hasSensitiveValue: false },

--- a/lib/services/android-plugin-build-service.ts
+++ b/lib/services/android-plugin-build-service.ts
@@ -61,6 +61,8 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 		private $watchIgnoreListService: IWatchIgnoreListService,
 	) {}
 
+	private static ABI_FILTERS_BUILD_DATA_KEY = "__abiFilters";
+
 	private static MANIFEST_ROOT = {
 		$: {
 			"xmlns:android": "http://schemas.android.com/apk/res/android",
@@ -233,6 +235,16 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			shortPluginName,
 		);
 
+		// the aar of a plugin built for a subset of the ABIs is not the aar of the
+		// same sources built for another subset, so the ABIs take part in the
+		// decision to rebuild - the sources alone would not change when a device
+		// with another ABI joins the run.
+		if (options.abiFilters && options.abiFilters.length) {
+			pluginSourceFileHashesInfo[
+				AndroidPluginBuildService.ABI_FILTERS_BUILD_DATA_KEY
+			] = options.abiFilters.join(",");
+		}
+
 		const shouldBuildAar = await this.shouldBuildAar({
 			manifestFilePath,
 			androidSourceDirectories,
@@ -264,6 +276,7 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 			await this.buildPlugin({
 				gradlePath: options.gradlePath,
 				gradleArgs: options.gradleArgs,
+				abiFilters: options.abiFilters,
 				pluginDir: pluginTempDir,
 				pluginName: options.pluginName,
 				projectDir: options.projectDir,
@@ -819,6 +832,19 @@ export class AndroidPluginBuildService implements IAndroidPluginBuildService {
 
 		if (pluginBuildSettings.gradleArgs) {
 			localArgs.push(pluginBuildSettings.gradleArgs);
+		}
+
+		// nothing in the gradle files generated here acts on `abiFilters` - it is
+		// passed for a plugin whose own include.gradle reads it to narrow a long
+		// native build down. An explicit `-PabiFilters` in the gradle args wins.
+		if (
+			pluginBuildSettings.abiFilters &&
+			pluginBuildSettings.abiFilters.length &&
+			(pluginBuildSettings.gradleArgs || "").indexOf("-PabiFilters") === -1
+		) {
+			localArgs.push(
+				`-PabiFilters=${pluginBuildSettings.abiFilters.join(",")}`
+			);
 		}
 
 		if (this.$logger.getLevel() === "INFO") {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -49,6 +49,7 @@ import { injector } from "../common/yok";
 import { INotConfiguredEnvOptions } from "../common/definitions/commands";
 import { AndroidPrepareData } from "../data/prepare-data";
 import { IProjectChangesInfo } from "../definitions/project-changes";
+import { getDevicesAbis } from "./android/devices-abis";
 
 interface NativeDependency {
 	name: string;
@@ -695,6 +696,7 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 			const options: IPluginBuildOptions = {
 				gradlePath: this.$options.gradlePath,
 				gradleArgs: this.$options.gradleArgs,
+				abiFilters: this.getPluginsAbiFilters(),
 				projectDir: projectData.projectDir,
 				pluginName: pluginData.name,
 				platformsAndroidDirPath: pluginPlatformsFolderPath,
@@ -708,6 +710,27 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 
 			this.$androidPluginBuildService.migrateIncludeGradle(options);
 		}
+	}
+
+	/**
+	 * The ABIs passed to the gradle build of a plugin built from source. Opt-in
+	 * (`--filter-plugins-devices-arch`): nothing in the gradle files the CLI
+	 * generates for a plugin acts on `abiFilters`, so this is only useful for a
+	 * plugin whose own `include.gradle` reads the property - a long native build
+	 * can then skip the ABIs this run is not going to deploy to.
+	 */
+	private getPluginsAbiFilters(): string[] {
+		if (!this.$options.filterPluginsDevicesArch) {
+			return null;
+		}
+
+		const abis = getDevicesAbis(
+			this.$devicesService,
+			this.$devicePlatformsConstants.Android,
+			{ device: this.$options.device, emulator: this.$options.emulator }
+		);
+
+		return abis.length ? abis : null;
 	}
 
 	public async processConfigurationFilesFromAppResources(): Promise<void> {

--- a/lib/services/android-project-service.ts
+++ b/lib/services/android-project-service.ts
@@ -47,6 +47,8 @@ import {
 import { IInjector } from "../common/definitions/yok";
 import { injector } from "../common/yok";
 import { INotConfiguredEnvOptions } from "../common/definitions/commands";
+import { AndroidPrepareData } from "../data/prepare-data";
+import { IProjectChangesInfo } from "../definitions/project-changes";
 
 interface NativeDependency {
 	name: string;
@@ -148,7 +150,9 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		private $androidPluginBuildService: IAndroidPluginBuildService,
 		private $platformEnvironmentRequirements: IPlatformEnvironmentRequirements,
 		private $androidResourcesMigrationService: IAndroidResourcesMigrationService,
+		private $devicesService: Mobile.IDevicesService,
 		private $filesHashService: IFilesHashService,
+		private $liveSyncProcessDataService: ILiveSyncProcessDataService,
 		private $gradleCommandService: IGradleCommandService,
 		private $gradleBuildService: IGradleBuildService,
 		private $analyticsService: IAnalyticsService
@@ -835,8 +839,61 @@ export class AndroidProjectService extends projectServiceBaseLib.PlatformProject
 		await adb.executeShellCommand(["rm", "-rf", deviceRootPath]);
 	}
 
-	public async checkForChanges(): Promise<void> {
-		// Nothing android specific to check yet.
+	/**
+	 * When the native build is narrowed down to the ABIs of the connected
+	 * devices, a device that joins later has no package of its own in the build
+	 * output. Nothing else would trigger a native rebuild for it - the sources
+	 * did not change - so flag it here.
+	 */
+	public async checkForChanges(
+		changesInfo: IProjectChangesInfo,
+		prepareData: AndroidPrepareData,
+		projectData: IProjectData
+	): Promise<void> {
+		if (changesInfo.nativeChanged) {
+			return;
+		}
+
+		const platformData = this.getPlatformData(projectData);
+		const deviceDescriptors = this.$liveSyncProcessDataService.getDeviceDescriptors(
+			projectData.projectDir
+		);
+
+		for (const deviceDescriptor of deviceDescriptors) {
+			const buildData = <IAndroidBuildData>deviceDescriptor.buildData;
+			if (!buildData || !buildData.buildFilterDevicesArch) {
+				continue;
+			}
+
+			const packagesOutputPath = platformData.getBuildOutputPath(buildData);
+			if (!this.$fs.exists(packagesOutputPath)) {
+				continue;
+			}
+
+			const builtPackages = this.$fs.readDirectory(packagesOutputPath);
+			// a universal package runs on every device, nothing to rebuild
+			if (_.some(builtPackages, (f) => f.indexOf("universal") !== -1)) {
+				continue;
+			}
+
+			const device = _.find(
+				this.$devicesService.getDevicesForPlatform(buildData.platform),
+				(d) => d.deviceInfo.identifier === deviceDescriptor.identifier
+			);
+			const abi = device && (device.deviceInfo.abis || [])[0];
+			if (!abi) {
+				continue;
+			}
+
+			const abiRegex = new RegExp(`${abi}.*\\.apk$`);
+			if (!_.some(builtPackages, (entry) => abiRegex.test(entry))) {
+				this.$logger.trace(
+					`No package was built for '${abi}', marking the native project as changed.`
+				);
+				changesInfo.nativeChanged = true;
+				return;
+			}
+		}
 	}
 
 	public getDeploymentTarget(projectData: IProjectData): semver.SemVer {

--- a/lib/services/android/devices-abis.ts
+++ b/lib/services/android/devices-abis.ts
@@ -1,0 +1,23 @@
+import * as _ from "lodash";
+
+/**
+ * The ABIs of the devices a build is about to be deployed to - the first (most
+ * preferred) ABI of every device, deduplicated. `device`/`emulator` narrow the
+ * set down the same way they narrow the run itself.
+ */
+export function getDevicesAbis(
+	$devicesService: Mobile.IDevicesService,
+	platform: string,
+	filter: { device?: string; emulator?: boolean } = {}
+): string[] {
+	let devices = $devicesService.getDevicesForPlatform(platform);
+	if (filter.device) {
+		devices = devices.filter((d) => d.deviceInfo.identifier === filter.device);
+	} else if (filter.emulator) {
+		devices = devices.filter((d) => d.isEmulator);
+	}
+
+	return _.uniq(
+		devices.map((d) => (d.deviceInfo.abis || [])[0]).filter((abi) => !!abi)
+	);
+}

--- a/lib/services/android/gradle-build-service.ts
+++ b/lib/services/android/gradle-build-service.ts
@@ -9,12 +9,14 @@ import {
 import { IAndroidBuildData } from "../../definitions/build";
 import { IChildProcess } from "../../common/declarations";
 import { injector } from "../../common/yok";
+import * as _ from "lodash";
 
 export class GradleBuildService
 	extends EventEmitter
 	implements IGradleBuildService {
 	constructor(
 		private $childProcess: IChildProcess,
+		private $devicesService: Mobile.IDevicesService,
 		private $gradleBuildArgsService: IGradleBuildArgsService,
 		private $gradleCommandService: IGradleCommandService
 	) {
@@ -28,6 +30,9 @@ export class GradleBuildService
 		const buildTaskArgs = await this.$gradleBuildArgsService.getBuildTaskArgs(
 			buildData
 		);
+
+		this.applyDevicesAbiFilter(buildTaskArgs, buildData);
+
 		const spawnOptions = {
 			emitOptions: { eventName: constants.BUILD_OUTPUT_EVENT_NAME },
 			throwError: true,
@@ -49,6 +54,47 @@ export class GradleBuildService
 				gradleCommandOptions
 			)
 		);
+	}
+
+	/**
+	 * Narrows the native build down to the ABIs of the devices this build is
+	 * about to be deployed to. The app's gradle configuration decides what to do
+	 * with `abiFilters` - typically an `ndk.abiFilters`/`splits` block in
+	 * `App_Resources/Android/app.gradle`. An explicitly passed `-PabiFilters`
+	 * always wins.
+	 */
+	private applyDevicesAbiFilter(
+		buildTaskArgs: string[],
+		buildData: IAndroidBuildData
+	): void {
+		if (!buildData.buildFilterDevicesArch) {
+			return;
+		}
+
+		if (_.some(buildTaskArgs, (arg) => arg.startsWith("-PabiFilters"))) {
+			return;
+		}
+
+		let devices = this.$devicesService.getDevicesForPlatform(
+			buildData.platform
+		);
+		if (buildData.device) {
+			devices = devices.filter(
+				(d) => d.deviceInfo.identifier === buildData.device
+			);
+		} else if (buildData.emulator) {
+			devices = devices.filter((d) => d.isEmulator);
+		}
+
+		const abis = _.uniq(
+			devices
+				.map((d) => (d.deviceInfo.abis || [])[0])
+				.filter((abi) => !!abi)
+		);
+
+		if (abis.length) {
+			buildTaskArgs.push(`-PabiFilters=${abis.join(",")}`);
+		}
 	}
 
 	public async cleanProject(

--- a/lib/services/android/gradle-build-service.ts
+++ b/lib/services/android/gradle-build-service.ts
@@ -9,6 +9,7 @@ import {
 import { IAndroidBuildData } from "../../definitions/build";
 import { IChildProcess } from "../../common/declarations";
 import { injector } from "../../common/yok";
+import { getDevicesAbis } from "./devices-abis";
 import * as _ from "lodash";
 
 export class GradleBuildService
@@ -75,22 +76,10 @@ export class GradleBuildService
 			return;
 		}
 
-		let devices = this.$devicesService.getDevicesForPlatform(
-			buildData.platform
-		);
-		if (buildData.device) {
-			devices = devices.filter(
-				(d) => d.deviceInfo.identifier === buildData.device
-			);
-		} else if (buildData.emulator) {
-			devices = devices.filter((d) => d.isEmulator);
-		}
-
-		const abis = _.uniq(
-			devices
-				.map((d) => (d.deviceInfo.abis || [])[0])
-				.filter((abi) => !!abi)
-		);
+		const abis = getDevicesAbis(this.$devicesService, buildData.platform, {
+			device: buildData.device,
+			emulator: buildData.emulator,
+		});
 
 		if (abis.length) {
 			buildTaskArgs.push(`-PabiFilters=${abis.join(",")}`);

--- a/lib/services/build-artifacts-service.ts
+++ b/lib/services/build-artifacts-service.ts
@@ -75,7 +75,12 @@ export class BuildArtifactsService implements IBuildArtifactsService {
 		return [];
 	}
 
-	public copyLatestAppPackage(
+	/**
+	 * Copies what the build produced to `targetPath`. A build can produce more
+	 * than one package - an app split per ABI - so a directory target receives
+	 * all of them, while a single file target receives the universal one.
+	 */
+	public copyAppPackages(
 		targetPath: string,
 		platformData: IPlatformData,
 		buildOutputOptions: IBuildOutputOptions
@@ -85,26 +90,36 @@ export class BuildArtifactsService implements IBuildArtifactsService {
 		const outputPath =
 			buildOutputOptions.outputPath ||
 			platformData.getBuildOutputPath(buildOutputOptions);
-		const applicationPackage = this.getLatestApplicationPackage(
+		const applicationPackages = this.getAllAppPackages(
 			outputPath,
 			platformData.getValidBuildOutputData(buildOutputOptions)
 		);
-		const packageFile = applicationPackage.packageName;
 
 		this.$fs.ensureDirectoryExists(path.dirname(targetPath));
 
-		if (
-			this.$fs.exists(targetPath) &&
-			this.$fs.getFsStats(targetPath).isDirectory()
-		) {
-			const sourceFileName = path.basename(packageFile);
+		const targetIsDirectory =
+			(this.$fs.exists(targetPath) &&
+				this.$fs.getFsStats(targetPath).isDirectory()) ||
+			!path.extname(targetPath);
+
+		let packagesToCopy = applicationPackages;
+		if (!targetIsDirectory && applicationPackages.length > 1) {
 			this.$logger.trace(
-				`Specified target path: '${targetPath}' is directory. Same filename will be used: '${sourceFileName}'.`
+				`Specified target path: '${targetPath}' is a single file, but the build produced ${applicationPackages.length} packages. Only the universal one will be copied.`
 			);
-			targetPath = path.join(targetPath, sourceFileName);
+			packagesToCopy = applicationPackages.filter((pack) =>
+				path.basename(pack.packageName).includes("universal")
+			);
 		}
-		this.$fs.copyFile(packageFile, targetPath);
-		this.$logger.info(`Copied file '${packageFile}' to '${targetPath}'.`);
+
+		_.each(packagesToCopy, (pack) => {
+			const packageFile = pack.packageName;
+			const targetFilePath = targetIsDirectory
+				? path.join(targetPath, path.basename(packageFile))
+				: targetPath;
+			this.$fs.copyFile(packageFile, targetFilePath);
+			this.$logger.info(`Copied file '${packageFile}' to '${targetFilePath}'.`);
+		});
 	}
 
 	private getLatestApplicationPackage(

--- a/lib/services/device/device-install-app-service.ts
+++ b/lib/services/device/device-install-app-service.ts
@@ -51,7 +51,8 @@ export class DeviceInstallAppService {
 		});
 
 		if (!packageFile) {
-			packageFile = await this.$buildArtifactsService.getLatestAppPackagePath(
+			packageFile = await this.getPackageForDevice(
+				device,
 				platformData,
 				buildData
 			);
@@ -89,6 +90,49 @@ export class DeviceInstallAppService {
 
 		this.$logger.info(
 			`Successfully installed on device with identifier '${device.deviceInfo.identifier}'.`
+		);
+	}
+
+	/**
+	 * A build narrowed down to the connected devices' ABIs produces one package
+	 * per ABI, so the one this device can run has to be picked. Falls back to
+	 * the universal package and then to the newest one, which is what a build
+	 * that was not split produces anyway.
+	 */
+	private async getPackageForDevice(
+		device: Mobile.IDevice,
+		platformData: IPlatformData,
+		buildData: IBuildData
+	): Promise<string> {
+		const outputPath =
+			buildData.outputPath || platformData.getBuildOutputPath(buildData);
+		const packages = this.$buildArtifactsService.getAllAppPackages(
+			outputPath,
+			platformData.getValidBuildOutputData(buildData)
+		);
+
+		if (packages.length > 1) {
+			const abis = device.deviceInfo.abis || [];
+			for (const abi of abis) {
+				const match = packages.find((p) =>
+					path.basename(p.packageName).includes(abi)
+				);
+				if (match) {
+					return match.packageName;
+				}
+			}
+
+			const universalPackage = packages.find((p) =>
+				path.basename(p.packageName).includes("universal")
+			);
+			if (universalPackage) {
+				return universalPackage.packageName;
+			}
+		}
+
+		return this.$buildArtifactsService.getLatestAppPackagePath(
+			platformData,
+			buildData
 		);
 	}
 

--- a/test/plugins-service.ts
+++ b/test/plugins-service.ts
@@ -185,6 +185,12 @@ function createTestInjector() {
 	);
 
 	testInjector.register("platformEnvironmentRequirements", {});
+	testInjector.register("devicesService", {
+		getDevicesForPlatform: (): Mobile.IDevice[] => [],
+	});
+	testInjector.register("liveSyncProcessDataService", {
+		getDeviceDescriptors: (): ILiveSyncDeviceDescriptor[] => [],
+	});
 	testInjector.register("filesHashService", {
 		hasChangesInShasums: (
 			oldPluginNativeHashes: IStringDictionary,

--- a/test/services/android-project-service.ts
+++ b/test/services/android-project-service.ts
@@ -19,6 +19,7 @@ import {
 	IFileSystem,
 	IProjectDir,
 } from "../../lib/common/declarations";
+import { IPluginBuildOptions } from "../../lib/definitions/android-plugin-migrator";
 
 const createTestInjector = (): IInjector => {
 	const testInjector = new Yok();
@@ -408,5 +409,93 @@ describe("androidProjectService", () => {
 				]);
 			});
 		});
+	});
+});
+
+describe("androidProjectService plugins abi filtering", () => {
+	const createDevice = (
+		identifier: string,
+		abis: string[],
+		isEmulator = false
+	): any => ({
+		deviceInfo: { identifier, abis, platform: "android" },
+		isEmulator,
+	});
+
+	const preparePluginNativeCode = async (
+		options: any,
+		devices: any[]
+	): Promise<IPluginBuildOptions> => {
+		const testInjector = createTestInjector();
+		let pluginBuildOptions: IPluginBuildOptions = null;
+		testInjector.register("androidPluginBuildService", {
+			buildAar: async (opts: IPluginBuildOptions): Promise<boolean> => {
+				pluginBuildOptions = opts;
+				return false;
+			},
+			migrateIncludeGradle: (): boolean => false,
+		});
+		testInjector.register("options", {
+			hostProjectModuleName: "app",
+			...options,
+		});
+		testInjector.register("devicesService", {
+			getDevicesForPlatform: (): any[] => devices,
+		});
+		testInjector.register("devicePlatformsConstants", { Android: "Android" });
+
+		const androidProjectService: IPlatformProjectService = testInjector.resolve(
+			"androidProjectService"
+		);
+		await androidProjectService.preparePluginNativeCode(
+			<any>{
+				name: "my-plugin",
+				pluginPlatformsFolderPath: (): string => "pluginPlatformsDir",
+			},
+			<any>{ projectDir: "projectDir", platformsDir: "platformsDir" }
+		);
+
+		return pluginBuildOptions;
+	};
+
+	it("passes the abis of the connected devices when the option is set", async () => {
+		const options = await preparePluginNativeCode(
+			{ filterPluginsDevicesArch: true },
+			[
+				createDevice("device1", ["arm64-v8a", "armeabi-v7a"]),
+				createDevice("emulator1", ["x86_64", "x86"], true),
+			]
+		);
+
+		assert.deepStrictEqual(options.abiFilters, ["arm64-v8a", "x86_64"]);
+	});
+
+	it("passes the abi of the selected device only", async () => {
+		const options = await preparePluginNativeCode(
+			{ filterPluginsDevicesArch: true, device: "device1" },
+			[
+				createDevice("device1", ["arm64-v8a"]),
+				createDevice("emulator1", ["x86_64"], true),
+			]
+		);
+
+		assert.deepStrictEqual(options.abiFilters, ["arm64-v8a"]);
+	});
+
+	it("passes no abis when the option is not set", async () => {
+		const options = await preparePluginNativeCode({}, [
+			createDevice("device1", ["arm64-v8a"]),
+		]);
+
+		assert.isNull(options.abiFilters);
+	});
+
+	it("passes no abis when no device reports its abis", async () => {
+		const options = await preparePluginNativeCode(
+			{ filterPluginsDevicesArch: true },
+			[createDevice("device1", [])]
+		);
+
+		assert.isNull(options.abiFilters);
 	});
 });

--- a/test/services/android-project-service.ts
+++ b/test/services/android-project-service.ts
@@ -38,6 +38,12 @@ const createTestInjector = (): IInjector => {
 	testInjector.register("filesHashService", {
 		saveHashesForProject: () => ({}),
 	});
+	testInjector.register("devicesService", {
+		getDevicesForPlatform: (): Mobile.IDevice[] => [],
+	});
+	testInjector.register("liveSyncProcessDataService", {
+		getDeviceDescriptors: (): ILiveSyncDeviceDescriptor[] => [],
+	});
 	testInjector.register("androidPluginBuildService", {});
 	testInjector.register("errors", stubs.ErrorsStub);
 	testInjector.register("logger", stubs.LoggerStub);

--- a/test/services/android/gradle-build-service.ts
+++ b/test/services/android/gradle-build-service.ts
@@ -1,0 +1,125 @@
+import { Yok } from "../../../lib/common/yok";
+import { GradleBuildService } from "../../../lib/services/android/gradle-build-service";
+import { assert } from "chai";
+import { IInjector } from "../../../lib/common/definitions/yok";
+import { IAndroidBuildData } from "../../../lib/definitions/build";
+
+const createDevice = (
+	identifier: string,
+	abis: string[],
+	isEmulator = false,
+): any => ({
+	deviceInfo: { identifier, abis, platform: "android" },
+	isEmulator,
+});
+
+function createTestInjector(devices: any[]): IInjector {
+	const injector = new Yok();
+	injector.register("childProcess", {
+		on: (): void => undefined,
+		removeListener: (): void => undefined,
+	});
+	injector.register("devicesService", {
+		getDevicesForPlatform: () => devices,
+	});
+	injector.register("gradleBuildArgsService", {
+		getBuildTaskArgs: async () => ["assembleDebug"],
+		getCleanTaskArgs: () => ["clean"],
+		getBuildLoggingArgs: (): string[] => [],
+	});
+	injector.register("gradleCommandService", {
+		executeCommand: async (args: string[]): Promise<any> => {
+			executedArgs = args;
+			return null;
+		},
+	});
+	injector.register("gradleBuildService", GradleBuildService);
+
+	return injector;
+}
+
+let executedArgs: string[] = null;
+
+const buildProject = async (
+	devices: any[],
+	buildData: Partial<IAndroidBuildData>,
+): Promise<string[]> => {
+	executedArgs = null;
+	const injector = createTestInjector(devices);
+	const gradleBuildService = injector.resolve("gradleBuildService");
+	await gradleBuildService.buildProject("projectRoot", <IAndroidBuildData>{
+		platform: "android",
+		...buildData,
+	});
+
+	return executedArgs;
+};
+
+describe("GradleBuildService", () => {
+	describe("abi filtering", () => {
+		it("passes the abis of the connected devices", async () => {
+			const args = await buildProject(
+				[
+					createDevice("device1", ["arm64-v8a", "armeabi-v7a"]),
+					createDevice("emulator1", ["x86_64", "x86"], true),
+				],
+				{ buildFilterDevicesArch: true },
+			);
+
+			assert.include(args, "-PabiFilters=arm64-v8a,x86_64");
+		});
+
+		it("passes the abi of the selected device only", async () => {
+			const args = await buildProject(
+				[
+					createDevice("device1", ["arm64-v8a"]),
+					createDevice("emulator1", ["x86_64"], true),
+				],
+				{ buildFilterDevicesArch: true, device: "device1" },
+			);
+
+			assert.include(args, "-PabiFilters=arm64-v8a");
+		});
+
+		it("passes the abis of the emulators only when --emulator is used", async () => {
+			const args = await buildProject(
+				[
+					createDevice("device1", ["arm64-v8a"]),
+					createDevice("emulator1", ["x86_64"], true),
+				],
+				{ buildFilterDevicesArch: true, emulator: true },
+			);
+
+			assert.include(args, "-PabiFilters=x86_64");
+		});
+
+		it("deduplicates the abis", async () => {
+			const args = await buildProject(
+				[
+					createDevice("device1", ["arm64-v8a"]),
+					createDevice("device2", ["arm64-v8a"]),
+				],
+				{ buildFilterDevicesArch: true },
+			);
+
+			assert.include(args, "-PabiFilters=arm64-v8a");
+		});
+
+		it("passes nothing when the filtering is off", async () => {
+			const args = await buildProject(
+				[createDevice("device1", ["arm64-v8a"])],
+				{ buildFilterDevicesArch: false },
+			);
+
+			assert.isUndefined(args.find((a) => a.startsWith("-PabiFilters")));
+		});
+
+		it("passes nothing when no device reports its abis", async () => {
+			const args = await buildProject([createDevice("device1", [])], {
+				buildFilterDevicesArch: true,
+			});
+
+			assert.isUndefined(args.find((a) => a.startsWith("-PabiFilters")));
+		});
+	});
+});


### PR DESCRIPTION
### What

`--filter-plugins-devices-arch` passes the same `-PabiFilters=<abis>` that #6130 computes for the app build to the gradle build of every plugin built from source.

A plugin with a long native build - an NDK/CMake one - can then build one ABI instead of four when a run is only going to deploy to one device.

### Stacked on #6130

**This branch is based on #6130** and its diff contains that PR's commit until it merges - the reviewable commit here is the second one, [`5ecb7c0`](https://github.com/NativeScript/nativescript-cli/pull/6134/commits/5ecb7c07a50374623dc4fea3a5277715ed8e0a8f). It cannot stand alone: the ABIs come from `deviceInfo.abis`, which #6130 adds. The device selection those two PRs share moved into `lib/services/android/devices-abis.ts`, so `GradleBuildService` and the plugin path compute the ABI set the same way instead of twice.

It is a separate PR because it is a separate decision: #6130 narrows the app build on by default, this narrows plugin builds only when asked.

### Why there is no gradle block for it

Nothing in the gradle files the CLI generates for a plugin acts on `abiFilters`, and this deliberately does not add such a block. What a plugin's native sources need per ABI is the plugin's business - a `splits` block would be wrong for a plugin producing an `.aar`, and an `ndk.abiFilters` block would silently change what every existing plugin builds.

The property is passed so that a plugin whose own `include.gradle` reads it can act on it. A plugin that ignores it builds exactly what it built before.

### Why it is off by default

Unlike the app-side narrowing, a narrowed `.aar` is a partial artifact that stays in `platforms/tempPlugin` and in the plugin's `platforms/android` directory, and the rebuild decision is keyed by the plugin sources - which do not change when a device with another ABI joins the run.

So the ABI set is now part of the plugin build data that decision reads (`__abiFilters` in `.ns-plugin-build-data.json`). Changing devices, or turning the flag back off, rebuilds the aar. Off by default keeps that cost out of the way of anyone who does not need it.

An explicit `-PabiFilters` in the gradle args still wins.

### Tests

`npm test` — 1866 passing (1862 on #6130). Four cases in `test/services/android-project-service.ts` covering the ABIs handed to `buildAar`: all devices, `--device`, the option off, and devices that report no ABIs.

### Notes

From https://github.com/Akylas/nativescript-cli, in production use there.

Merge order: after #6130. Expect small textual conflicts with #6129 (`IAndroidBuildOptions.gradleArgs` and the options object in `android-project-service`) and with #6132, whose `android.plugins` map is the natural home for a later per-plugin override of this flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android ABI filtering based on connected devices and emulators.
  * Added options to disable app ABI filtering or enable plugin ABI filtering.
  * Android builds now select device-compatible packages, with universal package fallback.
  * Builds can produce and copy multiple application packages.
* **Bug Fixes**
  * Improved detection and installation of device-specific Android packages.
* **Documentation**
  * Documented the new Android debugging and run options.
* **Tests**
  * Added coverage for device, emulator, plugin, and ABI filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->