### PR TITLE
chore: remove extensions note that appeared as a warning

### DIFF
--- a/lib/services/ios-project-service.ts
+++ b/lib/services/ios-project-service.ts
@@ -1574,14 +1574,12 @@ export class IOSProjectService
 		);
 		const platformData = this.getPlatformData(projectData);
 		const pbxProjPath = this.getPbxProjPath(projectData);
-		const addedExtensionsFromResources =
-			await this.$iOSExtensionsService.addExtensionsFromPath({
-				extensionsFolderPath: resorcesExtensionsPath,
-				projectData,
-				platformData,
-				pbxProjPath,
-			});
-		let addedExtensionsFromPlugins = false;
+		await this.$iOSExtensionsService.addExtensionsFromPath({
+			extensionsFolderPath: resorcesExtensionsPath,
+			projectData,
+			platformData,
+			pbxProjPath,
+		});
 		for (const pluginIndex in pluginsData) {
 			const pluginData = pluginsData[pluginIndex];
 			const pluginPlatformsFolderPath = pluginData.pluginPlatformsFolderPath(
@@ -1592,21 +1590,12 @@ export class IOSProjectService
 				pluginPlatformsFolderPath,
 				constants.NATIVE_EXTENSION_FOLDER,
 			);
-			const addedExtensionFromPlugin =
-				await this.$iOSExtensionsService.addExtensionsFromPath({
-					extensionsFolderPath: extensionPath,
-					projectData,
-					platformData,
-					pbxProjPath,
-				});
-			addedExtensionsFromPlugins =
-				addedExtensionsFromPlugins || addedExtensionFromPlugin;
-		}
-
-		if (addedExtensionsFromResources || addedExtensionsFromPlugins) {
-			this.$logger.warn(
-				"Let us know if there are other Extension features you'd like! https://github.com/NativeScript/NativeScript/issues",
-			);
+			await this.$iOSExtensionsService.addExtensionsFromPath({
+				extensionsFolderPath: extensionPath,
+				projectData,
+				platformData,
+				pbxProjPath,
+			});
 		}
 	}
 


### PR DESCRIPTION
A legacy note that appeared as a warning like something may be wrong, but all clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS project setup by reliably completing extension additions from app resources and plugins.
  * Removed an unnecessary warning that could appear when extensions were added successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->